### PR TITLE
Simplify ModelProcessor by extending A2UIModelProcessor

### DIFF
--- a/angular/projects/lib/src/lib/data/processor.ts
+++ b/angular/projects/lib/src/lib/data/processor.ts
@@ -24,41 +24,19 @@ export interface DispatchedEvent {
 }
 
 @Injectable({ providedIn: 'root' })
-export class ModelProcessor {
-  private readonly processor = new v0_8.Data.A2UIModelProcessor();
+export class ModelProcessor extends v0_8.Data.A2UIModelProcessor {
   readonly events = new Subject<DispatchedEvent>();
 
-  getSurfaces() {
-    return this.processor.getSurfaces();
-  }
-
-  resolvePath(path: string, dataContextPath?: string) {
-    return this.processor.resolvePath(path, dataContextPath);
-  }
-
-  setData(
+  override setData(
     node: v0_8.Types.AnyComponentNode,
     relativePath: string,
     value: v0_8.Types.DataValue,
     surfaceId?: v0_8.Types.SurfaceID | null
   ) {
-    return this.processor.setData(node, relativePath, value, surfaceId ?? undefined);
-  }
-
-  getData(
-    node: v0_8.Types.AnyComponentNode,
-    relativePath: string,
-    surfaceId?: string
-  ): v0_8.Types.DataValue | null {
-    return this.processor.getData(node, relativePath, surfaceId);
-  }
-
-  clearSurfaces() {
-    this.processor.clearSurfaces();
-  }
-
-  processMessages(messages: v0_8.Types.ServerToClientMessage[]) {
-    this.processor.processMessages(messages);
+    // Override setData to convert from optional inputs (which can be null)
+    // to undefined so that this correctly falls back to the default value for
+    // surfaceId.
+    return super.setData(node, relativePath, value, surfaceId ?? undefined);
   }
 
   dispatch(message: v0_8.Types.A2UIClientEventMessage): Promise<v0_8.Types.ServerToClientMessage[]> {


### PR DESCRIPTION
ModelProcessor was mostly a passthrough for methods; by doing it this way it makes ModelProcessor more readable by making it more clear what we're overriding or adding.

Plus less lines of code!

This is some pre-work that will benefit #118