### PR TITLE
Update gspencergoog in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 # - An email address (e.g., octocat@github.com)
 
 # Default ownership (is overriden by specfic rules below)
-* @dmandar @gspencer @jacobsimionato
+* @dmandar @gspencergoog @jacobsimionato
 
 # Agents
 /a2a_agents/ @nan-yu @dmandar


### PR DESCRIPTION
This fixes my github id in CODEOWNERS.  It was mis-entered with my email address.