### PR TITLE
Client: enable markdown rendering

### DIFF
--- a/samples/client/angular/projects/contact/src/app/app.config.ts
+++ b/samples/client/angular/projects/contact/src/app/app.config.ts
@@ -14,7 +14,8 @@
  limitations under the License.
  */
 
-import { DEFAULT_CATALOG, provideA2UI } from '@a2ui/angular';
+import { DEFAULT_CATALOG, provideA2UI, provideMarkdownRenderer } from '@a2ui/angular';
+import { renderMarkdown } from '@a2ui/markdown-it';
 import { IMAGE_CONFIG } from '@angular/common';
 import {
   ApplicationConfig,
@@ -33,6 +34,7 @@ export const appConfig: ApplicationConfig = {
       catalog: DEFAULT_CATALOG,
       theme: theme,
     }),
+    provideMarkdownRenderer(renderMarkdown),
     {
       provide: IMAGE_CONFIG,
       useValue: {


### PR DESCRIPTION
It integrates `@a2ui/markdown-it` as the markdown renderer for the contact sample.

This resolves issues where markdown sytax (sch as `##` and `####` header) was displayed as plain text and ensures that links and button labels are correctly rendered as shown in the updated UI.

See the before and after screenshots:

<img width="346" height="650" alt="9ssAC6WpiAqSzWJ" src="https://github.com/user-attachments/assets/94fc7408-7253-4f78-9823-5bfed842f30a" />

<img width="264" height="650" alt="4V25S5HaWNVgnyk" src="https://github.com/user-attachments/assets/911b6e67-53fe-4510-998b-d45a0e873b04" />

# Description

_Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots._

_List which issues are fixed by this PR. For larger changes, raising an issue first helps reduce redundant work._

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
