### PR TITLE
agent-sdk: raise error on example validation failure

### DIFF
--- a/agent_sdks/python/src/a2ui/core/schema/catalog.py
+++ b/agent_sdks/python/src/a2ui/core/schema/catalog.py
@@ -162,25 +162,23 @@ class A2uiCatalog:
       if filename.endswith(".json"):
         full_path = os.path.join(path, filename)
         basename = os.path.splitext(filename)[0]
-        try:
-          with open(full_path, "r", encoding="utf-8") as f:
-            content = f.read()
-            if validate and not self._validate_example(full_path, basename, content):
-              continue
-            merged_examples.append(
-                f"---BEGIN {basename}---\n{content}\n---END {basename}---"
-            )
-        except Exception as e:
-          logging.warning(f"Failed to load example {full_path}: {e}")
+        with open(full_path, "r", encoding="utf-8") as f:
+          content = f.read()
+
+        if validate:
+          self._validate_example(full_path, basename, content)
+
+        merged_examples.append(
+            f"---BEGIN {basename}---\n{content}\n---END {basename}---"
+        )
+
     if not merged_examples:
       return ""
     return "\n\n".join(merged_examples)
 
-  def _validate_example(self, full_path: str, basename: str, content: str) -> bool:
+  def _validate_example(self, full_path: str, basename: str, content: str) -> None:
     try:
       json_data = json.loads(content)
       self.validator.validate(json_data)
     except Exception as e:
-      logging.warning(f"Failed to validate example {full_path}: {e}")
-      return False
-    return True
+      raise ValueError(f"Failed to validate example {full_path}: {e}") from e

--- a/agent_sdks/python/tests/core/schema/test_catalog.py
+++ b/agent_sdks/python/tests/core/schema/test_catalog.py
@@ -74,6 +74,47 @@ def test_load_examples(tmp_path):
   assert "ignored" not in examples_str
 
 
+def test_load_examples_validation_fails_on_bad_json(tmp_path):
+  example_dir = tmp_path / "examples"
+  example_dir.mkdir()
+  (example_dir / "bad.json").write_text("{ this is bad json }")
+
+  catalog = A2uiCatalog(
+      version=VERSION_0_8,
+      name=BASIC_CATALOG_NAME,
+      s2c_schema={},
+      common_types_schema={},
+      catalog_schema={"catalogId": "basic"},
+  )
+
+  with pytest.raises(ValueError, match="Failed to validate example.*bad.json"):
+    catalog.load_examples(str(example_dir), validate=True)
+
+
+def test_load_examples_validation_fails_on_schema_error(tmp_path):
+  example_dir = tmp_path / "examples"
+  example_dir.mkdir()
+  (example_dir / "invalid.json").write_text('{"myKey": "stringValue"}')
+
+  # A schema that expects myKey to be an integer
+  schema = {
+      "type": "object",
+      "properties": {"myKey": {"type": "integer"}},
+      "required": ["myKey"],
+  }
+
+  catalog = A2uiCatalog(
+      version=VERSION_0_8,
+      name=BASIC_CATALOG_NAME,
+      s2c_schema=schema,
+      common_types_schema={},
+      catalog_schema={"catalogId": "basic"},
+  )
+
+  with pytest.raises(ValueError, match="Failed to validate example.*invalid.json"):
+    catalog.load_examples(str(example_dir), validate=True)
+
+
 def test_load_examples_none_or_invalid_path():
   catalog = A2uiCatalog(
       version=VERSION_0_8,


### PR DESCRIPTION
When the schema manager loads the schema with examples, it should validate the A2UI example. For validation failures, it should fail early so that users can fix them.

# Description

_Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots._

_List which issues are fixed by this PR. For larger changes, raising an issue first helps reduce redundant work._

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
