### PR TITLE
refactor: Remove placeholder loading text and caption usage hint from streaming components.

### DIFF
--- a/agent_sdks/python/src/a2ui/core/parser/streaming.py
+++ b/agent_sdks/python/src/a2ui/core/parser/streaming.py
@@ -48,6 +48,13 @@ CUTTABLE_KEYS = {
     "text",
 }
 
+# A safe placeholder used when referencing a child component that hasn't yet streamed in.
+PLACEHOLDER_COMPONENT = {
+    "Row": {
+        "children": {"explicitList": []},
+    }
+}
+
 
 class A2uiStreamParser:
   """Parses a stream of text for A2UI JSON messages with fine-grained component yielding."""
@@ -1230,12 +1237,7 @@ class A2uiStreamParser:
                   valid_children.append(placeholder_id)
                   placeholder_comp = {
                       "id": placeholder_id,
-                      "component": {
-                          "Text": {
-                              "text": {"literalString": f"Loading {child_id}..."},
-                              "usageHint": "caption",
-                          }
-                      },
+                      "component": PLACEHOLDER_COMPONENT,
                   }
                   # Avoid duplicates in extra_components
                   if not any(ec["id"] == placeholder_id for ec in extra_components):
@@ -1253,12 +1255,7 @@ class A2uiStreamParser:
                     valid_children.append(placeholder_id)
                     placeholder_comp = {
                         "id": placeholder_id,
-                        "component": {
-                            "Text": {
-                                "text": {"literalString": "Loading children..."},
-                                "usageHint": "caption",
-                            }
-                        },
+                        "component": PLACEHOLDER_COMPONENT,
                     }
                     if not any(ec["id"] == placeholder_id for ec in extra_components):
                       extra_components.append(placeholder_comp)
@@ -1270,12 +1267,7 @@ class A2uiStreamParser:
                 obj[field] = placeholder_id
                 placeholder_comp = {
                     "id": placeholder_id,
-                    "component": {
-                        "Text": {
-                            "text": {"literalString": f"Loading {child_id}..."},
-                            "usageHint": "caption",
-                        }
-                    },
+                    "component": PLACEHOLDER_COMPONENT,
                 }
                 if not any(ec["id"] == placeholder_id for ec in extra_components):
                   extra_components.append(placeholder_comp)

--- a/agent_sdks/python/tests/core/parser/test_streaming_v08.py
+++ b/agent_sdks/python/tests/core/parser/test_streaming_v08.py
@@ -30,7 +30,7 @@ from a2ui.core.parser.constants import (
     MSG_TYPE_DATA_MODEL_UPDATE,
 )
 from a2ui.core.schema.catalog import A2uiCatalog
-from a2ui.core.parser.streaming import A2uiStreamParser
+from a2ui.core.parser.streaming import A2uiStreamParser, PLACEHOLDER_COMPONENT
 from a2ui.core.parser.response_part import ResponsePart
 
 
@@ -145,6 +145,22 @@ def mock_catalog():
           "Text": {"type": "object", "additionalProperties": True},
           "Loading": {"type": "object", "additionalProperties": True},
           "List": {"type": "object", "additionalProperties": True},
+          "Row": {
+              "type": "object",
+              "properties": {
+                  "children": {
+                      "type": "object",
+                      "properties": {
+                          "explicitList": {
+                              "type": "array",
+                              "items": {"type": "string"},
+                          },
+                          "required": ["componentId", "dataBinding"],
+                      },
+                  }
+              },
+              "required": ["children"],
+          },
           "Column": {
               "type": "object",
               "properties": {
@@ -319,12 +335,7 @@ def test_incremental_yielding_v08(mock_catalog):
               },
               {
                   "id": "loading_children_root-column",
-                  "component": {
-                      "Text": {
-                          "text": {"literalString": "Loading children..."},
-                          "usageHint": "caption",
-                      }
-                  },
+                  "component": PLACEHOLDER_COMPONENT,
               },
           ],
       }
@@ -345,12 +356,7 @@ def test_incremental_yielding_v08(mock_catalog):
               },
               {
                   "id": "loading_c1",
-                  "component": {
-                      "Text": {
-                          "text": {"literalString": "Loading c1..."},
-                          "usageHint": "caption",
-                      }
-                  },
+                  "component": PLACEHOLDER_COMPONENT,
               },
           ],
       }
@@ -373,21 +379,11 @@ def test_incremental_yielding_v08(mock_catalog):
               },
               {
                   "id": "loading_c1",
-                  "component": {
-                      "Text": {
-                          "text": {"literalString": "Loading c1..."},
-                          "usageHint": "caption",
-                      }
-                  },
+                  "component": PLACEHOLDER_COMPONENT,
               },
               {
                   "id": "loading_c2",
-                  "component": {
-                      "Text": {
-                          "text": {"literalString": "Loading c2..."},
-                          "usageHint": "caption",
-                      }
-                  },
+                  "component": PLACEHOLDER_COMPONENT,
               },
           ],
       }
@@ -426,12 +422,7 @@ def test_incremental_yielding_v08(mock_catalog):
               },
               {
                   "id": "loading_c2",
-                  "component": {
-                      "Text": {
-                          "text": {"literalString": "Loading c2..."},
-                          "usageHint": "caption",
-                      }
-                  },
+                  "component": PLACEHOLDER_COMPONENT,
               },
           ],
       }
@@ -811,12 +802,7 @@ def test_partial_single_child_string(mock_catalog):
                   },
                   {
                       "id": "loading_c1",
-                      "component": {
-                          "Text": {
-                              "text": {"literalString": "Loading c1..."},
-                              "usageHint": "caption",
-                          }
-                      },
+                      "component": PLACEHOLDER_COMPONENT,
                   },
               ],
           }
@@ -884,12 +870,7 @@ def test_partial_template_componentId(mock_catalog):
                   },
                   {
                       "id": "loading_c1",
-                      "component": {
-                          "Text": {
-                              "text": {"literalString": "Loading c1..."},
-                              "usageHint": "caption",
-                          }
-                      },
+                      "component": PLACEHOLDER_COMPONENT,
                   },
               ],
           }
@@ -957,30 +938,15 @@ def test_partial_children_lists(mock_catalog):
                   },
                   {
                       "id": "loading_c1",
-                      "component": {
-                          "Text": {
-                              "text": {"literalString": "Loading c1..."},
-                              "usageHint": "caption",
-                          }
-                      },
+                      "component": PLACEHOLDER_COMPONENT,
                   },
                   {
                       "id": "loading_c2",
-                      "component": {
-                          "Text": {
-                              "text": {"literalString": "Loading c2..."},
-                              "usageHint": "caption",
-                          }
-                      },
+                      "component": PLACEHOLDER_COMPONENT,
                   },
                   {
                       "id": "loading_c3",
-                      "component": {
-                          "Text": {
-                              "text": {"literalString": "Loading c3..."},
-                              "usageHint": "caption",
-                          }
-                      },
+                      "component": PLACEHOLDER_COMPONENT,
                   },
               ],
           }
@@ -1013,21 +979,11 @@ def test_partial_children_lists(mock_catalog):
                   },
                   {
                       "id": "loading_c2",
-                      "component": {
-                          "Text": {
-                              "text": {"literalString": "Loading c2..."},
-                              "usageHint": "caption",
-                          }
-                      },
+                      "component": PLACEHOLDER_COMPONENT,
                   },
                   {
                       "id": "loading_c3",
-                      "component": {
-                          "Text": {
-                              "text": {"literalString": "Loading c3..."},
-                              "usageHint": "caption",
-                          }
-                      },
+                      "component": PLACEHOLDER_COMPONENT,
                   },
               ],
           }
@@ -2073,12 +2029,7 @@ def test_sniff_partial_component_discards_empty_children_dict(mock_catalog):
                       "id": "root-column",
                   },
                   {
-                      "component": {
-                          "Text": {
-                              "text": {"literalString": "Loading item-list..."},
-                              "usageHint": "caption",
-                          }
-                      },
+                      "component": PLACEHOLDER_COMPONENT,
                       "id": "loading_item-list",
                   },
               ],


### PR DESCRIPTION
# Description

# Before
- [contact lookup streaming demo.webm](https://github.com/user-attachments/assets/61ec8c0f-b121-4330-9ec0-ed380bdfbc64)

- [restaurant finder sample streaming demo.webm](https://github.com/user-attachments/assets/5deedfb9-d570-46db-a620-6bb196e0f215)



# After
- [streaming demo contact lookup.webm](https://github.com/user-attachments/assets/926a038a-9a3d-4624-84f9-ee7be0656ed2)

- [streaming demo restaurant finder.webm](https://github.com/user-attachments/assets/0d1b948e-2005-443c-8de9-f535bcc5275d)






## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
