### PR TITLE
[fix] set encoding to utf-8 in samples' tool.py while open sample data file

### DIFF
--- a/samples/agent/adk/contact_lookup/tools.py
+++ b/samples/agent/adk/contact_lookup/tools.py
@@ -34,7 +34,7 @@ def get_contact_info(name: str, tool_context: ToolContext, department: str = "")
     try:
         script_dir = os.path.dirname(__file__)
         file_path = os.path.join(script_dir, "contact_data.json")
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             contact_data_str = f.read()
             if base_url := tool_context.state.get("base_url"):                
                 contact_data_str = contact_data_str.replace("http://localhost:10002", base_url)

--- a/samples/agent/adk/restaurant_finder/tools.py
+++ b/samples/agent/adk/restaurant_finder/tools.py
@@ -34,7 +34,7 @@ def get_restaurants(cuisine: str, location: str,  tool_context: ToolContext, cou
         try:
             script_dir = os.path.dirname(__file__)
             file_path = os.path.join(script_dir, "restaurant_data.json")
-            with open(file_path) as f:
+            with open(file_path, encoding="utf-8") as f:
                 restaurant_data_str = f.read()
                 if base_url := tool_context.state.get("base_url"):                    
                     restaurant_data_str = restaurant_data_str.replace("http://localhost:10002", base_url)


### PR DESCRIPTION
##Problem##
The A2UI sample running in a Windows shell can get this, while using a different codec
<img width="1015" height="474" alt="image" src="https://github.com/user-attachments/assets/91ac2a57-5bc7-4dda-94b6-b760e3c669de" />

##Solution##
Set the encoding parameter while opening the xxx_data.json file