### PR TITLE
docs: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,14 +15,14 @@
 * @dmandar @gspencer @jacobsimionato
 
 # Agents
-/a2a_agents/ @nan-yu @dmandar 
+/a2a_agents/ @nan-yu @dmandar
 
 # Documentation
 /docs/ @zeroasterisk @dmandar @gspencer @jacobsimionato
 
 # Renderers
 /renderers/angular/ @ditman @ava-cassiopeia  @crisbeto
-/renderers/lit/ @ditman @ava-cassiopeia @paullewis 
+/renderers/lit/ @ditman @ava-cassiopeia @paullewis
 /renderers/web_core/ @ditman @ava-cassiopeia
 
 # Samples


### PR DESCRIPTION
This PR introduces a .github/CODEOWNERS file to clearly define ownership responsibilities across the repository.

**Changes:**
- Establishes default owners for the entire codebase.
- Assigns specific owners to top-level directories:
  - `/a2a_agents/`
  - `/docs/`
  - `/renderers/` (Angular, Lit, Web Core)
  - `/samples/`
  - `/specification/`
  - `/tools/`

This configuration ensures that the appropriate team members are automatically requested for review when changes are made to these areas.

As a next step, after this is submitted I will turn on the branch protection settings to *require* at least one of the owners listed here approves each PR.