### PR TITLE
fix(renderers): normalize DateTimeInput placeholder color

### DIFF
--- a/renderers/angular/src/v0_8/components/datetime-input.ts
+++ b/renderers/angular/src/v0_8/components/datetime-input.ts
@@ -41,6 +41,13 @@ import { Types } from '../types';
     :host {
       display: block;
     }
+    input {
+      color: #333;
+    }
+    input::-webkit-datetime-edit,
+    input::-webkit-datetime-edit-fields-wrapper {
+      color: #333;
+    }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/renderers/angular/src/v0_8/components/datetime-input.ts
+++ b/renderers/angular/src/v0_8/components/datetime-input.ts
@@ -41,9 +41,7 @@ import { Types } from '../types';
     :host {
       display: block;
     }
-    input {
-      color: #333;
-    }
+    input,
     input::-webkit-datetime-edit,
     input::-webkit-datetime-edit-fields-wrapper {
       color: #333;

--- a/renderers/angular/src/v0_9/catalog/basic/date-time-input.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/date-time-input.component.ts
@@ -78,8 +78,8 @@ import { BoundProperty } from '../../core/types';
         border: 1px solid #ccc;
         font-family: inherit;
         flex: 1;
-        color: #333;
       }
+      .a2ui-date-time-input,
       .a2ui-date-time-input::-webkit-datetime-edit,
       .a2ui-date-time-input::-webkit-datetime-edit-fields-wrapper {
         color: #333;

--- a/renderers/angular/src/v0_9/catalog/basic/date-time-input.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/date-time-input.component.ts
@@ -78,6 +78,11 @@ import { BoundProperty } from '../../core/types';
         border: 1px solid #ccc;
         font-family: inherit;
         flex: 1;
+        color: #333;
+      }
+      .a2ui-date-time-input::-webkit-datetime-edit,
+      .a2ui-date-time-input::-webkit-datetime-edit-fields-wrapper {
+        color: #333;
       }
     `,
   ],

--- a/renderers/lit/src/0.8/ui/datetime-input.ts
+++ b/renderers/lit/src/0.8/ui/datetime-input.ts
@@ -57,9 +57,9 @@ export class DateTimeInput extends Root {
         padding: 8px;
         border: 1px solid #ccc;
         width: 100%;
-        color: #333;
       }
 
+      input,
       input::-webkit-datetime-edit,
       input::-webkit-datetime-edit-fields-wrapper {
         color: #333;

--- a/renderers/lit/src/0.8/ui/datetime-input.ts
+++ b/renderers/lit/src/0.8/ui/datetime-input.ts
@@ -57,6 +57,12 @@ export class DateTimeInput extends Root {
         padding: 8px;
         border: 1px solid #ccc;
         width: 100%;
+        color: #333;
+      }
+
+      input::-webkit-datetime-edit,
+      input::-webkit-datetime-edit-fields-wrapper {
+        color: #333;
       }
     `,
   ];

--- a/renderers/lit/src/v0_9/catalogs/basic/components/DateTimeInput.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/DateTimeInput.ts
@@ -28,10 +28,7 @@ export class A2uiDateTimeInputElement extends A2uiLitElement<
   }
 
   static styles = css`
-    input {
-      color: #333;
-    }
-
+    input,
     input::-webkit-datetime-edit,
     input::-webkit-datetime-edit-fields-wrapper {
       color: #333;

--- a/renderers/lit/src/v0_9/catalogs/basic/components/DateTimeInput.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/DateTimeInput.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { html, nothing } from "lit";
+import { css, html, nothing } from "lit";
 import { customElement } from "lit/decorators.js";
 import { DateTimeInputApi } from "@a2ui/web_core/v0_9/basic_catalog";
 import { A2uiLitElement, A2uiController } from "@a2ui/lit/v0_9";
@@ -26,6 +26,17 @@ export class A2uiDateTimeInputElement extends A2uiLitElement<
   protected createController() {
     return new A2uiController(this, DateTimeInputApi);
   }
+
+  static styles = css`
+    input {
+      color: #333;
+    }
+
+    input::-webkit-datetime-edit,
+    input::-webkit-datetime-edit-fields-wrapper {
+      color: #333;
+    }
+  `;
 
   render() {
     const props = this.controller.props;

--- a/renderers/react/src/v0_8/styles/index.ts
+++ b/renderers/react/src/v0_8/styles/index.ts
@@ -292,8 +292,8 @@ export const componentSpecificStyles: string = `
   padding: 8px;
   border: 1px solid #ccc;
   width: 100%;
-  color: #333;
 }
+:where(.a2ui-surface .a2ui-datetime-input) input,
 :where(.a2ui-surface .a2ui-datetime-input) input::-webkit-datetime-edit,
 :where(.a2ui-surface .a2ui-datetime-input) input::-webkit-datetime-edit-fields-wrapper {
   color: #333;

--- a/renderers/react/src/v0_8/styles/index.ts
+++ b/renderers/react/src/v0_8/styles/index.ts
@@ -292,6 +292,11 @@ export const componentSpecificStyles: string = `
   padding: 8px;
   border: 1px solid #ccc;
   width: 100%;
+  color: #333;
+}
+:where(.a2ui-surface .a2ui-datetime-input) input::-webkit-datetime-edit,
+:where(.a2ui-surface .a2ui-datetime-input) input::-webkit-datetime-edit-fields-wrapper {
+  color: #333;
 }
 
 .a2ui-surface *,

--- a/renderers/react/src/v0_9/catalog/basic/components/DateTimeInput.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/DateTimeInput.tsx
@@ -55,6 +55,7 @@ export const DateTimeInput = createReactComponent(DateTimeInputApi, ({props}) =>
       }}
     >
       <style>{`
+        .${scopeClass},
         .${scopeClass}::-webkit-datetime-edit,
         .${scopeClass}::-webkit-datetime-edit-fields-wrapper {
           color: #333;

--- a/renderers/react/src/v0_9/catalog/basic/components/DateTimeInput.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/DateTimeInput.tsx
@@ -37,7 +37,12 @@ export const DateTimeInput = createReactComponent(DateTimeInputApi, ({props}) =>
     border: STANDARD_BORDER,
     borderRadius: STANDARD_RADIUS,
     boxSizing: 'border-box',
+    color: '#333',
   };
+
+  // CSS class scoped to this instance for pseudo-element rules that
+  // cannot be expressed as React inline styles (WebKit date/time inputs).
+  const scopeClass = `a2ui-dti-${uniqueId.replace(/:/g, '')}`;
 
   return (
     <div
@@ -49,6 +54,12 @@ export const DateTimeInput = createReactComponent(DateTimeInputApi, ({props}) =>
         margin: LEAF_MARGIN,
       }}
     >
+      <style>{`
+        .${scopeClass}::-webkit-datetime-edit,
+        .${scopeClass}::-webkit-datetime-edit-fields-wrapper {
+          color: #333;
+        }
+      `}</style>
       {props.label && (
         <label htmlFor={uniqueId} style={{fontSize: '14px', fontWeight: 'bold'}}>
           {props.label}
@@ -56,6 +67,7 @@ export const DateTimeInput = createReactComponent(DateTimeInputApi, ({props}) =>
       )}
       <input
         id={uniqueId}
+        className={scopeClass}
         type={type}
         style={style}
         value={props.value || ''}


### PR DESCRIPTION
## Description

Normalizes placeholder text color for `DateTimeInput` across all three renderers (Lit, React, Angular) and both protocol versions (v0.8, v0.9).

Adds `color: #333` on the input element and `::-webkit-datetime-edit` / `::-webkit-datetime-edit-fields-wrapper` pseudo-element selectors to ensure consistent rendering between `type="date"` and `type="time"` in Safari/WebKit.

React v0.9 uses a scoped `<style>` tag via `React.useId()` since inline styles cannot target pseudo-elements.

Fixes #792

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[Style Guide]: ../STYLE_GUIDE.md
[CHANGELOG]: ../CHANGELOG.md