### PR TITLE
fix(lit): correctly bind TextField type property to enable number inputs

### DIFF
--- a/renderers/lit/src/0.8/ui/root.ts
+++ b/renderers/lit/src/0.8/ui/root.ts
@@ -420,7 +420,7 @@ export class Root extends SignalWatcher(LitElement) {
             .dataContextPath=${node.dataContextPath}
             .label=${node.properties.label}
             .text=${node.properties.text}
-            .type=${node.properties.type}
+            .textFieldType=${node.properties.type}
             .validationRegexp=${node.properties.validationRegexp}
             .enableCustomElements=${this.enableCustomElements}
           ></a2ui-textfield>`;

--- a/renderers/lit/src/0.8/ui/text-field.ts
+++ b/renderers/lit/src/0.8/ui/text-field.ts
@@ -34,7 +34,7 @@ export class TextField extends Root {
   accessor label: StringValue | null = null;
 
   @property()
-  accessor inputType: ResolvedTextField["type"] | null = null;
+  accessor textFieldType: ResolvedTextField["type"] | null = null;
 
   static styles = [
     structuralStyles,
@@ -107,7 +107,7 @@ export class TextField extends Root {
         id="data"
         .value=${value}
         .placeholder=${"Please enter a value"}
-        type=${this.inputType === "number" ? "number" : "text"}
+        type=${this.textFieldType === "number" ? "number" : "text"}
       />
     </section>`;
   }

--- a/samples/agent/adk/restaurant_finder/a2ui_examples.py
+++ b/samples/agent/adk/restaurant_finder/a2ui_examples.py
@@ -132,7 +132,7 @@ RESTAURANT_UI_EXAMPLES = """
       {{ "id": "restaurant-address", "component": {{ "Text": {{ "text": {{ "path": "address" }} }} }} }},
       {{ "id": "party-size-field", "component": {{ "TextField": {{ "label": {{ "literalString": "Party Size" }}, "text": {{ "path": "partySize" }}, "type": "number" }} }} }},
       {{ "id": "datetime-field", "component": {{ "DateTimeInput": {{ "label": {{ "literalString": "Date & Time" }}, "value": {{ "path": "reservationTime" }}, "enableDate": true, "enableTime": true }} }} }},
-      {{ "id": "dietary-field", "component": {{ "TextField": {{ "label": {{ "literalString": "Dietary Requirements" }}, "text": {{ "path": "dietary" }} }} }} }},
+      {{ "id": "dietary-field", "component": {{ "TextField": {{ "label": {{ "literalString": "Dietary Requirements" }}, "text": {{ "path": "dietary" }}, "type": "shortText" }} }} }},
       {{ "id": "submit-button", "component": {{ "Button": {{ "child": "submit-reservation-text", "action": {{ "name": "submit_booking", "context": [ {{ "key": "restaurantName", "value": {{ "path": "restaurantName" }} }}, {{ "key": "partySize", "value": {{ "path": "partySize" }} }}, {{ "key": "reservationTime", "value": {{ "path": "reservationTime" }} }}, {{ "key": "dietary", "value": {{ "path": "dietary" }} }}, {{ "key": "imageUrl", "value": {{ "path": "imageUrl" }} }} ] }} }} }} }},
       {{ "id": "submit-reservation-text", "component": {{ "Text": {{ "text": {{ "literalString": "Submit Reservation" }} }} }} }}
     ]


### PR DESCRIPTION
## Description

This PR fixes an issue where the `TextField` component in the Lit renderer was ignoring the `type` property (e.g., `"number"`) from the A2UI JSON payload.

## Problem

A property name mismatch between the renderer and component caused the input type to be ignored:

| Location | Property Name | Code |
|----------|---------------|------|
| `root.ts` (Sender) | `.type` | `.type=${node.properties.type}` |
| `text-field.ts` (Receiver) | `inputType` | `accessor inputType` |

**Result:** `<input type="number">` rendered as `<input type="text">`, allowing non-numeric input in number fields.

## Solution

1. **Lit Component (`text-field.ts`)**: Renamed `inputType` → `textFieldType` to avoid conflicts with the component's class type identifier.

2. **Root Renderer (`root.ts`)**: Updated binding to `.textFieldType=${node.properties.type}`.

3. **Samples (`a2ui_examples.py`)**: Added explicit `"type": "shortText"` and `"type": "number"` usage for clarity.

## Verification

- ✅ `textFieldType` correctly receives values from JSON payload
- ✅ HTML input renders with `type="number"` when specified

---

Hi @jacobsimionato 👋

Could you please take a look or help arrange a review?

Thanks! 🙏
