### PR TITLE
Revert Change CallId to allow for more data. (#793)

### DIFF
--- a/specification/v0_10/json/client_to_server.json
+++ b/specification/v0_10/json/client_to_server.json
@@ -60,6 +60,10 @@
           "$ref": "common_types.json#/$defs/CallId",
           "description": "Unique ID for the instance of this function. MUST be copied verbatim from the function invocation."
         },
+        "call": {
+          "type": "string",
+          "description": "The name of the function which was called. MUST be copied verbatim from the function invocation. Useful for logging."
+        },
         "value": {
           "description": "The return value of the function invocation.",
           "type": [
@@ -72,7 +76,7 @@
           ]
         }
       },
-      "required": ["functionCallId", "value"],
+      "required": ["functionCallId", "call", "value"],
       "unevaluatedProperties": false
     },
     "error": {

--- a/specification/v0_10/json/common_types.json
+++ b/specification/v0_10/json/common_types.json
@@ -9,19 +9,8 @@
       "description": "The unique identifier for a component, used for both definitions and references within the same surface."
     },
     "CallId": {
-      "type": "object",
-      "description": "The unique identifier for a server initiated function call.",
-      "properties": {
-        "agentId": {
-          "type": "string",
-          "description": "Identifies the agent initiating the function call."
-        },
-        "callId": {
-          "type": "string",
-          "description": "Uniquely identifies this instance of the function call."
-        }
-      },
-      "required": ["callId"]
+      "type": "string",
+      "description": "The unique identifier for a server initiated function call."
     },
     "AccessibilityAttributes": {
       "type": "object",

--- a/specification/v0_10/test/cases/call_function_message.json
+++ b/specification/v0_10/test/cases/call_function_message.json
@@ -15,7 +15,7 @@
           "returnType": "void",
           "callableFrom": "clientOrRemote"
         },
-        "functionCallId": { "callId": "unique-call-id-123" },
+        "functionCallId": "unique-call-id-123",
         "wantResponse": true
       }
     },
@@ -29,7 +29,7 @@
           "returnType": "void",
           "callableFrom": "remoteOnly"
         },
-        "functionCallId": { "callId": "unique-call-id-123a" },
+        "functionCallId": "unique-call-id-123a",
         "wantResponse": false
       }
     },
@@ -46,7 +46,7 @@
           "returnType": "void",
           "callableFrom": "clientOrRemote"
         },
-        "functionCallId": { "callId": "unique-call-id-124" }
+        "functionCallId": "unique-call-id-124"
       }
     },
     {
@@ -67,7 +67,7 @@
       "valid": false,
       "data": {
         "version": "v0.10",
-        "functionCallId": { "callId": "unique-call-id-125" }
+        "functionCallId": "unique-call-id-125"
       }
     },
     {
@@ -81,7 +81,7 @@
           "returnType": "boolean",
           "callableFrom": "clientOnly"
         },
-        "functionCallId": { "callId": "unique-call-id-126" }
+        "functionCallId": "unique-call-id-126"
       }
     },
     {
@@ -94,7 +94,7 @@
           "args": { "value": "bar" },
           "returnType": "boolean"
         },
-        "functionCallId": { "callId": "unique-call-id-126b" }
+        "functionCallId": "unique-call-id-126b"
       }
     },
     {
@@ -110,7 +110,7 @@
           "returnType": "boolean",
           "callableFrom": "clientOrRemote"
         },
-        "functionCallId": { "callId": "unique-call-id-127" }
+        "functionCallId": "unique-call-id-127"
       }
     },
     {
@@ -126,7 +126,7 @@
           "returnType": "boolean",
           "callableFrom": "clientOrRemote"
         },
-        "functionCallId": { "callId": "unique-call-id-128" }
+        "functionCallId": "unique-call-id-128"
       }
     },
     {
@@ -140,7 +140,7 @@
           "returnType": "object",
           "callableFrom": "clientOrRemote"
         },
-        "functionCallId": { "callId": "unique-call-id-129" }
+        "functionCallId": "unique-call-id-129"
       }
     },
     {
@@ -156,7 +156,7 @@
           "returnType": "boolean",
           "callableFrom": "clientOrRemote"
         },
-        "functionCallId": { "callId": "id-3" }
+        "functionCallId": "id-3"
       }
     }
   ]

--- a/specification/v0_10/test/cases/client_messages.json
+++ b/specification/v0_10/test/cases/client_messages.json
@@ -50,7 +50,7 @@
         "version": "v0.10",
         "error": {
           "code": "FUNCTION_FAILED",
-          "functionCallId": { "callId": "unique-call-id-132" },
+          "functionCallId": "unique-call-id-132",
           "message": "Something went wrong"
         }
       }
@@ -62,7 +62,7 @@
         "version": "v0.10",
         "error": {
           "code": "FUNCTION_FAILED",
-          "functionCallId": { "callId": "unique-call-id-133" },
+          "functionCallId": "unique-call-id-133",
           "surfaceId": "main",
           "message": "Something went wrong"
         }

--- a/specification/v0_10/test/cases/function_response.json
+++ b/specification/v0_10/test/cases/function_response.json
@@ -7,7 +7,8 @@
       "data": {
         "version": "v0.10",
         "functionResponse": {
-          "functionCallId": { "callId": "unique-call-id-130" },
+          "functionCallId": "unique-call-id-130",
+          "call": "someFunction",
           "value": {
             "result": "success",
             "count": 42
@@ -33,7 +34,8 @@
       "data": {
         "version": "v0.10",
         "functionResponse": {
-          "functionCallId": { "callId": "unique-call-id-131a" },
+          "functionCallId": "unique-call-id-131a",
+          "call": "someFunction",
           "value": "success"
         }
       }
@@ -44,7 +46,8 @@
       "data": {
         "version": "v0.10",
         "functionResponse": {
-          "functionCallId": { "callId": "unique-call-id-131b" },
+          "functionCallId": "unique-call-id-131b",
+          "call": "someFunction",
           "value": 42
         }
       }
@@ -55,7 +58,8 @@
       "data": {
         "version": "v0.10",
         "functionResponse": {
-          "functionCallId": { "callId": "unique-call-id-131c" },
+          "functionCallId": "unique-call-id-131c",
+          "call": "someFunction",
           "value": true
         }
       }
@@ -66,7 +70,8 @@
       "data": {
         "version": "v0.10",
         "functionResponse": {
-          "functionCallId": { "callId": "unique-call-id-131d" },
+          "functionCallId": "unique-call-id-131d",
+          "call": "someFunction",
           "value": null
         }
       }
@@ -77,7 +82,8 @@
       "data": {
         "version": "v0.10",
         "functionResponse": {
-          "functionCallId": { "callId": "unique-call-id-131e" },
+          "functionCallId": "unique-call-id-131e",
+          "call": "someFunction",
           "value": [
             "one",
             2,
@@ -93,7 +99,8 @@
       "data": {
         "version": "v0.10",
         "functionResponse": {
-          "functionCallId": { "callId": "unique-call-id-131" },
+          "functionCallId": "unique-call-id-131",
+          "call": "someFunction",
           "value": {
             "result": { "nested": "object" }
           }
@@ -106,13 +113,49 @@
       "data": {
         "version": "v0.10",
         "functionResponse": {
-          "functionCallId": { "callId": "unique-call-id-131f" },
+          "functionCallId": "unique-call-id-131f",
+          "call": "someFunction",
           "value": [
             "one",
             {
               "nested": "object"
             }
           ]
+        }
+      }
+    },
+    {
+      "description": "functionResponse: Valid (with call property)",
+      "valid": true,
+      "data": {
+        "version": "v0.10",
+        "functionResponse": {
+          "functionCallId": "unique-call-id-132",
+          "call": "myAwesomeFunction",
+          "value": "success"
+        }
+      }
+    },
+    {
+      "description": "functionResponse: Invalid (call property is not a string)",
+      "valid": false,
+      "data": {
+        "version": "v0.10",
+        "functionResponse": {
+          "functionCallId": "unique-call-id-133",
+          "call": 123,
+          "value": "success"
+        }
+      }
+    },
+    {
+      "description": "functionResponse: Invalid (missing call)",
+      "valid": false,
+      "data": {
+        "version": "v0.10",
+        "functionResponse": {
+          "functionCallId": "unique-call-id-134",
+          "value": "success"
         }
       }
     }


### PR DESCRIPTION
# Description

After further discussion, we decided that the use case for passing the agent could be solved in a better way.

We're adding the `call` property to the `functionResponse` as we believe that will be useful for logging purposes.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
