### PR TITLE
doc: fixing A2UI logo display in specs

### DIFF
--- a/specification/0.9/docs/a2ui_protocol.md
+++ b/specification/0.9/docs/a2ui_protocol.md
@@ -2,7 +2,8 @@
 <!-- markdownlint-disable MD033 -->
 <div style="text-align: center;">
   <div class="centered-logo-text-group">
-    <img src="../../../docs/assets/A2UI_dark.svg" alt="A2UI Protocol Logo" width="100">
+    <!-- Logo for Light Mode (shows dark logo on light background) -->
+    <img src="assets/A2UI_light.svg" alt="A2UI Logo" width="120" class="light-mode-only" style="margin-bottom: 1rem;">
     <h1>A2UI (Agent to UI) Protocol v0.9</h1>
   </div>
 </div>


### PR DESCRIPTION
Hi,

Logo for A2UI doesn't display correctly in specification page. This PR tries to fix it for 0.9 in light mode.

Please, validate this change (without merging) and I am happy to extend the PR to dark mode as well for both v0.8 and v0.9

Cheers,

Didier