### PR TITLE
refactor: update `read_resource` uri parameter type hint from `types.…

### DIFF
--- a/samples/agent/mcp/calculator/server.py
+++ b/samples/agent/mcp/calculator/server.py
@@ -45,7 +45,7 @@ def main(port: int, transport: str) -> int:
     ]
 
   @app.read_resource()
-  async def read_resource(uri: types.ResourceIdentifier) -> str | bytes:
+  async def read_resource(uri: str) -> str | bytes:
     if str(uri) == "ui://calculator/app":
       try:
         return (pathlib.Path(__file__).parent / "apps" / "calculator.html").read_text()


### PR DESCRIPTION
…ResourceIdentifier` to `str`.

# Description

The `ResourceIdentifier` suggested by Gemini reviewer was none existent breaking the server.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
