### PR TITLE
Expand code ownership in the A2UI repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,24 +12,15 @@
 # - An email address (e.g., octocat@github.com)
 
 # Default ownership (is overriden by specfic rules below)
-* @dmandar @gspencergoog @jacobsimionato
+* @dmandar @gspencergoog @jacobsimionato @nan-yu @ditman @zeroasterisk
 
 # Agents
-/a2a_agents/ @nan-yu @dmandar
-
-# Documentation
-/docs/ @zeroasterisk @dmandar @gspencer @jacobsimionato
+/a2a_agents/ @nan-yu @dmandar @gspencergoog
 
 # Renderers
 /renderers/angular/ @ditman @ava-cassiopeia  @crisbeto
 /renderers/lit/ @ditman @ava-cassiopeia @paullewis
-/renderers/web_core/ @ditman @ava-cassiopeia
-
-# Samples
-/samples/ @dmandar @zeroasterisk
+/renderers/web_core/ @ditman @ava-cassiopeia @jacobsimionato
 
 # Specifications
 /specification/ @gspencergoog @jacobsimionato
-
-# Tools
-/tools/ @dmandar @jacobsimionato @paullewis


### PR DESCRIPTION
This is intended to reduce friction in getting PRs reviewed and landed.

- Add more people to top level ownership
- Remove specific ownership of `docs/` and `samples/`, instead letting the larger group of top level owners own it. This is intended to make it easier to land PRs which update agent SDKs or renderer SDKs and also make minor changes to the relevant docs or samples. These should not need review by separate doc experts etc.
- Add a couple more owners to specific components

The tighter ownership of the 'specification/`, `renderer/` and `a2a_agents/` folders reflects that these are core components intended to be widely depended upon, and so need a higher level of scrutiny than examples apps etc.