### PR TITLE
fix: Resolve Web Core CI failures (workflow, tests, and linting)

### DIFF
--- a/.github/workflows/web_build_and_test.yml
+++ b/.github/workflows/web_build_and_test.yml
@@ -18,11 +18,11 @@ on:
   push:
     branches: [ main ]
     paths:
-      - 'renderers/web_core/**/*'
+      - 'renderers/web_core/**'
       - '.github/workflows/web_build_and_test.yml'
   pull_request:
     paths:
-      - 'renderers/web_core/**/*'
+      - 'renderers/web_core/**'
       - '.github/workflows/web_build_and_test.yml'
 
 jobs:
@@ -49,6 +49,8 @@ jobs:
         working-directory: ./renderers/web_core
         run: npm run test
   lint:
+    runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v6
 

--- a/renderers/web_core/package.json
+++ b/renderers/web_core/package.json
@@ -64,7 +64,7 @@
     "build": "wireit",
     "build:tsc": "wireit",
     "test": "wireit",
-    "test:coverage": "c8 node --test \"dist/**/*.test.js\"",
+    "test:coverage": "c8 node --test dist/src/v0_8/*/*.test.js dist/src/v0_9/*/*.test.js dist/src/v0_9/*/*/*.test.js",
     "compile": "tsc",
     "lint": "gts lint",
     "fix": "gts fix"
@@ -104,7 +104,7 @@
       "clean": "if-file-deleted"
     },
     "test": {
-      "command": "node --test dist",
+      "command": "node --test dist/src/v0_8/*/*.test.js dist/src/v0_9/*/*.test.js dist/src/v0_9/*/*/*.test.js",
       "dependencies": [
         "build"
       ]

--- a/renderers/web_core/src/v0_9/catalog/types.test.ts
+++ b/renderers/web_core/src/v0_9/catalog/types.test.ts
@@ -107,8 +107,8 @@ describe('InferredComponentApiSchemaType', () => {
       name: 'MockComp',
       schema: mockSchema,
     } satisfies ComponentApi;
-    // Appease typescript-eslint/no-unused-vars
-    type _ = typeof mockApi;
+
+    assert.ok(mockApi);
 
     // Type-level equivalence assertion using z.infer
     type ExpectedType = z.infer<typeof mockSchema>;
@@ -120,6 +120,7 @@ describe('InferredComponentApiSchemaType', () => {
     // This happens when `mockApi: ComponentApi`, but doesn't when
     // `mockApi {} satisfies ComponentApi`!
     const inferredIsAny: IsAny<InferredType> = false;
+    assert.strictEqual(inferredIsAny, false);
 
     // When types are not "any", check that they're the same by checking if they
     // extend each other.
@@ -132,5 +133,6 @@ describe('InferredComponentApiSchemaType', () => {
     // typesMatchExact only accepts "true" if `TypesAreEquivalent`
     const typesMatchExact: TypesAreEquivalent<ExpectedType, InferredType> =
       true;
+    assert.strictEqual(typesMatchExact, true);
   });
 });


### PR DESCRIPTION

# Description

This PR addresses multiple issues preventing the `web_core` tests from running successfully locally and passing in CI.

## Description of Changes
* **GitHub Actions Workflow Fix:** Added the missing `runs-on: ubuntu-latest` property to the `lint` job in `.github/workflows/web_build_and_test.yml` and standardized the `paths` glob pattern to `renderers/web_core/**`.
* **Test Command Fix:** Updated the `test` and `test:coverage` scripts in `renderers/web_core/package.json` to use explicit single-level wildcard patterns (`dist/src/v0_8/*/*.test.js dist/src/v0_9/*/*.test.js dist/src/v0_9/*/*/*.test.js`) instead of simply pointing to the `dist` directory or using quoted `**` globs. 
* **Linting Fix:** Resolved `@typescript-eslint/no-unused-vars` linting errors in `renderers/web_core/src/v0_9/catalog/types.test.ts` by asserting the unused type-level variables at runtime via `assert.strictEqual()`.

## Rationale
* The missing `runs-on` property in the `lint` job caused GitHub Actions to throw a parsing error, marking the entire `web_build_and_test.yml` workflow as invalid and preventing both tests and linting from running at all.
* Node's native test runner (`node --test`) can fail with module resolution (`MODULE_NOT_FOUND`) errors when pointed directly at a compiled directory like `dist` in a `"type": "module"` project. Node 20 environments (like the one used in GitHub Actions) do not internally expand quoted `**` globbing without shell assistance. Switching to explicit wildcard globs allows the files to be correctly resolved by the runner across local and CI environments.
* The type-level assertions in the test files triggered the linter's unused variable detection, causing the `npm run lint` CI job to fail. Adding assertions removes the violations.

## Testing/Running Instructions
1. Pull down this branch locally.
2. Navigate to the `renderers/web_core` directory: `cd renderers/web_core`
3. Run the tests: `npm run test` (should pass successfully and find all tests).
4. Run the coverage checks: `npm run test:coverage`
5. Run linting: `npm run lint` (should pass with no errors).
6. Review the Actions tab in GitHub to ensure the `Web core` workflow now successfully parses, triggers, and completes both the `build-and-test` and `lint` jobs.

## Pre-launch Checklist
- [x] I read the [Contributors Guide].
- [x] My code changes (if any) have tests.
