### PR TITLE
fix(angular): correct 0-indexed month in DatetimeInput date formatting

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,6 @@
+# Contributors
+
+The following people have contributed to A2UI (in addition to the core Google team).
+Thank you!
+
+- Nathan Fant (https://github.com/nfant)

--- a/renderers/angular/src/lib/catalog/datetime-input.ts
+++ b/renderers/angular/src/lib/catalog/datetime-input.ts
@@ -94,7 +94,7 @@ export class DatetimeInput extends DynamicComponent {
     }
 
     const year = this.padNumber(date.getFullYear());
-    const month = this.padNumber(date.getMonth());
+    const month = this.padNumber(date.getMonth() + 1);
     const day = this.padNumber(date.getDate());
     const hours = this.padNumber(date.getHours());
     const minutes = this.padNumber(date.getMinutes());


### PR DESCRIPTION
## Summary

Fixes #566

`Date.getMonth()` returns `0–11`, but HTML `<input type="date">` requires months in the range `01–12`. The Angular `DatetimeInput` component was calling `this.padNumber(date.getMonth())` without the `+ 1`, producing strings like `2025-00-15` for January — which browsers reject and render as an empty input.

**The Lit renderer already has this fix** (`date.getMonth() + 1` on line 137 of `datetime-input.ts`). This PR brings the Angular renderer in line.

### Change

```ts
// Before
const month = this.padNumber(date.getMonth());

// After
const month = this.padNumber(date.getMonth() + 1);
```

**File:** `renderers/angular/src/lib/catalog/datetime-input.ts:97`

Also adds a `CONTRIBUTORS` file to track external contributors.

## Test plan

- [ ] Set a `DatetimeInput` component's initial value to a date in January (e.g. `2025-01-15`)
- [ ] Confirm the input renders `2025-01-15` instead of appearing blank (`2025-00-15` is rejected by browsers)
- [ ] Verify dates in other months still display correctly (no double-offset)