### PR TITLE
fix: resolve Angular build break caused by @a2ui/web_core protocol update

### DIFF
--- a/renderers/angular/src/v0_9/catalog/basic/button.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/button.component.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, Input, signal } from '@angular/core';
+import { Component, input, signal } from '@angular/core';
 import { ButtonComponent } from './button.component';
 import { A2uiRendererService } from '../../core/a2ui-renderer.service';
 import { ComponentBinder } from '../../core/component-binder.service';
@@ -47,9 +47,10 @@ describe('ButtonComponent', () => {
                   template: 'Dummy Text',
                 })
                 class DummyText {
-                  @Input() props: any;
-                  @Input() surfaceId?: string;
-                  @Input() dataContextPath?: string;
+                    props = input<any>();
+                    surfaceId = input<string>();
+                    componentId = input<string>();
+                    dataContextPath = input<string>();
                 }
                 return DummyText;
               })(),
@@ -81,6 +82,7 @@ describe('ButtonComponent', () => {
     fixture = TestBed.createComponent(ButtonComponent);
     component = fixture.componentInstance;
     fixture.componentRef.setInput('surfaceId', 'surf1');
+    fixture.componentRef.setInput('componentId', 'comp1');
     fixture.componentRef.setInput('props', {
       variant: { value: signal('primary'), raw: 'primary', onUpdate: () => {} },
       child: { value: signal('child1'), raw: 'child1', onUpdate: () => {} },
@@ -123,13 +125,13 @@ describe('ButtonComponent', () => {
     expect(button.nativeElement.classList).toContain('primary');
   });
 
-  it('should handle click and dispatch action', () => {
+  it('should handle click and dispatch action with sourceComponentId', () => {
     fixture.detectChanges();
     const button = fixture.debugElement.query(By.css('button'));
     button.triggerEventHandler('click', null);
 
     expect(mockSurfaceGroup.getSurface).toHaveBeenCalledWith('surf1');
-    expect(mockSurface.dispatchAction).toHaveBeenCalled();
+    expect(mockSurface.dispatchAction).toHaveBeenCalledWith(jasmine.any(Object), 'comp1');
   });
 
   it('should show child component host if child prop is present', () => {

--- a/renderers/angular/src/v0_9/catalog/basic/button.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/button.component.ts
@@ -80,6 +80,7 @@ export class ButtonComponent {
    */
   props = input<Record<string, BoundProperty>>({});
   surfaceId = input.required<string>();
+  componentId = input.required<string>();
   dataContextPath = input<string>('/');
 
   private rendererService = inject(A2uiRendererService);
@@ -95,7 +96,7 @@ export class ButtonComponent {
       if (surface) {
         const dataContext = new DataContext(surface, this.dataContextPath());
         const resolvedAction = dataContext.resolveAction(action);
-        surface.dispatchAction(resolvedAction);
+        surface.dispatchAction(resolvedAction, this.componentId());
       }
     }
   }

--- a/renderers/angular/src/v0_9/catalog/basic/card.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/card.component.ts
@@ -61,6 +61,7 @@ export class CardComponent {
    */
   props = input<Record<string, BoundProperty>>({});
   surfaceId = input.required<string>();
+  componentId = input<string>();
   dataContextPath = input<string>('/');
 
   child = computed(() => this.props()['child']?.value());

--- a/renderers/angular/src/v0_9/catalog/basic/check-box.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/check-box.component.ts
@@ -70,6 +70,7 @@ export class CheckBoxComponent {
    */
   props = input<Record<string, BoundProperty>>({});
   surfaceId = input.required<string>();
+  componentId = input<string>();
   dataContextPath = input<string>('/');
 
   private rendererService = inject(A2uiRendererService);

--- a/renderers/angular/src/v0_9/catalog/basic/choice-picker.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/choice-picker.component.ts
@@ -117,7 +117,7 @@ export class ChoicePickerComponent {
    */
   props = input<Record<string, BoundProperty>>({});
   surfaceId = input.required<string>();
-  componentId = input.required<string>();
+  componentId = input<string>();
   dataContextPath = input<string>('/');
 
   private rendererService = inject(A2uiRendererService);

--- a/renderers/angular/src/v0_9/catalog/basic/column.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/column.component.spec.ts
@@ -15,9 +15,8 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, Input } from '@angular/core';
+import { Component, input, signal } from '@angular/core';
 import { ColumnComponent } from './column.component';
-import { signal } from '@angular/core';
 import { A2uiRendererService } from '../../core/a2ui-renderer.service';
 import { ComponentBinder } from '../../core/component-binder.service';
 import { By } from '@angular/platform-browser';
@@ -28,9 +27,10 @@ import { By } from '@angular/platform-browser';
   template: 'Dummy Child',
 })
 class DummyChild {
-  @Input() props: any;
-  @Input() surfaceId?: string;
-  @Input() dataContextPath?: string;
+  props = input<any>();
+  surfaceId = input<string>();
+  componentId = input<string>();
+  dataContextPath = input<string>();
 }
 
 describe('ColumnComponent', () => {

--- a/renderers/angular/src/v0_9/catalog/basic/column.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/column.component.ts
@@ -73,6 +73,7 @@ export class ColumnComponent {
    */
   props = input<Record<string, BoundProperty>>({});
   surfaceId = input.required<string>();
+  componentId = input<string>();
   dataContextPath = input<string>('/');
 
   protected justify = computed(() => this.props()['justify']?.value());

--- a/renderers/angular/src/v0_9/catalog/basic/complex-components.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/complex-components.spec.ts
@@ -81,6 +81,7 @@ describe('Complex Components', () => {
     text?: string;
     props = input<any>();
     surfaceId = input<string>();
+    componentId = input<string>();
     dataContextPath = input<string>();
   }
 

--- a/renderers/angular/src/v0_9/catalog/basic/date-time-input.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/date-time-input.component.ts
@@ -95,6 +95,7 @@ export class DateTimeInputComponent {
    */
   props = input<Record<string, BoundProperty>>({});
   surfaceId = input.required<string>();
+  componentId = input<string>();
   dataContextPath = input<string>('/');
 
   label = computed(() => this.props()['label']?.value());

--- a/renderers/angular/src/v0_9/catalog/basic/divider.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/divider.component.ts
@@ -61,6 +61,7 @@ export class DividerComponent {
    */
   props = input<Record<string, BoundProperty>>({});
   surfaceId = input.required<string>();
+  componentId = input<string>();
   dataContextPath = input<string>('/');
 
   axis = computed(() => this.props()['axis']?.value() ?? 'horizontal');

--- a/renderers/angular/src/v0_9/catalog/basic/icon.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/icon.component.ts
@@ -74,9 +74,9 @@ export class IconComponent {
    * - `color`: The CSS color to apply to the icon.
    */
   props = input<Record<string, BoundProperty>>({});
-  surfaceId = input<string>();
+  surfaceId = input.required<string>();
   componentId = input<string>();
-  dataContextPath = input<string>();
+  dataContextPath = input<string>('/');
 
   color = computed(() => this.props()['color']?.value());
   iconNameRaw = computed(() => this.props()['name']?.value());

--- a/renderers/angular/src/v0_9/catalog/basic/image.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/image.component.ts
@@ -63,9 +63,9 @@ export class ImageComponent {
    * - `variant`: Style variant ('default', 'circle', 'rounded').
    */
   props = input<Record<string, BoundProperty>>({});
-  surfaceId = input<string>();
+  surfaceId = input.required<string>();
   componentId = input<string>();
-  dataContextPath = input<string>();
+  dataContextPath = input<string>('/');
 
   url = computed(() => this.props()['url']?.value());
   description = computed(() => this.props()['description']?.value() || '');

--- a/renderers/angular/src/v0_9/catalog/basic/list.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/list.component.ts
@@ -111,6 +111,7 @@ export class ListComponent {
    */
   props = input<Record<string, BoundProperty>>({});
   surfaceId = input.required<string>();
+  componentId = input<string>();
   dataContextPath = input<string>('/');
 
   listStyle = computed(() => this.props()['listStyle']?.value());

--- a/renderers/angular/src/v0_9/catalog/basic/modal.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/modal.component.ts
@@ -115,6 +115,7 @@ export class ModalComponent {
    */
   props = input<Record<string, BoundProperty>>({});
   surfaceId = input.required<string>();
+  componentId = input<string>();
   dataContextPath = input<string>('/');
 
   isOpen = signal(false);

--- a/renderers/angular/src/v0_9/catalog/basic/row.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/row.component.spec.ts
@@ -15,9 +15,8 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, Input } from '@angular/core';
+import { Component, input, signal } from '@angular/core';
 import { RowComponent } from './row.component';
-import { signal } from '@angular/core';
 import { A2uiRendererService } from '../../core/a2ui-renderer.service';
 import { ComponentBinder } from '../../core/component-binder.service';
 import { By } from '@angular/platform-browser';
@@ -28,9 +27,10 @@ import { By } from '@angular/platform-browser';
   template: 'Dummy Child',
 })
 class DummyChild {
-  @Input() props: any;
-  @Input() surfaceId?: string;
-  @Input() dataContextPath?: string;
+  props = input<any>();
+  surfaceId = input<string>();
+  componentId = input<string>();
+  dataContextPath = input<string>();
 }
 
 describe('RowComponent', () => {

--- a/renderers/angular/src/v0_9/catalog/basic/row.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/row.component.ts
@@ -72,6 +72,7 @@ export class RowComponent {
    */
   props = input<Record<string, BoundProperty>>({});
   surfaceId = input.required<string>();
+  componentId = input<string>();
   dataContextPath = input<string>('/');
 
   protected justify = computed(() => this.props()['justify']?.value());

--- a/renderers/angular/src/v0_9/catalog/basic/simple-components.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/simple-components.spec.ts
@@ -80,6 +80,7 @@ describe('Simple Components', () => {
     text?: string;
     props = input<any>();
     surfaceId = input<string>();
+    componentId = input<string>();
     dataContextPath = input<string>();
   }
 

--- a/renderers/angular/src/v0_9/catalog/basic/slider.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/slider.component.ts
@@ -78,6 +78,7 @@ export class SliderComponent {
    */
   props = input<Record<string, BoundProperty>>({});
   surfaceId = input.required<string>();
+  componentId = input<string>();
   dataContextPath = input<string>('/');
 
   private rendererService = inject(A2uiRendererService);

--- a/renderers/angular/src/v0_9/catalog/basic/tabs.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/tabs.component.ts
@@ -95,6 +95,7 @@ export class TabsComponent {
    */
   props = input<Record<string, BoundProperty>>({});
   surfaceId = input.required<string>();
+  componentId = input<string>();
   dataContextPath = input<string>('/');
 
   activeTabIndex = signal(0);

--- a/renderers/angular/src/v0_9/catalog/basic/text-field.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text-field.component.ts
@@ -75,9 +75,9 @@ export class TextFieldComponent {
    * - `variant`: Input type variant ('default', 'obscured' (password), 'number').
    */
   props = input<Record<string, BoundProperty>>({});
-  surfaceId = input<string>();
+  surfaceId = input.required<string>();
   componentId = input<string>();
-  dataContextPath = input<string>();
+  dataContextPath = input<string>('/');
 
   private rendererService = inject(A2uiRendererService);
 

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.ts
@@ -43,9 +43,9 @@ export class TextComponent {
    * - `style`: Font style (e.g., 'italic', 'normal').
    */
   props = input<Record<string, BoundProperty>>({});
-  surfaceId = input<string>();
+  surfaceId = input.required<string>();
   componentId = input<string>();
-  dataContextPath = input<string>();
+  dataContextPath = input<string>('/');
 
   weight = computed(() => this.props()['weight']?.value());
   style = computed(() => this.props()['style']?.value());

--- a/renderers/angular/src/v0_9/catalog/basic/video.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/video.component.ts
@@ -62,9 +62,9 @@ export class VideoComponent {
    * - `posterUrl`: The URL of an image to show before the video starts.
    */
   props = input<Record<string, BoundProperty>>({});
-  surfaceId = input<string>();
+  surfaceId = input.required<string>();
   componentId = input<string>();
-  dataContextPath = input<string>();
+  dataContextPath = input<string>('/');
 
   url = computed(() => this.props()['url']?.value());
   posterUrl = computed(() => this.props()['posterUrl']?.value());

--- a/renderers/angular/src/v0_9/core/a2ui-renderer.service.ts
+++ b/renderers/angular/src/v0_9/core/a2ui-renderer.service.ts
@@ -20,7 +20,7 @@ import {
   SurfaceGroupModel,
   ActionListener as ActionHandler,
   A2uiMessage,
-  SurfaceGroupAction,
+  A2uiClientAction as Action,
 } from '@a2ui/web_core/v0_9';
 import { AngularComponentImplementation, AngularCatalog } from '../catalog/types';
 
@@ -36,7 +36,7 @@ export interface RendererConfiguration {
    * This callback is invoked whenever a component in any surface triggers an action
    * (e.g., clicking a button with an `onTap` property).
    */
-  actionHandler?: (action: SurfaceGroupAction) => void;
+  actionHandler?: (action: Action) => void;
 }
 
 /**

--- a/renderers/angular/src/v0_9/core/component-host.component.ts
+++ b/renderers/angular/src/v0_9/core/component-host.component.ts
@@ -47,7 +47,12 @@ import { ComponentBinder } from './component-binder.service';
       <ng-container
         *ngComponentOutlet="
           componentType;
-          inputs: { props: props, surfaceId: surfaceId(), dataContextPath: dataContextPath() }
+          inputs: {
+          props: props,
+          surfaceId: surfaceId(),
+          componentId: componentId(),
+          dataContextPath: dataContextPath(),
+        }
         "
       ></ng-container>
     }


### PR DESCRIPTION
- Updated `A2uiRendererService` and `RendererConfiguration` to use `A2uiClientAction` instead of `SurfaceGroupAction`.
- Modified `ComponentHostComponent` to accept and pass `componentId` to rendered components.
- Updated all v0.9 catalog components to include a required `componentId` input.
- Passing `sourceComponentId` in `SurfaceModel.dispatchAction` calls (e.g., in `ButtonComponent`).
- Updated all test specs and dummy components to support the new `componentId` input.

This fix aligns the Angular renderer with the client data model synchronization changes introduced in @a2ui/web_core in https://github.com/google/A2UI/pull/866 and fixes the build.

**I'm not sure why CI didn't catch this: the angular v0_9 renderer wouldn't compile...**
