### PR TITLE
Add .geminiignore to exclude lock files

### DIFF
--- a/.geminiignore
+++ b/.geminiignore
@@ -1,0 +1,4 @@
+# Ignore large lock files that aren't useful for context
+**/pnpm-lock.yaml
+**/package-lock.json
+**/uv.lock


### PR DESCRIPTION
This PR adds a `.geminiignore` file to the repository root.
It configures the Gemini CLI (and other compatible agents) to ignore large lock files (`pnpm-lock.yaml`, `package-lock.json`, `uv.lock`).

**Benefits:**
*   Reduces token consumption by excluding large, auto-generated files from the context.
*   Prevents the agent from getting distracted by dependency details when they are not relevant to the task.
*   Improves the performance of context loading.