### PR TITLE
fix: Fix the sequence diagram in the a2ui documentation.

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -174,7 +174,7 @@ plugins:
   - search
   - macros
   # - include-markdown
-  # - mermaid2
+  - mermaid2
   # - llmstxt:
   #     full_output: llms-full.txt
   #     sections:


### PR DESCRIPTION
Previously, the diagram was not rendered due to `mermaid` library was not enabled.

fixes #433 