### PR TITLE
fix(docs): fix broken custom_functions link in v0.10 README

### DIFF
--- a/specification/v0_10/README.md
+++ b/specification/v0_10/README.md
@@ -9,6 +9,6 @@ If you have proposed changes or new features, please open an issue or submit a p
 ## Documentation
 
 - [Protocol](docs/a2ui_protocol.md)
-- [Custom Functions](docs/custom_functions.md)
+- [Custom Functions](docs/a2ui_custom_functions.md)
 - [Extension Specification](docs/a2ui_extension_specification.md)
 - [Evolution Guide](docs/evolution_guide.md)


### PR DESCRIPTION
# Description

The v0.10 README links to `docs/custom_functions.md` which doesn't exist. The actual file is `docs/a2ui_custom_functions.md`.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[Style Guide]: ../STYLE_GUIDE.md