### PR TITLE
Implement all options for DatetimeInput

### DIFF
--- a/angular/projects/lib/src/lib/catalog/default.ts
+++ b/angular/projects/lib/src/lib/catalog/default.ts
@@ -105,7 +105,11 @@ export const DEFAULT_CATALOG: Catalog = {
 
   DateTimeInput: {
     type: () => import('./datetime-input').then((r) => r.DatetimeInput),
-    bindings: ({ properties }) => [inputBinding('value', () => properties.value)],
+    bindings: ({ properties }) => [
+      inputBinding('enableDate', () => properties.enableDate),
+      inputBinding('enableTime', () => properties.enableTime),
+      inputBinding('value', () => properties.value),
+    ],
   },
 
   CheckBox: {

--- a/web/lib/src/0.8/ui/datetime-input.ts
+++ b/web/lib/src/0.8/ui/datetime-input.ts
@@ -31,6 +31,12 @@ export class DateTimeInput extends Root {
   @property()
   accessor label: StringValue | null = null;
 
+  @property({ reflect: false, type: Boolean })
+  accessor enableDate = true;
+
+  @property({ reflect: false, type: Boolean })
+  accessor enableTime = true;
+
   static styles = [
     structuralStyles,
     css`
@@ -76,7 +82,7 @@ export class DateTimeInput extends Root {
     );
   }
 
-  #renderField(value: string | number) {
+  #renderField(value: string) {
     return html`<div>
       <input
         autocomplete="off"
@@ -92,11 +98,66 @@ export class DateTimeInput extends Root {
           this.#setBoundValue(evt.target.value);
         }}
         id="data"
-        .value=${value}
-        placeholder="Date & Time"
-        type="datetime-local"
+        .value=${this.#formatInputValue(value)}
+        .placeholder=${this.#getPlaceholderText()}
+        .type=${this.#getInputType()}
       />
     </div>`;
+  }
+
+  #getInputType() {
+    if (this.enableDate && this.enableTime) {
+      return "datetime-local";
+    } else if (this.enableDate) {
+      return "date";
+    } else if (this.enableTime) {
+      return "time";
+    }
+
+    return "datetime-local";
+  }
+
+  #formatInputValue(value: string) {
+    const inputType = this.#getInputType();
+    const date = value ? new Date(value) : null;
+
+    if (!date || isNaN(date.getTime())) {
+      return "";
+    }
+
+    const year = this.#padNumber(date.getFullYear());
+    const month = this.#padNumber(date.getMonth());
+    const day = this.#padNumber(date.getDate());
+    const hours = this.#padNumber(date.getHours());
+    const minutes = this.#padNumber(date.getMinutes());
+
+    // Browsers are picky with what format they allow for the `value` attribute of date/time inputs.
+    // We need to parse it out of the provided value. Note that we don't use `toISOString`,
+    // because the resulting value is relative to UTC.
+    if (inputType === "date") {
+      return `${year}-${month}-${day}`;
+    } else if (inputType === "time") {
+      return `${hours}:${minutes}`;
+    }
+
+    return `${year}-${month}-${day}T${hours}:${minutes}`;
+  }
+
+  #padNumber(value: number) {
+    return value.toString().padStart(2, "0");
+  }
+
+  #getPlaceholderText() {
+    // TODO: this should likely be passed from the model.
+    const inputType = this.#getInputType();
+
+    if (inputType === "date") {
+      return "Date";
+    } else if (inputType === "time") {
+      return "Time";
+    }
+
+    return "Date & Time";
   }
 
   render() {

--- a/web/lib/src/0.8/ui/root.ts
+++ b/web/lib/src/0.8/ui/root.ts
@@ -290,8 +290,8 @@ export class Root extends SignalWatcher(LitElement) {
             .processor=${this.processor}
             .surfaceId=${this.surfaceId}
             .dataContextPath=${component.dataContextPath ?? ""}
-            .enableDate=${component.properties.enableDate}
-            .enableTime=${component.properties.enableTime}
+            .enableDate=${component.properties.enableDate ?? true}
+            .enableTime=${component.properties.enableTime ?? true}
             .outputFormat=${component.properties.outputFormat}
             .value=${component.properties.value}
           ></a2ui-datetimeinput>`;


### PR DESCRIPTION
Updates both the Lit and Angular implementations of the `DatetimeInput` component to account for the provided value, the `enableDate` and `enableTime` options.

Fixes #95.