### PR TITLE
docs: simplify convert_docs.py to uni-directional conversion

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -83,7 +83,7 @@ jobs:
           done
 
       - name: Convert Admonitions in Documentation
-        run: python docs/scripts/convert_docs.py --mode github-to-mkdocs
+        run: python docs/scripts/convert_docs.py
 
       - name: Build Documentation (PR Check)
         if: github.event_name == 'pull_request'

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -1,0 +1,39 @@
+# Documentation Transformation Scripts
+
+This directory contains utility scripts to prepare our documentation for the **MkDocs** build process.
+
+## Purpose
+
+To ensure a great reading experience both on GitHub and the hosted site, we use **GitHub-flavored Markdown** as our primary source of truth. This script transforms GitHub's native syntax into **MkDocs-compatible syntax** (specifically for the `pymdown-extensions`) during the build pipeline.
+
+## Supported Conversions (Uni-directional)
+
+The script performs a uni-directional transformation: **GitHub Markdown → MkDocs Syntax**.
+
+### Alert/Admonition Conversion
+
+- GitHub uses a blockquote-based syntax for alerts.
+- MkDocs requires the `!!!` or `???` syntax to render colored callout boxes.
+
+## Running the Conversion
+
+The conversion is run as part of the build pipeline. No additional steps are required. If you need to run the conversion manually, you can run the `convert_docs.py` script in the repository root.
+
+```bash
+python docs/scripts/convert_docs.py
+```
+
+### Example
+
+- **Source (GitHub-flavored Markdown):**
+  ```markdown
+  > ⚠️ **Attention**
+  >
+  > This is an alert.
+  ```
+
+- **Target (MkDocs Syntax):**
+  ```markdown
+  !!! warning "Attention"
+      This is an alert.
+  ```

--- a/docs/scripts/test_convert_docs.py
+++ b/docs/scripts/test_convert_docs.py
@@ -1,47 +1,39 @@
 import pytest
-from convert_docs import to_mkdocs, to_github
+from convert_docs import to_mkdocs
 
 # --- 1. A2UI Specific Header Cases ---
 ADMONITION_CASES = [
-    ('!!! info "Coming soon..."', "Coming soon..."),
-    ('!!! warning "Status: Early Stage Public Preview"', "Status: Early Stage Public Preview"),
-    ('!!! success "Stable Release"', "Stable Release"),
-    ('!!! note "Version Compatibility"', "Version Compatibility"),
-    ('!!! warning "Attention"', "Attention"),
-    ('!!! tip "It\'s Just JSON"', "It's Just JSON"),
+    ('!!! info "Coming soon..."', "Coming soon...", "ℹ️"),
+    ('!!! warning "Status: Early Stage Public Preview"', "Status: Early Stage Public Preview", "⚠️"),
+    ('!!! success "Stable Release"', "Stable Release", "✅"),
+    ('!!! note "Version Compatibility"', "Version Compatibility", "📝"),
+    ('!!! warning "Attention"', "Attention", "⚠️"),
+    ('!!! tip "It\'s Just JSON"', "It's Just JSON", "💡"),
 ]
 
-@pytest.mark.parametrize("header, expected_title", ADMONITION_CASES)
-def test_standard_a2ui_round_trip(header, expected_title):
-    """Verifies that all standard A2UI headers survive a round-trip conversion."""
+@pytest.mark.parametrize("expected_header, title, emoji", ADMONITION_CASES)
+def test_standard_a2ui_conversion(expected_header, title, emoji):
+    """Verifies that GitHub style converts to expected A2UI headers."""
     body = "    Line 1\n    Line 2"
-    original = f"{header}\n{body}\n"
+    github_input = f"> {emoji} **{title}**\n>\n> Line 1\n> Line 2\n"
     
-    # MkDocs -> GitHub
-    github = to_github(original)
-    assert f"**{expected_title}**" in github
+    expected = f"{expected_header}\n{body}\n"
     
     # GitHub -> MkDocs
-    back = to_mkdocs(github)
-    assert back.strip() == original.strip()
+    result = to_mkdocs(github_input)
+    assert result.strip() == expected.strip()
 
 
 # --- 2. Empty Title Edge Case ---
 def test_empty_title_case():
     """
-    Verifies !!! tip "" converts to '> 💡' exactly.
-    - No trailing spaces
-    - No bold markers (****)
+    Verifies '> 💡' converts to !!! tip "".
     """
-    original = '!!! tip ""\n    Content.\n'
-    github = to_github(original)
+    github_input = "> 💡\n>\n> Content.\n"
+    expected = '!!! tip ""\n    Content.\n'
     
-    lines = github.splitlines()
-    assert lines[0] == "> 💡"  # Strictly no space or bold markers
-    assert lines[1] == ">"     # Spacer line
-    
-    back = to_mkdocs(github)
-    assert back == original
+    result = to_mkdocs(github_input)
+    assert result == expected
 
 
 # --- 3. Spacing & Internal Paragraph Preservation ---
@@ -73,49 +65,37 @@ def test_paragraph_spacing_and_trailing_lines():
     assert result == expected
 
 
-# --- 4. Unmapped/Unknown Type Fallback ---
-def test_unknown_type_fallback():
-    """
-    Verifies that an unknown admonition type defaults to the 'note' emoji (📝).
-    """
-    original = '!!! mystery "Secret"\n    Content.\n'
-    github = to_github(original)
-    
-    assert "> 📝 **Secret**" in github
-    
-    # Note: Round trip will convert it back to '!!! note' 
-    # because the source type 'mystery' wasn't in the map.
-    back = to_mkdocs(github)
-    assert '!!! note "Secret"' in back
-
-
-# --- 5. Multiple Blocks & Isolation ---
+# --- 4. Multiple Blocks & Isolation ---
 def test_multiple_blocks_in_one_file():
     """Ensures multiple blocks are processed without bleeding into each other."""
-    original = (
+    github_input = (
+        '> ✅ **Block 1**\n'
+        '> Content 1\n'
+        '\n'
+        '> ℹ️ **Block 2**\n'
+        '> Content 2\n'
+    )
+    
+    expected = (
         '!!! success "Block 1"\n'
         '    Content 1\n'
         '\n'
         '!!! info "Block 2"\n'
         '    Content 2\n'
     )
-    github = to_github(original)
-    assert "> ✅ **Block 1**" in github
-    assert "> ℹ️ **Block 2**" in github
     
-    back = to_mkdocs(github)
-    assert back == original
+    result = to_mkdocs(github_input)
+    assert result == expected
 
 
-# --- 6. False Positive Prevention ---
+# --- 5. False Positive Prevention ---
 def test_regular_blockquote_ignored():
     """Ensures regular quotes are not touched."""
     source = "> This is just a quote, not an admonition."
     assert to_mkdocs(source) == source
-    assert to_github(source) == source
 
 
-# --- 7. GitHub Official Alert Syntax Support ---
+# --- 6. GitHub Official Alert Syntax Support ---
 def test_github_alert_to_mkdocs():
     """Verifies official [!TYPE] syntax conversion."""
     source = "> [!WARNING]\n> **Security Notice**\n> Do not share keys."


### PR DESCRIPTION
The bi-directional support was initially implemented to migrate existing *.md files from MkDocs admonitions to GitHub-flavored markdown.

With the migration complete, the reverse transformation is no longer needed. A uni-directional flow (GitHub -> MkDocs) is cleaner and sufficient for the build pipeline.

It also adds a README.md file to explain what the scripts do.

# Description

_Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots._

_List which issues are fixed by this PR. For larger changes, raising an issue first helps reduce redundant work._

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
