### PR TITLE
Remove `date` from `TextField` component to remove duplication relative to `DateTimeInput`

### DIFF
--- a/specification/0.9/json/standard_catalog_definition.json
+++ b/specification/0.9/json/standard_catalog_definition.json
@@ -507,7 +507,7 @@
             "usageHint": {
               "type": "string",
               "description": "The type of input field to display.",
-              "enum": ["date", "longText", "number", "shortText", "obscured"]
+              "enum": ["longText", "number", "shortText", "obscured"]
             },
             "validationRegexp": {
               "type": "string",


### PR DESCRIPTION
I think it adds confusion to have this seeing as we already have `DateTimeInput`.

There is still `validationRegexp` on `TextField`, so people can use this if they want.

Fixes https://github.com/google/A2UI/issues/281