### PR TITLE
refactor: remove redundant component re-yielding logic from streaming parser

### DIFF
--- a/agent_sdks/python/src/a2ui/core/parser/streaming.py
+++ b/agent_sdks/python/src/a2ui/core/parser/streaming.py
@@ -88,9 +88,6 @@ class A2uiStreamParser:
     # Set of unique component IDs yielded per surface
     self._yielded_ids: Dict[str, Set[str]] = {}  # surfaceId -> set of cids
     self._yielded_contents: Dict[Any, str] = {}  # (surfaceId, cid) -> hash of content
-    self._dirty_components: Set[str] = (
-        set()
-    )  # Set of component IDs that need re-yielding
     self._components_with_placeholders: Set[str] = (
         set()
     )  # cid set that were yielded as placeholders
@@ -695,9 +692,8 @@ class A2uiStreamParser:
                 delta_msg = {MSG_TYPE_DATA_MODEL_UPDATE: delta_msg_payload}
                 self._yield_messages([delta_msg], messages, strict_integrity=False)
                 self._yielded_data_model.update(contents_dict)
-                # Update internal model to trigger re-yielding of resolved placeholders
+                # Update internal model for path resolution
                 self.update_data_model(dm_obj, messages)
-                self.yield_reachable(messages, check_root=False)
 
         # v0.9: updateDataModel
         elif MSG_TYPE_UPDATE_DATA_MODEL in obj:
@@ -889,9 +885,6 @@ class A2uiStreamParser:
 
     self._data_model.update(contents)
     updated_keys = set(contents.keys())
-    for cid, paths in self._comp_paths.items():
-      if paths & updated_keys:
-        self._dirty_components.add(cid)
 
   def _handle_complete_object(
       self,
@@ -1078,9 +1071,7 @@ class A2uiStreamParser:
         return
 
       should_yield = False
-      if (available_reachable - yielded_for_surface) or (
-          available_reachable & self._dirty_components
-      ):
+      if available_reachable - yielded_for_surface:
         should_yield = True
       else:
         # Check if any yielded component's content has changed for this surface
@@ -1154,8 +1145,6 @@ class A2uiStreamParser:
           cid = comp["id"]
           self._yielded_contents[(surface_id, cid)] = json.dumps(comp, sort_keys=True)
           self._yielded_placeholders[cid] = self._get_placeholders(comp)
-          if cid in self._dirty_components:
-            self._dirty_components.remove(cid)
 
     except ValueError as e:
       if "Circular reference detected" in str(e):

--- a/agent_sdks/python/tests/core/parser/test_streaming_v08.py
+++ b/agent_sdks/python/tests/core/parser/test_streaming_v08.py
@@ -1091,19 +1091,6 @@ def test_data_model_after_components(mock_catalog):
               }],
           }
       },
-      {
-          "surfaceUpdate": {
-              "surfaceId": "s1",
-              "components": [{
-                  "id": "root",
-                  "component": {
-                      "Text": {
-                          "text": {"path": "/name"},
-                      }
-                  },
-              }],
-          }
-      },
   ]
   assertResponseContainsMessages(response_parts, expected)
 
@@ -1518,37 +1505,6 @@ def test_multiple_re_yielding_scenarios(mock_catalog):
               "contents": [{"key": "p1", "valueString": "v1"}],
           }
       },
-      {
-          "surfaceUpdate": {
-              "surfaceId": "s1",
-              "components": [
-                  {
-                      "id": "c1",
-                      "component": {
-                          "Text": {
-                              "text": {"path": "/p1"},
-                          }
-                      },
-                  },
-                  {
-                      "id": "c2",
-                      "component": {
-                          "Text": {
-                              "text": {"path": "/p2"},
-                          }
-                      },
-                  },
-                  {
-                      "id": "root",
-                      "component": {
-                          "Container": {
-                              "children": ["c1", "c2"],
-                          }
-                      },
-                  },
-              ],
-          }
-      },
   ]
   assertResponseContainsMessages(response_parts, expected)
 
@@ -1562,37 +1518,6 @@ def test_multiple_re_yielding_scenarios(mock_catalog):
           "dataModelUpdate": {
               "surfaceId": "s1",
               "contents": [{"key": "p2", "valueString": "v2"}],
-          }
-      },
-      {
-          "surfaceUpdate": {
-              "surfaceId": "s1",
-              "components": [
-                  {
-                      "id": "c1",
-                      "component": {
-                          "Text": {
-                              "text": {"path": "/p1"},
-                          }
-                      },
-                  },
-                  {
-                      "id": "c2",
-                      "component": {
-                          "Text": {
-                              "text": {"path": "/p2"},
-                          }
-                      },
-                  },
-                  {
-                      "id": "root",
-                      "component": {
-                          "Container": {
-                              "children": ["c1", "c2"],
-                          }
-                      },
-                  },
-              ],
           }
       },
   ]
@@ -1650,36 +1575,11 @@ def test_incremental_data_model_streaming(mock_catalog):
       ' "valueMap": ['
   )
   # The parser yields the data model early once it sniffs the start of it
-  # AND it triggers a re-yield of reachable components that depend on 'items'
   expected = [
       {
           "dataModelUpdate": {
               "contents": [{"key": "items", "valueMap": []}],
               "surfaceId": "default",
-          }
-      },
-      {
-          "surfaceUpdate": {
-              "surfaceId": "default",
-              "components": [
-                  {
-                      "id": "item-list",
-                      "component": {
-                          "List": {
-                              "children": {
-                                  "template": {
-                                      "componentId": "template-name",
-                                      "dataBinding": "/items",
-                                  }
-                              }
-                          }
-                      },
-                  },
-                  {
-                      "id": "template-name",
-                      "component": {"Text": {"text": {"path": "/name"}}},
-                  },
-              ],
           }
       },
   ]
@@ -1695,30 +1595,6 @@ def test_incremental_data_model_streaming(mock_catalog):
                   "key": "items",
                   "valueMap": [{"key": "name", "valueString": "Item 1"}],
               }],
-          }
-      },
-      {
-          "surfaceUpdate": {
-              "surfaceId": "default",
-              "components": [
-                  {
-                      "id": "item-list",
-                      "component": {
-                          "List": {
-                              "children": {
-                                  "template": {
-                                      "componentId": "template-name",
-                                      "dataBinding": "/items",
-                                  }
-                              }
-                          }
-                      },
-                  },
-                  {
-                      "id": "template-name",
-                      "component": {"Text": {"text": {"path": "/name"}}},
-                  },
-              ],
           }
       },
   ]
@@ -1737,30 +1613,6 @@ def test_incremental_data_model_streaming(mock_catalog):
                       {"key": "name", "valueString": "Item 2"},
                   ],
               }],
-          }
-      },
-      {
-          "surfaceUpdate": {
-              "surfaceId": "default",
-              "components": [
-                  {
-                      "id": "item-list",
-                      "component": {
-                          "List": {
-                              "children": {
-                                  "template": {
-                                      "componentId": "template-name",
-                                      "dataBinding": "/items",
-                                  }
-                              }
-                          }
-                      },
-                  },
-                  {
-                      "id": "template-name",
-                      "component": {"Text": {"text": {"path": "/name"}}},
-                  },
-              ],
           }
       },
   ]


### PR DESCRIPTION
The parser used to generate a placeholder for data that is not streamed in the dataModelUpdate message, and then update the placeholder when the data is available. It generated too much noise in the intermediate state, so the placeholder was removed, but the updated surfaceUpdate message was not removed.

This commit removes the surfaceUpdate message after a dataModelUpdate chunk to avoid duplicate.