### PR TITLE
docs: fix incorrect A2A server instruction link in contact sample

### DIFF
--- a/samples/client/lit/contact/README.md
+++ b/samples/client/lit/contact/README.md
@@ -24,7 +24,7 @@ This sample depends on the Lit renderer. Before running this sample, you need to
    ```
 
 3. **Run the servers:**
-   - Run the [A2A server](../../../agent/adk/contact_lookup/)
+   - Run the [A2A server](../../../agent/adk/contact_lookup/README.md)
    - Run the dev server: `npm run dev`
 
 After starting the dev server, you can open http://localhost:5173/ to view the sample.


### PR DESCRIPTION
This pull request addresses Issue #257, where the link for the A2A server instructions in the contact client sample was leading to an unhelpful directory view rather than the actual setup instructions.

The Problem: In samples/client/lit/contact/README.md, the "A2A server" link pointed to the contact_lookup folder. While not a literal 404, it forced users to hunt for the setup steps, which felt "broken" to new users.

The Fix: I have updated the link to use a direct relative path to the specific README.md file within the agent directory. This ensures that when a user clicks the link, they immediately see the:

Prerequisites (Python, UV)

API key setup instructions

Command to run the server (uv run .)

Related Issue
Fixes #257