### PR TITLE
docs: automate syncing of v0.9 schemas to hosted site (#232)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,7 @@ on:
       - "requirements-docs.txt"
       - "mkdocs.yml"
       - "docs/**"
+      - "specification/**"
   pull_request:
     branches:
       - main
@@ -31,6 +32,7 @@ on:
       - "requirements-docs.txt"
       - "mkdocs.yml"
       - "docs/**"
+      - "specification/**"
 
 jobs:
   build_and_deploy:
@@ -68,6 +70,11 @@ jobs:
 
       - name: Install documentation dependencies
         run: pip install -r requirements-docs.txt
+
+      - name: Sync Specification Schemas to Docs
+        run: |
+          mkdir -p docs/specification/0.9
+          cp -r specification/0.9/json/*.json docs/specification/0.9/
 
       - name: Build Documentation (PR Check)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Description
This PR automates the synchronization of v0.9 JSON schemas into the documentation build process. Previously, changes to the specification were not reflected on the hosted site unless manually moved.

### Changes
* **Workflow Triggers**: Added `specification/**` to the watch list so the docs rebuild whenever a schema is updated.
* **Auto-Sync Step**: Added a build step to create `docs/specification/0.9` and copy the latest `.json` schemas from the source directory before the MkDocs build.

Fixes #232
