### PR TITLE
refactor: Remove componentCatalog property and its usage from A2aServ…

### DIFF
--- a/samples/client/angular/projects/orchestrator/src/services/a2a-service-impl.ts
+++ b/samples/client/angular/projects/orchestrator/src/services/a2a-service-impl.ts
@@ -22,11 +22,10 @@ import { Injectable } from '@angular/core';
   providedIn: 'root',
 })
 export class A2aServiceImpl implements A2aService {
-  public componentCatalog: string = '';
 
   async sendMessage(parts: Part[], signal?: AbortSignal): Promise<SendMessageSuccessResponse> {
     const response = await fetch('/a2a', {
-      body: JSON.stringify({ parts: parts, component_catalog: this.componentCatalog }),
+      body: JSON.stringify({ parts: parts }),
       method: 'POST',
       signal,
     });


### PR DESCRIPTION
…iceImpl.

# Description

The `component_catalog` field is never used and is superfluous. 

The server-side receiver of this `/a2a` post method completely ignores this value and already prescribes the supported catalog itself. (https://github.com/google/A2UI/blob/main/samples/client/angular/projects/orchestrator/src/server.ts#L42-L97). 

This code is deadcode. 

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
