### PR TITLE
client: enable markdown rendering for other samples

### DIFF
--- a/samples/client/angular/angular.json
+++ b/samples/client/angular/angular.json
@@ -443,8 +443,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500KB",
-                  "maximumError": "1MB"
+                  "maximumWarning": "1.5MB",
+                  "maximumError": "2MB"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/samples/client/angular/projects/orchestrator/src/app/app.config.ts
+++ b/samples/client/angular/projects/orchestrator/src/app/app.config.ts
@@ -31,6 +31,8 @@ import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
 import { DEMO_CATALOG } from '../a2ui-catalog/catalog';
 import { A2aServiceImpl } from '../services/a2a-service-impl';
 import { routes } from './app.routes';
+import { provideMarkdownRenderer } from '@a2ui/angular';
+import { renderMarkdown } from '@a2ui/markdown-it';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -39,6 +41,7 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     provideClientHydration(withEventReplay()),
     provideCharts(withDefaultRegisterables()),
+    provideMarkdownRenderer(renderMarkdown),
     configureChatCanvasFeatures(
       usingA2aService(A2aServiceImpl),
       usingA2uiRenderers(DEMO_CATALOG),

--- a/samples/client/angular/projects/rizzcharts/src/app/app.config.ts
+++ b/samples/client/angular/projects/rizzcharts/src/app/app.config.ts
@@ -34,6 +34,8 @@ import { theme } from './theme';
 
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 import { routes } from './app.routes';
+import { provideMarkdownRenderer } from '@a2ui/angular';
+import { renderMarkdown } from '@a2ui/markdown-it';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -42,6 +44,7 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     provideClientHydration(withEventReplay()),
     provideCharts(withDefaultRegisterables()),
+    provideMarkdownRenderer(renderMarkdown),
     configureChatCanvasFeatures(
       usingA2aService(A2aService),
       usingA2uiRenderers(RIZZ_CHARTS_CATALOG, theme),


### PR DESCRIPTION
It integrates @a2ui/markdown-it as the markdown renderer for all samples.

This resolves issues where markdown sytax (sch as `##` and `####` header) was displayed as plain text and ensures that links and button labels are correctly rendered as shown in the updated UI.

<img width="375" height="313" alt="image" src="https://github.com/user-attachments/assets/9bc297fd-662a-483c-9d84-469f2c62138d" /> 


<img width="360" height="313" alt="image" src="https://github.com/user-attachments/assets/b9d249de-5c2c-44dc-9c2d-1071d0b4755b" />


## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
