### PR TITLE
Refine renderer guide, add Gallery App specifications, and strengthen generic constraints

### DIFF
--- a/specification/v0_9/docs/renderer_guide.md
+++ b/specification/v0_9/docs/renderer_guide.md
@@ -6,7 +6,7 @@ Both the core data structures and the rendering components interact with **Catal
 
 ## 1. Unified Architecture Overview
 
-The A2UI client architecture follows a strict, unidirectional data flow that bridges language-agnostic data structures with native UI frameworks. 
+The A2UI client architecture has a well-defined data flow that bridges language-agnostic data structures with native UI frameworks.
 
 1. **A2UI Messages** arrive from the server (JSON).
 2. The **`MessageProcessor`** parses these and updates the **`SurfaceModel`** (Agnostic State).


### PR DESCRIPTION
### Description of Changes
- **Model Reactivity Updates**: Clarified principles for the unsubscribe pattern, payload support, and ensured consistency across all state models.
- **Type Safety**: Strengthened generic type constraints across `SurfaceLifecycleListener`, `SurfaceGroupModel`, `SurfaceModel`, `MessageProcessor`, `ComponentContext`, and `Catalog` to extend `ComponentApi`.
- **DataContext Clarification**: Added note about the instantiating system's responsibility to provide available functions as a `FunctionInvoker`.
- **Client Capabilities Generation**: Added comprehensive documentation on dynamically generating the `a2uiClientCapabilities` payload, including schema type locations, detectable common types via tags (`REF:`), and required test cases.
- **Catalog API Expansion**: Detailed models for `Catalog`, `ComponentApi`, `FunctionApi`, and `FunctionImplementation`. Added guidelines on function observability and return types.
- **The Gallery App Specification**: Introduced a new major section defining the UX architecture (three-column layout) and integration testing requirements for the reference Gallery App.
- **Agent Implementation Guide**: Replaced the "Demo Application" milestone with the more robust "Gallery Application" milestone to align with the new specifications.

### Rationale
- **Clarity & Consistency**: These updates clarify the responsibilities of the data context, reactivity mechanisms, and provide a much more structured approach to client capabilities generation.
- **Standardization**: Strengthening generic constraints helps prevent invalid types from being used as component implementations across different renderers.
- **Reference Implementation Guidance**: Formally defining the Gallery App ensures that all A2UI renderer implementations have a consistent, high-quality reference environment for debugging and integration testing.

### Testing/Running Instructions
- This is a documentation-only change. Review the markdown file `specification/v0_9/docs/renderer_guide.md` for accuracy, formatting, and readability.