### PR TITLE
Remove SDK contact link

### DIFF
--- a/agent_sdks/python/agent_development.md
+++ b/agent_sdks/python/agent_development.md
@@ -235,7 +235,7 @@ For agents with a fixed set of UI capabilities, simply use the `schema_manager`
 to generate the system instruction.
 
 **Example Samples:**
-[contact_lookup](../../../samples/agent/adk/contact_lookup), [restaurant_finder](../../../samples/agent/adk/restaurant_finder)
+[restaurant_finder](../../../samples/agent/adk/restaurant_finder)
 
 ```python
 # Generate system prompt


### PR DESCRIPTION
## What was done
- Removed the link to `contact_lookup` sample in `agent_development.md`.

## Why
- Part of the plan to delete the contact sample.
- This is Part 2 of the deletion plan.

## Literal Plan Used
```markdown
# Plan: SDK Link Removal (Part 2)

This plan covers removing references to the contact lookup sample from the SDK documentation.

## Git Branch
`feature/remove-sdk-contact-link`

## Files to Update
- `agent_sdks/python/agent_development.md`: Remove the contact_lookup link.

## Validation Steps

### Manual Verification
- Verify that the file `agent_sdks/python/agent_development.md` no longer contains links to `contact_lookup`.
```

Related to #1113
