### PR TITLE
fix: broken links of `edit_uri` with mkdocs

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -70,6 +70,7 @@ nav:
 # Repository
 repo_name: google/A2UI
 repo_url: https://github.com/google/A2UI
+edit_uri: raw/main/docs/
 
 # Copyright
 copyright: Copyright Google 2025&nbsp;&nbsp;|&nbsp;&nbsp;<a href="//policies.google.com/terms">Terms</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="//policies.google.com/privacy">Privacy</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a href="#__consent">Manage cookies</a>


### PR DESCRIPTION
Hello,

Thanks for A2UI, really exciting open project!

While browsing the documentation on https://a2ui.org, I noticed a small issue with the “View file" button (I imagine that's for LLMs to see the raw).

For all pages, the link currently points to: `https://github.com/google/A2UI/raw/master/docs/...`

However, the default branch is `main`, not `master`, and using raw makes the navigation less user-friendly.

To address this, I added the `edit_uri` key to the MkDocs configuration and updated the link to point to `raw/main/docs/`.

Thanks!

https://github.com/user-attachments/assets/0a4a11eb-17fb-40c0-922b-5299da9c4644