### PR TITLE
Fix typo in custom catalog definition example

### DIFF
--- a/specification/v0_8/docs/a2ui_protocol.md
+++ b/specification/v0_8/docs/a2ui_protocol.md
@@ -272,7 +272,7 @@ In order to do the substitution, based on the standard `server_to_client_schema`
 
 ```py
 component_properties = custom_catalog_definition["components"]
-style_properties = custom_catalog_definition["components"]
+style_properties = custom_catalog_definition["styles"]
 resolved_schema = copy.deepcopy(server_to_client_schema)
 
 resolved_schema["properties"]["surfaceUpdate"]["properties"]["components"]["items"]["properties"]["component"]["properties"] = component_properties


### PR DESCRIPTION
This fixes a copy-paste error in the documentation where `components` was used instead of `styles` when extracting style properties.

Fixes https://github.com/google/A2UI/issues/432