### PR TITLE
docs: Fix manual install command in quickstart

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -246,7 +246,7 @@ python3 --version
 # The demo should auto-install dependencies via the npm script
 # If not, manually install them:
 cd ../../agent/adk/restaurant_finder
-pip install -r requirements.txt
+pip install .
 ```
 
 ### Still Having Issues?


### PR DESCRIPTION
Updates the quickstart guide to use `pip install .` instead of `pip install -r requirements.txt`, as the project uses `pyproject.toml`.

Fixes #424