### PR TITLE
Rename standard_catalog to basic_catalog

### DIFF
--- a/a2a_agents/python/a2ui_agent/src/a2ui/inference/schema/constants.py
+++ b/a2a_agents/python/a2ui_agent/src/a2ui/inference/schema/constants.py
@@ -33,7 +33,7 @@ SPEC_VERSION_MAP = {
     },
     "0.9": {
         SERVER_TO_CLIENT_SCHEMA_KEY: "specification/v0_9/json/server_to_client.json",
-        CATALOG_SCHEMA_KEY: "specification/v0_9/json/standard_catalog.json",
+        CATALOG_SCHEMA_KEY: "specification/v0_9/json/basic_catalog.json",
         COMMON_TYPES_SCHEMA_KEY: "specification/v0_9/json/common_types.json",
     },
 }

--- a/a2a_agents/python/a2ui_agent/src/a2ui/inference/schema/manager.py
+++ b/a2a_agents/python/a2ui_agent/src/a2ui/inference/schema/manager.py
@@ -45,7 +45,7 @@ def _load_basic_component(version: str, spec_name: str) -> Dict:
 
   Args:
     version: The version of the schema to load.
-    spec_name: The name of the schema component (e.g. 'server_to_client', 'standard_catalog', 'common_types') to load.
+    spec_name: The name of the schema component (e.g. 'server_to_client', 'basic_catalog', 'common_types') to load.
 
   Returns:
     The loaded schema component.
@@ -184,7 +184,7 @@ class A2uiSchemaManager(InferenceStrategy):
           # Strip the `json/` part from the catalog file path.
           SPEC_VERSION_MAP[version][CATALOG_SCHEMA_KEY].replace("/json/", "/")
           if CATALOG_SCHEMA_KEY in SPEC_VERSION_MAP[version]
-          else f"specification/{version}/standard_catalog.json"
+          else f"specification/{version}/basic_catalog.json"
       )
       basic_catalog_schema[CATALOG_ID_KEY] = BASE_SCHEMA_URL + catalog_file
     if "$schema" not in basic_catalog_schema:

--- a/a2a_agents/python/a2ui_agent/tests/inference/test_validator.py
+++ b/a2a_agents/python/a2ui_agent/tests/inference/test_validator.py
@@ -100,9 +100,9 @@ class TestValidator:
     }
     catalog_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "$id": "https://a2ui.org/specification/v0_9/standard_catalog.json",
-        "title": "A2UI Standard Catalog",
-        "catalogId": "https://a2ui.dev/specification/v0_9/standard_catalog.json",
+        "$id": "https://a2ui.org/specification/v0_9/basic_catalog.json",
+        "title": "A2UI Basic Catalog",
+        "catalogId": "https://a2ui.dev/specification/v0_9/basic_catalog.json",
         "components": {
             "Text": {
                 "type": "object",

--- a/a2a_agents/python/a2ui_agent/tests/integration/verify_load_real.py
+++ b/a2a_agents/python/a2ui_agent/tests/integration/verify_load_real.py
@@ -394,9 +394,7 @@ def verify():
             'version': 'v0.9',
             'createSurface': {
                 'surfaceId': 'contact_form_1',
-                'catalogId': (
-                    'https://a2ui.dev/specification/v0_9/standard_catalog.json'
-                ),
+                'catalogId': 'https://a2ui.dev/specification/v0_9/basic_catalog.json',
                 'fakeProperty': 'should be allowed',
             },
         },

--- a/docs/catalogs.md
+++ b/docs/catalogs.md
@@ -59,7 +59,7 @@ Whether you are building a simple prototype or a complex production application,
 
 ### The Basic Catalog
 
-To help developers get started quickly, the A2UI team maintains the [Basic Catalog](../specification/v0_9/json/standard_catalog.json).
+To help developers get started quickly, the A2UI team maintains the [Basic Catalog](../specification/v0_9/json/basic_catalog.json).
 
 This is a pre-defined catalog file that contains a standard set of general-purpose components (Buttons, Inputs, Cards) and functions. It is not a special "type" of catalog; it is simply a version of a catalog that we have already written and have open source renderers for. 
 
@@ -67,7 +67,7 @@ The basic catalog allows you to bootstrap an application or validate A2UI concep
 
 Since A2UI is designed for LLMs to generate the UI at either design time or runtime, we do not think portability requires a standardized catalog across multiple clients; the LLM can interpret the catalog for each individual frontend.
 
-[See the A2UI v0.9 basic catalog](../specification/v0_9/json/standard_catalog.json)
+[See the A2UI v0.9 basic catalog](../specification/v0_9/json/basic_catalog.json)
 
 ### Defining Your Own Catalog
 
@@ -172,7 +172,7 @@ This catalog imports all elements from the Basic Catalog and adds a new `Suggest
   "$id": "https://github.com/.../hello_world_with_all_basic/v1/catalog.json",
   "components": {
     "allOf": [
-      { "$ref": "standard_catalog_definition.json#/components" },
+      { "$ref": "basic_catalog_definition.json#/components" },
       {
         "SuggestionChips": {
           "type": "object",
@@ -202,8 +202,8 @@ This catalog imports only `Text` and `Icon` from the Basic Catalog to build a si
   "$id": "https://github.com/.../hello_world_with_some_basic/v1/catalog.json",
   "components": {
     "allOf": [
-      { "$ref": "standard_catalog_definition.json#/components/Text" },
-      { "$ref": "standard_catalog_definition.json#/components/Icon" },
+      { "$ref": "basic_catalog_definition.json#/components/Text" },
+      { "$ref": "basic_catalog_definition.json#/components/Icon" },
       {
         "Popup": { 
           "type": "object",
@@ -265,7 +265,7 @@ Example of an A2A AgentCard advertising that the agent supports the basic and ri
         "description": "Provides agent driven UI using the A2UI JSON format.",
         "params": {
           "supportedCatalogIds": [
-            "https://a2ui.org/specification/v0_9/standard_catalog.json",
+            "https://a2ui.org/specification/v0_9/basic_catalog.json",
             "https://github.com/.../rizzcharts_catalog_definition.json"
           ]
         }
@@ -291,7 +291,7 @@ Example of A2A message containing the supportedCatalogIds in metadata
   "metadata": {
     "a2uiClientCapabilities": {
       "supportedCatalogIds": [
-        "https://a2ui.org/specification/v0_9/standard_catalog.json",
+        "https://a2ui.org/specification/v0_9/basic_catalog.json",
         "https://github.com/.../rizzcharts_catalog_definition.json"
       ]
     }
@@ -309,7 +309,7 @@ Example A2UI Message from the agent defining the catalog_id used in a surface
 {
   "createSurface": {
     "surfaceId": "salesDashboard",
-    "catalogId": "https://a2ui.org/specification/v0_9/standard_catalog.json"
+    "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
   }
 }
 ```

--- a/docs/reference/components.md
+++ b/docs/reference/components.md
@@ -267,6 +267,6 @@ This launches a live gallery with all components, their variations, and interact
 
 ## Further Reading
 
-- **[Standard Catalog Definition](../../specification/v0_9/json/standard_catalog_definition.json)**: Complete technical specification
+- **[Basic Catalog Definition](../../specification/v0_9/json/basic_catalog.json)**: Complete technical specification
 - **[Custom Components Guide](../guides/custom-components.md)**: Build your own components
 - **[Theming Guide](../guides/theming.md)**: Style components to match your brand

--- a/specification/v0_9/docs/evolution_guide.md
+++ b/specification/v0_9/docs/evolution_guide.md
@@ -33,7 +33,7 @@ Version 0.9 represents a fundamental philosophical shift from "Structured Output
 **v0.8.1:**
 
 - Monolithic tendencies. `server_to_client.json` often contained deep definitions or relied on complex `oneOf` structures that were hard to decompose.
-- `standard_catalog_definition.json` existed but was often implicitly coupled.ß
+- `basic_catalog_definition.json` existed but was often implicitly coupled.
 
 **v0.9:**
 

--- a/tools/build_catalog/README.md
+++ b/tools/build_catalog/README.md
@@ -15,7 +15,7 @@ Example catalog (in specification/v0_9/json) that imports Text from the Basic Ca
   "$id": "sample_popup_catalog",
   "components": {
     "allOf": [
-      { "$ref": "standard_catalog.json#/components/Text" },
+      { "$ref": "basic_catalog.json#/components/Text" },
       {
         "Popup": {
           "type": "object",
@@ -89,7 +89,7 @@ Output from running build_catalog on the sample catalog, with all `$ref` to exte
         }
       ]
     },
-    "standard_catalog_components_Text": {
+    "basic_catalog_components_Text": {
       "type": "object",
       "allOf": [
         {
@@ -139,7 +139,7 @@ Output from running build_catalog on the sample catalog, with all `$ref` to exte
   "components": {
     "allOf": [
       {
-        "$ref": "#/$defs/standard_catalog_components_Text"
+        "$ref": "#/$defs/basic_catalog_components_Text"
       },
       {
         "Popup": {


### PR DESCRIPTION
A follow-up of PR #654 to replace remaining standard catalogs into basic catalogs.

# Description

_Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots._

_List which issues are fixed by this PR. For larger changes, raising an issue first helps reduce redundant work._

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
