### PR TITLE
Fix datetime input month formatting in Lit and Angular renderers

### DIFF
--- a/renderers/angular/src/lib/catalog/datetime-input.ts
+++ b/renderers/angular/src/lib/catalog/datetime-input.ts
@@ -94,7 +94,7 @@ export class DatetimeInput extends DynamicComponent {
     }
 
     const year = this.padNumber(date.getFullYear());
-    const month = this.padNumber(date.getMonth());
+    const month = this.padNumber(date.getMonth() + 1);
     const day = this.padNumber(date.getDate());
     const hours = this.padNumber(date.getHours());
     const minutes = this.padNumber(date.getMinutes());

--- a/renderers/lit/src/0.8/ui/datetime-input.ts
+++ b/renderers/lit/src/0.8/ui/datetime-input.ts
@@ -134,7 +134,7 @@ export class DateTimeInput extends Root {
     }
 
     const year = this.#padNumber(date.getFullYear());
-    const month = this.#padNumber(date.getMonth());
+    const month = this.#padNumber(date.getMonth() + 1);
     const day = this.#padNumber(date.getDate());
     const hours = this.#padNumber(date.getHours());
     const minutes = this.#padNumber(date.getMinutes());


### PR DESCRIPTION
## Summary
Fixes an off-by-one error in datetime input renderers (Lit and Angular).
In JavaScript, `Date.getMonth()` is zero-based (January = 0), which caused
rendered month values to be incorrect.

## Changes
- Normalize month formatting by using `getMonth() + 1`.
- Apply the fix consistently across Lit and Angular renderers.

## Impact
Prevents incorrect month rendering in datetime inputs, avoiding
user-facing data errors and improving UX consistency.