### PR TITLE
fix: Add explicit UTF-8 encoding for Windows compatibility

### DIFF
--- a/samples/agent/adk/contact_lookup/prompt_builder.py
+++ b/samples/agent/adk/contact_lookup/prompt_builder.py
@@ -113,6 +113,6 @@ if __name__ == "__main__":
     my_base_url = "http://localhost:8000"
     contact_prompt = get_ui_prompt(my_base_url, CONTACT_UI_EXAMPLES)
     print(contact_prompt)
-    with open("generated_prompt.txt", "w") as f:
+    with open("generated_prompt.txt", "w", encoding="utf-8") as f:
         f.write(contact_prompt)
     print("\nGenerated prompt saved to generated_prompt.txt")

--- a/samples/agent/adk/contact_lookup/tools.py
+++ b/samples/agent/adk/contact_lookup/tools.py
@@ -34,7 +34,7 @@ def get_contact_info(name: str, tool_context: ToolContext, department: str = "")
     try:
         script_dir = os.path.dirname(__file__)
         file_path = os.path.join(script_dir, "contact_data.json")
-        with open(file_path) as f:
+        with open(file_path, encoding='utf-8') as f:
             contact_data_str = f.read()
             if base_url := tool_context.state.get("base_url"):                
                 contact_data_str = contact_data_str.replace("http://localhost:10002", base_url)

--- a/samples/agent/adk/restaurant_finder/prompt_builder.py
+++ b/samples/agent/adk/restaurant_finder/prompt_builder.py
@@ -859,6 +859,6 @@ if __name__ == "__main__":
     print(restaurant_prompt)
 
     # This demonstrates how you could save the prompt to a file for inspection
-    with open("generated_prompt.txt", "w") as f:
+    with open("generated_prompt.txt", "w", encoding="utf-8") as f:
         f.write(restaurant_prompt)
     print("\nGenerated prompt saved to generated_prompt.txt")

--- a/samples/agent/adk/restaurant_finder/tools.py
+++ b/samples/agent/adk/restaurant_finder/tools.py
@@ -34,7 +34,7 @@ def get_restaurants(cuisine: str, location: str,  tool_context: ToolContext, cou
         try:
             script_dir = os.path.dirname(__file__)
             file_path = os.path.join(script_dir, "restaurant_data.json")
-            with open(file_path) as f:
+            with open(file_path, encoding='utf-8') as f:
                 restaurant_data_str = f.read()
                 if base_url := tool_context.state.get("base_url"):                    
                     restaurant_data_str = restaurant_data_str.replace("http://localhost:10002", base_url)


### PR DESCRIPTION
## Problem

The sample agents (`restaurant_finder` and `contact_lookup`) fail on Windows with the following error when reading JSON data files:

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0x86 in position 216: illegal multibyte sequence
```

## Cause

Python's `open()` function uses the system default encoding, which is **GBK/BIG5 on Chinese Windows systems** (and other non-UTF-8 locales). The JSON data files are UTF-8 encoded, causing the decode error.

## Fix

Explicitly specify `encoding='utf-8'` when opening JSON files:

```python
# Before
with open(file_path) as f:

# After
with open(file_path, encoding='utf-8') as f:
```

## Testing

- Demo runs successfully on Windows 11 after fix
- No impact on Linux/macOS (UTF-8 is the default)