### PR TITLE
spec(v0_8): harmonize server schemas and fix missing catalogId

### DIFF
--- a/renderers/web_core/src/v0_8/schema/server-to-client.ts
+++ b/renderers/web_core/src/v0_8/schema/server-to-client.ts
@@ -103,6 +103,12 @@ export const BeginRenderingMessageSchema = z
     surfaceId: z
       .string()
       .describe("The unique identifier for the UI surface to be rendered."),
+    catalogId: z
+      .string()
+      .optional()
+      .describe(
+        "The identifier of the component catalog to use for this surface. If omitted, the client MUST default to the standard catalog for this A2UI version (https://a2ui.org/specification/v0_8/standard_catalog_definition.json).",
+      ),
     root: z.string().describe("The ID of the root component to render."),
     styles: z
       .object({

--- a/specification/scripts/validate.py
+++ b/specification/scripts/validate.py
@@ -85,15 +85,25 @@ def validate_messages(root_schema, example_files, refs=None, temp_dir="temp_val"
     return success
 
 def compare_schemas(subset_path, standard_path):
-    """Compares that subset schema is a strict subset of standard schema."""
+    """Compares that subset schema is a subset of standard schema.
+    
+    Allows object keys and string arrays to be subsets. For non-string arrays
+    (e.g., arrays of objects), we enforce element-by-element equality in length 
+    and structure to simplify position-dependent matching.
+    """
     print(f"  Comparing {os.path.basename(subset_path)} is a subset of {os.path.basename(standard_path)}...")
     try:
         with open(subset_path, 'r') as f:
             subset = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"    [FAIL] Error loading or parsing subset schema '{os.path.basename(subset_path)}': {e}")
+        return False
+
+    try:
         with open(standard_path, 'r') as f:
             standard = json.load(f)
-    except Exception as e:
-        print(f"    [FAIL] Error loading schemas for comparison: {e}")
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"    [FAIL] Error loading or parsing standard schema '{os.path.basename(standard_path)}': {e}")
         return False
 
     success = True
@@ -129,10 +139,13 @@ def compare_schemas(subset_path, standard_path):
                       compare(sub[key], std[key], new_path)
         elif sub_type == "array":
              if all(isinstance(x, str) for x in sub) and all(isinstance(x, str) for x in std):
-                  if set(sub) != set(std):
-                      print(f"    [FAIL] String array mismatch at {path}: subset={sub}, standard={std}")
+                  if not set(sub).issubset(set(std)):
+                      print(f"    [FAIL] String array is not a subset at {path}: subset={sub}, standard={std}")
                       success = False
              else:
+                  # For non-string arrays (e.g. arrays of objects like inside anyOf), 
+                  # order and length typically matter for structure matching in this script.
+                  # To avoid complex matching, we enforce equality in length and structure.
                   if len(sub) != len(std):
                       print(f"    [FAIL] Array length mismatch at {path}: subset={len(sub)}, standard={len(std)}")
                       success = False

--- a/specification/scripts/validate.py
+++ b/specification/scripts/validate.py
@@ -84,6 +84,73 @@ def validate_messages(root_schema, example_files, refs=None, temp_dir="temp_val"
 
     return success
 
+def compare_schemas(subset_path, standard_path):
+    """Compares that subset schema is a strict subset of standard schema."""
+    print(f"  Comparing {os.path.basename(subset_path)} is a subset of {os.path.basename(standard_path)}...")
+    try:
+        with open(subset_path, 'r') as f:
+            subset = json.load(f)
+        with open(standard_path, 'r') as f:
+            standard = json.load(f)
+    except Exception as e:
+        print(f"    [FAIL] Error loading schemas for comparison: {e}")
+        return False
+
+    success = True
+    
+    # Approved exceptions where subset is generic and standard is restrictive
+    approved_exceptions = {
+        "properties.surfaceUpdate.properties.components.items.properties.component.additionalProperties",
+        "properties.beginRendering.properties.styles.additionalProperties"
+    }
+
+    def get_type_str(val):
+        if isinstance(val, dict): return "object"
+        if isinstance(val, list): return "array"
+        return "primitive"
+
+    def compare(sub, std, path=""):
+        nonlocal success
+        sub_type = get_type_str(sub)
+        std_type = get_type_str(std)
+
+        if sub_type != std_type:
+             print(f"    [FAIL] Type mismatch at {path}: subset={sub_type}, standard={std_type}")
+             success = False
+             return
+
+        if sub_type == "object":
+             for key in sub:
+                 new_path = f"{path}.{key}" if path else key
+                 if key not in std:
+                      print(f"    [FAIL] Key '{key}' in subset but missing in standard at {new_path}")
+                      success = False
+                 else:
+                      compare(sub[key], std[key], new_path)
+        elif sub_type == "array":
+             if all(isinstance(x, str) for x in sub) and all(isinstance(x, str) for x in std):
+                  if set(sub) != set(std):
+                      print(f"    [FAIL] String array mismatch at {path}: subset={sub}, standard={std}")
+                      success = False
+             else:
+                  if len(sub) != len(std):
+                      print(f"    [FAIL] Array length mismatch at {path}: subset={len(sub)}, standard={len(std)}")
+                      success = False
+                  else:
+                      for i in range(len(sub)):
+                          compare(sub[i], std[i], f"{path}[{i}]")
+        elif sub_type == "primitive":
+             if sub != std:
+                 if path in approved_exceptions:
+                      return
+                 print(f"    [FAIL] Value mismatch at {path}: subset={sub}, standard={std}")
+                 success = False
+
+    compare(subset, standard)
+    if success:
+         print("    [PASS] Subset comparison")
+    return success
+
 def main():
     repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
     
@@ -93,6 +160,7 @@ def main():
     configs = {
         "v0_8": {
             "root_schema": "specification/v0_8/json/server_to_client_with_standard_catalog.json",
+            "subset_schema": "specification/v0_8/json/server_to_client.json",
             "refs": [],
             "examples": "specification/v0_8/json/catalogs/basic/examples/*.json"
         },
@@ -139,6 +207,11 @@ def main():
         example_pattern = os.path.join(repo_root, config["examples"])
         example_files = glob.glob(example_pattern)
         
+        if "subset_schema" in config:
+            subset_path = os.path.join(repo_root, config["subset_schema"])
+            if not compare_schemas(subset_path, root_schema):
+                overall_success = False
+                
         if not example_files:
             print(f"No examples found for {version} matching {example_pattern}")
         else:

--- a/specification/v0_8/json/server_to_client.json
+++ b/specification/v0_8/json/server_to_client.json
@@ -57,7 +57,7 @@
               },
               "component": {
                 "type": "object",
-                "description": "A wrapper object that MUST contain exactly one key, which is the name of the component type. The value is an object containing the properties for that specific component.",
+                "description": "A wrapper object that MUST contain exactly one key, which is the name of the component type (e.g., 'Heading'). The value is an object containing the properties for that specific component.",
                 "additionalProperties": true
               }
             },

--- a/specification/v0_8/json/server_to_client_with_standard_catalog.json
+++ b/specification/v0_8/json/server_to_client_with_standard_catalog.json
@@ -13,6 +13,10 @@
           "type": "string",
           "description": "The unique identifier for the UI surface to be rendered."
         },
+        "catalogId": {
+          "type": "string",
+          "description": "The identifier of the component catalog to use for this surface. If omitted, the client MUST default to the standard catalog for this A2UI version (https://a2ui.org/specification/v0_8/standard_catalog_definition.json)."
+        },
         "root": {
           "type": "string",
           "description": "The ID of the root component to render."


### PR DESCRIPTION
# Description

This pull request enhances the A2UI specification by introducing explicit catalog selection for UI surfaces and improving schema consistency. It also establishes a robust automated validation mechanism to prevent future discrepancies between core and standard schemas, ensuring a more stable and predictable development environment for UI rendering.

### Highlights

* **Schema Harmonization**: The `catalogId` property was added to the `BeginRenderingMessageSchema` in both the Zod schema (`server-to-client.ts`) and the JSON schema (`server_to_client_with_standard_catalog.json`) to enable explicit surface-catalog selection.
* **Schema Description Alignment**: Descriptions within `server_to_client.json` were aligned and clarified, specifically for the `component` property, while maintaining its open-ended extensibility.
* **Automated Schema Validation**: A new `compare_schemas` function was introduced in `validate.py` and integrated into the CI process as a regression test. This function ensures that `server_to_client.json` remains a strict subset of `server_to_client_with_standard_catalog.json`, preventing future schema divergence.

<details>
<summary><b>Changelog</b></summary>

* **renderers/web_core/src/v0_8/schema/server-to-client.ts**
    * Added an optional `catalogId` property to the `BeginRenderingMessageSchema` to specify the component catalog for a UI surface.
* **specification/scripts/validate.py**
    * Implemented a new `compare_schemas` function to verify that one JSON schema is a strict subset of another.
    * Integrated the `compare_schemas` function into the main validation script to compare `server_to_client.json` against `server_to_client_with_standard_catalog.json` for the `v0_8` version.
* **specification/v0_8/json/server_to_client.json**
    * Updated the description for the `component` property to include an example, clarifying its usage.
* **specification/v0_8/json/server_to_client_with_standard_catalog.json**
    * Added the `catalogId` property to the `BeginRenderingMessage` definition, allowing for explicit component catalog identification.
</details>
