### PR TITLE
Add Rizzcharts & A2A chat canvas demo to the GH workflow

### DIFF
--- a/.github/workflows/ng_build_and_test.yml
+++ b/.github/workflows/ng_build_and_test.yml
@@ -48,3 +48,7 @@ jobs:
       - name: Build Rizzchart sample
         working-directory: ./angular
         run: npm run build rizzcharts
+
+      - name: Build A2A chat canvas demo
+        working-directory: ./angular
+        run: npm run build a2a-chat-canvas-demo


### PR DESCRIPTION
These seem to be in good shape and work OOTB without me having to do any fixing. The final Angular project - `a2a-chat-canvas` - does not build on my local machine, so I need to do some debugging on that. I'll try to fix that in a followup PR.