### PR TITLE
Add sprint task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/sprint-task.md
+++ b/.github/ISSUE_TEMPLATE/sprint-task.md
@@ -1,0 +1,10 @@
+---
+name: Sprint Task
+about: An issue to track a task used in a sprint
+title: ''
+labels: P2, sprint ready
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
This should make it easier to create a task for use in a sprint.
- Add sprint ready label
- Add default priority to ensure triage is skipped