### PR TITLE
v0.9 Spec: Add identity fields to theme

### DIFF
--- a/specification/v0_9/docs/a2ui_protocol.md
+++ b/specification/v0_9/docs/a2ui_protocol.md
@@ -583,7 +583,7 @@ The standard catalog defines the following theme properties that can be set in t
 
 | Property           | Type   | Description                                                                                               |
 | :----------------- | :----- | :-------------------------------------------------------------------------------------------------------- |
-| **primaryColor**   | String | The primary UI color as a hexadecimal code (e.g., '#00BFFF').                                             |
+| **primaryColor**   | String | The primary brand color used for highlights throughout the UI (e.g., primary buttons, active borders). The renderer may generate variants, such as lighter shades, as needed. Format: Hexadecimal code (e.g., '#00BFFF'). |
 | **iconUrl**        | URI    | A URL for an image (e.g., logo or avatar) that identifies the agent or tool associated with the surface.  |
 | **agentDisplayName**| String | Text to be displayed next to the surface to identify the agent or tool that created it (e.g. "Weather Bot").|
 

--- a/specification/v0_9/json/standard_catalog.json
+++ b/specification/v0_9/json/standard_catalog.json
@@ -736,7 +736,7 @@
   "theme": {
     "primaryColor": {
       "type": "string",
-      "description": "The primary UI color as a hexadecimal code (e.g., '#00BFFF').",
+      "description": "The primary brand color used for highlights (e.g., primary buttons, active borders). Renderers may generate variants of this color for different contexts. Format: Hexadecimal code (e.g., '#00BFFF').",
       "pattern": "^#[0-9a-fA-F]{6}$"
     },
     "iconUrl": {


### PR DESCRIPTION
This PR updates the v0.9 specification to include iconUrl and agentDisplayName in the standard catalog theme definition.

### Changes
- **standard_catalog.json**: Added iconUrl and agentDisplayName to the theme object.
- **a2ui_protocol.md**: Added a Theme section under Standard Component Catalog to document these new properties and explain their usage for identifying sub-agents and ensuring security against impersonation in orchestrator scenarios.