### PR TITLE
Fix references to build_catalog.py to now refer to assemble_catalog.py

### DIFF
--- a/docs/concepts/catalogs.md
+++ b/docs/concepts/catalogs.md
@@ -154,7 +154,7 @@ A2UI Catalogs must be standalone (no references to external files) to simplify L
 While the final catalog must be freestanding, you may still author your catalogs modularly using JSON Schema `$ref` pointing to external documents during local development. Run  `tools/build_catalog/assemble_catalog.py` before distributing your catalog to bundle all external file references into a single, independent JSON Schema file:
 
 ```bash
-uv run tools/build_catalog/assemble_catalog.py [INPUTS ...] --output-name <OUTPUT_NAME> [--version <VERSION>] [--extend-basic-catalog] [--out-dir <DIR>] [--verbose]
+uv run tools/build_catalog/assemble_catalog.py [INPUTS ...] --output-name <OUTPUT_NAME> [--catalog-id <ID>] [--version <VERSION>] [--extend-basic-catalog] [--out-dir <DIR>] [--verbose]
 ```
 
 where:
@@ -162,6 +162,7 @@ where:
 - `--output-name`: (Required) The desired name of the combined catalog (e.g.
   `my_merged_catalog`). The `.json` extension is appended automatically if
   omitted.
+- `--catalog-id`: Custom `catalogId` for the output. Defaults to `urn:a2ui:catalog:<base_name>`.
 - `--version`: The A2UI specification version to use for official catalog
   fallbacks. Choices are `0.9` or `0.10`. Defaults to `0.9`.
 - `--extend-basic-catalog`: If passed, automatically includes the entirety of

--- a/tools/build_catalog/README.md
+++ b/tools/build_catalog/README.md
@@ -38,7 +38,7 @@ official catalogs, and multi-file merging.
 ### Usage
 
 ```bash
-uv run tools/build_catalog/assemble_catalog.py [INPUTS ...] --output-name <OUTPUT_NAME> [--version <VERSION>] [--extend-basic-catalog] [--out-dir <DIR>] [--verbose]
+uv run tools/build_catalog/assemble_catalog.py [INPUTS ...] --output-name <OUTPUT_NAME> [--catalog-id <ID>] [--version <VERSION>] [--extend-basic-catalog] [--out-dir <DIR>] [--verbose]
 ```
 
 ### Arguments
@@ -47,6 +47,7 @@ uv run tools/build_catalog/assemble_catalog.py [INPUTS ...] --output-name <OUTPU
 - `--output-name`: (Required) The desired name of the combined catalog (e.g.
   `my_merged_catalog`). The `.json` extension is appended automatically if
   omitted.
+- `--catalog-id`: Custom `catalogId` for the output. Defaults to `urn:a2ui:catalog:<base_name>`.
 - `--version`: The A2UI specification version to use for official catalog
   fallbacks. Choices are `0.9` or `0.10`. Defaults to `0.9`.
 - `--extend-basic-catalog`: If passed, automatically includes the entirety of


### PR DESCRIPTION
## Pre-launch Checklist

- [x ] I signed the [CLA].
- [x ] I read the [Contributors Guide].
- [x ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ x] I updated/added relevant documentation.
- [ x] My code changes (if any) have tests.

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
