### PR TITLE
Use component ID for input and label to avoid ID collisions

### DIFF
--- a/renderers/lit/src/0.8/ui/checkbox.ts
+++ b/renderers/lit/src/0.8/ui/checkbox.ts
@@ -96,11 +96,12 @@ export class Checkbox extends Root {
 
           this.#setBoundValue(evt.target.checked);
         }}
-        id="data"
+        id="${this.id}-input"
+        name=${this.id}
         type="checkbox"
         .checked=${value}
       />
-      <label class=${classMap(this.theme.components.CheckBox.label)} for="data"
+      <label class=${classMap(this.theme.components.CheckBox.label)} for="${this.id}-input"
         >${extractStringValue(
           this.label,
           this.component,

--- a/renderers/lit/src/0.8/ui/datetime-input.ts
+++ b/renderers/lit/src/0.8/ui/datetime-input.ts
@@ -87,7 +87,7 @@ export class DateTimeInput extends Root {
       class=${classMap(this.theme.components.DateTimeInput.container)}
     >
       <label
-        for="data"
+        for="${this.id}-input"
         class=${classMap(this.theme.components.DateTimeInput.label)}
         >${this.#getPlaceholderText()}</label
       >
@@ -104,8 +104,8 @@ export class DateTimeInput extends Root {
 
           this.#setBoundValue(evt.target.value);
         }}
-        id="data"
-        name="data"
+        id="${this.id}-input"
+        name=${this.id}
         .value=${this.#formatInputValue(value)}
         .placeholder=${this.#getPlaceholderText()}
         .type=${this.#getInputType()}

--- a/renderers/lit/src/0.8/ui/slider.ts
+++ b/renderers/lit/src/0.8/ui/slider.ts
@@ -87,7 +87,7 @@ export class Slider extends Root {
       class=${classMap(this.theme.components.Slider.container)}
     >
       ${this.label
-        ? html`<label class=${classMap(this.theme.components.Slider.label)} for="data">
+        ? html`<label class=${classMap(this.theme.components.Slider.label)} for="${this.id}-input">
             ${extractStringValue(
               this.label,
               this.component,
@@ -109,8 +109,8 @@ export class Slider extends Root {
 
           this.#setBoundValue(evt.target.value);
         }}
-        id="data"
-        name="data"
+        id="${this.id}-input"
+        name=${this.id}
         .value=${value}
         type="range"
         min=${this.minValue ?? "0"}

--- a/renderers/lit/src/0.8/ui/text-field.ts
+++ b/renderers/lit/src/0.8/ui/text-field.ts
@@ -101,7 +101,7 @@ export class TextField extends Root {
       ${label && label !== ""
         ? html`<label
             class=${classMap(this.theme.components.TextField.label)}
-            for="data"
+            for="${this.id}-input"
             >${label}</label
           >`
         : nothing}
@@ -126,8 +126,8 @@ export class TextField extends Root {
 
           this.#setBoundValue(evt.target.value);
         }}
-        name="data"
-        id="data"
+        name=${this.id}
+        id="${this.id}-input"
         .value=${value}
         .placeholder=${"Please enter a value"}
         pattern=${this.validationRegexp || nothing}


### PR DESCRIPTION
This PR addresses a bug where the input IDs were hardcoded as `data` in the Lit renderer, which made browser automation difficult.

I made what I believe are reasonable changes, but since Paul wrote the initial version of this, I seriously doubt my changes and worry that his initial version is better. I defer to @paullewis but present this as a possible PR