### PR TITLE
v0.9 spec update: Rename 'styles' to 'theme' and add to createSurface, add primary color to standard catalog themes

### DIFF
--- a/specification/v0_9/docs/a2ui_protocol.md
+++ b/specification/v0_9/docs/a2ui_protocol.md
@@ -115,6 +115,7 @@ This message signals the client to create a new surface and begin rendering it. 
 
 - `surfaceId` (string, required): The unique identifier for the UI surface to be rendered.
 - `catalogId` (string, required): A string that uniquely identifies the catalog (components and functions) used for this surface. It is recommended to prefix this with an internet domain that you own, to avoid conflicts (e.g., `https://mycompany.com/1.0/somecatalog`).
+- `theme` (object, optional): A JSON object containing theme parameters (e.g., `primaryColor`) defined in the catalog's theme schema.
 - `broadcastDataModel` (boolean, optional): If true, the client will append the full data model of this surface to the metadata of every A2A message (like 'action') sent to the server. Defaults to false.
 
 **Example:**
@@ -123,7 +124,10 @@ This message signals the client to create a new surface and begin rendering it. 
 {
   "createSurface": {
     "surfaceId": "user_profile_card",
-    "catalogId": "https://a2ui.dev/specification/v0_9/standard_catalog.json"
+    "catalogId": "https://a2ui.dev/specification/v0_9/standard_catalog.json",
+    "theme": {
+      "primaryColor": "#00BFFF"
+    }
   }
 }
 ```

--- a/specification/v0_9/docs/evolution_guide.md
+++ b/specification/v0_9/docs/evolution_guide.md
@@ -78,7 +78,7 @@ Version 0.9 represents a fundamental philosophical shift from "Structured Output
 
 - **Replacement**: `beginRendering` is **REPLACED** by `createSurface`.
 - **Purpose**: `createSurface` signals the client to create a new surface and prepare for rendering.
-- **Style Information Removed**: `createSurface` does **NOT** contain style information. Theming is now handled via the client styles, decoupling it from the message stream.
+- **Theme Information**: `createSurface` includes a `theme` property to specify theme parameters (like `primaryColor`). This replaces the `styles` property in v0.8.
 - **Root Rule**: The rule is: "There must be exactly one component with the ID `root`." The "root" attribute that `beginRendering` had has been removed. The client is expected to render as soon as it has a valid tree with a root component.
 - **New Requirement**: `createSurface` now requires a **`catalogId`** (URI) to explicitly state which unified catalog (components and functions) is being used.
 
@@ -104,7 +104,10 @@ Version 0.9 represents a fundamental philosophical shift from "Structured Output
 {
   "createSurface": {
     "surfaceId": "user_profile_card",
-    "catalogId": "https://a2ui.dev/specification/v0_9/standard_catalog.json"
+    "catalogId": "https://a2ui.dev/specification/v0_9/standard_catalog.json",
+    "theme": {
+      "primaryColor": "#007bff"
+    }
   }
 }
 ```

--- a/specification/v0_9/json/a2ui_client_capabilities.json
+++ b/specification/v0_9/json/a2ui_client_capabilities.json
@@ -66,9 +66,9 @@
             "$ref": "#/$defs/FunctionDefinition"
           }
         },
-        "styles": {
-          "title": "A2UI Styles",
-          "description": "A schema that defines a catalog of A2UI styles. Each key is a style name, and each value is the JSON schema for that style's properties.",
+        "theme": {
+          "title": "A2UI Theme",
+          "description": "A schema that defines a catalog of A2UI theme properties. Each key is a theme property name (e.g. 'primaryColor'), and each value is the JSON schema for that property.",
           "type": "object",
           "additionalProperties": {
             "$ref": "https://json-schema.org/draft/2020-12/schema"

--- a/specification/v0_9/json/server_to_client.json
+++ b/specification/v0_9/json/server_to_client.json
@@ -26,6 +26,11 @@
               "description": "A string that uniquely identifies this catalog. It is recommended to prefix this with an internet domain that you own, to avoid conflicts e.g. mycompany.com:somecatalog'.",
               "type": "string"
             },
+            "theme": {
+              "type": "object",
+              "description": "Initial theme parameters for the surface (e.g., {'primaryColor': '#FF0000'}). These must validate against the 'theme' schema defined in the catalog.",
+              "additionalProperties": true
+            },
             "broadcastDataModel": {
               "type": "boolean",
               "description": "If true, the client will append the full data model of this surface to the metadata of every A2A message sent to the server. Defaults to false."

--- a/specification/v0_9/json/standard_catalog.json
+++ b/specification/v0_9/json/standard_catalog.json
@@ -733,6 +733,13 @@
       }
     }
   ],
+  "theme": {
+    "primaryColor": {
+      "type": "string",
+      "description": "The primary UI color as a hexadecimal code (e.g., '#00BFFF').",
+      "pattern": "^#[0-9a-fA-F]{6}$"
+    }
+  },
   "$defs": {
     "CatalogComponentCommon": {
       "type": "object",


### PR DESCRIPTION
This PR updates the v0.9 specification with the following changes:

- Renames the `styles` field to `theme` in the catalog definition (`a2ui_client_capabilities.json`) to reflect that these values are applied to an entire surface.
- Updates the `createSurface` message in `server_to_client.json` to include an optional `theme` field for specifying theme parameters.
- Adds the `theme` field with a `primaryColor` parameter to the `standard_catalog.json`.
- Updates the documentation (`a2ui_protocol.md` and `evolution_guide.md`) to reflect these changes and provide examples.