### PR TITLE
fix(lit): Pass enableCustomElements from Surface to Root

### DIFF
--- a/renderers/lit/src/0.8/ui/surface.ts
+++ b/renderers/lit/src/0.8/ui/surface.ts
@@ -121,6 +121,7 @@ export class Surface extends Root {
       .childComponents=${this.surface?.componentTree
         ? [this.surface.componentTree]
         : null}
+      .enableCustomElements=${this.enableCustomElements}
     ></a2ui-root>`;
   }
 


### PR DESCRIPTION
Surface accepts `enableCustomElements` but wasn't passing it to the child `<a2ui-root>`. This prevents custom components from rendering when using the Surface wrapper.

All other container components (List, Card, Column, Row, etc.) already pass this property—Surface was the only one missing it.