### PR TITLE
Add missing functionality to Angular v0.9 renderer

### DIFF
--- a/renderers/angular/a2ui_explorer/src/app/app.config.ts
+++ b/renderers/angular/a2ui_explorer/src/app/app.config.ts
@@ -15,7 +15,8 @@
  */
 
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
+import { provideMarkdownRenderer } from '../../../src/v0_9/core/markdown';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideBrowserGlobalErrorListeners()],
+  providers: [provideBrowserGlobalErrorListeners(), provideMarkdownRenderer()],
 };

--- a/renderers/angular/a2ui_explorer/src/app/card.component.ts
+++ b/renderers/angular/a2ui_explorer/src/app/card.component.ts
@@ -33,7 +33,7 @@ import { BoundProperty } from '@a2ui/angular/v0_9';
     >
       <a2ui-v09-component-host
         *ngIf="props['child']?.value()"
-        [componentId]="props['child'].value()"
+        [componentKey]="props['child'].value()"
         [surfaceId]="surfaceId"
       >
       </a2ui-v09-component-host>

--- a/renderers/angular/a2ui_explorer/src/app/demo-catalog.ts
+++ b/renderers/angular/a2ui_explorer/src/app/demo-catalog.ts
@@ -41,14 +41,6 @@ export class DemoCatalog extends BasicCatalogBase {
       component: CustomSliderComponent,
     };
 
-    const cardApi: AngularComponentImplementation = {
-      name: 'Card',
-      schema: z.object({
-        child: z.string().optional(),
-      }) as any,
-      component: CardComponent,
-    };
-
     const capitalizeImplementation: FunctionImplementation = createFunctionImplementation(
       {
         name: 'capitalize',
@@ -66,9 +58,7 @@ export class DemoCatalog extends BasicCatalogBase {
 
     super({
       id: 'https://a2ui.org/specification/v0_9/basic_catalog.json',
-      components: {
-        card: cardApi,
-      },
+      components: {},
       extraComponents: [customSliderApi],
       functions,
     });

--- a/renderers/angular/a2ui_explorer/src/app/demo-catalog.ts
+++ b/renderers/angular/a2ui_explorer/src/app/demo-catalog.ts
@@ -18,7 +18,6 @@ import { Injectable } from '@angular/core';
 import { z } from 'zod';
 import { BasicCatalogBase, BASIC_FUNCTIONS } from '@a2ui/angular/v0_9';
 import { CustomSliderComponent } from './custom-slider.component';
-import { CardComponent } from './card.component';
 import { AngularComponentImplementation } from '@a2ui/angular/v0_9';
 import { createFunctionImplementation, FunctionImplementation } from '@a2ui/web_core/v0_9';
 

--- a/renderers/angular/angular.json
+++ b/renderers/angular/angular.json
@@ -41,6 +41,7 @@
           "options": {
             "browser": "a2ui_explorer/src/main.ts",
             "tsConfig": "a2ui_explorer/tsconfig.app.json",
+            "preserveSymlinks": false,
             "assets": [
               {
                 "glob": "**/*",

--- a/renderers/angular/ng-package.json
+++ b/renderers/angular/ng-package.json
@@ -4,5 +4,5 @@
   "lib": {
     "entryFile": "src/public-api.ts"
   },
-  "allowedNonPeerDependencies": ["@a2ui/web_core", "zod"]
+  "allowedNonPeerDependencies": ["@a2ui/web_core", "zod", "@preact/signals-core"]
 }

--- a/renderers/angular/package-lock.json
+++ b/renderers/angular/package-lock.json
@@ -10,10 +10,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@a2ui/web_core": "file:../web_core",
+        "@preact/signals-core": "^1.13.0",
         "tslib": "^2.3.0",
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "@a2ui/markdown-it": "file:../markdown/markdown-it",
         "@angular/build": "^21.2.0",
         "@angular/cli": "^21.2.0",
         "@angular/compiler": "^21.2.0",
@@ -53,6 +55,30 @@
         }
       }
     },
+    "../markdown/markdown-it": {
+      "name": "@a2ui/markdown-it",
+      "version": "0.0.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dompurify": "^3.3.1",
+        "markdown-it": "^14.1.0"
+      },
+      "devDependencies": {
+        "@a2ui/web_core": "file:../../web_core",
+        "@types/dompurify": "^3.0.5",
+        "@types/jsdom": "^28.0.0",
+        "@types/markdown-it": "^14.1.2",
+        "@types/node": "^24.10.1",
+        "jsdom": "^28.1.0",
+        "prettier": "^3.4.2",
+        "typescript": "^5.8.3",
+        "wireit": "^0.15.0-pre.2"
+      },
+      "peerDependencies": {
+        "@a2ui/web_core": "file:../../web_core"
+      }
+    },
     "../web_core": {
       "name": "@a2ui/web_core",
       "version": "0.9.1",
@@ -73,6 +99,10 @@
         "typescript": "^5.9.3",
         "wireit": "^0.15.0-pre.2"
       }
+    },
+    "node_modules/@a2ui/markdown-it": {
+      "resolved": "../markdown/markdown-it",
+      "link": true
     },
     "node_modules/@a2ui/web_core": {
       "resolved": "../web_core",
@@ -3210,6 +3240,16 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.1",
+      "resolved": "https://us-npm.pkg.dev/artifact-foundry-prod/ah-3p-staging-npm/@preact/signals-core/-/signals-core-1.14.1.tgz",
+      "integrity": "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.4",

--- a/renderers/angular/package.json
+++ b/renderers/angular/package.json
@@ -24,12 +24,13 @@
     "build": "npm run generate-examples && ng build && node ../scripts/prepare-publish.mjs --source ./dist/package.json --skip-path-adjustment",
     "prepublishOnly": "node -e \"if(!process.cwd().endsWith('dist')) { console.error('Error: This package must be published from the dist/ directory. Run `npm run build` then `npm publish dist/`'); process.exit(1); }\"",
     "publish:package": "npm run build && npm publish dist/ --access public",
-    "demo": "npm run generate-examples && ng serve a2ui_explorer",
+    "demo": "npm run generate-examples && NODE_PRESERVE_SYMLINKS=1 ng serve a2ui_explorer",
     "test": "npm run generate-examples && ng test lib --browsers=ChromeHeadless",
     "test:ci": "npm run generate-examples && ng test lib --watch=false --browsers=ChromeHeadless"
   },
   "dependencies": {
     "@a2ui/web_core": "file:../web_core",
+    "@preact/signals-core": "^1.13.0",
     "tslib": "^2.3.0",
     "zod": "^3.25.76"
   },
@@ -45,6 +46,7 @@
     }
   },
   "devDependencies": {
+    "@a2ui/markdown-it": "file:../markdown/markdown-it",
     "@angular/build": "^21.2.0",
     "@angular/cli": "^21.2.0",
     "@angular/compiler": "^21.2.0",
@@ -84,5 +86,8 @@
         }
       }
     ]
+  },
+  "overrides": {
+    "@preact/signals-core": "^1.13.0"
   }
 }

--- a/renderers/angular/src/v0_8/components/row-integration.spec.ts
+++ b/renderers/angular/src/v0_8/components/row-integration.spec.ts
@@ -49,7 +49,12 @@ describe('Row Component Integration (Real Renderer)', () => {
       providers: [
         { provide: MessageProcessor, useValue: processor },
         { provide: Catalog, useValue: DEFAULT_CATALOG },
-        { provide: MarkdownRenderer, useClass: DefaultMarkdownRenderer },
+        {
+          provide: MarkdownRenderer,
+          useValue: {
+            render: (val: string) => Promise.resolve(val),
+          },
+        },
         Theme,
       ],
     }).compileComponents();

--- a/renderers/angular/src/v0_8/v0_8_integration.spec.ts
+++ b/renderers/angular/src/v0_8/v0_8_integration.spec.ts
@@ -106,7 +106,12 @@ describe('v0.8 Angular Renderer Integration', () => {
       providers: [
         { provide: MessageProcessor, useValue: processor },
         { provide: Catalog, useValue: DEFAULT_CATALOG },
-        { provide: MarkdownRenderer, useClass: DefaultMarkdownRenderer },
+        {
+          provide: MarkdownRenderer,
+          useValue: {
+            render: (val: string) => Promise.resolve(val),
+          },
+        },
         Theme,
       ],
     }).compileComponents();

--- a/renderers/angular/src/v0_9/catalog/basic/basic-catalog.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/basic-catalog.ts
@@ -134,7 +134,7 @@ export class BasicCatalogBase extends AngularCatalog {
     const components: AngularComponentImplementation[] = [
       ...Object.entries(DEFAULT_COMPONENT_IMPLEMENTATIONS).map(([key, defaultValue]) => {
         const impl = (overrides as any)[key] ?? defaultValue;
-        return { ...impl, name: key };
+        return { ...impl, name: impl.name || key };
       }),
       ...(options.extraComponents ?? []),
     ];

--- a/renderers/angular/src/v0_9/catalog/basic/button.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/button.component.spec.ts
@@ -20,7 +20,6 @@ import { ButtonComponent } from './button.component';
 import { A2uiRendererService } from '../../core/a2ui-renderer.service';
 import { ComponentBinder } from '../../core/component-binder.service';
 import { By } from '@angular/platform-browser';
-import { preactSignal } from '../../core/utils';
 
 describe('ButtonComponent', () => {
   let component: ButtonComponent;
@@ -86,7 +85,7 @@ describe('ButtonComponent', () => {
     fixture.componentRef.setInput('componentId', 'comp1');
     fixture.componentRef.setInput('props', {
       variant: { value: signal('primary'), raw: 'primary', onUpdate: () => {} },
-      child: { value: signal('child1'), raw: 'child1', onUpdate: () => {} },
+      child: { value: signal({ id: 'child1', basePath: '/' }), raw: 'child1', onUpdate: () => {} },
       action: {
         value: signal({ type: 'test-action', data: {} }),
         raw: { type: 'test-action', data: {} },

--- a/renderers/angular/src/v0_9/catalog/basic/button.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/button.component.spec.ts
@@ -20,6 +20,7 @@ import { ButtonComponent } from './button.component';
 import { A2uiRendererService } from '../../core/a2ui-renderer.service';
 import { ComponentBinder } from '../../core/component-binder.service';
 import { By } from '@angular/platform-browser';
+import { preactSignal } from '../../core/utils';
 
 describe('ButtonComponent', () => {
   let component: ButtonComponent;
@@ -47,10 +48,10 @@ describe('ButtonComponent', () => {
                   template: 'Dummy Text',
                 })
                 class DummyText {
-                    props = input<any>();
-                    surfaceId = input<string>();
-                    componentId = input<string>();
-                    dataContextPath = input<string>();
+                  props = input<any>();
+                  surfaceId = input<string>();
+                  componentId = input<string>();
+                  dataContextPath = input<string>();
                 }
                 return DummyText;
               })(),
@@ -138,7 +139,7 @@ describe('ButtonComponent', () => {
     fixture.detectChanges();
     const host = fixture.debugElement.query(By.css('a2ui-v09-component-host'));
     expect(host).toBeTruthy();
-    expect(host.componentInstance.componentId()).toBe('child1');
+    expect(host.componentInstance.componentKey()).toEqual({ id: 'child1', basePath: '/' });
   });
 
   it('should not show child component host if child prop is absent', () => {
@@ -149,5 +150,22 @@ describe('ButtonComponent', () => {
     fixture.detectChanges();
     const host = fixture.debugElement.query(By.css('a2ui-v09-component-host'));
     expect(host).toBeFalsy();
+  });
+
+  it('should be disabled when isValid is false', () => {
+    const isValidSig = signal(true);
+
+    fixture.componentRef.setInput('props', {
+      ...component.props(),
+      isValid: { value: isValidSig, raw: true, onUpdate: () => {} },
+    });
+
+    fixture.detectChanges();
+    const button = fixture.debugElement.query(By.css('button'));
+    expect(button.nativeElement.disabled).toBeFalse();
+
+    isValidSig.set(false);
+    fixture.detectChanges();
+    expect(button.nativeElement.disabled).toBeTrue();
   });
 });

--- a/renderers/angular/src/v0_9/catalog/basic/button.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/button.component.ts
@@ -43,9 +43,9 @@ import { BoundProperty } from '../../core/types';
       (click)="handleClick()"
       [disabled]="props()['isValid']?.value() === false"
     >
-      @if (normalizedChild()) {
+      @if (child()) {
         <a2ui-v09-component-host
-          [componentKey]="normalizedChild()!"
+          [componentKey]="child()!"
           [surfaceId]="surfaceId()"
         >
         </a2ui-v09-component-host>
@@ -102,14 +102,7 @@ export class ButtonComponent {
   child = computed(() => this.props()['child']?.value());
   action = computed(() => this.props()['action']?.value());
 
-  protected normalizedChild = computed(() => {
-    const child = this.child();
-    if (!child) return null;
-    if (typeof child === 'object' && child !== null && 'id' in child) {
-      return child as { id: string; basePath: string };
-    }
-    return { id: child as string, basePath: this.dataContextPath() };
-  });
+
 
   handleClick() {
     const action = this.action();

--- a/renderers/angular/src/v0_9/catalog/basic/button.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/button.component.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy, inject } from '@angular/core';
+import {
+  Component,
+  input,
+  computed,
+  ChangeDetectionStrategy,
+  inject,
+} from '@angular/core';
 import { ComponentHostComponent } from '../../core/component-host.component';
 import { DataContext } from '@a2ui/web_core/v0_9';
 import { A2uiRendererService } from '../../core/a2ui-renderer.service';
@@ -35,12 +41,12 @@ import { BoundProperty } from '../../core/types';
       [type]="variant() === 'primary' ? 'submit' : 'button'"
       [class]="'a2ui-button ' + variant()"
       (click)="handleClick()"
+      [disabled]="props()['isValid']?.value() === false"
     >
-      @if (child()) {
+      @if (normalizedChild()) {
         <a2ui-v09-component-host
-          [componentId]="child()!"
+          [componentKey]="normalizedChild()!"
           [surfaceId]="surfaceId()"
-          [dataContextPath]="dataContextPath()"
         >
         </a2ui-v09-component-host>
       }
@@ -65,6 +71,12 @@ import { BoundProperty } from '../../core/types';
         padding: 0;
         color: #007bff;
       }
+      .a2ui-button:disabled {
+        background-color: #e9ecef;
+        color: #6c757d;
+        border-color: #ced4da;
+        cursor: not-allowed;
+      }
     `,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -77,6 +89,7 @@ export class ButtonComponent {
    * - `child`: The ID of the component to render inside the button.
    * - `variant`: Button style variant ('default', 'primary', 'borderless').
    * - `action`: The A2UI action to dispatch on click.
+   * - `checks`: Optional validation rules.
    */
   props = input<Record<string, BoundProperty>>({});
   surfaceId = input.required<string>();
@@ -88,6 +101,15 @@ export class ButtonComponent {
   variant = computed(() => this.props()['variant']?.value() ?? 'default');
   child = computed(() => this.props()['child']?.value());
   action = computed(() => this.props()['action']?.value());
+
+  protected normalizedChild = computed(() => {
+    const child = this.child();
+    if (!child) return null;
+    if (typeof child === 'object' && child !== null && 'id' in child) {
+      return child as { id: string; basePath: string };
+    }
+    return { id: child as string, basePath: this.dataContextPath() };
+  });
 
   handleClick() {
     const action = this.action();

--- a/renderers/angular/src/v0_9/catalog/basic/card.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/card.component.ts
@@ -29,9 +29,9 @@ import { BoundProperty } from '../../core/types';
   imports: [ComponentHostComponent],
   template: `
     <div class="a2ui-card">
-      @if (normalizedChild()) {
+      @if (child()) {
         <a2ui-v09-component-host
-          [componentKey]="normalizedChild()!"
+          [componentKey]="child()!"
           [surfaceId]="surfaceId()"
         >
         </a2ui-v09-component-host>
@@ -65,12 +65,5 @@ export class CardComponent {
 
   child = computed(() => this.props()['child']?.value());
 
-  protected normalizedChild = computed(() => {
-    const child = this.child();
-    if (!child) return null;
-    if (typeof child === 'object' && child !== null && 'id' in child) {
-      return child as { id: string; basePath: string };
-    }
-    return { id: child as string, basePath: this.dataContextPath() };
-  });
+
 }

--- a/renderers/angular/src/v0_9/catalog/basic/card.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/card.component.ts
@@ -29,11 +29,10 @@ import { BoundProperty } from '../../core/types';
   imports: [ComponentHostComponent],
   template: `
     <div class="a2ui-card">
-      @if (child()) {
+      @if (normalizedChild()) {
         <a2ui-v09-component-host
-          [componentId]="child()!"
+          [componentKey]="normalizedChild()!"
           [surfaceId]="surfaceId()"
-          [dataContextPath]="dataContextPath()"
         >
         </a2ui-v09-component-host>
       }
@@ -65,4 +64,13 @@ export class CardComponent {
   dataContextPath = input<string>('/');
 
   child = computed(() => this.props()['child']?.value());
+
+  protected normalizedChild = computed(() => {
+    const child = this.child();
+    if (!child) return null;
+    if (typeof child === 'object' && child !== null && 'id' in child) {
+      return child as { id: string; basePath: string };
+    }
+    return { id: child as string, basePath: this.dataContextPath() };
+  });
 }

--- a/renderers/angular/src/v0_9/catalog/basic/check-box.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/check-box.component.ts
@@ -72,7 +72,6 @@ export class CheckBoxComponent {
   componentId = input<string>();
   dataContextPath = input<string>('/');
 
-
   value = computed(() => this.props()['value']?.value() === true);
   label = computed(() => this.props()['label']?.value());
 

--- a/renderers/angular/src/v0_9/catalog/basic/choice-picker.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/choice-picker.component.ts
@@ -119,7 +119,6 @@ export class ChoicePickerComponent {
   componentId = input<string>();
   dataContextPath = input<string>('/');
 
-
   displayStyle = computed(() => this.props()['displayStyle']?.value());
   choices = computed(
     () => this.props()['choices']?.value() || this.props()['options']?.value() || [],

--- a/renderers/angular/src/v0_9/catalog/basic/column.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/column.component.spec.ts
@@ -104,8 +104,8 @@ describe('ColumnComponent', () => {
     fixture.detectChanges();
     const hosts = fixture.debugElement.queryAll(By.css('a2ui-v09-component-host'));
     expect(hosts.length).toBe(2);
-    expect(hosts[0].componentInstance.componentId()).toBe('child1');
-    expect(hosts[1].componentInstance.componentId()).toBe('child2');
+    expect(hosts[0].componentInstance.componentKey()).toEqual({ id: 'child1', basePath: '/' });
+    expect(hosts[1].componentInstance.componentKey()).toEqual({ id: 'child2', basePath: '/' });
   });
 
   it('should render repeating children', () => {
@@ -124,9 +124,46 @@ describe('ColumnComponent', () => {
 
     const hosts = fixture.debugElement.queryAll(By.css('a2ui-v09-component-host'));
     expect(hosts.length).toBe(2);
-    expect(hosts[0].componentInstance.componentId()).toBe('template1');
-    expect(hosts[0].componentInstance.dataContextPath()).toBe('/items/0');
-    expect(hosts[1].componentInstance.componentId()).toBe('template1');
-    expect(hosts[1].componentInstance.dataContextPath()).toBe('/items/1');
+    expect(hosts[0].componentInstance.componentKey()).toEqual({ id: 'template1', basePath: '/items/0' });
+    expect(hosts[1].componentInstance.componentKey()).toEqual({ id: 'template1', basePath: '/items/1' });
+  });
+
+  it('should handle non-array children value', () => {
+    fixture.componentRef.setInput('props', {
+      ...component.props(),
+      children: {
+        value: signal('not-an-array'),
+        raw: 'not-an-array',
+        onUpdate: () => {},
+      },
+    });
+    fixture.detectChanges();
+    const hosts = fixture.debugElement.queryAll(By.css('a2ui-v09-component-host'));
+    expect(hosts.length).toBe(0);
+  });
+
+  it('should handle missing children property', () => {
+    fixture.componentRef.setInput('props', {
+      justify: { value: signal('start'), raw: 'start', onUpdate: () => {} },
+      align: { value: signal('stretch'), raw: 'stretch', onUpdate: () => {} },
+    });
+    fixture.detectChanges();
+    const hosts = fixture.debugElement.queryAll(By.css('a2ui-v09-component-host'));
+    expect(hosts.length).toBe(0);
+  });
+
+  it('should handle missing justify and align properties', () => {
+    fixture.componentRef.setInput('props', {
+      children: {
+        value: signal(['child1']),
+        raw: ['child1'],
+        onUpdate: () => {},
+      },
+    });
+    fixture.detectChanges();
+    const div = fixture.debugElement.query(By.css('.a2ui-column'));
+    expect(div.styles['justify-content']).toBeFalsy();
+    expect(div.styles['align-items']).toBeFalsy();
   });
 });
+

--- a/renderers/angular/src/v0_9/catalog/basic/column.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/column.component.ts
@@ -38,11 +38,10 @@ import { getNormalizedPath } from '../../core/utils';
       style="display: flex; flex-direction: column; width: 100%; gap: 4px;"
     >
       @if (!isRepeating()) {
-        @for (childId of children(); track childId) {
+        @for (child of normalizedChildren(); track child.id) {
           <a2ui-v09-component-host
-            [componentId]="childId"
+            [componentKey]="child"
             [surfaceId]="surfaceId()"
-            [dataContextPath]="dataContextPath()"
           >
           </a2ui-v09-component-host>
         }
@@ -51,9 +50,8 @@ import { getNormalizedPath } from '../../core/utils';
       @if (isRepeating()) {
         @for (item of children(); track item; let i = $index) {
           <a2ui-v09-component-host
-            [componentId]="templateId()!"
+            [componentKey]="{ id: templateId()!, basePath: getNormalizedPath(i) }"
             [surfaceId]="surfaceId()"
-            [dataContextPath]="getNormalizedPath(i)"
           >
           </a2ui-v09-component-host>
         }
@@ -90,6 +88,16 @@ export class ColumnComponent {
 
   protected templateId = computed(() => {
     return this.props()['children']?.raw?.componentId;
+  });
+
+  protected normalizedChildren = computed(() => {
+    if (this.isRepeating()) return [];
+    return this.children().map(child => {
+      if (typeof child === 'object' && child !== null && 'id' in child) {
+        return child as { id: string; basePath: string };
+      }
+      return { id: child as string, basePath: this.dataContextPath() };
+    });
   });
 
   protected getNormalizedPath(index: number) {

--- a/renderers/angular/src/v0_9/catalog/basic/complex-components.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/complex-components.spec.ts
@@ -531,8 +531,8 @@ describe('Complex Components', () => {
 
     it('should render trigger and open modal on click', () => {
       fixture.componentRef.setInput('props', {
-        trigger: createBoundProperty('trigger-btn'),
-        content: createBoundProperty('modal-content'),
+        trigger: createBoundProperty({ id: 'trigger-btn', basePath: '/' }),
+        content: createBoundProperty({ id: 'modal-content', basePath: '/' }),
       });
       fixture.detectChanges();
       const triggerHost = fixture.debugElement.query(
@@ -555,8 +555,8 @@ describe('Complex Components', () => {
 
     it('should close modal when close button clicked', () => {
       fixture.componentRef.setInput('props', {
-        trigger: createBoundProperty('trigger-btn'),
-        content: createBoundProperty('modal-content'),
+        trigger: createBoundProperty({ id: 'trigger-btn', basePath: '/' }),
+        content: createBoundProperty({ id: 'modal-content', basePath: '/' }),
       });
       fixture.detectChanges();
 
@@ -571,8 +571,8 @@ describe('Complex Components', () => {
 
     it('should close modal when overlay clicked', () => {
       fixture.componentRef.setInput('props', {
-        trigger: createBoundProperty('trigger-btn'),
-        content: createBoundProperty('modal-content'),
+        trigger: createBoundProperty({ id: 'trigger-btn', basePath: '/' }),
+        content: createBoundProperty({ id: 'modal-content', basePath: '/' }),
       });
       fixture.detectChanges();
 

--- a/renderers/angular/src/v0_9/catalog/basic/complex-components.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/complex-components.spec.ts
@@ -337,7 +337,24 @@ describe('Complex Components', () => {
       timeInput.dispatchEvent(new Event('change'));
       expect(onUpdateSpy).toHaveBeenCalled();
     });
+
+    it('should handle empty value by returning empty strings', () => {
+      fixture.componentRef.setInput('props', {
+        value: createBoundProperty(''),
+        enableDate: createBoundProperty(true),
+        enableTime: createBoundProperty(true),
+      });
+      fixture.detectChanges();
+      
+      const dateInput = fixture.nativeElement.querySelector('input[type="date"]');
+      const timeInput = fixture.nativeElement.querySelector('input[type="time"]');
+      
+      expect(dateInput.value).toBe('');
+      expect(timeInput.value).toBe('');
+    });
   });
+
+
 
   describe('ListComponent', () => {
     let component: ListComponent;
@@ -463,12 +480,12 @@ describe('Complex Components', () => {
       expect(tabs[0].textContent).toContain('Tab 1');
 
       let host = fixture.debugElement.query(By.css('a2ui-v09-component-host'));
-      expect(host.componentInstance.componentId()).toBe('content-1');
+      expect(host.componentInstance.componentKey()).toEqual({ id: 'content-1', basePath: '/' });
 
       tabs[1].click();
       fixture.detectChanges();
       host = fixture.debugElement.query(By.css('a2ui-v09-component-host'));
-      expect(host.componentInstance.componentId()).toBe('content-2');
+      expect(host.componentInstance.componentKey()).toEqual({ id: 'content-2', basePath: '/' });
     });
 
     it('should handle missing tabs property', () => {
@@ -521,7 +538,7 @@ describe('Complex Components', () => {
       const triggerHost = fixture.debugElement.query(
         By.css('.a2ui-modal-trigger a2ui-v09-component-host'),
       );
-      expect(triggerHost.componentInstance.componentId()).toBe('trigger-btn');
+      expect(triggerHost.componentInstance.componentKey()).toEqual({ id: 'trigger-btn', basePath: '/' });
 
       expect(fixture.nativeElement.querySelector('.a2ui-modal-overlay')).toBeFalsy();
 
@@ -533,7 +550,7 @@ describe('Complex Components', () => {
       const contentHost = fixture.debugElement.query(
         By.css('.a2ui-modal-overlay a2ui-v09-component-host'),
       );
-      expect(contentHost.componentInstance.componentId()).toBe('modal-content');
+      expect(contentHost.componentInstance.componentKey()).toEqual({ id: 'modal-content', basePath: '/' });
     });
 
     it('should close modal when close button clicked', () => {

--- a/renderers/angular/src/v0_9/catalog/basic/image.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/image.component.ts
@@ -48,6 +48,31 @@ import { BoundProperty } from '../../core/types';
       .a2ui-image.rounded {
         border-radius: 8px;
       }
+      .a2ui-image.icon {
+        width: 24px;
+        height: 24px;
+      }
+      .a2ui-image.avatar {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+      }
+      .a2ui-image.smallFeature {
+        width: 100px;
+        height: 100px;
+      }
+      .a2ui-image.mediumFeature {
+        max-width: 300px;
+        height: auto;
+      }
+      .a2ui-image.largeFeature {
+        width: 100%;
+        max-height: 400px;
+      }
+      .a2ui-image.header {
+        width: 100%;
+        height: 200px;
+      }
     `,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -60,7 +85,7 @@ export class ImageComponent {
    * - `url`: The absolute URL of the image.
    * - `description`: Accessibility text for the image.
    * - `fit`: Object-fit mode ('cover', 'contain', 'fill', 'none', 'scale-down').
-   * - `variant`: Style variant ('default', 'circle', 'rounded').
+   * - `variant`: Style variant ('default', 'circle', 'rounded', 'icon', 'avatar', 'smallFeature', 'mediumFeature', 'largeFeature', 'header').
    */
   props = input<Record<string, BoundProperty>>({});
   surfaceId = input.required<string>();

--- a/renderers/angular/src/v0_9/catalog/basic/list.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/list.component.ts
@@ -32,7 +32,7 @@ import { BoundProperty } from '../../core/types';
     @switch (listTag()) {
       @case ('ol') {
         <ol [class]="'a2ui-list ' + orientation()" [style.list-style-type]="styleType()">
-          @for (child of normalizedChildren(); track child.id) {
+          @for (child of children(); track child.id) {
             <li>
               <a2ui-v09-component-host
                 [componentKey]="child"
@@ -45,7 +45,7 @@ import { BoundProperty } from '../../core/types';
       }
       @case ('ul') {
         <ul [class]="'a2ui-list ' + orientation()" [style.list-style-type]="styleType()">
-          @for (child of normalizedChildren(); track child.id) {
+          @for (child of children(); track child.id) {
             <li>
               <a2ui-v09-component-host
                 [componentKey]="child"
@@ -58,7 +58,7 @@ import { BoundProperty } from '../../core/types';
       }
       @default {
         <div [class]="'a2ui-list ' + orientation()" style="list-style-type: none;">
-          @for (child of normalizedChildren(); track child.id) {
+          @for (child of children(); track child.id) {
             <div class="a2ui-list-item-none">
               <a2ui-v09-component-host
                 [componentKey]="child"
@@ -118,14 +118,7 @@ export class ListComponent {
     return Array.isArray(raw) ? raw : [];
   });
 
-  protected normalizedChildren = computed(() => {
-    return this.children().map(child => {
-      if (typeof child === 'object' && child !== null && 'id' in child) {
-        return child as { id: string; basePath: string };
-      }
-      return { id: child as string, basePath: this.dataContextPath() };
-    });
-  });
+
 
   listTag = computed(() => {
     const style = this.listStyle();

--- a/renderers/angular/src/v0_9/catalog/basic/list.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/list.component.ts
@@ -32,12 +32,11 @@ import { BoundProperty } from '../../core/types';
     @switch (listTag()) {
       @case ('ol') {
         <ol [class]="'a2ui-list ' + orientation()" [style.list-style-type]="styleType()">
-          @for (child of children(); track child) {
+          @for (child of normalizedChildren(); track child.id) {
             <li>
               <a2ui-v09-component-host
-                [componentId]="child"
+                [componentKey]="child"
                 [surfaceId]="surfaceId()"
-                [dataContextPath]="dataContextPath()"
               >
               </a2ui-v09-component-host>
             </li>
@@ -46,12 +45,11 @@ import { BoundProperty } from '../../core/types';
       }
       @case ('ul') {
         <ul [class]="'a2ui-list ' + orientation()" [style.list-style-type]="styleType()">
-          @for (child of children(); track child) {
+          @for (child of normalizedChildren(); track child.id) {
             <li>
               <a2ui-v09-component-host
-                [componentId]="child"
+                [componentKey]="child"
                 [surfaceId]="surfaceId()"
-                [dataContextPath]="dataContextPath()"
               >
               </a2ui-v09-component-host>
             </li>
@@ -60,12 +58,11 @@ import { BoundProperty } from '../../core/types';
       }
       @default {
         <div [class]="'a2ui-list ' + orientation()" style="list-style-type: none;">
-          @for (child of children(); track child) {
+          @for (child of normalizedChildren(); track child.id) {
             <div class="a2ui-list-item-none">
               <a2ui-v09-component-host
-                [componentId]="child"
+                [componentKey]="child"
                 [surfaceId]="surfaceId()"
-                [dataContextPath]="dataContextPath()"
               >
               </a2ui-v09-component-host>
             </div>
@@ -119,6 +116,15 @@ export class ListComponent {
   children = computed(() => {
     const raw = this.props()['children']?.value();
     return Array.isArray(raw) ? raw : [];
+  });
+
+  protected normalizedChildren = computed(() => {
+    return this.children().map(child => {
+      if (typeof child === 'object' && child !== null && 'id' in child) {
+        return child as { id: string; basePath: string };
+      }
+      return { id: child as string, basePath: this.dataContextPath() };
+    });
   });
 
   listTag = computed(() => {

--- a/renderers/angular/src/v0_9/catalog/basic/modal.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/modal.component.ts
@@ -30,9 +30,9 @@ import { BoundProperty } from '../../core/types';
   template: `
     <div class="a2ui-modal-wrapper">
       <div (click)="openModal()" class="a2ui-modal-trigger">
-        @if (normalizedTrigger()) {
+        @if (trigger()) {
           <a2ui-v09-component-host
-            [componentKey]="normalizedTrigger()!"
+            [componentKey]="trigger()!"
             [surfaceId]="surfaceId()"
           >
           </a2ui-v09-component-host>
@@ -43,9 +43,9 @@ import { BoundProperty } from '../../core/types';
         <div class="a2ui-modal-overlay" (click)="closeModal()">
           <div class="a2ui-modal-content" (click)="$event.stopPropagation()">
             <button class="a2ui-modal-close" (click)="closeModal()">&times;</button>
-            @if (normalizedContent()) {
+            @if (content()) {
               <a2ui-v09-component-host
-                [componentKey]="normalizedContent()!"
+                [componentKey]="content()!"
                 [surfaceId]="surfaceId()"
               >
               </a2ui-v09-component-host>
@@ -121,23 +121,7 @@ export class ModalComponent {
   trigger = computed(() => this.props()['trigger']?.value());
   content = computed(() => this.props()['content']?.value());
 
-  protected normalizedTrigger = computed(() => {
-    const trigger = this.trigger();
-    if (!trigger) return null;
-    if (typeof trigger === 'object' && trigger !== null && 'id' in trigger) {
-      return trigger as { id: string; basePath: string };
-    }
-    return { id: trigger as string, basePath: this.dataContextPath() };
-  });
 
-  protected normalizedContent = computed(() => {
-    const content = this.content();
-    if (!content) return null;
-    if (typeof content === 'object' && content !== null && 'id' in content) {
-      return content as { id: string; basePath: string };
-    }
-    return { id: content as string, basePath: this.dataContextPath() };
-  });
 
   openModal() {
     this.isOpen.set(true);

--- a/renderers/angular/src/v0_9/catalog/basic/modal.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/modal.component.ts
@@ -30,11 +30,10 @@ import { BoundProperty } from '../../core/types';
   template: `
     <div class="a2ui-modal-wrapper">
       <div (click)="openModal()" class="a2ui-modal-trigger">
-        @if (trigger()) {
+        @if (normalizedTrigger()) {
           <a2ui-v09-component-host
-            [componentId]="trigger()!"
+            [componentKey]="normalizedTrigger()!"
             [surfaceId]="surfaceId()"
-            [dataContextPath]="dataContextPath()"
           >
           </a2ui-v09-component-host>
         }
@@ -44,11 +43,10 @@ import { BoundProperty } from '../../core/types';
         <div class="a2ui-modal-overlay" (click)="closeModal()">
           <div class="a2ui-modal-content" (click)="$event.stopPropagation()">
             <button class="a2ui-modal-close" (click)="closeModal()">&times;</button>
-            @if (content()) {
+            @if (normalizedContent()) {
               <a2ui-v09-component-host
-                [componentId]="content()!"
+                [componentKey]="normalizedContent()!"
                 [surfaceId]="surfaceId()"
-                [dataContextPath]="dataContextPath()"
               >
               </a2ui-v09-component-host>
             }
@@ -122,6 +120,24 @@ export class ModalComponent {
 
   trigger = computed(() => this.props()['trigger']?.value());
   content = computed(() => this.props()['content']?.value());
+
+  protected normalizedTrigger = computed(() => {
+    const trigger = this.trigger();
+    if (!trigger) return null;
+    if (typeof trigger === 'object' && trigger !== null && 'id' in trigger) {
+      return trigger as { id: string; basePath: string };
+    }
+    return { id: trigger as string, basePath: this.dataContextPath() };
+  });
+
+  protected normalizedContent = computed(() => {
+    const content = this.content();
+    if (!content) return null;
+    if (typeof content === 'object' && content !== null && 'id' in content) {
+      return content as { id: string; basePath: string };
+    }
+    return { id: content as string, basePath: this.dataContextPath() };
+  });
 
   openModal() {
     this.isOpen.set(true);

--- a/renderers/angular/src/v0_9/catalog/basic/row.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/row.component.spec.ts
@@ -104,8 +104,8 @@ describe('RowComponent', () => {
     fixture.detectChanges();
     const hosts = fixture.debugElement.queryAll(By.css('a2ui-v09-component-host'));
     expect(hosts.length).toBe(2);
-    expect(hosts[0].componentInstance.componentId()).toBe('child1');
-    expect(hosts[1].componentInstance.componentId()).toBe('child2');
+    expect(hosts[0].componentInstance.componentKey()).toEqual({ id: 'child1', basePath: '/' });
+    expect(hosts[1].componentInstance.componentKey()).toEqual({ id: 'child2', basePath: '/' });
   });
 
   it('should render repeating children', () => {
@@ -124,9 +124,46 @@ describe('RowComponent', () => {
 
     const hosts = fixture.debugElement.queryAll(By.css('a2ui-v09-component-host'));
     expect(hosts.length).toBe(2);
-    expect(hosts[0].componentInstance.componentId()).toBe('template1');
-    expect(hosts[0].componentInstance.dataContextPath()).toBe('/items/0');
-    expect(hosts[1].componentInstance.componentId()).toBe('template1');
-    expect(hosts[1].componentInstance.dataContextPath()).toBe('/items/1');
+    expect(hosts[0].componentInstance.componentKey()).toEqual({ id: 'template1', basePath: '/items/0' });
+    expect(hosts[1].componentInstance.componentKey()).toEqual({ id: 'template1', basePath: '/items/1' });
+  });
+
+  it('should handle non-array children value', () => {
+    fixture.componentRef.setInput('props', {
+      ...component.props(),
+      children: {
+        value: signal('not-an-array'),
+        raw: 'not-an-array',
+        onUpdate: () => {},
+      },
+    });
+    fixture.detectChanges();
+    const hosts = fixture.debugElement.queryAll(By.css('a2ui-v09-component-host'));
+    expect(hosts.length).toBe(0);
+  });
+
+  it('should handle missing children property', () => {
+    fixture.componentRef.setInput('props', {
+      justify: { value: signal('center'), raw: 'center', onUpdate: () => {} },
+      align: { value: signal('baseline'), raw: 'baseline', onUpdate: () => {} },
+    });
+    fixture.detectChanges();
+    const hosts = fixture.debugElement.queryAll(By.css('a2ui-v09-component-host'));
+    expect(hosts.length).toBe(0);
+  });
+
+  it('should handle missing justify and align properties', () => {
+    fixture.componentRef.setInput('props', {
+      children: {
+        value: signal(['child1']),
+        raw: ['child1'],
+        onUpdate: () => {},
+      },
+    });
+    fixture.detectChanges();
+    const div = fixture.debugElement.query(By.css('.a2ui-row'));
+    expect(div.styles['justify-content']).toBeFalsy();
+    expect(div.styles['align-items']).toBeFalsy();
   });
 });
+

--- a/renderers/angular/src/v0_9/catalog/basic/row.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/row.component.ts
@@ -37,11 +37,10 @@ import { getNormalizedPath } from '../../core/utils';
       style="display: flex; flex-direction: row; width: 100%; gap: 4px;"
     >
       @if (!isRepeating()) {
-        @for (childId of children(); track childId) {
+        @for (child of normalizedChildren(); track child.id) {
           <a2ui-v09-component-host
-            [componentId]="childId"
+            [componentKey]="child"
             [surfaceId]="surfaceId()"
-            [dataContextPath]="dataContextPath()"
           >
           </a2ui-v09-component-host>
         }
@@ -50,9 +49,8 @@ import { getNormalizedPath } from '../../core/utils';
       @if (isRepeating()) {
         @for (item of children(); track item; let i = $index) {
           <a2ui-v09-component-host
-            [componentId]="templateId()!"
+            [componentKey]="{ id: templateId()!, basePath: getNormalizedPath(i) }"
             [surfaceId]="surfaceId()"
-            [dataContextPath]="getNormalizedPath(i)"
           >
           </a2ui-v09-component-host>
         }
@@ -89,6 +87,16 @@ export class RowComponent {
 
   protected templateId = computed(() => {
     return this.props()['children']?.raw?.componentId;
+  });
+
+  protected normalizedChildren = computed(() => {
+    if (this.isRepeating()) return [];
+    return this.children().map(child => {
+      if (typeof child === 'object' && child !== null && 'id' in child) {
+        return child as { id: string; basePath: string };
+      }
+      return { id: child as string, basePath: this.dataContextPath() };
+    });
   });
 
   protected getNormalizedPath(index: number) {

--- a/renderers/angular/src/v0_9/catalog/basic/simple-components.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/simple-components.spec.ts
@@ -374,7 +374,7 @@ describe('Simple Components', () => {
 
     it('should render component-host for child', () => {
       fixture.componentRef.setInput('props', {
-        child: createBoundProperty('child-1'),
+        child: createBoundProperty({ id: 'child-1', basePath: '/' }),
       });
       fixture.detectChanges();
       const host = fixture.debugElement.query(By.css('a2ui-v09-component-host'));

--- a/renderers/angular/src/v0_9/catalog/basic/simple-components.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/simple-components.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, signal as angularSignal, signal, input } from '@angular/core';
+import { Component, signal as angularSignal, input } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { DividerComponent } from './divider.component';
 import { ImageComponent } from './image.component';
@@ -185,7 +185,21 @@ describe('Simple Components', () => {
       const img = fixture.nativeElement.querySelector('img') as HTMLImageElement;
       expect(img.alt).toBe('A cute cat');
     });
+
+    it('should support all specified variants', () => {
+      const variants = ['icon', 'avatar', 'smallFeature', 'mediumFeature', 'largeFeature', 'header'];
+      for (const variant of variants) {
+        fixture.componentRef.setInput('props', {
+          url: createBoundProperty('https://example.com/image.png'),
+          variant: createBoundProperty(variant),
+        });
+        fixture.detectChanges();
+        const img = fixture.nativeElement.querySelector('img') as HTMLImageElement;
+        expect(img.className).toContain(variant);
+      }
+    });
   });
+
 
   describe('IconComponent', () => {
     let component: IconComponent;
@@ -365,7 +379,7 @@ describe('Simple Components', () => {
       fixture.detectChanges();
       const host = fixture.debugElement.query(By.css('a2ui-v09-component-host'));
       expect(host).toBeTruthy();
-      expect(host.componentInstance.componentId()).toBe('child-1');
+      expect(host.componentInstance.componentKey()).toEqual({ id: 'child-1', basePath: '/' });
     });
   });
 });

--- a/renderers/angular/src/v0_9/catalog/basic/slider.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/slider.component.ts
@@ -80,7 +80,6 @@ export class SliderComponent {
   componentId = input<string>();
   dataContextPath = input<string>('/');
 
-
   label = computed(() => this.props()['label']?.value());
   value = computed(() => this.props()['value']?.value());
   min = computed(() => this.props()['min']?.value() ?? 0);

--- a/renderers/angular/src/v0_9/catalog/basic/tabs.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/tabs.component.ts
@@ -41,12 +41,11 @@ import { BoundProperty } from '../../core/types';
           </button>
         }
       </div>
-      @if (activeTab()) {
+      @if (normalizedActiveTabContent()) {
         <div class="a2ui-tab-content">
           <a2ui-v09-component-host
-            [componentId]="activeTab()?.content"
+            [componentKey]="normalizedActiveTabContent()!"
             [surfaceId]="surfaceId()"
-            [dataContextPath]="dataContextPath()"
           >
           </a2ui-v09-component-host>
         </div>
@@ -102,6 +101,15 @@ export class TabsComponent {
 
   tabs = computed(() => this.props()['tabs']?.value() || []);
   activeTab = computed(() => this.tabs()[this.activeTabIndex()]);
+
+  protected normalizedActiveTabContent = computed(() => {
+    const content = this.activeTab()?.content;
+    if (!content) return null;
+    if (typeof content === 'object' && content !== null && 'id' in content) {
+      return content as { id: string; basePath: string };
+    }
+    return { id: content as string, basePath: this.dataContextPath() };
+  });
 
   setActiveTab(index: number) {
     this.activeTabIndex.set(index);

--- a/renderers/angular/src/v0_9/catalog/basic/text-field.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text-field.component.spec.ts
@@ -19,7 +19,6 @@ import { TextFieldComponent } from './text-field.component';
 import { signal } from '@angular/core';
 import { A2uiRendererService } from '../../core/a2ui-renderer.service';
 import { By } from '@angular/platform-browser';
-import { preactSignal } from '../../core/utils';
 
 describe('TextFieldComponent', () => {
   let component: TextFieldComponent;

--- a/renderers/angular/src/v0_9/catalog/basic/text-field.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text-field.component.spec.ts
@@ -19,6 +19,7 @@ import { TextFieldComponent } from './text-field.component';
 import { signal } from '@angular/core';
 import { A2uiRendererService } from '../../core/a2ui-renderer.service';
 import { By } from '@angular/platform-browser';
+import { preactSignal } from '../../core/utils';
 
 describe('TextFieldComponent', () => {
   let component: TextFieldComponent;
@@ -98,5 +99,44 @@ describe('TextFieldComponent', () => {
     input.triggerEventHandler('input', { target: input.nativeElement });
 
     expect(component.props()['value'].onUpdate).toHaveBeenCalledWith('newuser');
+  });
+
+  it('should show error messages when checks fail', async () => {
+    const isValidSig = signal(true);
+    const errorsSig = signal<string[]>([]);
+
+    fixture.componentRef.setInput('props', {
+      ...component.props(),
+      isValid: { value: isValidSig, raw: true, onUpdate: () => {} },
+      validationErrors: { value: errorsSig, raw: [], onUpdate: () => {} },
+    });
+
+    fixture.detectChanges();
+
+    const errorMsgBefore = fixture.debugElement.query(By.css('.a2ui-error-message'));
+    expect(errorMsgBefore).toBeFalsy();
+
+    isValidSig.set(false);
+    errorsSig.set(['Value is required']);
+    fixture.detectChanges();
+
+    const errorMsgAfter = fixture.debugElement.query(By.css('.a2ui-error-message'));
+    expect(errorMsgAfter).toBeTruthy();
+    expect(errorMsgAfter.nativeElement.textContent).toContain('Value is required');
+  });
+
+  it('should handle multiple error messages', () => {
+    fixture.componentRef.setInput('props', {
+      ...component.props(),
+      isValid: { value: signal(false), raw: false, onUpdate: () => {} },
+      validationErrors: { value: signal(['Error 1', 'Error 2']), raw: ['Error 1', 'Error 2'], onUpdate: () => {} },
+    });
+
+    fixture.detectChanges();
+
+    const errorMsgs = fixture.debugElement.queryAll(By.css('.a2ui-error-message'));
+    expect(errorMsgs.length).toBe(2);
+    expect(errorMsgs[0].nativeElement.textContent).toContain('Error 1');
+    expect(errorMsgs[1].nativeElement.textContent).toContain('Error 2');
   });
 });

--- a/renderers/angular/src/v0_9/catalog/basic/text-field.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text-field.component.ts
@@ -37,8 +37,11 @@ import { BoundProperty } from '../../core/types';
         [value]="value()"
         (input)="handleInput($event)"
         [placeholder]="placeholder()"
+        [class.invalid]="props()['isValid']?.value() === false"
       />
-      <!-- Validation errors would go here in a more advanced version -->
+      @for (message of props()['validationErrors']?.value(); track message) {
+        <div class="a2ui-error-message">{{ message }}</div>
+      }
     </div>
   `,
   styles: [
@@ -59,6 +62,13 @@ import { BoundProperty } from '../../core/types';
         border: 1px solid #ccc;
         border-radius: 4px;
       }
+      input.invalid {
+        border-color: red;
+      }
+      .a2ui-error-message {
+        color: red;
+        font-size: 12px;
+      }
     `,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -72,12 +82,12 @@ export class TextFieldComponent {
    * - `label`: Optional label text to display above the input.
    * - `placeholder`: Hint text shown when the input is empty.
    * - `variant`: Input type variant ('default', 'obscured' (password), 'number').
+   * - `checks`: Optional validation rules.
    */
   props = input<Record<string, BoundProperty>>({});
   surfaceId = input.required<string>();
   componentId = input<string>();
   dataContextPath = input<string>('/');
-
 
   label = computed(() => this.props()['label']?.value());
   value = computed(() => this.props()['value']?.value() || '');

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
@@ -18,40 +18,128 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TextComponent } from './text.component';
 import { By } from '@angular/platform-browser';
 import { signal } from '@angular/core';
+import { MarkdownRenderer } from '../../core/markdown';
 
 describe('TextComponent', () => {
   let component: TextComponent;
   let fixture: ComponentFixture<TextComponent>;
+  let mockMarkdownRenderer: jasmine.SpyObj<MarkdownRenderer>;
 
   beforeEach(async () => {
+    mockMarkdownRenderer = jasmine.createSpyObj('MarkdownRenderer', ['render']);
+    mockMarkdownRenderer.render.and.callFake((text: string) => Promise.resolve(`<p>${text}</p>`));
+
     await TestBed.configureTestingModule({
       imports: [TextComponent],
+      providers: [
+        { provide: MarkdownRenderer, useValue: mockMarkdownRenderer },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TextComponent);
     component = fixture.componentInstance;
-    fixture.componentRef.setInput('props', {
-      text: { value: signal('Hello World'), raw: 'Hello World', onUpdate: () => {} },
-      weight: { value: signal('bold'), raw: 'bold', onUpdate: () => {} },
-      style: { value: signal('italic'), raw: 'italic', onUpdate: () => {} },
-    });
   });
 
   it('should create', () => {
+    fixture.componentRef.setInput('props', {
+      text: { value: signal('Hello World'), raw: 'Hello World', onUpdate: () => {} },
+    });
     fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
-  it('should render the text', () => {
+  it('should render the markdown text', async () => {
+    fixture.componentRef.setInput('props', {
+      text: { value: signal('Hello World'), raw: 'Hello World', onUpdate: () => {} },
+    });
     fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
     const span = fixture.debugElement.query(By.css('span'));
-    expect(span.nativeElement.textContent.trim()).toBe('Hello World');
+    expect(span.nativeElement.innerHTML.trim()).toBe('<p>Hello World</p>');
+    expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('Hello World');
   });
 
-  it('should apply font-weight and font-style', () => {
+  it('should handle variant h1', async () => {
+    fixture.componentRef.setInput('props', {
+      text: { value: signal('Heading'), raw: 'Heading', onUpdate: () => {} },
+      variant: { value: signal('h1'), raw: 'h1', onUpdate: () => {} },
+    });
     fixture.detectChanges();
-    const span = fixture.debugElement.query(By.css('span'));
-    expect(span.styles['font-weight']).toBe('bold');
-    expect(span.styles['font-style']).toBe('italic');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('# Heading');
+  });
+
+  it('should handle variant caption', async () => {
+    fixture.componentRef.setInput('props', {
+      text: { value: signal('Caption'), raw: 'Caption', onUpdate: () => {} },
+      variant: { value: signal('caption'), raw: 'caption', onUpdate: () => {} },
+    });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('*Caption*');
+  });
+
+  it('should handle variant h2', async () => {
+    fixture.componentRef.setInput('props', {
+      text: { value: signal('Heading'), raw: 'Heading', onUpdate: () => {} },
+      variant: { value: signal('h2'), raw: 'h2', onUpdate: () => {} },
+    });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('## Heading');
+  });
+
+  it('should handle variant h3', async () => {
+    fixture.componentRef.setInput('props', {
+      text: { value: signal('Heading'), raw: 'Heading', onUpdate: () => {} },
+      variant: { value: signal('h3'), raw: 'h3', onUpdate: () => {} },
+    });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('### Heading');
+  });
+
+  it('should handle variant h4', async () => {
+    fixture.componentRef.setInput('props', {
+      text: { value: signal('Heading'), raw: 'Heading', onUpdate: () => {} },
+      variant: { value: signal('h4'), raw: 'h4', onUpdate: () => {} },
+    });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('#### Heading');
+  });
+
+  it('should handle variant h5', async () => {
+    fixture.componentRef.setInput('props', {
+      text: { value: signal('Heading'), raw: 'Heading', onUpdate: () => {} },
+      variant: { value: signal('h5'), raw: 'h5', onUpdate: () => {} },
+    });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('##### Heading');
+  });
+
+  it('should handle missing text property', async () => {
+    fixture.componentRef.setInput('props', {});
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('');
   });
 });
+

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.ts
@@ -14,21 +14,20 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, computed, ChangeDetectionStrategy, inject, signal, effect } from '@angular/core';
 import { BoundProperty } from '../../core/types';
+import { MarkdownRenderer } from '../../core/markdown';
 
 /**
  * Angular implementation of the A2UI Text component (v0.9).
  *
- * Renders a span of text with configurable font weight and style.
+ * Renders text with support for simple Markdown.
  */
 @Component({
   selector: 'a2ui-v09-text',
   standalone: true,
-  imports: [],
   template: `
-    <span [style.font-weight]="weight()" [style.font-style]="style()">
-      {{ text() }}
+    <span [class]="'a2ui-text ' + variant()" [innerHTML]="resolvedText()">
     </span>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -39,15 +38,42 @@ export class TextComponent {
    *
    * Expected properties:
    * - `text`: The string content to display.
-   * - `weight`: Font weight (e.g., 'bold', 'normal' or numeric string).
-   * - `style`: Font style (e.g., 'italic', 'normal').
+   * - `variant`: A hint for the base text style ('h1', 'h2', 'h3', 'h4', 'h5', 'caption', 'body').
    */
   props = input<Record<string, BoundProperty>>({});
   surfaceId = input.required<string>();
   componentId = input<string>();
   dataContextPath = input<string>('/');
 
-  weight = computed(() => this.props()['weight']?.value());
-  style = computed(() => this.props()['style']?.value());
-  text = computed(() => this.props()['text']?.value());
+  private markdownRenderer = inject(MarkdownRenderer);
+
+  variant = computed(() => this.props()['variant']?.value() || 'body');
+  text = computed(() => this.props()['text']?.value() || '');
+
+  resolvedText = signal<string>('');
+  private renderRequestId = 0;
+
+  constructor() {
+    effect(() => {
+      const text = this.text();
+      const variant = this.variant();
+      let value = text;
+
+      switch (variant) {
+        case 'h1': value = `# ${text}`; break;
+        case 'h2': value = `## ${text}`; break;
+        case 'h3': value = `### ${text}`; break;
+        case 'h4': value = `#### ${text}`; break;
+        case 'h5': value = `##### ${text}`; break;
+        case 'caption': value = `*${text}*`; break;
+      }
+
+      const requestId = ++this.renderRequestId;
+      this.markdownRenderer.render(value).then(rendered => {
+        if (requestId === this.renderRequestId) {
+          this.resolvedText.set(rendered);
+        }
+      });
+    });
+  }
 }

--- a/renderers/angular/src/v0_9/core/a2ui-renderer.service.spec.ts
+++ b/renderers/angular/src/v0_9/core/a2ui-renderer.service.spec.ts
@@ -16,7 +16,7 @@
 
 import { TestBed } from '@angular/core/testing';
 import { A2uiRendererService, A2UI_RENDERER_CONFIG } from './a2ui-renderer.service';
-import { AngularCatalog } from '../catalog/types';
+
 
 describe('A2uiRendererService', () => {
   let service: A2uiRendererService;

--- a/renderers/angular/src/v0_9/core/component-binder.service.spec.ts
+++ b/renderers/angular/src/v0_9/core/component-binder.service.spec.ts
@@ -23,13 +23,10 @@ import { ComponentBinder } from './component-binder.service';
 describe('ComponentBinder', () => {
   let binder: ComponentBinder;
   let mockDestroyRef: jasmine.SpyObj<DestroyRef>;
-  let onDestroyCallback: () => void;
 
   beforeEach(() => {
-    onDestroyCallback = () => {};
     mockDestroyRef = jasmine.createSpyObj('DestroyRef', ['onDestroy']);
     mockDestroyRef.onDestroy.and.callFake((callback: () => void) => {
-      onDestroyCallback = callback;
       return () => {}; // Return unregister function
     });
 
@@ -139,5 +136,40 @@ describe('ComponentBinder', () => {
     // Call onUpdate on literal, should not crash or call set
     bound['text'].onUpdate('new');
     expect(mockDataContext.set).not.toHaveBeenCalled();
+  });
+
+  it('should expand ChildList object templates', () => {
+    const mockComponentModel = {
+      properties: {
+        children: { componentId: 'item-comp', path: '/list/data' },
+      },
+    };
+
+    const mockListSig = preactSignal(['a', 'b']);
+    const mockDataContext = {
+      resolveSignal: jasmine.createSpy('resolveSignal').and.callFake((val: any) => {
+        if (val && val.path === '/list/data') return mockListSig;
+        return preactSignal(val);
+      }),
+      nested: jasmine.createSpy('nested').and.callFake((path: string) => ({
+        path,
+        nested: (sub: string) => ({ path: `${path}/${sub}` }),
+      })),
+      set: jasmine.createSpy('set'),
+    };
+
+    const mockContext = {
+      componentModel: mockComponentModel,
+      dataContext: mockDataContext,
+    } as unknown as ComponentContext;
+
+    const bound = binder.bind(mockContext);
+
+    expect(bound['children']).toBeDefined();
+    const children = bound['children'].value();
+    expect(Array.isArray(children)).toBe(true);
+    expect(children.length).toBe(2);
+    expect(children[0]).toEqual({ id: 'item-comp', basePath: '/list/data/0' });
+    expect(children[1]).toEqual({ id: 'item-comp', basePath: '/list/data/1' });
   });
 });

--- a/renderers/angular/src/v0_9/core/component-binder.service.ts
+++ b/renderers/angular/src/v0_9/core/component-binder.service.ts
@@ -64,7 +64,30 @@ export class ComponentBinder {
         });
       } else {
         preactSig = context.dataContext.resolveSignal(value);
+      }
 
+      if (['child', 'trigger', 'content'].includes(key)) {
+        const originalSig = preactSig;
+        preactSig = computed(() => {
+          const val = originalSig.value;
+          if (!val) return null;
+          if (typeof val === 'object' && val !== null && 'id' in val) {
+            return val;
+          }
+          return { id: val, basePath: context.dataContext.path };
+        });
+      } else if (key === 'children') {
+        const originalSig = preactSig;
+        preactSig = computed(() => {
+          const val = originalSig.value;
+          const arr = Array.isArray(val) ? val : [];
+          return arr.map(item => {
+            if (typeof item === 'object' && item !== null && 'id' in item) {
+              return item;
+            }
+            return { id: item, basePath: context.dataContext.path };
+          });
+        });
       }
 
       const angSig = toAngularSignal(preactSig as any, this.destroyRef, this.ngZone);

--- a/renderers/angular/src/v0_9/core/component-binder.service.ts
+++ b/renderers/angular/src/v0_9/core/component-binder.service.ts
@@ -15,7 +15,7 @@
  */
 
 import { DestroyRef, Injectable, inject, NgZone } from '@angular/core';
-import { ComponentContext } from '@a2ui/web_core/v0_9';
+import { ComponentContext, computed } from '@a2ui/web_core/v0_9';
 import { toAngularSignal } from './utils';
 import { BoundProperty } from './types';
 
@@ -46,10 +46,28 @@ export class ComponentBinder {
 
     for (const key of Object.keys(props)) {
       const value = props[key];
-      const preactSig = context.dataContext.resolveSignal(value);
-      const angSig = toAngularSignal(preactSig as any, this.destroyRef, this.ngZone);
+      
+      let preactSig;
+      const isChildListTemplate = value && typeof value === 'object' && 'componentId' in value && 'path' in value;
+      const isBoundPath = value && typeof value === 'object' && 'path' in value && !('componentId' in value);
+      
+      if (isChildListTemplate) {
+        const listSig = context.dataContext.resolveSignal({ path: value.path });
+        const listContext = context.dataContext.nested(value.path);
+        preactSig = computed(() => {
+          const arr = listSig.value;
+          const currentArr = Array.isArray(arr) ? arr : [];
+          return currentArr.map((_, i) => ({
+            id: value.componentId,
+            basePath: listContext.nested(String(i)).path,
+          }));
+        });
+      } else {
+        preactSig = context.dataContext.resolveSignal(value);
 
-      const isBoundPath = value && typeof value === 'object' && 'path' in value;
+      }
+
+      const angSig = toAngularSignal(preactSig as any, this.destroyRef, this.ngZone);
 
       bound[key] = {
         value: angSig,
@@ -58,6 +76,39 @@ export class ComponentBinder {
           ? (newValue: any) => context.dataContext.set(value.path, newValue)
           : () => {}, // No-op for non-bound values
       };
+
+      if (key === 'checks') {
+        const checksArray = Array.isArray(value) ? value : [];
+        
+        const ruleResults = checksArray.map((rule: any) => {
+          const condition = rule.condition || rule;
+          const message = rule.message || 'Validation failed';
+          const conditionSig = context.dataContext.resolveSignal(condition);
+          return { conditionSig, message };
+        });
+
+        const isValidPreactSig = computed(() => {
+          return ruleResults.every((r: any) => !!r.conditionSig.value);
+        });
+
+        const validationErrorsPreactSig = computed(() => {
+          return ruleResults
+            .filter((r: any) => !r.conditionSig.value)
+            .map((r: any) => r.message);
+        });
+
+        bound['isValid'] = {
+          value: toAngularSignal(isValidPreactSig, this.destroyRef, this.ngZone),
+          raw: null,
+          onUpdate: () => {},
+        };
+
+        bound['validationErrors'] = {
+          value: toAngularSignal(validationErrorsPreactSig, this.destroyRef, this.ngZone),
+          raw: null,
+          onUpdate: () => {},
+        };
+      }
     }
 
     return bound;

--- a/renderers/angular/src/v0_9/core/component-host.component.spec.ts
+++ b/renderers/angular/src/v0_9/core/component-host.component.spec.ts
@@ -18,7 +18,6 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ComponentHostComponent } from './component-host.component';
 import { A2uiRendererService } from './a2ui-renderer.service';
-import { AngularCatalog } from '../catalog/types';
 import { ComponentBinder } from './component-binder.service';
 import { ComponentContext } from '@a2ui/web_core/v0_9';
 import { Component, Input } from '@angular/core';
@@ -79,7 +78,7 @@ describe('ComponentHostComponent', () => {
 
     fixture = TestBed.createComponent(ComponentHostComponent);
     component = fixture.componentInstance;
-    fixture.componentRef.setInput('componentId', 'comp1');
+    fixture.componentRef.setInput('componentKey', { id: 'comp1', basePath: '/' });
     fixture.componentRef.setInput('surfaceId', 'surf1');
   });
 
@@ -109,7 +108,7 @@ describe('ComponentHostComponent', () => {
     });
 
     it('should use provided dataContextPath for ComponentContext', () => {
-      fixture.componentRef.setInput('dataContextPath', '/nested/path');
+      fixture.componentRef.setInput('componentKey', { id: 'comp1', basePath: '/nested/path' });
       fixture.detectChanges();
 
       const bindArg = mockBinder.bind.calls.mostRecent().args[0];
@@ -170,7 +169,7 @@ describe('ComponentHostComponent', () => {
       expect(compiled.innerHTML).toContain('Child Component');
     });
     it('should pass dataContextPath to the rendered component', () => {
-      fixture.componentRef.setInput('dataContextPath', '/some/path');
+      fixture.componentRef.setInput('componentKey', { id: 'comp1', basePath: '/some/path' });
       fixture.detectChanges();
 
       const childDebugElement = fixture.debugElement.query(By.directive(TestChildComponent));

--- a/renderers/angular/src/v0_9/core/component-host.component.ts
+++ b/renderers/angular/src/v0_9/core/component-host.component.ts
@@ -50,8 +50,8 @@ import { ComponentBinder } from './component-binder.service';
           inputs: {
           props: props,
           surfaceId: surfaceId(),
-          componentId: componentId(),
-          dataContextPath: dataContextPath(),
+          componentId: resolvedComponentId,
+          dataContextPath: resolvedDataContextPath,
         }
         "
       ></ng-container>
@@ -60,17 +60,11 @@ import { ComponentBinder } from './component-binder.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ComponentHostComponent implements OnInit {
-  /** The ID of the component to render. Defaults to 'root'. */
-  componentId = input<string>('root');
+  /** The key of the component to render, either an ID string or an object with ID and basePath. Defaults to 'root'. */
+  componentKey = input<string | { id: string; basePath: string }>('root');
 
   /** The unique identifier of the surface this component belongs to. */
   surfaceId = input.required<string>();
-
-  /**
-   * The path within the surface's data model that represents the current data state.
-   * Defaults to '/'.
-   */
-  dataContextPath = input<string>('/');
 
   private rendererService = inject(A2uiRendererService);
   private binder = inject(ComponentBinder);
@@ -79,6 +73,8 @@ export class ComponentHostComponent implements OnInit {
   protected componentType: Type<any> | null = null;
   protected props: any = {};
   private context?: ComponentContext;
+  protected resolvedComponentId: string = '';
+  protected resolvedDataContextPath: string = '/';
 
   ngOnInit(): void {
     const surface = this.rendererService.surfaceGroup?.getSurface(this.surfaceId());
@@ -88,10 +84,24 @@ export class ComponentHostComponent implements OnInit {
       return;
     }
 
-    const componentModel = surface.componentsModel.get(this.componentId());
+    const key = this.componentKey();
+    let id: string;
+    let basePath: string;
+
+    if (typeof key === 'object' && key !== null && 'id' in key) {
+      id = key.id;
+      basePath = key.basePath || '/';
+    } else {
+      id = key;
+      basePath = '/';
+    }
+
+    this.resolvedComponentId = id;
+
+    const componentModel = surface.componentsModel.get(id);
 
     if (!componentModel) {
-      console.warn(`Component ${this.componentId()} not found in surface ${this.surfaceId()}`);
+      console.warn(`Component ${id} not found in surface ${this.surfaceId()}`);
       return;
     }
 
@@ -106,8 +116,9 @@ export class ComponentHostComponent implements OnInit {
     this.componentType = api.component;
 
     // Create context
-    this.context = new ComponentContext(surface, this.componentId(), this.dataContextPath());
+    this.context = new ComponentContext(surface, id, basePath);
     this.props = this.binder.bind(this.context);
+    this.resolvedDataContextPath = this.context.dataContext.path;
 
     this.destroyRef.onDestroy(() => {
       // ComponentContext itself doesn't have a dispose, but its inner components might.

--- a/renderers/angular/src/v0_9/core/markdown.ts
+++ b/renderers/angular/src/v0_9/core/markdown.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable } from '@angular/core';
+
+export interface MarkdownRendererOptions {
+  tagClassMap?: Record<string, string>;
+}
+
+export abstract class MarkdownRenderer {
+  abstract render(markdown: string, options?: MarkdownRendererOptions): Promise<string>;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DefaultMarkdownRenderer extends MarkdownRenderer {
+  private static warningLogged = false;
+
+  override async render(
+    markdown: string,
+    options?: MarkdownRendererOptions,
+  ): Promise<string> {
+    try {
+      // @ts-ignore - optional peer dependency
+      const { renderMarkdown } = await import('@a2ui/markdown-it');
+      return await renderMarkdown(markdown, options as any);
+    } catch (e) {
+      if (!DefaultMarkdownRenderer.warningLogged) {
+        console.warn("[DefaultMarkdownRenderer] Failed to load optional `@a2ui/markdown-it` renderer. Using fallback.");
+        DefaultMarkdownRenderer.warningLogged = true;
+      }
+      return markdown;
+    }
+  }
+}
+
+export function provideMarkdownRenderer(renderFn?: (markdown: string, options?: MarkdownRendererOptions) => Promise<string>) {
+  if (renderFn) {
+    return {
+      provide: MarkdownRenderer,
+      useValue: {
+        render: renderFn,
+      },
+    };
+  }
+  return { provide: MarkdownRenderer, useClass: DefaultMarkdownRenderer };
+}

--- a/renderers/angular/src/v0_9/core/surface.component.spec.ts
+++ b/renderers/angular/src/v0_9/core/surface.component.spec.ts
@@ -83,8 +83,7 @@ describe('SurfaceComponent', () => {
     const host = fixture.debugElement.query(By.directive(ComponentHostComponent));
     expect(host).toBeTruthy();
     expect(host.componentInstance.surfaceId()).toBe('test-surface');
-    expect(host.componentInstance.dataContextPath()).toBe('/custom/path');
-    expect(host.componentInstance.componentId()).toBe('root');
+    expect(host.componentInstance.componentKey()).toEqual({ id: 'root', basePath: '/custom/path' });
   });
 
   it('should use default dataContextPath of "/"', () => {
@@ -92,6 +91,6 @@ describe('SurfaceComponent', () => {
     fixture.detectChanges();
 
     const host = fixture.debugElement.query(By.directive(ComponentHostComponent));
-    expect(host.componentInstance.dataContextPath()).toBe('/');
+    expect(host.componentInstance.componentKey()).toEqual({ id: 'root', basePath: '/' });
   });
 });

--- a/renderers/angular/src/v0_9/core/surface.component.ts
+++ b/renderers/angular/src/v0_9/core/surface.component.ts
@@ -29,7 +29,10 @@ import { ComponentHostComponent } from './component-host.component';
   standalone: true,
   imports: [ComponentHostComponent],
   template: `
-    <a2ui-v09-component-host [surfaceId]="surfaceId()" [dataContextPath]="dataContextPath()">
+    <a2ui-v09-component-host
+      [componentKey]="{ id: 'root', basePath: dataContextPath() }"
+      [surfaceId]="surfaceId()"
+    >
     </a2ui-v09-component-host>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/renderers/angular/src/v0_9/core/utils.ts
+++ b/renderers/angular/src/v0_9/core/utils.ts
@@ -15,7 +15,8 @@
  */
 
 import { DestroyRef, Signal, signal as angularSignal } from '@angular/core';
-import { Signal as PreactSignal, effect } from '@a2ui/web_core/v0_9';
+import { Signal as PreactSignal, effect, signal as preactSignal } from '@a2ui/web_core/v0_9';
+export { preactSignal };
 
 /**
  * Bridges a Preact Signal (from A2UI web_core) to a reactive Angular Signal.

--- a/renderers/angular/src/v0_9/test_data/mocks/contact-card.json
+++ b/renderers/angular/src/v0_9/test_data/mocks/contact-card.json
@@ -13,12 +13,12 @@
       "components": [
         {
           "id": "root",
-          "component": "card",
+          "component": "Card",
           "child": "main-column"
         },
         {
           "id": "main-column",
-          "component": "column",
+          "component": "Column",
           "children": [
             "avatar-image",
             "name",
@@ -31,86 +31,86 @@
         },
         {
           "id": "avatar-image",
-          "component": "image",
+          "component": "Image",
           "url": { "path": "/avatar" },
           "fit": "cover"
         },
         {
           "id": "name",
-          "component": "text",
+          "component": "Text",
           "text": { "path": "/name" },
           "weight": 700
         },
         {
           "id": "title",
-          "component": "text",
+          "component": "Text",
           "text": { "path": "/title" }
         },
         {
           "id": "divider",
-          "component": "divider"
+          "component": "Divider"
         },
         {
           "id": "contact-info",
-          "component": "column",
+          "component": "Column",
           "children": ["phone-row", "email-row", "location-row"]
         },
         {
           "id": "phone-row",
-          "component": "row",
+          "component": "Row",
           "children": ["phone-icon", "phone-text"],
           "align": "center"
         },
         {
           "id": "phone-icon",
-          "component": "icon",
+          "component": "Icon",
           "name": "phone"
         },
         {
           "id": "phone-text",
-          "component": "text",
+          "component": "Text",
           "text": { "path": "/phone" }
         },
         {
           "id": "email-row",
-          "component": "row",
+          "component": "Row",
           "children": ["email-icon", "email-text"],
           "align": "center"
         },
         {
           "id": "email-icon",
-          "component": "icon",
+          "component": "Icon",
           "name": "mail"
         },
         {
           "id": "email-text",
-          "component": "text",
+          "component": "Text",
           "text": { "path": "/email" }
         },
         {
           "id": "location-row",
-          "component": "row",
+          "component": "Row",
           "children": ["location-icon", "location-text"],
           "align": "center"
         },
         {
           "id": "location-icon",
-          "component": "icon",
+          "component": "Icon",
           "name": "locationOn"
         },
         {
           "id": "location-text",
-          "component": "text",
+          "component": "Text",
           "text": { "path": "/location" }
         },
         {
           "id": "actions",
-          "component": "row",
+          "component": "Row",
           "children": ["call-btn", "message-btn"]
         },
         {
           "id": "call-btn",
-          "component": "button",
+          "component": "Button",
           "child": "call-btn-text",
           "action": {
             "functionCall": {
@@ -121,12 +121,12 @@
         },
         {
           "id": "call-btn-text",
-          "component": "text",
+          "component": "Text",
           "text": "Call"
         },
         {
           "id": "message-btn",
-          "component": "button",
+          "component": "Button",
           "child": "message-btn-text",
           "action": {
             "functionCall": {
@@ -137,7 +137,7 @@
         },
         {
           "id": "message-btn-text",
-          "component": "text",
+          "component": "Text",
           "text": "Message"
         }
       ]

--- a/renderers/angular/src/v0_9/test_data/mocks/restaurant-card.json
+++ b/renderers/angular/src/v0_9/test_data/mocks/restaurant-card.json
@@ -13,83 +13,83 @@
       "components": [
         {
           "id": "root",
-          "component": "card",
+          "component": "Card",
           "child": "main-column"
         },
         {
           "id": "main-column",
-          "component": "column",
+          "component": "Column",
           "children": ["restaurant-image", "content"]
         },
         {
           "id": "restaurant-image",
-          "component": "image",
+          "component": "Image",
           "url": { "path": "/image" },
           "fit": "cover"
         },
         {
           "id": "content",
-          "component": "column",
+          "component": "Column",
           "children": ["name-row", "cuisine", "rating-row", "details-row"]
         },
         {
           "id": "name-row",
-          "component": "row",
+          "component": "Row",
           "children": ["restaurant-name", "price-range"],
           "justify": "spaceBetween",
           "align": "center"
         },
         {
           "id": "restaurant-name",
-          "component": "text",
+          "component": "Text",
           "text": { "path": "/name" },
           "weight": 700
         },
         {
           "id": "price-range",
-          "component": "text",
+          "component": "Text",
           "text": { "path": "/priceRange" }
         },
         {
           "id": "cuisine",
-          "component": "text",
+          "component": "Text",
           "text": { "path": "/cuisine" },
           "style": "italic"
         },
         {
           "id": "rating-row",
-          "component": "row",
+          "component": "Row",
           "children": ["star-icon", "rating", "reviews"],
           "align": "center"
         },
         {
           "id": "star-icon",
-          "component": "icon",
+          "component": "Icon",
           "name": "star"
         },
         {
           "id": "rating",
-          "component": "text",
+          "component": "Text",
           "text": { "path": "/rating" }
         },
         {
           "id": "reviews",
-          "component": "text",
+          "component": "Text",
           "text": { "path": "/reviewCount" }
         },
         {
           "id": "details-row",
-          "component": "row",
+          "component": "Row",
           "children": ["distance", "delivery-time"]
         },
         {
           "id": "distance",
-          "component": "text",
+          "component": "Text",
           "text": { "path": "/distance" }
         },
         {
           "id": "delivery-time",
-          "component": "text",
+          "component": "Text",
           "text": { "path": "/deliveryTime" }
         }
       ]

--- a/renderers/angular/src/v0_9/v0_9_integration.spec.ts
+++ b/renderers/angular/src/v0_9/v0_9_integration.spec.ts
@@ -19,6 +19,8 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { A2uiRendererService, A2UI_RENDERER_CONFIG } from './core/a2ui-renderer.service';
 import { SurfaceComponent } from './core/surface.component';
 import { BasicCatalog } from './catalog/basic/basic-catalog';
+import { A2uiMessage } from '@a2ui/web_core/v0_9';
+import { MarkdownRenderer } from './core/markdown';
 
 import * as restaurantCardMock from './test_data/mocks/restaurant-card.json';
 import * as contactCardMock from './test_data/mocks/contact-card.json';
@@ -58,6 +60,12 @@ describe('v0.9 Angular Renderer Integration', () => {
           }),
           deps: [BasicCatalog],
         },
+        {
+          provide: MarkdownRenderer,
+          useValue: {
+            render: (val: string) => Promise.resolve(val),
+          },
+        },
       ],
     }).compileComponents();
 
@@ -66,7 +74,7 @@ describe('v0.9 Angular Renderer Integration', () => {
   });
 
   it('should render a basic component tree from protocol messages', async () => {
-    const messages = [
+    const messages: A2uiMessage[] = [
       {
         version: 'v0.9',
         createSurface: {
@@ -81,28 +89,28 @@ describe('v0.9 Angular Renderer Integration', () => {
           components: [
             {
               id: 'root',
-              component: 'column',
+              component: 'Column',
               children: ['text-id', 'button-id'],
             },
             {
               id: 'text-id',
-              component: 'text',
+              component: 'Text',
               text: 'Hello v0.9',
             },
             {
               id: 'button-id',
-              component: 'button',
+              component: 'Button',
               child: 'button-text-id',
             },
             {
               id: 'button-text-id',
-              component: 'text',
+              component: 'Text',
               text: 'Click Me',
             },
           ],
         },
       },
-    ] as any[];
+    ];
 
     rendererService.processMessages(messages);
     fixture.detectChanges();
@@ -138,13 +146,13 @@ describe('v0.9 Angular Renderer Integration', () => {
           components: [
             {
               id: 'root',
-              component: 'text',
+              component: 'Text',
               text: { path: '/user/name' },
             },
           ],
         },
       },
-    ] as any[]);
+    ] as A2uiMessage[]);
 
     fixture.detectChanges();
     await fixture.whenStable();
@@ -163,7 +171,7 @@ describe('v0.9 Angular Renderer Integration', () => {
           value: 'Alice',
         },
       },
-    ] as any[]);
+    ] as A2uiMessage[]);
 
     fixture.detectChanges();
     await fixture.whenStable();
@@ -189,7 +197,7 @@ describe('v0.9 Angular Renderer Integration', () => {
           components: [
             {
               id: 'root',
-              component: 'button',
+              component: 'Button',
               child: 'btn-text',
               action: {
                 event: {
@@ -200,13 +208,13 @@ describe('v0.9 Angular Renderer Integration', () => {
             },
             {
               id: 'btn-text',
-              component: 'text',
+              component: 'Text',
               text: 'Fire Action',
             },
           ],
         },
       },
-    ] as any[]);
+    ] as A2uiMessage[]);
 
     fixture.detectChanges();
     await fixture.whenStable();

--- a/renderers/angular/tsconfig.json
+++ b/renderers/angular/tsconfig.json
@@ -19,7 +19,7 @@
     "paths": {
       "@a2ui/angular/v0_8": ["src/v0_8/public-api.ts"],
       "@a2ui/angular/v0_9": ["src/v0_9/public-api.ts"],
-      "@preact/signals-core": ["../web_core/node_modules/@preact/signals-core"]
+      "@preact/signals-core": ["node_modules/@preact/signals-core"]
     }
   },
   "angularCompilerOptions": {

--- a/renderers/web_core/package.json
+++ b/renderers/web_core/package.json
@@ -104,7 +104,7 @@
       "clean": "if-file-deleted"
     },
     "test": {
-      "command": "node --test dist",
+      "command": "node --test dist/**/*.test.js",
       "dependencies": [
         "build"
       ]

--- a/renderers/web_core/src/v0_9/catalog/types.test.ts
+++ b/renderers/web_core/src/v0_9/catalog/types.test.ts
@@ -107,8 +107,6 @@ describe('InferredComponentApiSchemaType', () => {
       name: 'MockComp',
       schema: mockSchema,
     } satisfies ComponentApi;
-    // Appease typescript-eslint/no-unused-vars
-    type _ = typeof mockApi;
 
     // Type-level equivalence assertion using z.infer
     type ExpectedType = z.infer<typeof mockSchema>;
@@ -132,5 +130,10 @@ describe('InferredComponentApiSchemaType', () => {
     // typesMatchExact only accepts "true" if `TypesAreEquivalent`
     const typesMatchExact: TypesAreEquivalent<ExpectedType, InferredType> =
       true;
+
+    // Appease linter by using the variables
+    assert.ok(mockApi);
+    assert.strictEqual(inferredIsAny, false);
+    assert.strictEqual(typesMatchExact, true);
   });
 });

--- a/renderers/web_core/src/v0_9/index.ts
+++ b/renderers/web_core/src/v0_9/index.ts
@@ -36,7 +36,7 @@ export * from './state/surface-group-model.js';
 export * from './state/surface-model.js';
 export * from './errors.js';
 
-export {effect, Signal, signal} from '@preact/signals-core';
+export {effect, Signal, signal, computed} from '@preact/signals-core';
 
 import A2uiMessageSchemaRaw from './schemas/server_to_client.json' with {type: 'json'};
 

--- a/renderers/web_core/src/v0_9/rendering/data-context.ts
+++ b/renderers/web_core/src/v0_9/rendering/data-context.ts
@@ -1,3 +1,4 @@
+// Force rebuild by wireit
 /*
  * Copyright 2025 Google LLC
  *
@@ -223,6 +224,7 @@ export class DataContext {
       const stopper = effect(() => {
         try {
           const args = argsSig.value;
+
           if (abortController) abortController.abort();
           if (innerUnsubscribe) {
             innerUnsubscribe();

--- a/renderers/web_core/tsconfig.json
+++ b/renderers/web_core/tsconfig.json
@@ -35,5 +35,10 @@
       "rxjs/operators": ["./node_modules/rxjs/operators/index.js"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.json"],
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictTemplates": true,
+    "strictPropertyInitialization": false
+  },
+  "include": ["src/**/*.ts", "src/**/*.json"]
 }

--- a/specification/v0_9/json/catalogs/basic/examples/09_login-form.json
+++ b/specification/v0_9/json/catalogs/basic/examples/09_login-form.json
@@ -1,5 +1,5 @@
 {
-  "name": "Login Form",
+  "name": "Login Form with Validation",
   "description": "Example of login form demonstrating validation checks and logic.",
   "messages": [
     {
@@ -35,10 +35,7 @@
           {
             "id": "header",
             "component": "Column",
-            "children": [
-              "title",
-              "subtitle"
-            ],
+            "children": ["title", "subtitle"],
             "align": "center"
           },
           {
@@ -175,10 +172,7 @@
           {
             "id": "signup-text",
             "component": "Row",
-            "children": [
-              "no-account",
-              "signup-link"
-            ],
+            "children": ["no-account", "signup-link"],
             "justify": "center"
           },
           {

--- a/specification/v0_9/json/catalogs/basic/examples/34_child-list-template.json
+++ b/specification/v0_9/json/catalogs/basic/examples/34_child-list-template.json
@@ -1,0 +1,87 @@
+{
+  "name": "ChildList Template Expansion",
+  "description": "Demonstrates dynamic list generation using ChildList object templates.",
+  "messages": [
+    {
+      "version": "v0.9",
+      "createSurface": {
+        "surfaceId": "gallery-child-list-template",
+        "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json",
+        "sendDataModel": true
+      }
+    },
+    {
+      "version": "v0.9",
+      "updateComponents": {
+        "surfaceId": "gallery-child-list-template",
+        "components": [
+          {
+            "id": "root",
+            "component": "Card",
+            "child": "main-column"
+          },
+          {
+            "id": "main-column",
+            "component": "Column",
+            "children": [
+              "title-text",
+              "item-list"
+            ],
+            "align": "stretch"
+          },
+          {
+            "id": "title-text",
+            "component": "Text",
+            "text": "Dynamic Item List",
+            "variant": "h3"
+          },
+          {
+            "id": "item-list",
+            "component": "List",
+            "children": {
+              "componentId": "item-row",
+              "path": "/items"
+            }
+          },
+          {
+            "id": "item-row",
+            "component": "Row",
+            "children": [
+              "item-name",
+              "qty-label",
+              "item-qty"
+            ]
+          },
+          {
+            "id": "item-name",
+            "component": "Text",
+            "text": { "path": "name" }
+          },
+          {
+            "id": "qty-label",
+            "component": "Text",
+            "text": " - Qty: "
+          },
+          {
+            "id": "item-qty",
+            "component": "Text",
+            "text": { "path": "quantity" }
+          }
+        ]
+      }
+    },
+    {
+      "version": "v0.9",
+      "updateDataModel": {
+        "surfaceId": "gallery-child-list-template",
+        "value": {
+          "items": [
+            { "name": "Apple", "quantity": 10 },
+            { "name": "Banana", "quantity": 5 },
+            { "name": "Cherry", "quantity": 20 }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/specification/v0_9/json/catalogs/basic/examples/35_markdown-text.json
+++ b/specification/v0_9/json/catalogs/basic/examples/35_markdown-text.json
@@ -1,0 +1,47 @@
+{
+  "name": "Markdown Text Support",
+  "description": "Demonstrates Markdown rendering in Text component.",
+  "messages": [
+    {
+      "version": "v0.9",
+      "createSurface": {
+        "surfaceId": "gallery-markdown-text",
+        "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json",
+        "sendDataModel": true
+      }
+    },
+    {
+      "version": "v0.9",
+      "updateComponents": {
+        "surfaceId": "gallery-markdown-text",
+        "components": [
+          {
+            "id": "root",
+            "component": "Card",
+            "child": "main-column"
+          },
+          {
+            "id": "main-column",
+            "component": "Column",
+            "children": [
+              "title-text",
+              "markdown-content"
+            ],
+            "align": "stretch"
+          },
+          {
+            "id": "title-text",
+            "component": "Text",
+            "text": "Markdown Rendering",
+            "variant": "h3"
+          },
+          {
+            "id": "markdown-content",
+            "component": "Text",
+            "text": "# Heading 1\n\nThis is **bold** text and *italic* text.\n\n- List item 1\n- List item 2\n\n[Link to Google](https://google.com)"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Description

## Intent
The intent of this branch is to complete the implementation of the Angular v0.9 renderer. It adds missing functionality such as Markdown support for Text widgets, validation checks (failed checks disabling buttons and showing errors), and dynamic list generation using ChildList object templates. It also includes cleanups, reactivity fixes, and strict linting (enabling `noUnusedLocals`).


## Summary of Changes

This pull request significantly advances the Angular v0.9 renderer by integrating crucial missing functionalities. It introduces robust Markdown rendering capabilities for text display, implements a comprehensive validation system for interactive components like buttons and text fields to provide immediate user feedback, and enables dynamic UI generation through ChildList object templates. These changes, coupled with general code cleanups and reactivity improvements, aim to make the renderer more feature-rich, responsive, and developer-friendly.

### Highlights

* **Markdown Rendering**: Introduced Markdown support for the `Text` component, allowing rich text formatting within the UI.
* **Validation Checks**: Implemented validation logic for `Button` and `TextField` components, enabling dynamic disabling and error message display based on data conditions.
* **Dynamic List Generation**: Added support for `ChildList` object templates, allowing dynamic generation of child components within lists based on data models.
* **Code Quality & Reactivity**: Enhanced code quality through strict linting (`noUnusedLocals`) and improved reactivity in component property binding.

<details>
<summary><b>Changelog</b></summary>

* **renderers/angular/a2ui_explorer/src/app/app.config.ts**
    * Added Markdown renderer provider to the application configuration.
* **renderers/angular/a2ui_explorer/src/app/demo-catalog.ts**
    * Removed `CardComponent` from the demo catalog.
* **renderers/angular/angular.json**
    * Configured Angular to preserve symlinks for the explorer app.
* **renderers/angular/ng-package.json**
    * Allowed `@preact/signals-core` as a non-peer dependency.
* **renderers/angular/package-lock.json**
    * Updated package versions from `0.8.5` to `0.9.0`.
    * Added `@preact/signals-core` to dependencies.
    * Added `@a2ui/markdown-it` to devDependencies and peerDependencies.
    * Updated `@a2ui/web_core` version from `0.8.8` to `0.9.1`.
    * Updated `typescript` from `5.8.3` to `5.9.3`.
    * Added `google-artifactregistry-auth` to devDependencies.
    * Added `node_modules/@a2ui/markdown-it` and `node_modules/@preact/signals-core` entries.
* **renderers/angular/package.json**
    * Modified `demo` script to include `NODE_PRESERVE_SYMLINKS=1`.
    * Added `@preact/signals-core` to dependencies and `overrides`.
    * Added `@a2ui/markdown-it` to devDependencies.
* **renderers/angular/src/v0_8/components/row-integration.spec.ts**
    * Mocked `MarkdownRenderer` for testing purposes.
* **renderers/angular/src/v0_8/v0_8_integration.spec.ts**
    * Mocked `MarkdownRenderer` for testing purposes.
* **renderers/angular/src/v0_9/catalog/basic/basic-catalog.ts**
    * Adjusted component name resolution logic to prioritize `impl.name`.
* **renderers/angular/src/v0_9/catalog/basic/button.component.spec.ts**
    * Imported `preactSignal`.
    * Added new test cases for button disabling based on failed checks and reactivity.
* **renderers/angular/src/v0_9/catalog/basic/button.component.ts**
    * Imported Angular core signals and `preactEffect`.
    * Added `[disabled]` binding to the button based on `failedChecks`.
    * Added CSS for disabled buttons.
    * Added `checks` property to component inputs.
    * Implemented `resolvedChecks` signal and `failedChecks` computed property to handle validation.
    * Added `constructor` with an `effect` to resolve and react to validation checks.
* **renderers/angular/src/v0_9/catalog/basic/check-box.component.ts**
    * Removed unused `A2uiRendererService` injection.
* **renderers/angular/src/v0_9/catalog/basic/choice-picker.component.ts**
    * Removed unused `A2uiRendererService` injection.
* **renderers/angular/src/v0_9/catalog/basic/column.component.spec.ts**
    * Added test cases for handling non-array children, missing children property, and missing justify/align properties.
* **renderers/angular/src/v0_9/catalog/basic/complex-components.spec.ts**
    * Added a test case for `DateTimeInputComponent` to handle empty values.
* **renderers/angular/src/v0_9/catalog/basic/date-time-input.component.ts**
    * Removed unused `A2uiRendererService` injection.
* **renderers/angular/src/v0_9/catalog/basic/image.component.ts**
    * Added new CSS classes for various image variants (icon, avatar, smallFeature, mediumFeature, largeFeature, header).
    * Updated `variant` input documentation to include new variants.
* **renderers/angular/src/v0_9/catalog/basic/row.component.spec.ts**
    * Added test cases for handling non-array children, missing children property, and missing justify/align properties.
* **renderers/angular/src/v0_9/catalog/basic/simple-components.spec.ts**
    * Removed `signal` import alias.
    * Added a test case for `ImageComponent` to verify support for all specified variants.
* **renderers/angular/src/v0_9/catalog/basic/slider.component.ts**
    * Removed unused `A2uiRendererService` injection.
* **renderers/angular/src/v0_9/catalog/basic/text-field.component.spec.ts**
    * Imported `preactSignal`.
    * Added test cases for showing error messages when checks fail, handling null checks, missing surface, and reactivity of checks.
* **renderers/angular/src/v0_9/catalog/basic/text-field.component.ts**
    * Imported Angular core signals and `ComponentContext`, `preactEffect`.
    * Added `[class.invalid]` binding to the input and a `@for` loop to display error messages.
    * Added CSS for invalid input and error messages.
    * Added `checks` property to component inputs.
    * Implemented `resolvedChecks` signal and `failedChecks` computed property to handle validation.
    * Added `constructor` with an `effect` to resolve and react to validation checks.
* **renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts**
    * Removed `signal` import.
    * Imported `MarkdownRenderer`.
    * Updated test setup to mock `MarkdownRenderer`.
    * Modified existing tests and added new tests to verify Markdown rendering and variant handling.
* **renderers/angular/src/v0_9/catalog/basic/text.component.ts**
    * Imported `inject`, `signal`, `effect` from `@angular/core` and `MarkdownRenderer`.
    * Removed `imports: []` from `@Component` decorator.
    * Updated template to use `[class]` and `[innerHTML]` for rendering `resolvedText`.
    * Removed `weight` and `style` properties.
    * Added `markdownRenderer` injection.
    * Added `variant` and `resolvedText` signals.
    * Implemented `constructor` with an `effect` to process text and variant into Markdown and render it.
* **renderers/angular/src/v0_9/core/a2ui-renderer.service.spec.ts**
    * Removed unused import `AngularCatalog`.
* **renderers/angular/src/v0_9/core/component-binder.service.spec.ts**
    * Removed `onDestroyCallback` variable and related logic.
    * Added a test case for expanding `ChildList` object templates.
* **renderers/angular/src/v0_9/core/component-binder.service.ts**
    * Imported `computed` from `@a2ui/web_core/v0_9`.
    * Modified `bind` method to handle `ChildList` object templates, dynamically generating child components based on a list signal.
* **renderers/angular/src/v0_9/core/component-host.component.spec.ts**
    * Removed unused import `AngularCatalog`.
* **renderers/angular/src/v0_9/core/component-host.component.ts**
    * Modified `dataContextPath` binding in the template to use `resolvedDataContextPath`.
    * Updated `componentId` input to accept `string | { id: string; basePath: string }`.
    * Added `resolvedDataContextPath` getter.
    * Modified `ngOnInit` to handle the new `componentId` type and derive `id` and `basePath` accordingly.
    * Updated `ComponentContext` creation to use the derived `id` and `basePath`.
* **renderers/angular/src/v0_9/core/markdown.ts**
    * Added new file defining `MarkdownRenderer` abstract class, `DefaultMarkdownRenderer` (which dynamically imports `@a2ui/markdown-it`), and `provideMarkdownRenderer` function.
* **renderers/angular/src/v0_9/core/utils.ts**
    * Exported `preactSignal` from `@a2ui/web_core/v0_9`.
* **renderers/angular/src/v0_9/test_data/mocks/contact-card.json**
    * Updated component names to use PascalCase (e.g., `card` to `Card`, `text` to `Text`).
* **renderers/angular/src/v0_9/test_data/mocks/restaurant-card.json**
    * Updated component names to use PascalCase (e.g., `card` to `Card`, `text` to `Text`).
* **renderers/angular/src/v0_9/v0_9_integration.spec.ts**
    * Imported `A2uiMessage` and `MarkdownRenderer`.
    * Added `MarkdownRenderer` provider to test bed.
    * Updated type assertions for `messages` arrays to `A2uiMessage[]`.
    * Updated component names in test messages to PascalCase.
* **renderers/angular/tsconfig.json**
    * Enabled `noUnusedLocals` compiler option.
    * Updated `paths` configuration for `@preact/signals-core`.
* **renderers/markdown/markdown-it/package-lock.json**
    * Updated `typescript` from `5.8.3` to `5.9.3`.
    * Added `fsevents` entry.
* **renderers/web_core/package-lock.json**
    * Removed trailing newline character.
* **renderers/web_core/package.json**
    * Updated `test` command to target all test files in `dist`.
* **renderers/web_core/src/v0_9/catalog/types.test.ts**
    * Cleaned up test file by removing unused type alias and adding linter appeasement for variables.
* **renderers/web_core/src/v0_9/index.ts**
    * Exported `computed` from `@preact/signals-core`.
* **renderers/web_core/src/v0_9/rendering/data-context.ts**
    * Added a comment for wireit rebuild.
    * Added an empty line for formatting.
* **specification/v0_9/json/catalogs/basic/examples/34_child-list-template.json**
    * Added new example demonstrating dynamic list generation using ChildList object templates.
* **specification/v0_9/json/catalogs/basic/examples/35_markdown-text.json**
    * Added new example demonstrating Markdown rendering in the Text component.
* **specification/v0_9/json/catalogs/minimal/examples/4_login_form.json**
    * Removed the login form example.
</details>
