### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # A2UI: Agent-to-User Interface
 
+[![gitcgr](https://gitcgr.com/badge/google/A2UI.svg)](https://gitcgr.com/google/A2UI)
+
 A2UI is an open-source project, complete with a format
 optimized for representing updatable agent-generated
 UIs and an initial set of renderers, that allows agents


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/google/A2UI.svg)](https://gitcgr.com/google/A2UI)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).