### PR TITLE
docs: add korean docs

### DIFF
--- a/docs/ecosystem/community.md
+++ b/docs/ecosystem/community.md
@@ -27,6 +27,13 @@ A2UI is developed in collaboration with Google Opal, Flutter (GenUI SDK), Gemini
 
 If you have made significant contributions to A2UI, please submit your name to this list.
 
+## Translations
+
+Community-provided translations of the A2UI documentation.
+
+- 🇰🇷 [Korean (한국어) Documentation](https://a2ui-labs.github.io/docs-ko/)
+
+
 ## Code of Conduct
 
 We are committed to providing a welcoming and inclusive environment for everyone. All participants are expected to:


### PR DESCRIPTION
Add a 'Translations' subsection to docs/ecosystem/community.md to list community-provided documentation translations and include a link to the Korean (한국어) docs hosted at https://a2ui-labs.github.io/docs-ko/.

# Description

_Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots._

_List which issues are fixed by this PR. For larger changes, raising an issue first helps reduce redundant work._

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
