### PR TITLE
Fix bullet list in catalog

### DIFF
--- a/docs/concepts/catalogs.md
+++ b/docs/concepts/catalogs.md
@@ -158,18 +158,19 @@ uv run tools/build_catalog/assemble_catalog.py [INPUTS ...] --output-name <OUTPU
 ```
 
 where:
-- `inputs`: One or more paths or URLs to A2UI component catalog JSONs.
-- `--output-name`: (Required) The desired name of the combined catalog (e.g.
+
+* `inputs`: One or more paths or URLs to A2UI component catalog JSONs.
+* `--output-name`: (Required) The desired name of the combined catalog (e.g.
   `my_merged_catalog`). The `.json` extension is appended automatically if
   omitted.
-- `--catalog-id`: Custom `catalogId` for the output. Defaults to `urn:a2ui:catalog:<base_name>`.
-- `--version`: The A2UI specification version to use for official catalog
+* `--catalog-id`: Custom `catalogId` for the output. Defaults to `urn:a2ui:catalog:<base_name>`.
+* `--version`: The A2UI specification version to use for official catalog
   fallbacks. Choices are `0.9` or `0.10`. Defaults to `0.9`.
-- `--extend-basic-catalog`: If passed, automatically includes the entirety of
+* `--extend-basic-catalog`: If passed, automatically includes the entirety of
   `basic_catalog.json` in the root output regardless of whether the input
   catalogs explicitly reference it.
-- `--out-dir`, `-o`: The directory where the assembled catalog will be saved. Defaults to `dist`.
-- `--verbose`, `-v`: If passed, enables verbose debug logging to help diagnose issues.
+* `--out-dir`, `-o`: The directory where the assembled catalog will be saved. Defaults to `dist`.
+* `--verbose`, `-v`: If passed, enables verbose debug logging to help diagnose issues.
 
 ### Composition & Imports
 


### PR DESCRIPTION
# Description

This list is broken on https://a2ui.org/concepts/catalogs/#freestanding-catalogs

I think the missing newline is the issue. Also use `*` for the bullet list since the rest of the file uses that but I don't think that affects rendering.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
