### PR TITLE
fix: Correct A2UI MIME type constant in Lit clients

### DIFF
--- a/samples/client/lit/contact/middleware/a2a.ts
+++ b/samples/client/lit/contact/middleware/a2a.ts
@@ -25,7 +25,7 @@ import {
 } from "@a2a-js/sdk";
 import { v4 as uuidv4 } from "uuid";
 
-const A2AUI_MIME_TYPE = "application/json+a2aui";
+const A2UI_MIME_TYPE = "application/json+a2ui";
 
 const fetchWithCustomHeader: typeof fetch = async (url, init) => {
   const headers = new Headers(init?.headers);
@@ -92,7 +92,7 @@ export const plugin = (): Plugin => {
                       {
                         kind: "data",
                         data: clientEvent,
-                        metadata: { 'mimeType': A2AUI_MIME_TYPE },
+                        metadata: { 'mimeType': A2UI_MIME_TYPE },
                       } as Part,
                     ],
                     kind: "message",

--- a/samples/client/lit/shell/client.ts
+++ b/samples/client/lit/shell/client.ts
@@ -18,7 +18,7 @@ import { Part, SendMessageSuccessResponse, Task } from "@a2a-js/sdk";
 import { A2AClient } from "@a2a-js/sdk/client";
 import { v0_8 } from "@a2ui/lit";
 
-const A2AUI_MIME_TYPE = "application/json+a2aui";
+const A2UI_MIME_TYPE = "application/json+a2ui";
 
 export class A2UIClient {
   #serverUrl: string;
@@ -67,7 +67,7 @@ export class A2UIClient {
           parts = [{
             kind: "data",
             data: parsed as unknown as Record<string, unknown>,
-            mimeType: A2AUI_MIME_TYPE,
+            mimeType: A2UI_MIME_TYPE,
           } as Part];
         } else {
           parts = [{ kind: "text", text: message }];
@@ -79,7 +79,7 @@ export class A2UIClient {
       parts = [{
         kind: "data",
         data: message as unknown as Record<string, unknown>,
-        mimeType: A2AUI_MIME_TYPE,
+        mimeType: A2UI_MIME_TYPE,
       } as Part];
     }
 

--- a/samples/client/lit/shell/middleware/a2a.ts
+++ b/samples/client/lit/shell/middleware/a2a.ts
@@ -25,7 +25,7 @@ import {
 } from "@a2a-js/sdk";
 import { v4 as uuidv4 } from "uuid";
 
-const A2AUI_MIME_TYPE = "application/json+a2aui";
+const A2UI_MIME_TYPE = "application/json+a2ui";
 
 const fetchWithCustomHeader: typeof fetch = async (url, init) => {
   const headers = new Headers(init?.headers);
@@ -92,7 +92,7 @@ export const plugin = (): Plugin => {
                       {
                         kind: "data",
                         data: clientEvent,
-                        metadata: { 'mimeType': A2AUI_MIME_TYPE }, 
+                        metadata: { 'mimeType': A2UI_MIME_TYPE },
                       } as Part,
                     ],
                     kind: "message",


### PR DESCRIPTION
## Summary
This PR corrects the A2UI MIME type constant in Lit client files to match the server-side definition.

## Changes
- Renamed `A2AUI_MIME_TYPE` to `A2UI_MIME_TYPE` for consistency with server-side naming
- Fixed value from `application/json+a2aui` to `application/json+a2ui`

### Affected files:
- [samples/client/lit/shell/client.ts](cci:7://file:///Users/doitundoit/Documents/A2UI/samples/client/lit/shell/client.ts:0:0-0:0)
- [samples/client/lit/shell/middleware/a2a.ts](cci:7://file:///Users/doitundoit/Documents/A2UI/samples/client/lit/shell/middleware/a2a.ts:0:0-0:0)
- [samples/client/lit/contact/middleware/a2a.ts](cci:7://file:///Users/doitundoit/Documents/A2UI/samples/client/lit/contact/middleware/a2a.ts:0:0-0:0)
## Verification
- TypeScript build passes (`npm run build:tsc`)

## Related
Split from #396 as requested by reviewer to keep commit scope narrow and targeted.