### PR TITLE
feat(react,v0.9): Add markdown support via dependency injection to Text component

### DIFF
--- a/.github/workflows/react_renderer.yml
+++ b/.github/workflows/react_renderer.yml
@@ -47,6 +47,12 @@ jobs:
           npm ci
           npm run build
 
+      - name: Build markdown-it dependency
+        working-directory: ./renderers/markdown/markdown-it
+        run: |
+          npm ci
+          npm run build
+
       - name: Install React renderer deps
         working-directory: ./renderers/react
         run: npm ci
@@ -76,6 +82,12 @@ jobs:
           npm ci
           npm run build
 
+      - name: Build markdown-it dependency
+        working-directory: ./renderers/markdown/markdown-it
+        run: |
+          npm ci
+          npm run build
+
       - name: Install React renderer deps
         working-directory: ./renderers/react
         run: npm ci
@@ -101,6 +113,12 @@ jobs:
 
       - name: Build web_core dependency
         working-directory: ./renderers/web_core
+        run: |
+          npm ci
+          npm run build
+
+      - name: Build markdown-it dependency
+        working-directory: ./renderers/markdown/markdown-it
         run: |
           npm ci
           npm run build

--- a/renderers/react/a2ui_explorer/src/App.tsx
+++ b/renderers/react/a2ui_explorer/src/App.tsx
@@ -16,8 +16,9 @@
 
 import {useState, useEffect, useSyncExternalStore, useCallback} from 'react';
 import {MessageProcessor, SurfaceModel} from '@a2ui/web_core/v0_9';
-import {minimalCatalog, basicCatalog, A2uiSurface, type ReactComponentImplementation} from '@a2ui/react/v0_9';
+import {minimalCatalog, basicCatalog, A2uiSurface, type ReactComponentImplementation, MarkdownProvider} from '@a2ui/react/v0_9';
 import {exampleFiles, getMessages} from './examples';
+import {renderMarkdown} from '@a2ui/markdown-it';
 
 const DataModelViewer = ({surface}: {surface: SurfaceModel<any>}) => {
   const subscribeHook = useCallback(
@@ -206,7 +207,9 @@ export default function App() {
                     background: '#fff',
                   }}
                 >
-                  <A2uiSurface surface={surface} />
+                  <MarkdownProvider renderer={renderMarkdown}>
+                    <A2uiSurface surface={surface} />
+                  </MarkdownProvider>
                 </div>
               </div>
             );

--- a/renderers/react/package-lock.json
+++ b/renderers/react/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@a2ui/markdown-it": "file:../markdown/markdown-it",
         "@a2ui/web_core": "file:../web_core",
         "clsx": "^2.1.0",
         "markdown-it": "^14.0.0",
@@ -72,6 +73,29 @@
         "wireit": "^0.15.0-pre.2"
       }
     },
+    "../markdown/markdown-it": {
+      "name": "@a2ui/markdown-it",
+      "version": "0.0.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dompurify": "^3.3.1",
+        "markdown-it": "^14.1.0"
+      },
+      "devDependencies": {
+        "@a2ui/web_core": "file:../../web_core",
+        "@types/dompurify": "^3.0.5",
+        "@types/jsdom": "^28.0.0",
+        "@types/markdown-it": "^14.1.2",
+        "@types/node": "^24.10.1",
+        "jsdom": "^28.1.0",
+        "prettier": "^3.4.2",
+        "typescript": "^5.8.3",
+        "wireit": "^0.15.0-pre.2"
+      },
+      "peerDependencies": {
+        "@a2ui/web_core": "file:../../web_core"
+      }
+    },
     "../web_core": {
       "name": "@a2ui/web_core",
       "version": "0.8.7",
@@ -89,6 +113,10 @@
         "typescript": "^5.8.3",
         "wireit": "^0.15.0-pre.2"
       }
+    },
+    "node_modules/@a2ui/markdown-it": {
+      "resolved": "../markdown/markdown-it",
+      "link": true
     },
     "node_modules/@a2ui/web_core": {
       "resolved": "../web_core",

--- a/renderers/react/package-lock.json
+++ b/renderers/react/package-lock.json
@@ -85,6 +85,7 @@
       "devDependencies": {
         "@types/node": "^24.11.0",
         "c8": "^11.0.0",
+        "gts": "^7.0.0",
         "typescript": "^5.8.3",
         "wireit": "^0.15.0-pre.2"
       }

--- a/renderers/react/package.json
+++ b/renderers/react/package.json
@@ -71,11 +71,12 @@
     "test:demo": "cd a2ui_explorer && vitest run src"
   },
   "dependencies": {
+    "@a2ui/markdown-it": "file:../markdown/markdown-it",
     "@a2ui/web_core": "file:../web_core",
     "clsx": "^2.1.0",
     "markdown-it": "^14.0.0",
-    "zod": "^3.23.8",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "zod": "^3.23.8"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
@@ -29,11 +29,21 @@ const MarkdownContent: React.FC<{
   const [html, setHtml] = useState<string | null>(null);
 
   useEffect(() => {
+    let isMounted = true;
     if (renderer) {
-      renderer(text).then(setHtml).catch(console.error);
+      renderer(text)
+        .then((htmlResult) => {
+          if (isMounted) {
+            setHtml(htmlResult);
+          }
+        })
+        .catch(console.error);
     } else {
       setHtml(null); // Fallback to plain text
     }
+    return () => {
+      isMounted = false;
+    };
   }, [text, renderer]);
 
   const content = html === null ? text : undefined;

--- a/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
@@ -14,10 +14,80 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 import {createReactComponent} from '../../../adapter';
 import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {getBaseLeafStyle} from '../utils';
+import {useMarkdown} from '../../../context/MarkdownContext';
+
+const MarkdownContent: React.FC<{
+  text: string;
+  variant?: string;
+  style?: React.CSSProperties;
+}> = ({text, variant, style}) => {
+  const renderer = useMarkdown();
+  const [html, setHtml] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (renderer) {
+      renderer(text).then(setHtml);
+    } else {
+      setHtml(null); // Fallback to plain text
+    }
+  }, [text, renderer]);
+
+  const content = html === null ? text : undefined;
+  const dangerouslySetInnerHTML = html !== null ? {__html: html} : undefined;
+
+  switch (variant) {
+    case 'h1':
+      return (
+        <h1 style={style} dangerouslySetInnerHTML={dangerouslySetInnerHTML}>
+          {content}
+        </h1>
+      );
+    case 'h2':
+      return (
+        <h2 style={style} dangerouslySetInnerHTML={dangerouslySetInnerHTML}>
+          {content}
+        </h2>
+      );
+    case 'h3':
+      return (
+        <h3 style={style} dangerouslySetInnerHTML={dangerouslySetInnerHTML}>
+          {content}
+        </h3>
+      );
+    case 'h4':
+      return (
+        <h4 style={style} dangerouslySetInnerHTML={dangerouslySetInnerHTML}>
+          {content}
+        </h4>
+      );
+    case 'h5':
+      return (
+        <h5 style={style} dangerouslySetInnerHTML={dangerouslySetInnerHTML}>
+          {content}
+        </h5>
+      );
+    case 'caption':
+      return (
+        <caption
+          style={{...style, color: '#666', textAlign: 'left'}}
+          dangerouslySetInnerHTML={dangerouslySetInnerHTML}
+        >
+          {content}
+        </caption>
+      );
+    case 'body':
+    default:
+      return (
+        <span style={style} dangerouslySetInnerHTML={dangerouslySetInnerHTML}>
+          {content}
+        </span>
+      );
+  }
+};
 
 export const Text = createReactComponent(TextApi, ({props}) => {
   const text = props.text ?? '';
@@ -26,21 +96,11 @@ export const Text = createReactComponent(TextApi, ({props}) => {
     display: 'inline-block',
   };
 
-  switch (props.variant) {
-    case 'h1':
-      return <h1 style={style}>{text}</h1>;
-    case 'h2':
-      return <h2 style={style}>{text}</h2>;
-    case 'h3':
-      return <h3 style={style}>{text}</h3>;
-    case 'h4':
-      return <h4 style={style}>{text}</h4>;
-    case 'h5':
-      return <h5 style={style}>{text}</h5>;
-    case 'caption':
-      return <caption style={{...style, color: '#666', textAlign: 'left'}}>{text}</caption>;
-    case 'body':
-    default:
-      return <span style={style}>{text}</span>;
-  }
+  return (
+    <MarkdownContent
+      text={text}
+      variant={props.variant}
+      style={style}
+    />
+  );
 });

--- a/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
@@ -30,7 +30,7 @@ const MarkdownContent: React.FC<{
 
   useEffect(() => {
     if (renderer) {
-      renderer(text).then(setHtml);
+      renderer(text).then(setHtml).catch(console.error);
     } else {
       setHtml(null); // Fallback to plain text
     }
@@ -96,11 +96,5 @@ export const Text = createReactComponent(TextApi, ({props}) => {
     display: 'inline-block',
   };
 
-  return (
-    <MarkdownContent
-      text={text}
-      variant={props.variant}
-      style={style}
-    />
-  );
+  return <MarkdownContent text={text} variant={props.variant} style={style} />;
 });

--- a/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
@@ -46,7 +46,7 @@ const MarkdownContent: React.FC<{
     };
   }, [text, renderer]);
 
-  const content = html === null ? text : undefined;
+  const content = renderer ? undefined : text;
   const dangerouslySetInnerHTML = html !== null ? {__html: html} : undefined;
 
   switch (variant) {

--- a/renderers/react/src/v0_9/context/MarkdownContext.tsx
+++ b/renderers/react/src/v0_9/context/MarkdownContext.tsx
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-export * from './A2uiSurface';
-export * from './adapter';
-export * from './context/MarkdownContext';
+import React, {createContext, useContext} from 'react';
+import {type MarkdownRenderer} from '@a2ui/web_core/v0_9';
 
-// Export basic catalog components directly for 3P developers
-export * from './catalog/basic';
+const MarkdownContext = createContext<MarkdownRenderer | undefined>(undefined);
 
-// Export minimal catalog under a namespace to avoid symbol conflicts
-export * as MinimalCatalog from './catalog/minimal';
-export {minimalCatalog} from './catalog/minimal';
+export const MarkdownProvider: React.FC<{
+  renderer?: MarkdownRenderer;
+  children: React.ReactNode;
+}> = ({renderer, children}) => (
+  <MarkdownContext.Provider value={renderer}>{children}</MarkdownContext.Provider>
+);
+
+export const useMarkdown = () => useContext(MarkdownContext);

--- a/renderers/react/tests/utils.tsx
+++ b/renderers/react/tests/utils.tsx
@@ -29,6 +29,10 @@ export interface RenderA2uiOptions {
   additionalComponents?: ComponentModel[];
   /** Functions to include in the catalog */
   functions?: any[];
+  /** Theme to apply to the surface */
+  theme?: any;
+  /** Optional wrapper for the component under test (e.g. providers) */
+  wrapper?: React.JSXElementConstructor<{children: React.ReactNode}>;
 }
 
 /**
@@ -45,13 +49,15 @@ export function renderA2uiComponent(
     initialData = {}, 
     additionalImpls = [], 
     additionalComponents = [],
-    functions = BASIC_FUNCTIONS
+    functions = BASIC_FUNCTIONS,
+    theme = {},
+    wrapper
   } = options;
 
   // Combine all implementations into the catalog
   const allImpls = [impl, ...additionalImpls];
   const catalog = new Catalog('test-catalog', allImpls, functions);
-  const surface = new SurfaceModel<ReactComponentImplementation>('test-surface', catalog);
+  const surface = new SurfaceModel<ReactComponentImplementation>('test-surface', catalog, theme);
   
   // Setup data model
   surface.dataModel.set('/', initialData);
@@ -91,7 +97,8 @@ export function renderA2uiComponent(
   const ComponentToRender = impl.render;
 
   const view = render(
-    <ComponentToRender context={mainContext} buildChild={buildChild} />
+    <ComponentToRender context={mainContext} buildChild={buildChild} />,
+    { wrapper }
   );
 
   return { 

--- a/renderers/react/tests/v0_9/markdown.test.tsx
+++ b/renderers/react/tests/v0_9/markdown.test.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { screen, act } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { renderA2uiComponent } from '../utils';
 import { MarkdownProvider, Text } from '../../src/v0_9';
 import { type MarkdownRenderer } from '@a2ui/web_core/v0_9';
@@ -40,15 +40,8 @@ describe('Markdown Rendering in React v0.9', () => {
       )
     });
 
-    // Initial render might show plain text or nothing while promise resolves
     // Wait for the mock renderer to be called and state to update
-    await act(async () => {
-      await Promise.resolve(); // Allow useEffect to trigger
-      await Promise.resolve(); // Allow renderer promise to resolve
-      await Promise.resolve(); // Allow setHtml to trigger re-render
-    });
-
-    expect(mockRenderer).toHaveBeenCalledWith('**Bold**');
+    await waitFor(() => expect(mockRenderer).toHaveBeenCalledWith('**Bold**'));
     
     // Check for rendered HTML. dangerouslySetInnerHTML is used.
     const element = screen.getByText('Bold');
@@ -67,14 +60,10 @@ describe('Markdown Rendering in React v0.9', () => {
       )
     });
 
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
+    await waitFor(() => {
+      const h2 = view.container.querySelector('h2');
+      expect(h2).not.toBeNull();
+      expect(h2?.innerHTML).toBe('<u>Underline</u>');
     });
-
-    const h2 = view.container.querySelector('h2');
-    expect(h2).not.toBeNull();
-    expect(h2?.innerHTML).toBe('<u>Underline</u>');
   });
 });

--- a/renderers/react/tests/v0_9/markdown.test.tsx
+++ b/renderers/react/tests/v0_9/markdown.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { screen, act } from '@testing-library/react';
+import { renderA2uiComponent } from '../utils';
+import { MarkdownProvider, Text } from '../../src/v0_9';
+import { type MarkdownRenderer } from '@a2ui/web_core/v0_9';
+
+describe('Markdown Rendering in React v0.9', () => {
+  it('renders plain text when no markdown renderer is provided', async () => {
+    renderA2uiComponent(Text, 't1', { text: '**Bold**' });
+    
+    // It should render the raw markdown string as plain text
+    expect(screen.getByText('**Bold**')).toBeDefined();
+  });
+
+  it('renders markdown when a renderer is provided via MarkdownProvider', async () => {
+    const mockRenderer: MarkdownRenderer = vi.fn().mockResolvedValue('<strong>Bold</strong>');
+
+    renderA2uiComponent(Text, 't1', { text: '**Bold**' }, {
+      wrapper: ({ children }) => (
+        <MarkdownProvider renderer={mockRenderer}>
+          {children}
+        </MarkdownProvider>
+      )
+    });
+
+    // Initial render might show plain text or nothing while promise resolves
+    // Wait for the mock renderer to be called and state to update
+    await act(async () => {
+      await Promise.resolve(); // Allow useEffect to trigger
+      await Promise.resolve(); // Allow renderer promise to resolve
+      await Promise.resolve(); // Allow setHtml to trigger re-render
+    });
+
+    expect(mockRenderer).toHaveBeenCalledWith('**Bold**');
+    
+    // Check for rendered HTML. dangerouslySetInnerHTML is used.
+    const element = screen.getByText('Bold');
+    expect(element.tagName).toBe('STRONG');
+    expect(element.parentElement?.tagName).toBe('SPAN'); // Default body variant is span
+  });
+
+  it('renders with correct semantic wrapper and injected markdown', async () => {
+    const mockRenderer: MarkdownRenderer = vi.fn().mockResolvedValue('<u>Underline</u>');
+
+    const { view } = renderA2uiComponent(Text, 't1', { text: 'text', variant: 'h2' }, {
+      wrapper: ({ children }) => (
+        <MarkdownProvider renderer={mockRenderer}>
+          {children}
+        </MarkdownProvider>
+      )
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const h2 = view.container.querySelector('h2');
+    expect(h2).not.toBeNull();
+    expect(h2?.innerHTML).toBe('<u>Underline</u>');
+  });
+});

--- a/renderers/web_core/src/v0_9/catalog/types.ts
+++ b/renderers/web_core/src/v0_9/catalog/types.ts
@@ -108,6 +108,11 @@ export type MarkdownRendererOptions = {
 
 /**
  * Renders `markdown` using `options`.
+ * 
+ * SECURITY WARNING: The resulting HTML will be injected directly into the DOM
+ * (e.g., using dangerouslySetInnerHTML). Implementations MUST ensure the 
+ * HTML is properly sanitized to prevent Cross-Site Scripting (XSS) attacks.
+ * 
  * @returns A promise that resolves to the rendered HTML as a string.
  */
 export type MarkdownRenderer = (

--- a/renderers/web_core/src/v0_9/catalog/types.ts
+++ b/renderers/web_core/src/v0_9/catalog/types.ts
@@ -95,6 +95,27 @@ export function createFunctionImplementation<
 import {FunctionInvoker} from './function_invoker.js';
 
 /**
+ * A map of tag names to a list of classnames to be applied to a tag.
+ */
+export type MarkdownRendererTagClassMap = Record<string, string[]>;
+
+/**
+ * The options for the markdown renderer passed from A2UI.
+ */
+export type MarkdownRendererOptions = {
+  tagClassMap?: MarkdownRendererTagClassMap;
+};
+
+/**
+ * Renders `markdown` using `options`.
+ * @returns A promise that resolves to the rendered HTML as a string.
+ */
+export type MarkdownRenderer = (
+  markdown: string,
+  options?: MarkdownRendererOptions,
+) => Promise<string>;
+
+/**
  * A definition of a UI component's API.
  * This interface defines the contract for a component's capabilities and properties,
  * independent of any specific rendering implementation.

--- a/renderers/web_core/src/v0_9/rendering/component-context.ts
+++ b/renderers/web_core/src/v0_9/rendering/component-context.ts
@@ -34,6 +34,8 @@ export class ComponentContext {
   readonly dataContext: DataContext;
   /** The collection of all component models for the current surface, allowing lookups by ID. */
   readonly surfaceComponents: SurfaceComponentsModel;
+  /** The theme applied to this surface. */
+  readonly theme?: any;
 
   /**
    * Creates a new component context.
@@ -53,6 +55,7 @@ export class ComponentContext {
     }
     this.componentModel = model;
     this.surfaceComponents = surface.componentsModel;
+    this.theme = surface.theme;
 
     this.dataContext = new DataContext(surface, dataModelBasePath);
     this._actionDispatcher = action =>


### PR DESCRIPTION
## Description of Changes
This PR integrates markdown rendering support into the `Text` component of the React v0.9 renderer using a dependency injection approach.

- **web_core v0.9 Updates**: Duplicated the markdown-related types (`MarkdownRenderer`, `MarkdownRendererOptions`, `MarkdownRendererTagClassMap`) from v0.8 into `web_core/v0_9/catalog/types.ts` to ensure structural compatibility without coupling the two versions. Updated `ComponentContext` to expose the `theme` property.
- **React Dependency Injection**: Created `MarkdownContext.tsx` containing `MarkdownProvider` and `useMarkdown`, allowing applications to inject a markdown renderer (like `@a2ui/markdown-it`) at the root level.
- **Text Component Refactor**: Removed complex, outdated theming logic (`clsx`, deeply nested CSS class lookup) from the `Text` component. The component now acts as a clean semantic wrapper (`h1`, `span`, etc.) that renders injected markdown via `dangerouslySetInnerHTML`.
- **Testing**: Added a dedicated test suite (`markdown.test.tsx`) to verify the `MarkdownProvider` integration and semantic wrapper behavior. Updated the `renderA2uiComponent` test utility to support `wrapper` and `theme` parameters.

## Rationale
To ensure the React v0.9 renderer supports markdown according to the A2UI protocol, we needed a way to inject a markdown renderer (like `markdown-it`) without tightly coupling the renderer package to a specific markdown library. 

Additionally, the previous `Text` component implementation contained outdated, brittle theming logic (e.g. `theme.components?.Text.all`) left over from v0.8. In v0.9, the protocol theme is much simpler, and specific styling (like markdown `tagClassMap`) should be handled at the markdown integration layer (e.g. configuring the renderer before passing it to `MarkdownProvider`). The `Text` component was simplified to just use the correct semantic HTML tag for the `variant`.

## Testing/Running Instructions
1. Navigate to `renderers/react`.
2. Run `npm install`.
3. Run the unit tests via `npm run test` or `npx vitest tests/v0_9/markdown.test.tsx`.

Fixes https://github.com/google/A2UI/issues/944