### PR TITLE
Move string interpolation into a `string_format` function

### DIFF
--- a/specification/v0_9/docs/a2ui_protocol.md
+++ b/specification/v0_9/docs/a2ui_protocol.md
@@ -603,7 +603,7 @@ The [`standard_catalog.json`] provides the baseline set of components and functi
 | **email**         | Checks that the value is a valid email address.                          |
 | **string_format** | Does string interpolation of data model values and registered functions. |
 
-### **The `string_format` function**
+### The `string_format` function
 
 The `string_format` function supports embedding dynamic expressions directly within string properties. This allows for mixing static text with data model values and function results.
 

--- a/specification/v0_9/docs/a2ui_protocol.md
+++ b/specification/v0_9/docs/a2ui_protocol.md
@@ -626,7 +626,7 @@ Values from the data model can be interpolated using their JSON Pointer path.
   "component": "Text",
   "text": {
     "call": "string_format",
-    "args": ["Hello, ${/user/firstName}! Welcome back to ${/appName}."]
+    "args": { "value": "Hello, ${/user/firstName}! Welcome back to ${/appName}." }
   }
 }
 ```

--- a/specification/v0_9/json/common_types.json
+++ b/specification/v0_9/json/common_types.json
@@ -75,7 +75,7 @@
       ]
     },
     "DynamicString": {
-      "description": "Represents a string that can contain interpolated expressions in the `${expression}` format. Supported expression types include: 1) JSON Pointer paths to the data model (e.g., `${/absolute/path}` or `${relative/path}`), and 2) client-side function calls (e.g., `${now()}`). Function arguments must be literals (quoted strings, numbers, booleans) or nested expressions (e.g., `${formatDate(${/currentDate}, 'MM-dd')}`). To include a literal `${` sequence, escape it as `\\${`.",
+      "description": "Represents a string",
       "oneOf": [
         {
           "type": "string"

--- a/specification/v0_9/json/standard_catalog.json
+++ b/specification/v0_9/json/standard_catalog.json
@@ -699,7 +699,7 @@
     },
     {
       "name": "string_format",
-      "description": "Performs string interpolation of data model values and registered functions and returns the resulting string.",
+      "description": "Performs string interpolation of data model values and other functions in the catalog functions list and returns the resulting string. The value string can contain interpolated expressions in the `${expression}` format. Supported expression types include: JSON Pointer paths to the data model (e.g., `${/absolute/path}` or `${relative/path}`), and client-side function calls (e.g., `${now()}`). Function arguments must be literals (quoted strings, numbers, booleans) or nested expressions (e.g., `${formatDate(${/currentDate}, 'MM-dd')}`). To include a literal `${` sequence, escape it as `\\${`.",
       "returnType": "string",
       "parameters": {
         "allOf": [

--- a/specification/v0_9/json/standard_catalog.json
+++ b/specification/v0_9/json/standard_catalog.json
@@ -696,6 +696,23 @@
         ],
         "unevaluatedProperties": false
       }
+    },
+    {
+      "name": "string_format",
+      "description": "Performs string interpolation of data model values and registered functions and returns the resulting string.",
+      "returnType": "string",
+      "parameters": {
+        "allOf": [
+          { "$ref": "#/$defs/valueParam" },
+          {
+            "type": "object",
+            "properties": {
+              "value": { "type": "string" }
+            }
+          }
+        ],
+        "unevaluatedProperties": false
+      }
     }
   ],
   "$defs": {


### PR DESCRIPTION
# Description

This moves the string interpolation into the standard functions as `string_format` and removes it from the `DynamicString` description.

## Summary of Changes

This pull request streamlines the A2UI protocol by formalizing string interpolation as a dedicated `string_format` function. This change enhances clarity and consistency, moving interpolation logic from an implicit `DynamicString` behavior to an explicit, callable function. The documentation and schema have been updated to reflect this new, more structured approach.

### Highlights

* **Refactored String Interpolation**: The mechanism for string interpolation has been moved from an implicit feature of `DynamicString` to an explicit `string_format` function, enhancing clarity and consistency.
* **Documentation Update**: The `a2ui_protocol.md` file has been significantly updated to remove the old string interpolation section and introduce a new, detailed section for the `string_format` function, including its syntax, data model binding, client-side functions, nested interpolation, and type conversion.
* **Schema Definition**: A new `string_format` function has been added to `standard_catalog.json`, defining its parameters and return type.
* **`DynamicString` Simplification**: The `DynamicString` type description in `common_types.json` has been simplified, as its interpolation capabilities are now handled by the `string_format` function.
* **Minor Formatting Fixes**: Several minor formatting inconsistencies in `a2ui_protocol.md` have been addressed, such as bullet point styles and a trailing comma in a JSON example.

<details>
<summary><b>Changelog</b></summary>

* **specification/v0_9/docs/a2ui_protocol.md**
    * Removed the 'String Interpolation' section and its related content.
    * Introduced a new 'Functions' section, detailing the `string_format` function, its syntax, data model binding, client-side functions, nested interpolation, and type conversion.
    * Corrected bullet point styling from `*` to `-` in several sections.
    * Removed a superfluous trailing comma from a JSON example.
* **specification/v0_9/json/common_types.json**
    * Updated the `DynamicString` description to be more concise, removing details about string interpolation.
* **specification/v0_9/json/standard_catalog.json**
    * Added a new function definition for `string_format`, specifying its name, description, return type, and expected `value` parameter.
</details>
