### PR TITLE
Mcp Apps 3 : Integrate MCP Apps Sample Agent into Orchestrator Sample

### DIFF
--- a/samples/agent/adk/orchestrator/README.md
+++ b/samples/agent/adk/orchestrator/README.md
@@ -42,17 +42,30 @@ Subagents are configured using RemoteA2aAgent which translates ADK events to A2A
    uv run . --port=10005
    ```
 
+   Optionally, run the MCP Server and MCP App Proxy Agent to MCP Apps in A2UI demo:
+
+   ```bash
+   cd samples/agent/mcp
+   uv run . --port=8000
+   ```
+
+   ```bash
+   cd samples/agent/adk/mcp_app_proxy
+   uv run . --port=10006
+   ```
+
 3. Run the orchestrator agent:
 
    ```bash
    cd samples/agent/adk/orchestrator
-   uv run . --port=10002 --subagent_urls=http://localhost:10003 --subagent_urls=http://localhost:10004 --subagent_urls=http://localhost:10005
+   uv run . --port=10002 --subagent_urls=http://localhost:10003 --subagent_urls=http://localhost:10004 --subagent_urls=http://localhost:10005 --subagent_urls=http://localhost:10006
    ```
 
 4. Try commands that work with any agent: 
    a. "Who is Alex Jordan?" (routed to contact lookup agent)
    b. "Show me chinese food restaurants in NYC" (routed to restaurant finder agent)
    c. "Show my sales data for Q4" (routed to rizzcharts)
+   d. "Open calculator" (routed to mcp app proxy)
 
 ## Disclaimer
 

--- a/samples/client/angular/projects/orchestrator/README.md
+++ b/samples/client/angular/projects/orchestrator/README.md
@@ -16,8 +16,12 @@ This angular app connects to an Orchastrator Agent which takes user messages and
 2. Build the shared dependencies by running `npm run build` in the `renderers/web_core` directory
 3. Install the dependencies: `npm i`
 4. Run the A2A server for all of the agents. ([Link to instructions](../../../../agent/adk/orchestrator/README.md))
-5. Run the app:
+5. Optionally, build the `sandbox.js` for testing MCP Apps in A2UI demo
+
+- `npm run build:sandbox`
+
+6. Run the app:
 
 - `npm start -- orchestrator`
 
-6. Open http://localhost:4200/
+7. Open http://localhost:4200/

--- a/samples/client/angular/projects/orchestrator/src/server.ts
+++ b/samples/client/angular/projects/orchestrator/src/server.ts
@@ -63,6 +63,7 @@ app.post('/a2a', (req, res) => {
           a2uiClientCapabilities: {
             supportedCatalogIds: [
               'https://a2ui.org/specification/v0_8/standard_catalog_definition.json',
+              'a2ui.org:a2ui/v0.8/mcp_app_catalog.json',
             ],
           },
         },


### PR DESCRIPTION
# Description

This PR incorporates the MCP Apps demo into the Angular Orchestrator Sample. 
It completes the following 3 staged PRs into a demo.

 0: https://github.com/google/A2UI/pull/791 introduced a new Calculator App resource in the Sample MCP Server
 1: https://github.com/google/A2UI/pull/801 introduced a new A2UI Angular Component `McpApps` that can containerize and display MCP Apps resrource as a A2UI Component/
 2: https://github.com/google/A2UI/pull/815 set up a standalone A2A Agent that show cases how the relay of MCP Apps retrieved from MCP Servers can be translated into A2UI protocol for A2UI client consumption.


and then 3: this PR updates the existing Orchestrator A2UI demo to integrate with the A2A Agent prepared in #2. 


See demo: https://screencast.googleplex.com/cast/NTU3NTU5MTg4MDI5NDQwMHxhZTA1OGM1Mi1kNg


## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
