### PR TITLE
fix: wire the lit orchestrator demo to its required subagents

### DIFF
--- a/samples/client/lit/package.json
+++ b/samples/client/lit/package.json
@@ -10,12 +10,15 @@
   "scripts": {
     "serve:agent:restaurant": "cd ../../agent/adk/restaurant_finder && uv run .",
     "serve:agent:contact_lookup": "cd ../../agent/adk/contact_lookup && uv run .",
-    "serve:agent:orchestrator": "cd ../../agent/adk/orchestrator && uv run .",
+    "serve:agent:restaurant:orchestrator": "cd ../../agent/adk/restaurant_finder && uv run . --port=10003",
+    "serve:agent:contact_lookup:orchestrator": "cd ../../agent/adk/contact_lookup && uv run . --port=10004",
+    "serve:agent:rizzcharts:orchestrator": "cd ../../agent/adk/rizzcharts && uv run . --port=10005",
+    "serve:agent:orchestrator": "cd ../../agent/adk/orchestrator && uv run . --port=10002 --subagent_urls=http://localhost:10003 --subagent_urls=http://localhost:10004 --subagent_urls=http://localhost:10005",
     "serve:shell": "cd shell && npm run dev",
     "build:renderer": "cd ../../../renderers && for dir in 'web_core' 'markdown/markdown-it' 'lit'; do (cd \"$dir\" && npm install && npm run build); done",
     "demo:restaurant": "npm install && npm run build:renderer && concurrently -k -n \"SHELL,REST\" -c \"magenta,blue\" \"npm run serve:shell\" \"npm run serve:agent:restaurant\"",
     "demo:contact": "npm install && npm run build:renderer && concurrently -k -n \"SHELL,CONT1\" -c \"magenta,green\" \"npm run serve:shell\" \"npm run serve:agent:contact_lookup\"",
-    "demo:orchestrator": "npm install && npm run build:renderer && concurrently -k -n \"SHELL,ORCH\" -c \"magenta,cyan\" \"npm run serve:shell\" \"npm run serve:agent:orchestrator\""
+    "demo:orchestrator": "npm install && npm run build:renderer && concurrently -k -n \"SHELL,REST,CONT,RIZZ,ORCH\" -c \"magenta,blue,green,yellow,cyan\" \"npm run serve:shell\" \"npm run serve:agent:restaurant:orchestrator\" \"npm run serve:agent:contact_lookup:orchestrator\" \"npm run serve:agent:rizzcharts:orchestrator\" \"npm run serve:agent:orchestrator\""
   },
   "devDependencies": {
     "concurrently": "9.2.1"


### PR DESCRIPTION
# Description

This wires the Lit orchestrator sample to the ports already documented in the orchestrator README so `npm run demo:orchestrator` can actually boot the full sample stack.

What changed:
- added orchestrator-specific subagent scripts for the restaurant, contact lookup, and rizzcharts agents
- updated `serve:agent:orchestrator` to pass the default `--subagent_urls` values the orchestrator requires
- updated `demo:orchestrator` to launch the shell plus all three subagents before starting the orchestrator

Fixes #586.

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

Tests:
- added a local Node assertion that validates the updated `package.json` scripts wire the documented ports and subagent URLs.

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[Style Guide]: ../STYLE_GUIDE.md
