### PR TITLE
Safely convert text value to string before rendering

### DIFF
--- a/angular/projects/lib/src/lib/catalog/text.ts
+++ b/angular/projects/lib/src/lib/catalog/text.ts
@@ -45,8 +45,8 @@ export class Text extends DynamicComponent {
     return value == null
       ? '(empty)'
       : this.markdownRenderer.render(
-          value,
-          v0_8.Styles.appendToAll(this.theme.markdown, ['ol', 'ul', 'li'], {})
+          String(value),
+          v0_8.Styles.appendToAll(this.theme.markdown, ['ol', 'ul', 'li'], {}),
         );
   });
 }


### PR DESCRIPTION
In dynamic-component.ts, NumberValue is handled prior to StringValue, so it's likely for the value to be resolved as a number at runtime.

Ensures that non-string values (like numbers) resolved from data bindings do not break the markdown renderer in the Text component.