### PR TITLE
docs: add directory path for gallery app in quickstart page

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -196,6 +196,14 @@ The repository includes several other demos:
 
 See all available A2UI components:
 
+Step 1: Navigate to the Gallery Angular App:
+
+```bash
+cd samples/client/angular
+```
+
+Step 2: Run
+
 ```bash
 npm start -- gallery
 ```


### PR DESCRIPTION
The Quickstart page in the documentation didn't show a directory path to going to the gallery app. My update clarifies newcomers to navigate to the Angular portion of the client demos.