### PR TITLE
docs: fix updatable spelling in README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ security risk. A2UI is a declarative data format, not executable
 code. Your client application maintains a "catalog" of trusted, pre-approved
 UI components (e.g., Card, Button, TextField), and the agent can only request
 to render components from that catalog.
-* **LLM-friendly and incrementally updateable**: The UI is represented as a flat
+* **LLM-friendly and incrementally updatable**: The UI is represented as a flat
 list of components with ID references which is easy for LLMs to generate
 incrementally, allowing for progressive rendering and a responsive user
 experience. An agent can efficiently make incremental changes to the UI based


### PR DESCRIPTION
Fix README intro spelling: updateable -> updatable. Docs-only change.