### PR TITLE
fix(contact): update lit client to use port 10003 matching server

### DIFF
--- a/samples/client/lit/contact/middleware/a2a.ts
+++ b/samples/client/lit/contact/middleware/a2a.ts
@@ -52,7 +52,7 @@ const createOrGetClient = async () => {
   if (!client) {
     // Create a client pointing to the agent's Agent Card URL.
     client = await A2AClient.fromCardUrl(
-      "http://localhost:10002/.well-known/agent-card.json",
+      "http://localhost:10003/.well-known/agent-card.json",
       { fetchImpl: fetchWithCustomHeader }
     );
   }


### PR DESCRIPTION
The contact lookup agent runs on port 10003, but the Lit client was hardcoded to 10002. This fixes the mismatch.