### PR TITLE
Fix promise for Angular renderer actions

### DIFF
--- a/renderers/angular/src/lib/data/processor.ts
+++ b/renderers/angular/src/lib/data/processor.ts
@@ -19,16 +19,35 @@ import * as Types from '@a2ui/web_core/v0_8';
 import { Injectable } from '@angular/core';
 import { firstValueFrom, Subject } from 'rxjs';
 
+/**
+ * Represents an event that has been dispatched through the MessageProcessor.
+ *
+ * This interface combines the original message with a completion subject that
+ * is used to signal the end of processing and return the server's response.
+ */
 export interface DispatchedEvent {
   message: Types.A2UIClientEventMessage;
   completion: Subject<Types.ServerToClientMessage[]>;
 }
 
+/**
+ * Angular-specific implementation of A2uiMessageProcessor.
+ *
+ * This service handles data synchronization and event dispatching for the A2UI renderer.
+ * It extends the core message processor and adapts it to work with Angular's dependency
+ * injection and RxJS-based event system.
+ */
 @Injectable({ providedIn: 'root' })
 export class MessageProcessor extends A2uiMessageProcessor {
   constructor() {
     super();
   }
+  /**
+   * Observable stream of dispatched events.
+   *
+   * External handlers (e.g., an A2aService) should subscribe to this stream to
+   * catch and process client-side events.
+   */
   readonly events = new Subject<DispatchedEvent>();
 
   override setData(
@@ -43,6 +62,26 @@ export class MessageProcessor extends A2uiMessageProcessor {
     return super.setData(node, relativePath, value, surfaceId ?? undefined);
   }
 
+  /**
+   * Dispatches a client event message for processing and returns a promise that resolves
+   * with the server's response.
+   *
+   * This method is called by DynamicComponent.sendAction to signal user interactions (e.g., clicks,
+   * form submissions) that need to be handled by the backend or agent.
+   *
+   * @param message The client event message to dispatch.
+   * @returns A promise that resolves to an array of messages from the server in response to the event.
+   *
+   * @example
+   * ```typescript
+   * const response = await messageProcessor.dispatch({
+   *   event: {
+   *     type: 'click',
+   *     componentId: 'my-button',
+   *   },
+   * });
+   * ```
+   */
   dispatch(message: Types.A2UIClientEventMessage): Promise<Types.ServerToClientMessage[]> {
     const completion = new Subject<Types.ServerToClientMessage[]>();
     const promise = firstValueFrom(completion);


### PR DESCRIPTION
# Description

Without this change, triggering an action can cause this error to be logged in the dev console when triggering an action in the Angular renderer. The action works either way, but this change removes the error.

Uncaught (in promise) EmptyError: no elements in sequence
    at Object.complete (firstValueFrom.ts:72:16)
    at ConsumerObserver.complete (Subscriber.ts:188:25)
    at SafeSubscriber._complete (Subscriber.ts:137:22)
    at SafeSubscriber.complete (Subscriber.ts:116:12)
    at Subject._checkFinalizedStatuses (Subject.ts:157:18)
    at Subject._subscribe (Subject.ts:141:10)
    at Subject._trySubscribe (Observable.ts:251:19)
    at Subject._trySubscribe (Subject.ts:135:18)
    at Subject.subscribe (Observable.ts:242:16)
    at eval (firstValueFrom.ts:75:12)

## Pre-launch Checklist

- [ x] I signed the [CLA].
- [ x] I read the [Contributors Guide].
- [ x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
