### PR TITLE
Fixed `ResolvedMap` to be compatible with primitives, like `StringValue`

### DIFF
--- a/renderers/web_core/src/v0_8/types/types.ts
+++ b/renderers/web_core/src/v0_8/types/types.ts
@@ -312,7 +312,7 @@ export type ResolvedValue =
   | ResolvedArray;
 
 /** A generic map where each value has been recursively resolved. */
-export type ResolvedMap = { [key: string]: ResolvedValue };
+export type ResolvedMap = { [key: string]?: ResolvedValue };
 
 /** A generic array where each item has been recursively resolved. */
 export type ResolvedArray = ResolvedValue[];


### PR DESCRIPTION
When implementing a custom node, [StringValue](https://github.com/google/A2UI/blob/main/renderers/web_core/src/v0_8/types/primitives.ts#L17) is incompatible with [ResolvedValue](https://github.com/google/A2UI/blob/main/renderers/web_core/src/v0_8/types/types.ts#L305) despite being supported for nodes like `TextNode`. The `ResolvedMap` type requires that all provided keys be non-optional, so I've updated it to support optional keys.

# Description

_Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots._

_List which issues are fixed by this PR. For larger changes, raising an issue first helps reduce redundant work._

## Pre-launch Checklist

- (N/A) I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- (N/A) My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
