### PR TITLE
fix: Close the html tag for the MultipleChoice component in Lit library.

### DIFF
--- a/renderers/lit/src/0.8/ui/multiple-choice.ts
+++ b/renderers/lit/src/0.8/ui/multiple-choice.ts
@@ -109,7 +109,7 @@ export class MultipleChoice extends Root {
     )}>
       <label class=${classMap(
         this.theme.components.MultipleChoice.label
-      )} for="data">${this.description ?? "Select an item"}</div>
+      )} for="data">${this.description ?? "Select an item"}</label>
       <select
         name="data"
         id="data"


### PR DESCRIPTION
# Description

Simple HTML fix for the Lit MultipleChoice component. 
Recent changes seems to have broken the HTML leaving the <label> tag unclosed. This is a patch to ensure that the tag is closed for type-strict compilers to able to build the component.

## Pre-launch Checklist

- [x ] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
