### PR TITLE
Make Lit copy-spec cross-platform

### DIFF
--- a/renderers/lit/package.json
+++ b/renderers/lit/package.json
@@ -30,7 +30,7 @@
   },
   "wireit": {
     "copy-spec": {
-      "command": "mkdir -p src/0.8/schemas && cp ../../specification/0.8/json/*.json src/0.8/schemas",
+      "command": "node scripts/copy-spec.mjs",
       "files": [
         "../../specification/0.8/json/*.json"
       ],

--- a/renderers/lit/scripts/copy-spec.mjs
+++ b/renderers/lit/scripts/copy-spec.mjs
@@ -1,0 +1,19 @@
+import { mkdir, readdir, copyFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, "..");
+const sourceDir = path.resolve(rootDir, "..", "..", "specification", "0.8", "json");
+const destDir = path.resolve(rootDir, "src", "0.8", "schemas");
+
+await mkdir(destDir, { recursive: true });
+
+const entries = await readdir(sourceDir, { withFileTypes: true });
+const jsonFiles = entries.filter((entry) => entry.isFile() && entry.name.endsWith(".json"));
+
+for (const file of jsonFiles) {
+  const sourcePath = path.join(sourceDir, file.name);
+  const destPath = path.join(destDir, file.name);
+  await copyFile(sourcePath, destPath);
+}


### PR DESCRIPTION
## Summary
The Lit renderer build currently relies on `mkdir -p` and `cp`, which fail on Windows. This replaces that step with a small Node script so `npm run build` works cross-platform.

## Changes
- Replace the `copy-spec` command with a Node script.
- Add `scripts/copy-spec.mjs` to copy spec JSON files into `src/0.8/schemas`.

## Why this matters
Windows contributors currently hit a hard build failure during `copy-spec`. This makes the build portable across OSes without changing outputs.

## Testing
- `cd renderers/lit`
- `npm install`
- `npm run build`
- - Tested on Windows (PowerShell)
<img width="287" height="80" alt="image" src="https://github.com/user-attachments/assets/11085106-59d2-4cea-892d-81591e44b1b2" />
