### PR TITLE
Fix Angular lib build for the new text node implementation

### DIFF
--- a/angular/angular.json
+++ b/angular/angular.json
@@ -191,5 +191,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/angular/projects/lib/src/lib/catalog/default.ts
+++ b/angular/projects/lib/src/lib/catalog/default.ts
@@ -59,10 +59,19 @@ export const DEFAULT_CATALOG: Catalog = {
   Heading: {
     type: () => import('./heading').then((r) => r.Heading),
     bindings: (node) => {
-      const properties = (node as v0_8.Types.HeadingNode).properties;
+      const properties = (node as v0_8.Types.TextNode).properties;
+      // Figure out the heading level based on the hint. If the hint isn't
+      // a hint for a heading, we can't render a heading.
+      let level: number;
+      if (["h1", "h2", "h3", "h4", "h5"].includes(properties.usageHint)) {
+        level = Number(properties.usageHint[1]);
+      } else {
+        throw new Error(`Cannot render heading: usageHint wasn't a heading level, it was ${properties.usageHint}`);
+      }
+
       return [
         inputBinding('text', () => properties.text),
-        inputBinding('level', () => properties.level),
+        inputBinding('level', () => level),
       ];
     },
   },

--- a/angular/projects/lib/src/lib/catalog/heading.ts
+++ b/angular/projects/lib/src/lib/catalog/heading.ts
@@ -39,14 +39,15 @@ import { DynamicComponent } from '../rendering/dynamic-component';
 })
 export class Heading extends DynamicComponent {
   readonly text = input.required<v0_8.Primitives.StringValue | null>();
+  // TODO: Render a different heading level based on this input.
   readonly level = input.required<string | undefined>();
   protected resolvedText = computed(() => super.resolvePrimitive(this.text()) ?? '');
 
   protected readonly classes = computed(() => {
-    const classKey = `level${this.level()}` as keyof typeof this.theme.components.Heading;
     return v0_8.Styles.merge(
-      this.theme.components.Heading.all,
-      this.theme.components.Heading[classKey]
+      this.theme.components.Text.all,
+      // TODO: Render a different heading level based on input.
+      // this.theme.components.Text[classKey]
     );
   });
 }


### PR DESCRIPTION
This build is currently broken at head because it references `Header` which no longer exists (replaced with `Text` + usage hints).