### PR TITLE
fix(lit): update Slider display value on user input

### DIFF
--- a/renderers/lit/src/0.8/ui/root.ts
+++ b/renderers/lit/src/0.8/ui/root.ts
@@ -30,7 +30,7 @@ import { map } from "lit/directives/map.js";
 import { effect } from "signal-utils/subtle/microtask-effect";
 import { A2uiMessageProcessor } from "@a2ui/web_core/data/model-processor";
 import { StringValue } from "@a2ui/web_core/types/primitives";
-import { AnyComponentNode, SurfaceID, Theme } from "@a2ui/web_core/types/types";
+import { AnyComponentNode, DataValue, SurfaceID, Theme } from "@a2ui/web_core/types/types";
 import { themeContext } from "./context/theme.js";
 import { structuralStyles } from "./styles.js";
 import { componentRegistry } from "./component-registry.js";
@@ -75,6 +75,19 @@ export class Root extends SignalWatcher(LitElement) {
   }
 
   #weight: string | number = 1;
+
+  protected updateBoundData(relativePath: string, value: DataValue) {
+    if (!this.processor) {
+      return;
+    }
+    this.processor.setData(
+      this.component,
+      relativePath,
+      value,
+      this.surfaceId ?? A2uiMessageProcessor.DEFAULT_SURFACE_ID
+    );
+    this.requestUpdate();
+  }
 
   static styles = [
     structuralStyles,

--- a/renderers/lit/src/0.8/ui/slider.ts
+++ b/renderers/lit/src/0.8/ui/slider.ts
@@ -19,7 +19,6 @@ import { customElement, property } from "lit/decorators.js";
 import { Root } from "./root.js";
 import { A2uiMessageProcessor } from "@a2ui/web_core/data/model-processor";
 import * as Primitives from "@a2ui/web_core/types/primitives";
-import * as Types from "@a2ui/web_core/types/types";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { structuralStyles } from "./styles.js";
@@ -62,24 +61,10 @@ export class Slider extends Root {
   ];
 
   #setBoundValue(value: string) {
-    if (!this.value || !this.processor) {
+    if (!this.value || !("path" in this.value) || !this.value.path) {
       return;
     }
-
-    if (!("path" in this.value)) {
-      return;
-    }
-
-    if (!this.value.path) {
-      return;
-    }
-
-    this.processor.setData(
-      this.component,
-      this.value.path,
-      value,
-      this.surfaceId ?? A2uiMessageProcessor.DEFAULT_SURFACE_ID
-    );
+    this.updateBoundData(this.value.path, value);
   }
 
   #renderField(value: string | number) {


### PR DESCRIPTION
# Description

The Lit v0.8 Slider component does not update its displayed value when the user drags the slider. The `<span>` showing the current numeric value remains stuck at the initial value.

**Root cause:** `#setBoundValue` calls `processor.setData()` to update the data model, but the component never re-renders because the signal change from `SignalMap.set()` is not being picked up by `SignalWatcher`. As a result, `render()` is never called again after the initial render, and `extractNumberValue()` in the `<span>` keeps showing the stale value.

**Fix:** Add a `updateBoundData()` helper method to the `Root` base class that encapsulates the `setData()` + `requestUpdate()` pattern. Refactored the Slider's `#setBoundValue` to use it. This is consistent with the existing pattern in the `MultipleChoice` component (`multiple-choice.ts:308`), which already calls `requestUpdate()` after updating the data model.

Also removed an unused `Types` import from the Slider.

Closes #597

## Notes

Other interactive components (`TextField`, `DateTimeInput`, `CheckBox`) use the same `setData()`-without-`requestUpdate()` pattern and likely have the same latent bug. It is less visible in `TextField` because the native `<input>` element displays typed characters regardless of Lit re-renders. These components can now be easily refactored to use `updateBoundData()` in follow-up PRs.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md