### PR TITLE
Add codespell support with configuration and fixes

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git*,*.svg,package-lock.json,*-lock.yaml,*.lock,*.css,.codespellrc
+skip = .git*,*.svg,package-lock.json,*-lock.yaml,*.lock,*.css,.codespellrc,.cache,.npm
 check-hidden = true
 ignore-regex = ^\s*"image/\S+": ".*
 # ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -3,4 +3,4 @@
 skip = .git*,*.svg,package-lock.json,*-lock.yaml,*.lock,*.css,.codespellrc,.cache,.npm
 check-hidden = true
 ignore-regex = ^\s*"image/\S+": ".*
-# ignore-words-list =
+ignore-words-list = ser,cyclin

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,*.svg,package-lock.json,*-lock.yaml,*.lock,*.css,.codespellrc
+check-hidden = true
+ignore-regex = ^\s*"image/\S+": ".*
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -2,5 +2,6 @@
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 skip = .git*,*.svg,package-lock.json,*-lock.yaml,*.lock,*.css,.codespellrc,.cache,.npm
 check-hidden = true
-ignore-regex = ^\s*"image/\S+": ".*
+# Ignore embedded base64 images in notebooks and camelCase/PascalCase identifiers
+ignore-regex = ^\s*"image/\S+": ".*|\b[a-z]+[A-Z]\w*\b|\b[A-Z][a-z]+[A-Z]\w*\b
 ignore-words-list = ser,cyclin

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -19,7 +19,5 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Annotate locations with typos
-        uses: codespell-project/codespell-problem-matcher@v1
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/samples/client/angular/README.md
+++ b/samples/client/angular/README.md
@@ -7,7 +7,7 @@ These are sample implementations of A2UI in Angular.
 1. [nodejs](https://nodejs.org/en)
 2. [uv](https://docs.astral.sh/uv/getting-started/installation/)
 
-NOTE: [For the rizzcharts app](../../agent/adk/rizzcharts/), you will need GoogleMap API ([How to get the API key](https://developers.google.com/maps/documentation/javascript/get-api-key)) to display Google Map custome components. Please refer to [Rizzcharts README](./projects/rizzcharts/README.md)
+NOTE: [For the rizzcharts app](../../agent/adk/rizzcharts/), you will need GoogleMap API ([How to get the API key](https://developers.google.com/maps/documentation/javascript/get-api-key)) to display Google Map custom components. Please refer to [Rizzcharts README](./projects/rizzcharts/README.md)
 
 ## Running
 

--- a/samples/client/angular/projects/a2a-chat-canvas/src/lib/components/chat/input-area/input-area.scss
+++ b/samples/client/angular/projects/a2a-chat-canvas/src/lib/components/chat/input-area/input-area.scss
@@ -18,7 +18,7 @@
   display: block;
   padding-inline: 16px;
   margin-block-end: 24px;
-  // Lets the ::before pseudo element be positioned absolutely releative to
+  // Lets the ::before pseudo element be positioned absolutely relative to
   // the InputArea.
   position: relative;
 

--- a/samples/client/angular/projects/a2a-chat-canvas/src/lib/services/chat-service.ts
+++ b/samples/client/angular/projects/a2a-chat-canvas/src/lib/services/chat-service.ts
@@ -258,7 +258,7 @@ export class ChatService {
   /**
    * Creates the agent role based on the agent card and the message response if available.
    *
-   * @param response The reponse message received from the agent.
+   * @param response The response message received from the agent.
    * @returns A new UiAgent object representing the agent that the user is chatting with.
    */
   private createRole(response?: SendMessageSuccessResponse): UiAgent {

--- a/specification/v0_9/docs/a2ui_protocol.md
+++ b/specification/v0_9/docs/a2ui_protocol.md
@@ -99,7 +99,7 @@ While A2UI is agnostic, it is most commonly used with the following transports.
 #### A2A (Agent2Agent) binding
 
 [A2A (Agent-to-Agent)](https://a2a-protocol.org/latest/) is an excellent transport option for A2UI in agentic systems, extending A2A with additional payloads.
-A2A is uniquely capable of handling remote agent communication, and can also provide a secure and effecient transport between an agentic backend and front end application.
+A2A is uniquely capable of handling remote agent communication, and can also provide a secure and efficient transport between an agentic backend and front end application.
 
 - **Message mapping**: Each A2UI envelope (e.g., `updateComponents`) corresponds to the payload of a single A2A message Part.
 - **Metadata**:

--- a/tools/editor/middleware/gemini.ts
+++ b/tools/editor/middleware/gemini.ts
@@ -20,7 +20,7 @@ import { GoogleGenAI } from "@google/genai";
 import { v0_8 } from "@a2ui/lit";
 import { createA2UIPrompt, createImageParsePrompt } from "./prompts";
 
-// TODO: Reenable.
+// TODO: Re-enable.
 // import ServerToClientMessage from "../schemas/a2ui-message.js";
 
 let catalog: v0_8.Types.ClientCapabilitiesDynamic | null = null;


### PR DESCRIPTION
Add codespell configuration and fix existing typos. This is a reincarnated 

- #546 

which was closed due to rot (conflicts) etc.

More about codespell: https://github.com/codespell-project/codespell

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

## Changes

### Configuration & Infrastructure
- Added `.codespellrc` with skip patterns for SVG, lock files, CSS, cache dirs
- Created GitHub Actions workflow to check spelling on push to main and PRs
- Added `ignore-regex` for camelCase/PascalCase identifiers (e.g., `doubleClick`)
- Added `ignore-words-list` for domain terms: `ser` (biology: serine), `cyclin` (biology: protein)

### Ambiguous Typos Fixed Manually (2 fixes)
- `custome` -> `custom` (samples/client/angular/README.md) - "Google Map custom components"
- `Reenable` -> `Re-enable` (tools/editor/middleware/gemini.ts) - TODO comment

### Non-Ambiguous Typos Fixed with `codespell -w` (3 fixes)
- `releative` -> `relative` (input-area.scss)
- `reponse` -> `response` (chat-service.ts)
- `effecient` -> `efficient` (a2ui_protocol.md)

All typo fixes are in comments/docs - no functional code changes.

## Testing

Codespell passes with zero errors after all fixes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) and love to typos free code
