### PR TITLE
fix: Update the Lit Contact application to point to port 10003 instea…

### DIFF
--- a/samples/client/lit/contact/middleware/a2a.ts
+++ b/samples/client/lit/contact/middleware/a2a.ts
@@ -52,7 +52,7 @@ const createOrGetClient = async () => {
   if (!client) {
     // Create a client pointing to the agent's Agent Card URL.
     client = await A2AClient.fromCardUrl(
-      "http://localhost:10002/.well-known/agent-card.json",
+      "http://localhost:10003/.well-known/agent-card.json",
       { fetchImpl: fetchWithCustomHeader }
     );
   }


### PR DESCRIPTION
…d of 10002.



# Description

The sample Contact agent runs on 10003 by default since https://github.com/google/A2UI/commit/2d069d361194a7a1572a5ae009c480e8898de757. As a result the Lit sample app was unable to find the agent card to operate correctly out-of-box.

This PR updates the sample Contact application (Lit-version) to point to port 10003 to connect to the agent allowing the demo to work out-of-box with the commands listed in the README.md.


## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
