### PR TITLE
Update a2a extension URI to https://a2ui.org/a2a-extension/a2ui/v0.8 everywhere

### DIFF
--- a/a2a_agents/python/a2ui_extension/src/a2ui_ext/__init__.py
+++ b/a2a_agents/python/a2ui_extension/src/a2ui_ext/__init__.py
@@ -20,7 +20,7 @@ from a2a.types import AgentExtension, Part, DataPart
 
 logger = logging.getLogger(__name__)
 
-A2UI_EXTENSION_URI = "https://a2ui.org/a2a-extension/v0.8"
+A2UI_EXTENSION_URI = "https://a2ui.org/a2a-extension/a2ui/v0.8"
 
 MIME_TYPE_KEY = "mimeType"
 A2UI_MIME_TYPE = "application/json+a2ui"

--- a/a2a_agents/python/adk/samples/orchestrator/README.md
+++ b/a2a_agents/python/adk/samples/orchestrator/README.md
@@ -2,11 +2,11 @@
 
 This sample uses the Agent Development Kit (ADK) along with the A2A protocol to create an orchestrator agent that routes requests to different expert subagents.
 
-The orchestrator agent needs the A2UI extension enabled by adding the header X-A2A-Extensions=https://a2ui.org/a2a-extension/v0.8 to requests, however it is hardcoded to true for this sample to simplify inspection.
+The orchestrator agent needs the A2UI extension enabled by adding the header X-A2A-Extensions=https://a2ui.org/a2a-extension/a2ui/v0.8 to requests, however it is hardcoded to true for this sample to simplify inspection.
 
 The orchestrator does an inference call on every request to decide which agent to route to, and then uses transfer_to_agent in ADK to pass the original message to the subagent. This routing is done on subsequent calls including on A2UI userAction, and a future version could optimize this by programatically routing userAction to the agent that created the surface using before_model_callback to shortcut the orchestrator LLM.
 
-Subagents are configured using RemoteA2aAgent which translates ADK events to A2A messages that are sent to the subagent's A2A server. The HTTP header X-A2A-Extensions=https://a2ui.org/a2a-extension/v0.8 is added to requests from the RemoteA2aAgent to enable the A2UI extension.
+Subagents are configured using RemoteA2aAgent which translates ADK events to A2A messages that are sent to the subagent's A2A server. The HTTP header X-A2A-Extensions=https://a2ui.org/a2a-extension/a2ui/v0.8 is added to requests from the RemoteA2aAgent to enable the A2UI extension.
 
 ## Prerequisites
 

--- a/angular/projects/a2a-chat-canvas-demo/src/server.ts
+++ b/angular/projects/a2a-chat-canvas-demo/src/server.ts
@@ -115,7 +115,7 @@ if (isMainModule(import.meta.url) || process.env['pm_id']) {
 
 async function fetchWithCustomHeader(url: string | URL | Request, init?: RequestInit) {
   const headers = new Headers(init?.headers);
-  headers.set('X-A2A-Extensions', 'https://a2ui.org/a2a-extension/v0.8');
+  headers.set('X-A2A-Extensions', 'https://a2ui.org/a2a-extension/a2ui/v0.8');
   const newInit = { ...init, headers };
   return fetch(url, newInit);
 }

--- a/angular/projects/contact/src/server.ts
+++ b/angular/projects/contact/src/server.ts
@@ -115,7 +115,7 @@ if (isMainModule(import.meta.url) || process.env['pm_id']) {
 
 async function fetchWithCustomHeader(url: string | URL | Request, init?: RequestInit) {
   const headers = new Headers(init?.headers);
-  headers.set('X-A2A-Extensions', 'https://a2ui.org/a2a-extension/v0.8');
+  headers.set('X-A2A-Extensions', 'https://a2ui.org/a2a-extension/a2ui/v0.8');
   const newInit = { ...init, headers };
   return fetch(url, newInit);
 }

--- a/angular/projects/restaurant/src/server.ts
+++ b/angular/projects/restaurant/src/server.ts
@@ -115,7 +115,7 @@ if (isMainModule(import.meta.url) || process.env['pm_id']) {
 
 async function fetchWithCustomHeader(url: string | URL | Request, init?: RequestInit) {
   const headers = new Headers(init?.headers);
-  headers.set('X-A2A-Extensions', 'https://a2ui.org/a2a-extension/v0.8');
+  headers.set('X-A2A-Extensions', 'https://a2ui.org/a2a-extension/a2ui/v0.8');
   const newInit = { ...init, headers };
   return fetch(url, newInit);
 }

--- a/angular/projects/rizzcharts/src/server.ts
+++ b/angular/projects/rizzcharts/src/server.ts
@@ -116,7 +116,7 @@ if (isMainModule(import.meta.url) || process.env['pm_id']) {
 
 async function fetchWithCustomHeader(url: string | URL | Request, init?: RequestInit) {
   const headers = new Headers(init?.headers);
-  headers.set('X-A2A-Extensions', 'https://a2ui.org/a2a-extension/v0.8');
+  headers.set('X-A2A-Extensions', 'https://a2ui.org/a2a-extension/a2ui/v0.8');
   const newInit = { ...init, headers };
   return fetch(url, newInit);
 }

--- a/samples/client/lit/contact/middleware/a2a.ts
+++ b/samples/client/lit/contact/middleware/a2a.ts
@@ -29,7 +29,7 @@ const A2AUI_MIME_TYPE = "application/json+a2aui";
 
 const fetchWithCustomHeader: typeof fetch = async (url, init) => {
   const headers = new Headers(init?.headers);
-  headers.set("X-A2A-Extensions", "https://a2ui.org/a2a-extension/v0.8");
+  headers.set("X-A2A-Extensions", "https://a2ui.org/a2a-extension/a2ui/v0.8");
 
   const newInit = { ...init, headers };
   return fetch(url, newInit);

--- a/samples/client/lit/restaurant/middleware/a2a.ts
+++ b/samples/client/lit/restaurant/middleware/a2a.ts
@@ -29,7 +29,7 @@ const A2AUI_MIME_TYPE = "application/json+a2aui";
 
 const fetchWithCustomHeader: typeof fetch = async (url, init) => {
   const headers = new Headers(init?.headers);
-  headers.set("X-A2A-Extensions", "https://a2ui.org/a2a-extension/v0.8");
+  headers.set("X-A2A-Extensions", "https://a2ui.org/a2a-extension/a2ui/v0.8");
 
   const newInit = { ...init, headers };
   return fetch(url, newInit);


### PR DESCRIPTION
This avoids using the `a2a-ui` name which is deprecated, and also uses a structure that opens the door for us to add more extensions in the future.