### PR TITLE
fix(lit): accept partial hinted text styles

### DIFF
--- a/renderers/lit/src/0.8/hinted-styles.test.ts
+++ b/renderers/lit/src/0.8/hinted-styles.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { isHintedStyles } from "./ui/hinted-styles.js";
+
+describe("isHintedStyles", () => {
+  it("accepts partial hinted text styles", () => {
+    assert.strictEqual(
+      isHintedStyles({
+        body: { color: "red" },
+        h1: { fontWeight: "700" },
+      }),
+      true
+    );
+  });
+
+  it("rejects flat style maps", () => {
+    assert.strictEqual(
+      isHintedStyles({
+        color: "red",
+        fontWeight: "700",
+      }),
+      false
+    );
+  });
+
+  it("rejects scalar hinted keys", () => {
+    assert.strictEqual(
+      isHintedStyles({
+        body: "red",
+      }),
+      false
+    );
+  });
+});

--- a/renderers/lit/src/0.8/ui/hinted-styles.ts
+++ b/renderers/lit/src/0.8/ui/hinted-styles.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface HintedStyles {
+  h1: Record<string, string>;
+  h2: Record<string, string>;
+  h3: Record<string, string>;
+  h4: Record<string, string>;
+  h5: Record<string, string>;
+  body: Record<string, string>;
+  caption: Record<string, string>;
+}
+
+const hintedStyleKeys = ["h1", "h2", "h3", "h4", "h5", "caption", "body"] as const;
+
+export function isHintedStyles(styles: unknown): styles is HintedStyles {
+  if (!styles || typeof styles !== "object" || Array.isArray(styles)) {
+    return false;
+  }
+
+  const styleRecord = styles as Record<string, unknown>;
+  return hintedStyleKeys.some((key) => {
+    const value = styleRecord[key];
+    return !!value && typeof value === "object" && !Array.isArray(value);
+  });
+}

--- a/renderers/lit/src/0.8/ui/text.ts
+++ b/renderers/lit/src/0.8/ui/text.ts
@@ -27,16 +27,7 @@ import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { structuralStyles } from "./styles.js";
 import { Styles } from "../index.js";
-
-interface HintedStyles {
-  h1: Record<string, string>;
-  h2: Record<string, string>;
-  h3: Record<string, string>;
-  h4: Record<string, string>;
-  h5: Record<string, string>;
-  body: Record<string, string>;
-  caption: Record<string, string>;
-}
+import { isHintedStyles } from "./hinted-styles.js";
 
 @customElement("a2ui-text")
 export class Text extends Root {
@@ -131,23 +122,14 @@ export class Text extends Root {
     )}`;
   }
 
-  #areHintedStyles(styles: unknown): styles is HintedStyles {
-    if (typeof styles !== "object") return false;
-    if (Array.isArray(styles)) return false;
-    if (!styles) return false;
-
-    const expected = ["h1", "h2", "h3", "h4", "h5", "h6", "caption", "body"];
-    return expected.every((v) => v in styles);
-  }
-
   #getAdditionalStyles() {
     let additionalStyles: Record<string, string> = {};
     const styles = this.theme.additionalStyles?.Text;
     if (!styles) return additionalStyles;
 
-    if (this.#areHintedStyles(styles)) {
+    if (isHintedStyles(styles)) {
       const hint = this.usageHint ?? "body";
-      additionalStyles = styles[hint] as Record<string, string>;
+      additionalStyles = styles[hint] ?? {};
     } else {
       additionalStyles = styles;
     }


### PR DESCRIPTION
## Summary
- stop the lit text renderer from requiring every hinted text style key before it recognizes `additionalStyles.Text` as hinted styles
- remove the impossible `h6` expectation and treat partial hinted style maps as hinted when they contain at least one recognized hinted key
- add a regression test covering partial hinted styles vs flat style maps

## Testing
- `cd renderers/web_core && npm run build`
- `cd renderers/lit && npm test`

Fixes #602
