### PR TITLE
fix(lit): make copy-spec script cross-platform compatible

### DIFF
--- a/renderers/lit/package-lock.json
+++ b/renderers/lit/package-lock.json
@@ -993,7 +993,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/signal-polyfill/-/signal-polyfill-0.2.2.tgz",
       "integrity": "sha512-p63Y4Er5/eMQ9RHg0M0Y64NlsQKpiu6MDdhBXpyywRuWiPywhJTpKJ1iB5K2hJEbFZ0BnDS7ZkJ+0AfTuL37Rg==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/signal-utils": {
       "version": "0.21.1",

--- a/renderers/lit/package.json
+++ b/renderers/lit/package.json
@@ -30,9 +30,10 @@
   },
   "wireit": {
     "copy-spec": {
-      "command": "mkdir -p src/0.8/schemas && cp ../../specification/0.8/json/*.json src/0.8/schemas",
+      "command": "node scripts/copy-spec.js",
       "files": [
-        "../../specification/0.8/json/*.json"
+        "../../specification/0.8/json/*.json",
+        "scripts/copy-spec.js"
       ],
       "output": [
         "src/0.8/schemas/*.json"

--- a/renderers/lit/scripts/copy-spec.js
+++ b/renderers/lit/scripts/copy-spec.js
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const srcDir = path.resolve(__dirname, '../../../specification/0.8/json');
+const destDir = path.resolve(__dirname, '../src/0.8/schemas');
+
+console.log(`Copying specs from ${srcDir} to ${destDir}`);
+
+if (!fs.existsSync(destDir)) {
+  fs.mkdirSync(destDir, { recursive: true });
+}
+
+if (!fs.existsSync(srcDir)) {
+    console.error(`Source directory not found: ${srcDir}`);
+    process.exit(1);
+}
+
+const files = fs.readdirSync(srcDir);
+
+files.forEach(file => {
+  if (path.extname(file) === '.json') {
+    fs.copyFileSync(path.join(srcDir, file), path.join(destDir, file));
+    console.log(`Copied ${file}`);
+  }
+});


### PR DESCRIPTION
# Objective: Resolve build failures on Windows operating systems caused by Unix-specific shell commands in the copy-spec script.

## 1. The Problem
The original `package.json` script for `copy-spec` relied on shell commands that are native to Linux and macOS but incompatible with the standard Windows Command Prompt (cmd.exe):

*   `mkdir -p`: The `-p` flag (create parent directories) is not supported by the Windows `mkdir` command.
*   `cp`: This is a Unix copy command; Windows uses `copy` or `xcopy`.

**Original Code (Fails on Windows):**

```json
"copy-spec": {
  "command": "mkdir -p src/0.8/schemas && cp ../../specification/0.8/json/*.json src/0.8/schemas",
  ...
}
```

## 2. The Solution
We replaced the platform-dependent shell commands with a Node.js script. Since Node.js is already a requirement for the project, using its built-in `fs` (File System) module allows us to perform file operations that work identically on Windows, Linux, and macOS.

## 3. Implementation Details

### A. Created `scripts/copy-spec.js`
We added a new script that handles the logic programmatically:

1.  **Resolve Paths**: Uses `path.resolve` to correctly locate the source (`../../specification/0.8/json`) and destination (`src/0.8/schemas`) directories relative to the script location, ensuring path separators (`/` vs `\`) are handled correctly for the OS.
2.  **Ensure Directory Exists**: Uses `fs.mkdirSync(destDir, { recursive: true })`. The `recursive: true` option is the cross-platform equivalent of `mkdir -p`.
3.  **Copy Files**: properly iterates through files in the source directory and uses `fs.copyFileSync` to copy them one by one.

### B. Updated `package.json`
We modified the `copy-spec` entry in `package.json` to execute this new script using the `node` runtime.

**New Code (Works Everywhere):**

```json
"copy-spec": {
  "command": "node scripts/copy-spec.js",
  "files": [
    "../../specification/0.8/json/*.json",
    "scripts/copy-spec.js" 
  ],
  ...
}
```

## 4. Key Benefits
*   **Cross-Platform Compatibility**: The project can now be built by contributors using Windows without needing WSL (Windows Subsystem for Linux) or Git Bash.
*   **Stability**: Eliminates "syntax error" crashes during the build process on Windows.
*   **Maintainability**: JavaScript logic is easier to read, debug, and extend than maintaining complex, chained shell commands.
