### PR TITLE
Fix the lit sample by removing deleted restaurant workspace and updating dependencies

### DIFF
--- a/samples/client/lit/package.json
+++ b/samples/client/lit/package.json
@@ -5,23 +5,31 @@
   "description": "A2UI Lit Samples",
   "workspaces": [
     "contact",
-    "restaurant",
     "shell"
   ],
   "scripts": {
-    "serve:agent:restaurant": "cd ../../agent/adk/restaurant_finder && uv run .",
     "serve:agent:contact_lookup": "cd ../../agent/adk/contact_lookup && uv run .",
     "serve:agent:rizzcharts": "cd ../../agent/adk/rizzcharts && uv run .",
     "serve:agent:orchestrator": "cd ../../agent/adk/orchestrator && uv run .",
     "serve:shell": "cd shell && npm run dev",
     "build:renderer": "cd ../../../renderers && for dir in 'web_core' 'markdown/markdown-it' 'lit'; do (cd \"$dir\" && npm install && npm run build); done",
-    "demo:all": "npm install && npm run build:renderer && concurrently -k -n \"SHELL,REST,CONT1\" -c \"magenta,blue,green\" \"npm run serve:shell\" \"npm run serve:agent:restaurant\" \"npm run serve:agent:contact_lookup\"",
-    "demo:restaurant": "npm install && npm run build:renderer && concurrently -k -n \"SHELL,REST\" -c \"magenta,blue\" \"npm run serve:shell\" \"npm run serve:agent:restaurant\"",
+    "demo:all": "npm install && npm run build:renderer && concurrently -k -n \"SHELL,CONT1\" -c \"magenta,green\" \"npm run serve:shell\" \"npm run serve:agent:contact_lookup\"",
     "demo:contact": "npm install && npm run build:renderer && concurrently -k -n \"SHELL,CONT1\" -c \"magenta,green\" \"npm run serve:shell\" \"npm run serve:agent:contact_lookup\"",
     "demo:rizzcharts": "npm install && npm run build:renderer && concurrently -k -n \"SHELL,RIZZ\" -c \"magenta,yellow\" \"npm run serve:shell\" \"npm run serve:agent:rizzcharts\"",
     "demo:orchestrator": "npm install && npm run build:renderer && concurrently -k -n \"SHELL,ORCH\" -c \"magenta,cyan\" \"npm run serve:shell\" \"npm run serve:agent:orchestrator\""
   },
   "devDependencies": {
     "concurrently": "9.2.1"
+  },
+  "dependencies": {
+    "@a2a-js/sdk": "^0.3.4",
+    "@a2ui/lit": "file:../../../renderers/lit",
+    "@a2ui/markdown-it": "file:../../../renderers/markdown/markdown-it",
+    "@a2ui/web_core": "file:../../../renderers/web_core",
+    "@google/genai": "^1.22.0",
+    "@lit-labs/signals": "^0.1.3",
+    "@lit/context": "^1.1.4",
+    "@types/node": "^24.7.1",
+    "lit": "^3.3.1"
   }
 }

--- a/samples/client/lit/package.json
+++ b/samples/client/lit/package.json
@@ -13,7 +13,6 @@
     "serve:agent:orchestrator": "cd ../../agent/adk/orchestrator && uv run .",
     "serve:shell": "cd shell && npm run dev",
     "build:renderer": "cd ../../../renderers && for dir in 'web_core' 'markdown/markdown-it' 'lit'; do (cd \"$dir\" && npm install && npm run build); done",
-    "demo:all": "npm install && npm run build:renderer && concurrently -k -n \"SHELL,CONT1\" -c \"magenta,green\" \"npm run serve:shell\" \"npm run serve:agent:contact_lookup\"",
     "demo:contact": "npm install && npm run build:renderer && concurrently -k -n \"SHELL,CONT1\" -c \"magenta,green\" \"npm run serve:shell\" \"npm run serve:agent:contact_lookup\"",
     "demo:rizzcharts": "npm install && npm run build:renderer && concurrently -k -n \"SHELL,RIZZ\" -c \"magenta,yellow\" \"npm run serve:shell\" \"npm run serve:agent:rizzcharts\"",
     "demo:orchestrator": "npm install && npm run build:renderer && concurrently -k -n \"SHELL,ORCH\" -c \"magenta,cyan\" \"npm run serve:shell\" \"npm run serve:agent:orchestrator\""

--- a/samples/client/lit/shell/app.ts
+++ b/samples/client/lit/shell/app.ts
@@ -71,7 +71,7 @@ export class A2UILayoutEditor extends SignalWatcher(LitElement) {
   accessor #lastMessages: v0_8.Types.ServerToClientMessage[] = [];
 
   @state()
-  accessor config: AppConfig = configs.restaurant;
+  accessor config: AppConfig = configs.contacts;
 
   @state()
   accessor #loadingTextIndex = 0;
@@ -289,8 +289,8 @@ export class A2UILayoutEditor extends SignalWatcher(LitElement) {
 
     // Load config from URL
     const urlParams = new URLSearchParams(window.location.search);
-    const appKey = urlParams.get("app") || "restaurant";
-    this.config = configs[appKey] || configs.restaurant;
+    const appKey = urlParams.get("app") || "contacts";
+    this.config = configs[appKey] || configs.contacts;
 
     // Apply the theme directly, which will use the Lit context.
     if (this.config.theme) {

--- a/samples/client/lit/shell/app.ts
+++ b/samples/client/lit/shell/app.ts
@@ -289,8 +289,8 @@ export class A2UILayoutEditor extends SignalWatcher(LitElement) {
 
     // Load config from URL
     const urlParams = new URLSearchParams(window.location.search);
-    const appKey = urlParams.get("app") || "contacts";
-    this.config = configs[appKey] || configs.contacts;
+    const appKey = urlParams.get("app");
+    this.config = (appKey && configs[appKey]) || configs.contacts;
 
     // Apply the theme directly, which will use the Lit context.
     if (this.config.theme) {


### PR DESCRIPTION
# Description

This allows the lit example to display the contact demo by default, since the restaurant directory is gone.

Also, updates the dependencies to include markdown so that markdown works again.