### PR TITLE
fix(lit): add requestUpdate to TextField, DateTimeInput, CheckBox

### DIFF
--- a/renderers/lit/src/0.8/ui/checkbox.ts
+++ b/renderers/lit/src/0.8/ui/checkbox.ts
@@ -59,24 +59,10 @@ export class Checkbox extends Root {
   ];
 
   #setBoundValue(value: boolean) {
-    if (!this.value || !this.processor) {
+    if (!this.value || !("path" in this.value) || !this.value.path) {
       return;
     }
-
-    if (!("path" in this.value)) {
-      return;
-    }
-
-    if (!this.value.path) {
-      return;
-    }
-
-    this.processor.setData(
-      this.component,
-      this.value.path,
-      value,
-      this.surfaceId ?? A2uiMessageProcessor.DEFAULT_SURFACE_ID
-    );
+    this.updateBoundData(this.value.path, value);
   }
 
   #renderField(value: boolean | number) {

--- a/renderers/lit/src/0.8/ui/datetime-input.ts
+++ b/renderers/lit/src/0.8/ui/datetime-input.ts
@@ -62,24 +62,10 @@ export class DateTimeInput extends Root {
   ];
 
   #setBoundValue(value: string) {
-    if (!this.value || !this.processor) {
+    if (!this.value || !("path" in this.value) || !this.value.path) {
       return;
     }
-
-    if (!("path" in this.value)) {
-      return;
-    }
-
-    if (!this.value.path) {
-      return;
-    }
-
-    this.processor.setData(
-      this.component,
-      this.value.path,
-      value,
-      this.surfaceId ?? A2uiMessageProcessor.DEFAULT_SURFACE_ID
-    );
+    this.updateBoundData(this.value.path, value);
   }
 
   #renderField(value: string) {

--- a/renderers/lit/src/0.8/ui/root.ts
+++ b/renderers/lit/src/0.8/ui/root.ts
@@ -30,7 +30,7 @@ import { map } from "lit/directives/map.js";
 import { effect } from "signal-utils/subtle/microtask-effect";
 import { A2uiMessageProcessor } from "@a2ui/web_core/data/model-processor";
 import { StringValue } from "@a2ui/web_core/types/primitives";
-import { AnyComponentNode, SurfaceID, Theme } from "@a2ui/web_core/types/types";
+import { AnyComponentNode, DataValue, SurfaceID, Theme } from "@a2ui/web_core/types/types";
 import { themeContext } from "./context/theme.js";
 import { structuralStyles } from "./styles.js";
 import { componentRegistry } from "./component-registry.js";
@@ -75,6 +75,19 @@ export class Root extends SignalWatcher(LitElement) {
   }
 
   #weight: string | number = 1;
+
+  protected updateBoundData(relativePath: string, value: DataValue) {
+    if (!this.processor) {
+      return;
+    }
+    this.processor.setData(
+      this.component,
+      relativePath,
+      value,
+      this.surfaceId ?? A2uiMessageProcessor.DEFAULT_SURFACE_ID
+    );
+    this.requestUpdate();
+  }
 
   static styles = [
     structuralStyles,

--- a/renderers/lit/src/0.8/ui/slider.ts
+++ b/renderers/lit/src/0.8/ui/slider.ts
@@ -19,7 +19,6 @@ import { customElement, property } from "lit/decorators.js";
 import { Root } from "./root.js";
 import { A2uiMessageProcessor } from "@a2ui/web_core/data/model-processor";
 import * as Primitives from "@a2ui/web_core/types/primitives";
-import * as Types from "@a2ui/web_core/types/types";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { structuralStyles } from "./styles.js";
@@ -62,24 +61,10 @@ export class Slider extends Root {
   ];
 
   #setBoundValue(value: string) {
-    if (!this.value || !this.processor) {
+    if (!this.value || !("path" in this.value) || !this.value.path) {
       return;
     }
-
-    if (!("path" in this.value)) {
-      return;
-    }
-
-    if (!this.value.path) {
-      return;
-    }
-
-    this.processor.setData(
-      this.component,
-      this.value.path,
-      value,
-      this.surfaceId ?? A2uiMessageProcessor.DEFAULT_SURFACE_ID
-    );
+    this.updateBoundData(this.value.path, value);
   }
 
   #renderField(value: string | number) {

--- a/renderers/lit/src/0.8/ui/text-field.ts
+++ b/renderers/lit/src/0.8/ui/text-field.ts
@@ -17,7 +17,6 @@
 import { html, css, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { Root } from "./root.js";
-import { A2uiMessageProcessor } from "@a2ui/web_core/data/model-processor";
 import * as Primitives from "@a2ui/web_core/types/primitives";
 import * as Types from "@a2ui/web_core/types/types";
 import { Events } from "@a2ui/web_core";
@@ -76,22 +75,10 @@ export class TextField extends Root {
   ];
 
   #setBoundValue(value: string) {
-    if (!this.text || !this.processor) {
+    if (!this.text || !("path" in this.text) || !this.text.path) {
       return;
     }
-    if (!("path" in this.text)) {
-      return;
-    }
-    if (!this.text.path) {
-      return;
-    }
-
-    this.processor.setData(
-      this.component,
-      this.text.path,
-      value,
-      this.surfaceId ?? A2uiMessageProcessor.DEFAULT_SURFACE_ID
-    );
+    this.updateBoundData(this.text.path, value);
   }
 
   #renderField(value: string | number, label: string) {


### PR DESCRIPTION
# Description

Refactors `TextField`, `DateTimeInput`, and `CheckBox` (v0.8) to use the `updateBoundData()` helper introduced in #1022, ensuring these components call `requestUpdate()` after `setData()`.

Without this fix, these components update the data model but do not trigger a re-render, so other components bound to the same data path will not reflect the new value.

Fixes #1023
Depends on #1022

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md