### PR TITLE
Stop yielding the accumulated final response

### DIFF
--- a/samples/agent/adk/contact_lookup/agent.py
+++ b/samples/agent/adk/contact_lookup/agent.py
@@ -42,11 +42,10 @@ from prompt_builder import get_text_prompt, ROLE_DESCRIPTION, WORKFLOW_DESCRIPTI
 from tools import get_contact_info
 from a2ui.core.schema.constants import VERSION_0_8, VERSION_0_9, A2UI_OPEN_TAG, A2UI_CLOSE_TAG
 from a2ui.core.schema.manager import A2uiSchemaManager
-from a2ui.core.parser.parser import parse_response, ResponsePart
+from a2ui.core.parser.parser import parse_response
 from a2ui.basic_catalog.provider import BasicCatalog
 from a2ui.a2a import (
     get_a2ui_agent_extension,
-    parse_response_to_parts,
     stream_response_to_parts,
 )
 
@@ -358,16 +357,13 @@ class ContactAgent:
 
       if is_valid:
         logger.info(
-            "--- ContactAgent.stream: Response is valid. Sending final response"
-            f" (Attempt {attempt}). ---"
-        )
-        final_parts = parse_response_to_parts(
-            final_response_content, fallback_text="OK."
+            "--- ContactAgent.stream: Response is valid. Task complete (Attempt"
+            f" {attempt}). ---"
         )
 
         yield {
             "is_task_complete": True,
-            "parts": final_parts,
+            "parts": [],
         }
         return  # We're done, exit the generator
 

--- a/samples/agent/adk/restaurant_finder/agent.py
+++ b/samples/agent/adk/restaurant_finder/agent.py
@@ -43,12 +43,11 @@ from prompt_builder import (
 from tools import get_restaurants
 from a2ui.core.schema.constants import VERSION_0_8, VERSION_0_9, A2UI_OPEN_TAG, A2UI_CLOSE_TAG
 from a2ui.core.schema.manager import A2uiSchemaManager
-from a2ui.core.parser.parser import parse_response, ResponsePart
+from a2ui.core.parser.parser import parse_response
 from a2ui.basic_catalog.provider import BasicCatalog
 from a2ui.core.schema.common_modifiers import remove_strict_validation
 from a2ui.a2a import (
     get_a2ui_agent_extension,
-    parse_response_to_parts,
     stream_response_to_parts,
 )
 
@@ -327,16 +326,13 @@ class RestaurantAgent:
 
       if is_valid:
         logger.info(
-            "--- RestaurantAgent.stream: Response is valid. Sending final response"
+            "--- RestaurantAgent.stream: Response is valid. Task complete"
             f" (Attempt {attempt}). ---"
-        )
-        final_parts = parse_response_to_parts(
-            final_response_content, fallback_text="OK."
         )
 
         yield {
             "is_task_complete": True,
-            "parts": final_parts,
+            "parts": [],
         }
         return  # We're done, exit the generator
 


### PR DESCRIPTION
# Description

The agent samples yield the accumulated final response after sending all streaming chunks, which is duplicate. It now cleanly yields `{"is_task_complete": True, "parts": []}`.

Need to rebase after #905 and #918 are merged.


## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
