### PR TITLE
Populate error state in UI when agent communication fails

### DIFF
--- a/samples/client/lit/shell/app.ts
+++ b/samples/client/lit/shell/app.ts
@@ -410,6 +410,7 @@ export class A2UILayoutEditor extends SignalWatcher(LitElement) {
   ): Promise<v0_8.Types.ServerToClientMessage[]> {
     try {
       this.#requesting = true;
+      this.#error = null;
       this.#startLoadingAnimation();
       const response = this.#a2uiClient.send(message);
       await response;
@@ -418,7 +419,12 @@ export class A2UILayoutEditor extends SignalWatcher(LitElement) {
 
       return response;
     } catch (err) {
-      this.snackbar(err as string, SnackType.ERROR);
+      if (err instanceof Error) {
+        this.#error = err.message;
+      } else {
+        this.#error = String(err);
+      }
+      this.snackbar(this.#error, SnackType.ERROR);
     } finally {
       this.#requesting = false;
       this.#stopLoadingAnimation();


### PR DESCRIPTION
This PR improves error handling in the shell client by populating the existing #error state when agent communication fails, making errors visible in the main UI.