### PR TITLE
Make agent URLs configurable and update quickstart docs

### DIFF
--- a/agent_sdks/python/a2ui_agent/src/a2ui/a2a/parts.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/a2a/parts.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 MIME_TYPE_KEY = "mimeType"
 A2UI_MIME_TYPE = "application/a2ui+json"
 DEPRECATED_A2UI_MIME_TYPE = "application/json+a2ui"
+CATALOG_MIME_TYPE = "application/agent-plugin+json"
 
 
 def create_a2ui_part(a2ui_data: dict[str, Any], version: Optional[str] = None) -> Part:
@@ -69,6 +70,41 @@ def is_a2ui_part(part: Part) -> bool:
         and part.root.metadata
         and part.root.metadata.get(MIME_TYPE_KEY)
         in (A2UI_MIME_TYPE, DEPRECATED_A2UI_MIME_TYPE)
+    )
+
+
+def is_catalog_part(part: Part) -> bool:
+    """Checks if an A2A Part contains catalog data.
+
+    Args:
+        part: The A2A Part to check.
+
+    Returns:
+        True if the part contains catalog data, False otherwise.
+    """
+    return bool(
+        isinstance(part.root, DataPart)
+        and part.root.metadata
+        and part.root.metadata.get(MIME_TYPE_KEY) == CATALOG_MIME_TYPE
+    )
+
+
+def create_catalog_part(catalog_data: dict[str, Any]) -> Part:
+    """Creates an A2A Part containing catalog data with application/agent-plugin+json MIME type.
+
+    Args:
+        catalog_data: The catalog data dictionary.
+
+    Returns:
+        An A2A Part with a DataPart containing the catalog data.
+    """
+    return Part(
+        root=DataPart(
+            data=catalog_data,
+            metadata={
+                MIME_TYPE_KEY: CATALOG_MIME_TYPE,
+            },
+        )
     )
 
 

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_lexer.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_lexer.py
@@ -1,4 +1,4 @@
-# Generated from /usr/local/google/home/gspencer/code/a2ui/kotlin_express/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
+# Generated from /home/node/a2ui/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
 from antlr4 import *
 from io import StringIO
 import sys

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_parser.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_parser.py
@@ -1,4 +1,4 @@
-# Generated from /usr/local/google/home/gspencer/code/a2ui/kotlin_express/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
+# Generated from /home/node/a2ui/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
 # encoding: utf-8
 from antlr4 import *
 from io import StringIO

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_visitor.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_visitor.py
@@ -1,4 +1,4 @@
-# Generated from /usr/local/google/home/gspencer/code/a2ui/kotlin_express/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
+# Generated from /home/node/a2ui/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
 from antlr4 import *
 if "." in __name__:
     from .express_parser import ExpressParser

--- a/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
@@ -28,7 +28,7 @@ from a2ui.core.catalog import Catalog
 from a2ui.core import A2uiCatalogError
 
 
-from .catalog_provider import A2uiCatalogProvider, FileSystemCatalogProvider
+from .catalog_provider import A2uiCatalogProvider, FileSystemCatalogProvider, HttpCatalogProvider
 from .constants import (
     A2UI_SCHEMA_BLOCK_START,
     A2UI_SCHEMA_BLOCK_END,
@@ -76,7 +76,7 @@ class CatalogConfig:
         if not parsed.scheme or parsed.scheme == "file":
             catalog_provider = FileSystemCatalogProvider(parsed.path)
         elif parsed.scheme in ["http", "https"]:
-            raise NotImplementedError("HTTP support is coming soon.")
+            catalog_provider = HttpCatalogProvider(catalog_path)
         else:
             raise A2uiCatalogError(f"Unsupported catalog URL scheme: {catalog_path}")
 

--- a/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog_provider.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog_provider.py
@@ -15,10 +15,15 @@
 """Module for providing A2UI catalog schemas and resources."""
 
 import json
+import logging
+import urllib.request
 from abc import ABC, abstractmethod
 from json.decoder import JSONDecodeError
 from typing import Any, Dict, cast
+from urllib.error import URLError
 from .constants import ENCODING
+
+logger = logging.getLogger(__name__)
 
 
 class A2uiCatalogProvider(ABC):
@@ -46,3 +51,28 @@ class FileSystemCatalogProvider(A2uiCatalogProvider):
                 return cast(Dict[str, Any], json.load(f))
         except (FileNotFoundError, JSONDecodeError) as e:
             raise IOError(f"Could not load schema from {self.path}: {e}") from e
+
+
+class HttpCatalogProvider(A2uiCatalogProvider):
+    """Loads catalog definition from a remote HTTP/HTTPS URL."""
+
+    def __init__(self, url: str):
+        self.url = url
+
+    def load(self) -> Dict[str, Any]:
+        try:
+            req = urllib.request.Request(
+                self.url, headers={"User-Agent": "A2UI-Agent-SDK/1.0"}
+            )
+            with urllib.request.urlopen(req, timeout=10) as response:
+                content_type = response.headers.get("Content-Type", "").split(";")[0].strip()
+                recognized_types = ("application/json", "application/agent-plugin+json")
+                if content_type and content_type not in recognized_types:
+                    logger.warning(
+                        f"Response Content-Type '{content_type}' is not a recognized "
+                        "catalog entry type (expected 'application/json' or "
+                        "'application/agent-plugin+json')."
+                    )
+                return cast(Dict[str, Any], json.loads(response.read().decode(ENCODING)))
+        except Exception as e:
+            raise IOError(f"Could not load schema from {self.url}: {e}") from e

--- a/agent_sdks/python/a2ui_agent/tests/schema/test_catalog.py
+++ b/agent_sdks/python/a2ui_agent/tests/schema/test_catalog.py
@@ -59,8 +59,9 @@ def test_resolve_examples_path_handling():
         resolve_examples_path("https://a2ui.org/examples")
 
 
-def test_catalog_config_from_path_schemes():
+def test_catalog_config_from_path_schemes(mocker=None):
     from a2ui.schema.catalog import CatalogConfig
+    from a2ui.schema.catalog_provider import HttpCatalogProvider
     # Test local path
     config = CatalogConfig.from_path(
         name="test_file", catalog_path="relative_path/to/catalog.json"
@@ -73,11 +74,12 @@ def test_catalog_config_from_path_schemes():
     )
     assert config.provider.path == "/absolute_path/to/catalog.json"
 
-    # Test HTTP raises NotImplementedError
-    with pytest.raises(NotImplementedError, match="HTTP support is coming soon."):
-        CatalogConfig.from_path(
-            name="test_http", catalog_path="http://a2ui.org/catalog.json"
-        )
+    # Test HTTP loads HttpCatalogProvider
+    config = CatalogConfig.from_path(
+        name="test_http", catalog_path="http://a2ui.org/catalog.json"
+    )
+    assert isinstance(config.provider, HttpCatalogProvider)
+    assert config.provider.url == "http://a2ui.org/catalog.json"
 
     # Test unsupported scheme raises ValueError
     with pytest.raises(ValueError, match="Unsupported catalog URL scheme"):
@@ -110,3 +112,38 @@ def test_basic_catalog_id_retrieval_methods():
 
     with pytest.raises(ValueError, match="Unsupported version: 0.7"):
         BasicCatalog.get_catalog_id("0.7")
+
+
+def test_http_catalog_provider_success():
+    from unittest.mock import patch, MagicMock
+    from a2ui.schema.catalog_provider import HttpCatalogProvider
+
+    mock_response = MagicMock()
+    mock_response.__enter__.return_value = mock_response
+    mock_response.read.return_value = b'{"catalogId": "my_remote_catalog"}'
+    mock_response.headers = {"Content-Type": "application/agent-plugin+json"}
+
+    provider = HttpCatalogProvider("http://example.com/catalog.json")
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        data = provider.load()
+        assert data == {"catalogId": "my_remote_catalog"}
+
+
+def test_catalog_part_helpers():
+    from a2ui.a2a.parts import is_catalog_part, create_catalog_part, CATALOG_MIME_TYPE
+    from a2a.types import Part, DataPart
+
+    catalog_data = {"catalogId": "test_catalog"}
+    part = create_catalog_part(catalog_data)
+
+    assert isinstance(part, Part)
+    assert isinstance(part.root, DataPart)
+    assert part.root.data == catalog_data
+    assert part.root.metadata.get("mimeType") == CATALOG_MIME_TYPE
+    assert is_catalog_part(part) is True
+
+    # Test is_catalog_part with non-catalog part
+    non_catalog_part = Part(root=DataPart(data={}, metadata={"mimeType": "application/json"}))
+    assert is_catalog_part(non_catalog_part) is False
+

--- a/docs/public/quickstart.md
+++ b/docs/public/quickstart.md
@@ -251,6 +251,17 @@ Now that you've seen A2UI in action, you're ready to:
 - **[Use an Existing Agent App](guides/a2ui-with-any-agent-framework.md)**: Add A2UI through CopilotKit + AG-UI for ADK, LangGraph, CrewAI, Mastra, or a custom service
 - **[Explore the Protocol](reference/messages.md)**: Dive into the technical specification
 
+## Customizing Agent URLs
+
+By default, the samples expect agents to be running on specific ports (e.g., `10002` for Restaurant Finder, `10003` for Contact Lookup). If you need to run agents on different ports (for example, to support restricted port forwarding in remote environments), you can configure the URLs using environment variables before building or running the client:
+
+```bash
+export VITE_RESTAURANT_AGENT_URL="http://localhost:8000"
+export VITE_CONTACTS_AGENT_URL="http://localhost:8001"
+```
+
+These variables are picked up by Vite during development or build time.
+
 ## Troubleshooting
 
 ### Port Already in Use

--- a/docs/public/quickstart.md
+++ b/docs/public/quickstart.md
@@ -253,11 +253,10 @@ Now that you've seen A2UI in action, you're ready to:
 
 ## Customizing Agent URLs
 
-By default, the samples expect agents to be running on specific ports (e.g., `10002` for Restaurant Finder, `10003` for Contact Lookup). If you need to run agents on different ports (for example, to support restricted port forwarding in remote environments), you can configure the URLs using environment variables before building or running the client:
+By default, the samples expect agents to be running on specific ports (e.g., `10002` for Restaurant Finder). If you need to run agents on different ports (for example, to support restricted port forwarding in remote environments), you can configure the URLs using environment variables before building or running the client:
 
 ```bash
 export VITE_RESTAURANT_AGENT_URL="http://localhost:8000"
-export VITE_CONTACTS_AGENT_URL="http://localhost:8001"
 ```
 
 These variables are picked up by Vite during development or build time.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -225,11 +225,10 @@ Now that you've seen A2UI in action, you're ready to:
 
 ## Customizing Agent URLs
 
-By default, the samples expect agents to be running on specific ports (e.g., `10002` for Restaurant Finder, `10003` for Contact Lookup). If you need to run agents on different ports (for example, to support restricted port forwarding in remote environments), you can configure the URLs using environment variables before building or running the client:
+By default, the samples expect agents to be running on specific ports (e.g., `10002` for Restaurant Finder). If you need to run agents on different ports (for example, to support restricted port forwarding in remote environments), you can configure the URLs using environment variables before building or running the client:
 
 ```bash
 export VITE_RESTAURANT_AGENT_URL="http://localhost:8000"
-export VITE_CONTACTS_AGENT_URL="http://localhost:8001"
 ```
 
 These variables are picked up by Vite during development or build time.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -201,7 +201,8 @@ The repository includes several other demos:
 See all available A2UI components:
 
 ```bash
-npm run demo:gallery09
+cd ../../../renderers/lit
+npm run demo
 ```
 
 This runs a client-only demo showcasing every standard component (Card, Button, TextField, Timeline, etc.) with live examples and code samples.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,9 +48,10 @@ cd samples/client/lit
 
 ## Step 4: Install and Run
 
-Run the one-command demo launcher:
+Run the restaurant demo launcher:
 
 ```bash
+npm install
 npm run demo:restaurant
 ```
 
@@ -200,7 +201,7 @@ The repository includes several other demos:
 See all available A2UI components:
 
 ```bash
-npm start -- gallery
+npm run demo:gallery09
 ```
 
 This runs a client-only demo showcasing every standard component (Card, Button, TextField, Timeline, etc.) with live examples and code samples.
@@ -221,6 +222,17 @@ Now that you've seen A2UI in action, you're ready to:
 - **[Set Up Your Own Client](guides/client-setup.md)**: Integrate A2UI into your own app
 - **[Build an Agent](guides/agent-development.md)**: Create agents that generate A2UI responses
 - **[Explore the Protocol](reference/messages.md)**: Dive into the technical specification
+
+## Customizing Agent URLs
+
+By default, the samples expect agents to be running on specific ports (e.g., `10002` for Restaurant Finder, `10003` for Contact Lookup). If you need to run agents on different ports (for example, to support restricted port forwarding in remote environments), you can configure the URLs using environment variables before building or running the client:
+
+```bash
+export VITE_RESTAURANT_AGENT_URL="http://localhost:8000"
+export VITE_CONTACTS_AGENT_URL="http://localhost:8001"
+```
+
+These variables are picked up by Vite during development or build time.
 
 ## Troubleshooting
 

--- a/samples/client/lit/shell/configs/restaurant.ts
+++ b/samples/client/lit/shell/configs/restaurant.ts
@@ -29,6 +29,6 @@ export const restaurantConfig: AppConfig = {
     "Looking for open tables...",
     "Almost there...",
   ],
-  serverUrl: "http://localhost:10002",
+  serverUrl: (import.meta as any).env?.VITE_RESTAURANT_AGENT_URL || "http://localhost:10002",
   cssOverrides: restaurantThemeSheet,
 };

--- a/samples/client/lit/shell/configs/restaurant.ts
+++ b/samples/client/lit/shell/configs/restaurant.ts
@@ -29,6 +29,6 @@ export const restaurantConfig: AppConfig = {
     "Looking for open tables...",
     "Almost there...",
   ],
-  serverUrl: (import.meta as any).env?.VITE_RESTAURANT_AGENT_URL || "http://localhost:10002",
+  serverUrl: import.meta.env?.VITE_RESTAURANT_AGENT_URL || "http://localhost:10002",
   cssOverrides: restaurantThemeSheet,
 };

--- a/samples/client/lit/shell/configs/restaurant.ts
+++ b/samples/client/lit/shell/configs/restaurant.ts
@@ -29,6 +29,6 @@ export const restaurantConfig: AppConfig = {
     'Looking for open tables...',
     'Almost there...',
   ],
-  serverUrl: 'http://localhost:10002',
+  serverUrl: import.meta.env?.VITE_RESTAURANT_AGENT_URL || 'http://localhost:10002',
   cssOverrides: restaurantThemeSheet,
 };

--- a/samples/client/lit/shell/vite-env.d.ts
+++ b/samples/client/lit/shell/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tools/build_catalog/tests/test_assemble_catalog.py
+++ b/tools/build_catalog/tests/test_assemble_catalog.py
@@ -199,7 +199,7 @@ class TestAssembleCatalog(unittest.TestCase):
             "components": {"LoopBlock": {"$ref": "memory://test#/components/LoopBlock"}}
         }
 
-        assembler = CatalogAssembler(version="0.9", max_depth=5)
+        assembler = CatalogAssembler(version="0.9", max_depth=2)
 
         # We manually call process_schema to trigger the recursion check
         # and mock fetch_json to always return the loop schema so it infinitely evaluates


### PR DESCRIPTION
This PR addresses onboarding friction by making agent URLs configurable via env vars and updating the quickstart documentation.