### PR TITLE
fix hydration and validation errors in theater app

### DIFF
--- a/tools/composer/src/app/theater/page.tsx
+++ b/tools/composer/src/app/theater/page.tsx
@@ -390,7 +390,7 @@ export default function TheaterPage() {
                     <span className="text-[10px] text-muted-foreground font-mono">{selectedScenario}</span>
                   </div>
                   <div className="p-4 bg-dot-pattern">
-                    {activeMessages.length > 0 && surfaceState.components.length > 0 ? (
+                    {surfaceState.components.length > 0 ? (
                       <div className="w-full flex items-start justify-center">
                         <A2UIViewer
                           root={surfaceState.root}


### PR DESCRIPTION
- Fix hydration error on initial load by delaying rendering until the component is mounted on the client. This handles scenario initialization from URL query parameters correctly without server/client mismatch.

- Fix Zod validation error (`Array must contain at least 1 element(s)`) by ensuring `A2UIViewer` is only rendered when the aggregated components list is not empty.

# Description

_Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots._

_List which issues are fixed by this PR. For larger changes, raising an issue first helps reduce redundant work._

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../STYLE_GUIDE.md
