### PR TITLE
Add image and text hints, allow markdown in text

### DIFF
--- a/docs_private/a2ui_protocol.md
+++ b/docs_private/a2ui_protocol.md
@@ -152,8 +152,8 @@ The following is a complete, minimal example of a JSONL stream that renders a us
 {"surfaceUpdate": {"components": [{"id": "header_row", "component": {"Row": {"alignment": "center", "children": {"explicitList": ["avatar", "name_column"]}}}}]}}
 {"surfaceUpdate": {"components": [{"id": "avatar", "component": {"Image": {"url": {"literalString": "https://www.example.com/profile.jpg"}}}}]}}
 {"surfaceUpdate": {"components": [{"id": "name_column", "component": {"Column": {"alignment": "start", "children": {"explicitList": ["name_text", "handle_text"]}}}}]}}
-{"surfaceUpdate": {"components": [{"id": "name_text", "component": {"Text": {"hint": "h3", "text": {"literalString": "Flutter Fan"}}}}]}}
-{"surfaceUpdate": {"components": [{"id": "handle_text", "component": {"Text": {"text": {"literalString": "@flutterdev"}}}}]}}
+{"surfaceUpdate": {"components": [{"id": "name_text", "component": {"Text": {"usageHint": "h3", "text": {"literalString": "A2A Fan"}}}}]}}
+{"surfaceUpdate": {"components": [{"id": "handle_text", "component": {"Text": {"text": {"literalString": "@a2a_fan"}}}}]}}
 {"surfaceUpdate": {"components": [{"id": "bio_text", "component": {"Text": {"text": {"literalString": "Building beautiful apps from a single codebase."}}}}]}}
 {"dataModelUpdate": {"contents": {}}}
 {"beginRendering": {"root": "root"}}

--- a/specification/json/server_to_client.json
+++ b/specification/json/server_to_client.json
@@ -76,7 +76,7 @@
                           }
                         }
                       },
-                      "hint": {
+                      "usageHint": {
                         "type": "string",
                         "description": "A hint for the base text style. One of:\n- `h1`: Largest heading.\n- `h2`: Second largest heading.\n- `h3`: Third largest heading.\n- `h4`: Fourth largest heading.\n- `h5`: Fifth largest heading.\n- `caption`: Small text for captions.\n- `body`: Standard body text.",
                         "enum": [
@@ -118,7 +118,7 @@
                           "scale-down"
                         ]
                       },
-                      "hint": {
+                      "usageHint": {
                         "type": "string",
                         "description": "A hint for the image size and style. One of:\n- `icon`: Small square icon.\n- `avatar`: Circular avatar image.\n- `smallFeature`: Small feature image.\n- `mediumFeature`: Medium feature image.\n- `largeFeature`: Large feature image.\n- `header`: Full-width, full bleed, header image.",
                         "enum": [


### PR DESCRIPTION
# Description

Adds `Text` and `Image` `usageHint` property, removes `Heading`.  Allows simple Markdown for `Text` content.