### PR TITLE
schema: preventing additional properties in A2UI schmae

### DIFF
--- a/samples/agent/adk/contact_lookup/a2ui_schema.py
+++ b/samples/agent/adk/contact_lookup/a2ui_schema.py
@@ -20,6 +20,7 @@ A2UI_SCHEMA = r'''
   "title": "A2UI Message Schema",
   "description": "Describes a JSON payload for an A2UI (Agent to UI) message, which is used to dynamically construct and update user interfaces. A message MUST contain exactly ONE of the action properties: 'beginRendering', 'surfaceUpdate', 'dataModelUpdate', or 'deleteSurface'.",
   "type": "object",
+  "additionalProperties": false
   "properties": {
     "beginRendering": {
       "type": "object",


### PR DESCRIPTION
Hi,

We suggest to add `"additionalProperties": false` in the schema definition based on https://tour.json-schema.org/content/03-Objects/02-Additional-Properties

It allows simpler validation parsing of the A2UI items by the agent before sending them to the renderer.  This property will make `jsonschema.validate()`raise exceptions on all properties not in the official schema. So, it will make sure that only a list of beginRendering, surfaceUpdate, dataModelUpdate and deleteSurface are sent to the renderer. It will also ensure that only properties existing in official schema are defined for those commands.

It has at least 2 positives consequences:

- more solid / resilient renderer behavior: for dynamically generated (i.e by the LLM) A2UI templates, we can be easily sure that only valid command are sent
- security aspects: the agent can make sure that the renderer will not be sent onto unsecure code path due to incorrect commands

If required, I can also extend this PR to add `"additionalProperties": false` for each of the commands so that we also avoid unknown properties at this additional level.

Cheers,
Didier

 