### PR TITLE
Fix example validation errors

### DIFF
--- a/samples/agent/adk/contact_lookup/examples/follow_success.json
+++ b/samples/agent/adk/contact_lookup/examples/follow_success.json
@@ -14,10 +14,8 @@
           "component": {
             "Icon": {
               "name": {
-                "literalString": "check_circle"
-              },
-              "size": 48.0,
-              "color": "#4CAF50"
+                "literalString": "check"
+              }
             }
           }
         },

--- a/samples/agent/adk/restaurant_finder/examples/confirmation.json
+++ b/samples/agent/adk/restaurant_finder/examples/confirmation.json
@@ -22,6 +22,25 @@
           }
         },
         {
+          "id": "confirmation-column",
+          "component": {
+            "Column": {
+              "children": {
+                "explicitList": [
+                  "confirm-title",
+                  "confirm-image",
+                  "divider1",
+                  "confirm-details",
+                  "divider2",
+                  "confirm-dietary",
+                  "divider3",
+                  "confirm-text"
+                ]
+              }
+            }
+          }
+        },
+        {
           "id": "confirm-title",
           "component": {
             "Text": {


### PR DESCRIPTION
The python agent SDK validates the examples before generating system prompt.
- The confirmation.json file is missing a component.
- The follow_success.json doesn't have a `check_circle` enum in the basic catalog: https://github.com/google/A2UI/blob/3ef981f7250d952b6a22084f114f1dfebcbb357b/specification/v0_8/json/standard_catalog_definition.json#L94-L143.

# Description

_Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots._

_List which issues are fixed by this PR. For larger changes, raising an issue first helps reduce redundant work._

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
