### PR TITLE
fix(lit): use cross-platform script for copy-spec to support Windows

### DIFF
--- a/renderers/lit/package.json
+++ b/renderers/lit/package.json
@@ -30,7 +30,7 @@
   },
   "wireit": {
     "copy-spec": {
-      "command": "mkdir -p src/0.8/schemas && cp ../../specification/0.8/json/*.json src/0.8/schemas",
+      "command": "node scripts/copy-schemas.js",
       "files": [
         "../../specification/0.8/json/*.json"
       ],

--- a/renderers/lit/scripts/copy-schemas.js
+++ b/renderers/lit/scripts/copy-schemas.js
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const srcDir = path.resolve(__dirname, '../../../specification/0.8/json');
+const destDir = path.resolve(__dirname, '../src/0.8/schemas');
+
+console.log(`Copying schemas from ${srcDir} to ${destDir}...`);
+
+if (!fs.existsSync(destDir)) {
+  fs.mkdirSync(destDir, { recursive: true });
+}
+
+try {
+  const files = fs.readdirSync(srcDir);
+  let count = 0;
+  for (const file of files) {
+    if (file.endsWith('.json')) {
+      const srcFile = path.join(srcDir, file);
+      const destFile = path.join(destDir, file);
+      fs.copyFileSync(srcFile, destFile);
+      count++;
+    }
+  }
+  console.log(`Successfully copied ${count} schema files.`);
+} catch (err) {
+  console.error('Error copying schemas:', err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Problem
The `renderers/lit` build script `copy-spec` relied on Unix-specific commands (`mkdir -p` and `cp`), causing the build to fail on Windows environments.

## Solution
Replaced the shell command with a new cross-platform Node.js script `scripts/copy-schemas.js` that uses the `fs` module to securely copy the schema files.

## Verification
- Verified that `npm run copy-spec` runs successfully on Windows 11.
- Verified that `npm run build` completes without errors.
- Confirmed that the Restaurant Finder demo now starts and runs correctly.