### PR TITLE
fix(agent): Autofix trailing commas in LLM-generated JSON

### DIFF
--- a/a2a_agents/python/a2ui_agent/src/a2ui/extension/send_a2ui_to_client_toolset.py
+++ b/a2a_agents/python/a2ui_agent/src/a2ui/extension/send_a2ui_to_client_toolset.py
@@ -262,7 +262,9 @@ class SendA2uiToClientToolset(base_toolset.BaseToolset):
 
           # Auto-wrap single object in list
           if not isinstance(a2ui_json_payload, list):
-            logger.info("Received a single JSON object, wrapping in a list for validation.")
+            logger.info(
+                "Received a single JSON object, wrapping in a list for validation."
+            )
             a2ui_json_payload = [a2ui_json_payload]
 
           jsonschema.validate(instance=a2ui_json_payload, schema=a2ui_schema)
@@ -282,7 +284,9 @@ class SendA2uiToClientToolset(base_toolset.BaseToolset):
 
             # Auto-wrap single object in list
             if not isinstance(a2ui_json_payload, list):
-              logger.info("Received a single JSON object, wrapping in a list for validation.")
+              logger.info(
+                  "Received a single JSON object, wrapping in a list for validation."
+              )
               a2ui_json_payload = [a2ui_json_payload]
 
             jsonschema.validate(instance=a2ui_json_payload, schema=a2ui_schema)

--- a/a2a_agents/python/a2ui_agent/tests/extension/test_send_a2ui_to_client_toolset.py
+++ b/a2a_agents/python/a2ui_agent/tests/extension/test_send_a2ui_to_client_toolset.py
@@ -253,9 +253,11 @@ async def test_send_tool_run_async_handles_trailing_comma(caplog):
 
   # Malformed JSON with a trailing comma in the list
   malformed_a2ui_str = '[{"type": "Text", "text": "Hello"},]'
-  
+
   args = {
-      SendA2uiToClientToolset._SendA2uiJsonToClientTool.A2UI_JSON_ARG_NAME: malformed_a2ui_str
+      SendA2uiToClientToolset._SendA2uiJsonToClientTool.A2UI_JSON_ARG_NAME: (
+          malformed_a2ui_str
+      )
   }
 
   result = await tool.run_async(args=args, tool_context=tool_context_mock)
@@ -263,9 +265,11 @@ async def test_send_tool_run_async_handles_trailing_comma(caplog):
   # Assert that the fix was successful and the result is correct
   expected_a2ui = [{"type": "Text", "text": "Hello"}]
   assert result == {
-      SendA2uiToClientToolset._SendA2uiJsonToClientTool.VALIDATED_A2UI_JSON_KEY: expected_a2ui
+      SendA2uiToClientToolset._SendA2uiJsonToClientTool.VALIDATED_A2UI_JSON_KEY: (
+          expected_a2ui
+      )
   }
-  
+
   # Assert that the warning was logged
   assert "Detected trailing commas in LLM output; applied autofix." in caplog.text
 


### PR DESCRIPTION
Fixes `json.JSONDecodeError` caused by LLMs returning JSON with trailing commas.

## Changes
- Added a regex pre-processing step in `RestaurantAgent` to strip trailing commas before calling `json.loads()`.
- Improves parsing robustness and prevents unnecessary retries.

## Fixes
Resolves [#480](https://github.com/google/A2UI/issues/480)