### PR TITLE
feat(ui): dispatch validation events from TextField

### DIFF
--- a/renderers/lit/src/0.8/core.ts
+++ b/renderers/lit/src/0.8/core.ts
@@ -22,8 +22,8 @@ import * as Styles from "@a2ui/web_core/styles/index";
 import { A2uiMessageProcessor } from "@a2ui/web_core/data/model-processor";
 import * as Primitives from "@a2ui/web_core/types/primitives";
 import { create as createSignalA2uiMessageProcessor } from "./data/signal-model-processor.js";
-
-export { Types, Guards, Schemas, Styles, A2uiMessageProcessor, Primitives };
+import { Events as WebEvents } from "@a2ui/web_core";
+export { Types, Guards, Schemas, Styles, A2uiMessageProcessor, Primitives, WebEvents };
 
 export const Data = {
   createSignalA2uiMessageProcessor,

--- a/renderers/lit/src/0.8/ui/text-field.ts
+++ b/renderers/lit/src/0.8/ui/text-field.ts
@@ -20,6 +20,7 @@ import { Root } from "./root.js";
 import { A2uiMessageProcessor } from "@a2ui/web_core/data/model-processor";
 import * as Primitives from "@a2ui/web_core/types/primitives";
 import * as Types from "@a2ui/web_core/types/types";
+import { Events } from "@a2ui/web_core";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { extractStringValue } from "./utils/utils.js";
@@ -116,15 +117,11 @@ export class TextField extends Root {
           }
 
       this.dispatchEvent(
-        new CustomEvent("a2ui-validation-input", {
-          bubbles: true,
-          composed: true,
-          detail: {
-            componentId: this.id,
-            value: evt.target.value,
-            valid: evt.target.checkValidity(),
-          },
-        })
+        new Events.A2UIValidationEvent({
+          componentId: this.id,
+          value: evt.target.value,
+          valid: evt.target.checkValidity(),
+            })
       );
 
           this.#setBoundValue(evt.target.value);

--- a/renderers/web_core/src/v0_8/events/base.ts
+++ b/renderers/web_core/src/v0_8/events/base.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A base interface for event details.
+ * All A2UI event payloads should extend this to ensure they have an eventType property
+ * that matches the event name.
+ */
+export interface BaseEventDetail<EventType extends string> {
+  readonly eventType: EventType;
+}

--- a/renderers/web_core/src/v0_8/events/index.ts
+++ b/renderers/web_core/src/v0_8/events/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./base.js";
+export * from "./validation-event.js";

--- a/renderers/web_core/src/v0_8/events/validation-event.ts
+++ b/renderers/web_core/src/v0_8/events/validation-event.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BaseEventDetail } from "./base.js";
+
+/**
+ * Detailed payload for the `a2ui-validation-input` event.
+ */
+export interface ValidationEventDetail
+  extends BaseEventDetail<"a2ui-validation-input"> {
+  /**
+   * The ID of the component that is being validated.
+   */
+  readonly componentId: string;
+
+  /**
+   * The current value of the input component.
+   */
+  readonly value: string;
+
+  /**
+   * Whether the current value matches the validation constraints.
+   */
+  readonly valid: boolean;
+}
+
+/**
+ * Event dispatched when an input component's validation state is updated.
+ */
+export class A2UIValidationEvent extends CustomEvent<ValidationEventDetail> {
+  static readonly EVENT_NAME = "a2ui-validation-input";
+
+  constructor(
+    detail: Omit<ValidationEventDetail, "eventType">,
+    eventInitDict?: EventInit
+  ) {
+    super(A2UIValidationEvent.EVENT_NAME, {
+      bubbles: true,
+      composed: true,
+      ...eventInitDict,
+      detail: {
+        ...detail,
+        eventType: A2UIValidationEvent.EVENT_NAME,
+      },
+    });
+  }
+}
+
+declare global {
+  interface HTMLElementEventMap {
+    "a2ui-validation-input": A2UIValidationEvent;
+  }
+}

--- a/renderers/web_core/src/v0_8/index.ts
+++ b/renderers/web_core/src/v0_8/index.ts
@@ -4,6 +4,7 @@ export * from "./types/primitives.js";
 export * from "./types/types.js";
 export * from "./types/colors.js";
 export * from "./styles/index.js";
+export * as Events from "./events/index.js";
 import A2UIClientEventMessage from "./schemas/server_to_client_with_standard_catalog.json" with { type: "json" };
 
 export const Schemas = {

--- a/renderers/web_core/src/v0_8/schemas/standard_catalog_definition.json
+++ b/renderers/web_core/src/v0_8/schemas/standard_catalog_definition.json
@@ -31,7 +31,9 @@
           ]
         }
       },
-      "required": ["text"]
+      "required": [
+        "text"
+      ]
     },
     "Image": {
       "type": "object",
@@ -74,7 +76,9 @@
           ]
         }
       },
-      "required": ["url"]
+      "required": [
+        "url"
+      ]
     },
     "Icon": {
       "type": "object",
@@ -144,7 +148,9 @@
           }
         }
       },
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     },
     "Video": {
       "type": "object",
@@ -164,7 +170,9 @@
           }
         }
       },
-      "required": ["url"]
+      "required": [
+        "url"
+      ]
     },
     "AudioPlayer": {
       "type": "object",
@@ -197,7 +205,9 @@
           }
         }
       },
-      "required": ["url"]
+      "required": [
+        "url"
+      ]
     },
     "Row": {
       "type": "object",
@@ -226,7 +236,10 @@
                   "type": "string"
                 }
               },
-              "required": ["componentId", "dataBinding"]
+              "required": [
+                "componentId",
+                "dataBinding"
+              ]
             }
           }
         },
@@ -245,10 +258,17 @@
         "alignment": {
           "type": "string",
           "description": "Defines the alignment of children along the cross axis (vertically). This corresponds to the CSS 'align-items' property.",
-          "enum": ["start", "center", "end", "stretch"]
+          "enum": [
+            "start",
+            "center",
+            "end",
+            "stretch"
+          ]
         }
       },
-      "required": ["children"]
+      "required": [
+        "children"
+      ]
     },
     "Column": {
       "type": "object",
@@ -277,7 +297,10 @@
                   "type": "string"
                 }
               },
-              "required": ["componentId", "dataBinding"]
+              "required": [
+                "componentId",
+                "dataBinding"
+              ]
             }
           }
         },
@@ -296,10 +319,17 @@
         "alignment": {
           "type": "string",
           "description": "Defines the alignment of children along the cross axis (horizontally). This corresponds to the CSS 'align-items' property.",
-          "enum": ["center", "end", "start", "stretch"]
+          "enum": [
+            "center",
+            "end",
+            "start",
+            "stretch"
+          ]
         }
       },
-      "required": ["children"]
+      "required": [
+        "children"
+      ]
     },
     "List": {
       "type": "object",
@@ -328,22 +358,35 @@
                   "type": "string"
                 }
               },
-              "required": ["componentId", "dataBinding"]
+              "required": [
+                "componentId",
+                "dataBinding"
+              ]
             }
           }
         },
         "direction": {
           "type": "string",
           "description": "The direction in which the list items are laid out.",
-          "enum": ["vertical", "horizontal"]
+          "enum": [
+            "vertical",
+            "horizontal"
+          ]
         },
         "alignment": {
           "type": "string",
           "description": "Defines the alignment of children along the cross axis.",
-          "enum": ["start", "center", "end", "stretch"]
+          "enum": [
+            "start",
+            "center",
+            "end",
+            "stretch"
+          ]
         }
       },
-      "required": ["children"]
+      "required": [
+        "children"
+      ]
     },
     "Card": {
       "type": "object",
@@ -354,7 +397,9 @@
           "description": "The ID of the component to be rendered inside the card."
         }
       },
-      "required": ["child"]
+      "required": [
+        "child"
+      ]
     },
     "Tabs": {
       "type": "object",
@@ -384,11 +429,16 @@
                 "type": "string"
               }
             },
-            "required": ["title", "child"]
+            "required": [
+              "title",
+              "child"
+            ]
           }
         }
       },
-      "required": ["tabItems"]
+      "required": [
+        "tabItems"
+      ]
     },
     "Divider": {
       "type": "object",
@@ -397,7 +447,10 @@
         "axis": {
           "type": "string",
           "description": "The orientation of the divider.",
-          "enum": ["horizontal", "vertical"]
+          "enum": [
+            "horizontal",
+            "vertical"
+          ]
         }
       }
     },
@@ -414,7 +467,10 @@
           "description": "The ID of the component to be displayed inside the modal."
         }
       },
-      "required": ["entryPointChild", "contentChild"]
+      "required": [
+        "entryPointChild",
+        "contentChild"
+      ]
     },
     "Button": {
       "type": "object",
@@ -465,14 +521,22 @@
                     }
                   }
                 },
-                "required": ["key", "value"]
+                "required": [
+                  "key",
+                  "value"
+                ]
               }
             }
           },
-          "required": ["name"]
+          "required": [
+            "name"
+          ]
         }
       },
-      "required": ["child", "action"]
+      "required": [
+        "child",
+        "action"
+      ]
     },
     "CheckBox": {
       "type": "object",
@@ -505,7 +569,10 @@
           }
         }
       },
-      "required": ["label", "value"]
+      "required": [
+        "label",
+        "value"
+      ]
     },
     "TextField": {
       "type": "object",
@@ -553,7 +620,9 @@
           "description": "A regular expression used for client-side validation of the input."
         }
       },
-      "required": ["label"]
+      "required": [
+        "label"
+      ]
     },
     "DateTimeInput": {
       "type": "object",
@@ -581,7 +650,9 @@
           "description": "If true, allows the user to select a time."
         }
       },
-      "required": ["value"]
+      "required": [
+        "value"
+      ]
     },
     "MultipleChoice": {
       "type": "object",
@@ -632,7 +703,10 @@
                 "description": "The value to be associated with this option when selected."
               }
             },
-            "required": ["label", "value"]
+            "required": [
+              "label",
+              "value"
+            ]
           }
         },
         "maxAllowedSelections": {
@@ -650,7 +724,7 @@
         "filterable": {
           "type": "boolean",
           "description": "If true, displays a search input to filter the options."
-        },
+        }
       }
     },
     "Slider": {
@@ -679,7 +753,9 @@
           "description": "The maximum value of the slider."
         }
       },
-      "required": ["value"]
+      "required": [
+        "value"
+      ]
     }
   },
   "styles": {

--- a/samples/client/lit/component_gallery/component-gallery.ts
+++ b/samples/client/lit/component_gallery/component-gallery.ts
@@ -204,7 +204,8 @@ export class A2UIComponentGallery extends SignalWatcher(LitElement) {
 
   // Debug Validation Events
   #handleValidationInput = (e: Event) => {
-    const detail = (e as CustomEvent).detail;
+    const detail = (e as v0_8.WebEvents.A2UIValidationEvent).detail;
+    if (!detail) return;
 
     // Log to Console
     console.log(


### PR DESCRIPTION
This PR introduces the a2ui-validation-input event to the 
TextField
 component to bubble validation state changes.

Changes
TextField (
text-field.ts
):
Added dispatch of a2ui-validation-input on every input event.
Payload: { componentId, value, valid: boolean }.
Reason: Native invalid events do not cross the Shadow DOM boundary. This custom event allows parent components (like the Shell) to observe real-time validation status.
Component Gallery (
component-gallery.ts
):
Added a listener for a2ui-validation-input at the document root.
Logs validation events to both the Console and the internal Debug Panel for visual verification.
Verification
Verified manually in the Component Gallery:
Typing in "TextField (Regex)" now triggers logs in the Debug Panel.
Valid/Invalid states strictly match the regex rules.

## Pre-launch Checklist

- [X ] I signed the [CLA].
- [ X] I read the [Contributors Guide].
- [ X] I read the [Style Guide].
- [ X] I have added updates to the [CHANGELOG].
- [ X] I updated/added relevant documentation.
- [ X] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
