### PR TITLE
fix: add override keyword to Lit component lifecycle methods

### DIFF
--- a/samples/client/lit/contact/ui/snackbar.ts
+++ b/samples/client/lit/contact/ui/snackbar.ts
@@ -215,7 +215,7 @@ export class Snackbar extends LitElement {
     });
   }
 
-  render() {
+  override render() {
     let rotate = false;
     let icon = "";
     for (let i = this.#messages.length - 1; i >= 0; i--) {

--- a/samples/client/lit/shell/ui/snackbar.ts
+++ b/samples/client/lit/shell/ui/snackbar.ts
@@ -215,7 +215,7 @@ export class Snackbar extends LitElement {
     });
   }
 
-  render() {
+  override render() {
     let rotate = false;
     let icon = "";
     for (let i = this.#messages.length - 1; i >= 0; i--) {

--- a/samples/personalized_learning/src/flashcard.ts
+++ b/samples/personalized_learning/src/flashcard.ts
@@ -222,7 +222,7 @@ export class Flashcard extends LitElement {
     this._flipped = !this._flipped;
   }
 
-  render() {
+  override render() {
     const frontText = this.resolveStringValue(this.front);
     const backText = this.resolveStringValue(this.back);
     const categoryText = this.resolveStringValue(this.category);

--- a/samples/personalized_learning/src/quiz-card.ts
+++ b/samples/personalized_learning/src/quiz-card.ts
@@ -269,7 +269,7 @@ export class QuizCard extends LitElement {
     return selected?.isCorrect ?? false;
   }
 
-  render() {
+  override render() {
     const questionText = this.resolveStringValue(this.question);
     const categoryText = this.resolveStringValue(this.category);
     const explanationText = this.resolveStringValue(this.explanation);

--- a/tools/editor/ui/drawable-canvas.ts
+++ b/tools/editor/ui/drawable-canvas.ts
@@ -200,12 +200,12 @@ export class DrawableCanvas extends LitElement {
       (localStorage.getItem("drawable-mode") as RenderMode) ?? "free";
   }
 
-  connectedCallback(): void {
+  override connectedCallback(): void {
     super.connectedCallback();
     this.#resizeObserver.observe(this);
   }
 
-  disconnectedCallback(): void {
+  override disconnectedCallback(): void {
     super.disconnectedCallback();
     this.#resizeObserver.disconnect();
   }
@@ -347,7 +347,7 @@ export class DrawableCanvas extends LitElement {
     }
   }
 
-  render() {
+  override render() {
     return html`${svg`
       <svg
         viewBox="${this.#adjustment.x} ${this.#adjustment.y} ${this.#bounds.width

--- a/tools/editor/ui/item-select.ts
+++ b/tools/editor/ui/item-select.ts
@@ -290,7 +290,7 @@ export class ItemSelect extends LitElement {
     this.requestUpdate();
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     if (!this.autoActivate) {
       return;
     }
@@ -304,7 +304,7 @@ export class ItemSelect extends LitElement {
     });
   }
 
-  render() {
+  override render() {
     const idx = this.freezeValue !== -1 ? this.freezeValue : this.#selected;
     const renderedValue = this.#values[idx] ?? {
       title: "No items available",

--- a/tools/editor/ui/splitter.ts
+++ b/tools/editor/ui/splitter.ts
@@ -118,13 +118,13 @@ export class Splitter extends LitElement {
     this.#setAndStore();
   });
 
-  connectedCallback(): void {
+  override connectedCallback(): void {
     super.connectedCallback();
 
     this.#resizeObserver.observe(this);
   }
 
-  disconnectedCallback(): void {
+  override disconnectedCallback(): void {
     super.disconnectedCallback();
 
     this.#resizeObserver.disconnect();
@@ -238,7 +238,7 @@ export class Splitter extends LitElement {
     return value;
   }
 
-  firstUpdated() {
+  override firstUpdated() {
     if (!this.name) {
       console.warn("Splitter has no name; it won't have any values stored.");
       return;
@@ -337,7 +337,7 @@ export class Splitter extends LitElement {
     }
   }
 
-  protected willUpdate(
+  protected override willUpdate(
     changedProperties:
       | PropertyValueMap<{ direction: Direction }>
       | Map<PropertyKey, unknown>
@@ -349,7 +349,7 @@ export class Splitter extends LitElement {
     this.#updateStyles();
   }
 
-  render() {
+  override render() {
     return html`${this.split.map((_, idx) => {
       const handle =
         idx < this.split.length - 1

--- a/tools/inspector/ui/snackbar.ts
+++ b/tools/inspector/ui/snackbar.ts
@@ -216,7 +216,7 @@ export class Snackbar extends LitElement {
     });
   }
 
-  render() {
+  override render() {
     let rotate = false;
     let icon = "";
     for (let i = this.#messages.length - 1; i >= 0; i--) {

--- a/tools/inspector/ui/splitter.ts
+++ b/tools/inspector/ui/splitter.ts
@@ -118,13 +118,13 @@ export class Splitter extends LitElement {
     this.#setAndStore();
   });
 
-  connectedCallback(): void {
+  override connectedCallback(): void {
     super.connectedCallback();
 
     this.#resizeObserver.observe(this);
   }
 
-  disconnectedCallback(): void {
+  override disconnectedCallback(): void {
     super.disconnectedCallback();
 
     this.#resizeObserver.disconnect();
@@ -238,7 +238,7 @@ export class Splitter extends LitElement {
     return value;
   }
 
-  firstUpdated() {
+  override firstUpdated() {
     if (!this.name) {
       console.warn("Splitter has no name; it won't have any values stored.");
       return;
@@ -337,7 +337,7 @@ export class Splitter extends LitElement {
     }
   }
 
-  protected willUpdate(
+  protected override willUpdate(
     changedProperties:
       | PropertyValueMap<{ direction: Direction }>
       | Map<PropertyKey, unknown>
@@ -349,7 +349,7 @@ export class Splitter extends LitElement {
     this.#updateStyles();
   }
 
-  render() {
+  override render() {
     return html`${this.split.map((_, idx) => {
       const handle =
         idx < this.split.length - 1


### PR DESCRIPTION
Add the TypeScript `override` keyword to all Lit component methods that override parent class methods. This is required for Google's internal repository compilation.

Methods updated:
- render()
- connectedCallback()
- disconnectedCallback()
- firstUpdated()
- willUpdate()

Fixes #463