### PR TITLE
docs(react): update README with v0.9 protocol and implementation guide

### DIFF
--- a/renderers/react/README.md
+++ b/renderers/react/README.md
@@ -3,654 +3,257 @@
 React renderer for A2UI (Agent-to-User Interface) - enables AI agents to
 generate rich, interactive user interfaces through declarative JSON.
 
-## Table of Contents
+## Features
 
--   [Installation](#installation)
--   [Quick Start](#quick-start)
--   [Architecture](#architecture)
--   [Components](#components)
--   [Hooks](#hooks)
--   [Theme System](#theme-system)
--   [Component Registry](#component-registry)
--   [Styles](#styles)
--   [Development](#development)
--   [Visual Parity Testing](#visual-parity-testing)
--   [API Reference](#api-reference)
--   [Contributing](#contributing)
+- **v0.9 Native**: Built specifically for the A2UI v0.9 protocol with improved modularity and type safety.
+- **Deep Reactivity**: Powered by the A2UI Generic Binder for automatic, fine-grained updates.
+- **Strongly Typed**: Inferred property types from Zod schemas ensure compile-time safety.
+- **Extensible**: Easily define custom component catalogs and logic functions.
+- **Multi-Surface**: Built-in support for managing independent UI surfaces.
 
 ## Installation
 
 ```bash
-npm install @a2ui/react
+npm install @a2ui/react @a2ui/web_core
 ```
 
-**Peer Dependencies:** - React 18.x or 19.x - React DOM 18.x or 19.x
+## Protocol Versioning
+
+A2UI supports multiple protocol versions to ensure backward compatibility. For new projects, it is recommended to use the **v0.9** protocol.
+
+To use the v0.9 implementation, import from the versioned path:
+
+```typescript
+import { A2uiSurface, basicCatalog } from '@a2ui/react/v0_9';
+```
 
 ## Quick Start
 
-```tsx
-import { A2UIProvider, A2UIRenderer, injectStyles } from '@a2ui/react';
-import { useA2UI } from '@a2ui/react';
+The React renderer works alongside the `MessageProcessor` from `@a2ui/web_core`.
 
-// Inject A2UI styles once at app startup
-injectStyles();
+```tsx
+import { useState, useEffect } from 'react';
+import { MessageProcessor } from '@a2ui/web_core/v0_9';
+import { A2uiSurface, basicCatalog } from '@a2ui/react/v0_9';
 
 function App() {
-  const { processMessages } = useA2UI();
+  // 1. Initialize the MessageProcessor with your catalogs
+  const [processor] = useState(() => new MessageProcessor([basicCatalog]));
+  const [surface, setSurface] = useState(null);
 
-  // Process A2UI messages from your AI agent
-  const handleAgentResponse = (messages) => {
-    processMessages(messages);
-  };
+  useEffect(() => {
+    // 2. Listen for surface creation
+    const sub = processor.onSurfaceCreated(s => {
+      // You can filter by surfaceId or manage multiple surfaces
+      if (s.id === 'main-chat') setSurface(s);
+    });
+
+    // 3. Process messages from your agent (e.g., via WebSocket or SSE)
+    // For demo purposes, we manually process a creation message:
+    processor.processMessages([{
+      version: 'v0.9',
+      createSurface: { 
+        surfaceId: 'main-chat', 
+        catalogId: basicCatalog.id // 'https://a2ui.org/specification/v0_9/basic_catalog.json'
+      }
+    }]);
+
+    return () => sub.unsubscribe();
+  }, [processor]);
+
+  // 4. Render the surface once it's available
+  return (
+    <div className="a2ui-container">
+      {surface ? <A2uiSurface surface={surface} /> : <div>Initializing Agent UI...</div>}
+    </div>
+  );
+}
+```
+
+## Defining Custom Components
+
+A2UI v0.9 strictly separates a component's API (Schema) from its implementation.
+
+### 1. Define the Component API
+Use Zod to define the properties. Using `CommonSchemas` from `web_core` enables automatic binding for A2UI primitives.
+
+```typescript
+import { z } from 'zod';
+import { CommonSchemas } from '@a2ui/web_core/v0_9';
+
+export const MyProfileApi = {
+  name: 'Profile',
+  schema: z.object({
+    username: CommonSchemas.DynamicString,  // Can be literal "Alice" or {path: "/user/name"}
+    bio: CommonSchemas.DynamicString,
+    avatarUrl: CommonSchemas.DynamicString,
+    onEdit: CommonSchemas.Action,           // Resolves to a clickable () => void
+    isEditable: CommonSchemas.DynamicBoolean,
+    // Add 'checks' if you want validation support (standard in v0.9 interactive components)
+    checks: CommonSchemas.Checkable.shape.checks,
+  }),
+};
+```
+
+### 2. Create the React Implementation
+The `createComponentImplementation` factory uses a **Generic Binder** to resolve all dynamic values before your component renders.
+
+```tsx
+import { createComponentImplementation } from '@a2ui/react/v0_9';
+
+export const MyProfile = createComponentImplementation(
+  MyProfileApi, 
+  ({ props, buildChild }) => {
+    // 'props' is strictly inferred from the Zod schema:
+    // props.username is 'string' (resolved from DynamicString)
+    // props.onEdit is '() => void' (resolved from Action)
+    
+    return (
+      <div className="profile-widget">
+        <img src={props.avatarUrl ?? ''} alt={props.username} />
+        <h2>{props.username}</h2>
+        <p>{props.bio}</p>
+        
+        {props.isEditable && (
+          <button onClick={props.onEdit} disabled={props.isValid === false}>
+            Edit Profile
+          </button>
+        )}
+        
+        {/* Render validation errors if any check fails */}
+        {props.validationErrors?.map((err, i) => (
+          <div key={i} className="error-hint" style={{color: 'red'}}>{err}</div>
+        ))}
+      </div>
+    );
+  }
+);
+```
+
+## Generic Binder Features
+
+The Generic Binder is a framework-agnostic engine that transforms raw JSON payload configurations into a cohesive reactive stream of strongly-typed props.
+
+- **Automatic Resolution**: Properties typed as `DynamicString`, `DynamicNumber`, and `DynamicBoolean` are automatically resolved to their current values (strings, numbers, booleans).
+- **Two-Way Binding**: If a schema uses a dynamic type (like `DynamicString`), the binder automatically injects a setter. For a property `username`, it adds `props.setUsername(val: string)`, which updates the underlying data model.
+- **Action Context**: `Action` properties are resolved into ready-to-call functions. When called, they automatically resolve their deep context bindings (e.g., gathering form data from the model) before notifying the server.
+- **Reactive Validation**: If your schema includes `checks`, the binder reactively evaluate the rules and injects `props.isValid` and `props.validationErrors` based on the results of the logic functions.
+
+## Binderless Components
+
+For advanced use cases where you need direct access to the `ComponentContext` or want to manage reactivity manually (e.g., for performance-critical animations), use `createBinderlessComponentImplementation`.
+
+```tsx
+import { createBinderlessComponentImplementation } from '@a2ui/react/v0_9';
+
+export const RawInspector = createBinderlessComponentImplementation(
+  InspectorApi, 
+  ({ context }) => {
+    // Access the raw, unresolved component model and the data model directly
+    const rawData = context.componentModel.properties;
+    const surfaceId = context.componentModel.id;
+    
+    return (
+      <details>
+        <summary>Raw Component State (ID: {surfaceId})</summary>
+        <pre>{JSON.stringify(rawData, null, 2)}</pre>
+      </details>
+    );
+  }
+);
+```
+
+## Defining Catalogs and Functions
+
+Group your components and logic functions into a `Catalog` to be used by the `MessageProcessor`.
+
+```typescript
+import { Catalog, createFunctionImplementation } from '@a2ui/web_core/v0_9';
+import { z } from 'zod';
+
+// 1. Implement a custom logic function
+const myCheckFunc = createFunctionImplementation(
+  { 
+    name: 'is_admin', 
+    returnType: 'boolean', 
+    schema: z.object({ role: z.string() }) 
+  },
+  (args) => args.role === 'admin'
+);
+
+// 2. Compose the catalog
+export const myCatalog = new Catalog(
+  'https://example.com/catalogs/v1.json',
+  [MyProfile, RawInspector], // List of ReactComponentImplementation
+  [myCheckFunc]               // List of FunctionImplementation
+);
+```
+
+## Basic Catalog Components
+
+The `@a2ui/react/v0_9` package includes a `basicCatalog` with standard components:
+
+- **Layout**: `Row`, `Column`, `List`, `Card`, `Tabs`, `Modal`, `Divider`
+- **Content**: `Text`, `Image`, `Icon`, `Video`, `AudioPlayer`
+- **Input**: `Button`, `TextField`, `CheckBox`, `ChoicePicker`, `Slider`, `DateTimeInput`
+
+---
+
+## Legacy Support (v0.8)
+
+A2UI v0.8 is maintained for backward compatibility. While it remains the default export for the `@a2ui/react` package, it is recommended to transition to v0.9 for new features like type-safe binders and logic functions.
+
+### Import and Usage
+
+To use the v0.8 renderer, you use the `A2UIProvider` and `A2UIRenderer` components:
+
+```tsx
+import { A2UIProvider, A2UIRenderer, injectStyles } from '@a2ui/react/v0_8';
+
+// Inject v0.8 styles
+injectStyles();
+
+function LegacyApp() {
+  const handleAction = (msg) => console.log('Action:', msg);
 
   return (
     <A2UIProvider onAction={handleAction}>
+      {/* Renders the surface using v0.8 logic */}
       <A2UIRenderer surfaceId="main" />
     </A2UIProvider>
   );
 }
-
-// Handle user interactions
-function handleAction(message) {
-  console.log('User action:', message);
-  // Send to your AI agent backend
-}
 ```
 
-### Standalone Viewer
+### Key Differences (v0.8 vs v0.9)
 
-For simpler use cases, use the all-in-one `A2UIViewer`:
+| Feature | v0.8 (Legacy) | v0.9 (Current) |
+| :--- | :--- | :--- |
+| **Protocol** | Uses `BeginRendering`, `SurfaceUpdate`. | Uses `createSurface`, `updateComponents`, `updateDataModel`. |
+| **Data Flow** | Unidirectional surface updates. | Bidirectional synchronization (`sendDataModel`). |
+| **Type Safety** | Props accessed via `node.properties`. | Strongly typed `props` inferred from Zod schemas. |
+| **Logic** | Limited client-side logic. | Extensible `Function` system (e.g., `formatString`, `required`). |
+| **Reactivity** | Hooks-based (`useA2UIComponent`). | Automatic via the **Generic Binder** middleware. |
+| **Binding** | Manual resolution in component body. | Declarative two-way binding with injected setters. |
+
+In v0.8, components are responsible for resolving their own dynamic values using hooks:
 
 ```tsx
-import { A2UIViewer, injectStyles } from '@a2ui/react';
-
-injectStyles();
-
-function App() {
-  const messages = [...]; // A2UI messages from agent
-
-  return (
-    <A2UIViewer
-      messages={messages}
-      onAction={(msg) => console.log('Action:', msg)}
-    />
-  );
-}
-```
-
-## Architecture
-
-### Versioned Structure
-
-To support the evolution of the A2UI protocol, the `@a2ui/react` package is organized into versioned subdirectories (e.g., `v0_8/`, and soon `v0_9/`). 
-
-```
-renderers/react/
-├── src/
-│   ├── v0_8/           # Implementation of the v0.8 protocol
-│   │   ├── components/
-│   │   ├── core/
-│   │   └── ...
-│   ├── index.ts        # Proxy export for backward compatibility -> ./v0_8/index
-│   ├── types.ts        # Proxy export -> ./v0_8/types
-│   └── styles/         # Proxy export -> ../v0_8/styles/index
-```
-
-**Backward Compatibility & Future Roadmap**
-
-The top-level exports in `package.json` and the proxy files in the `src/` root currently default to the `v0_8` implementation. This guarantees that existing applications relying on `import { A2UIProvider } from '@a2ui/react'` will continue to work without modification.
-
-Applications can also explicitly import from a specific version path if desired (e.g., `import { A2UIProvider } from '@a2ui/react/v0_8'`). 
-
-As the `v0_9` protocol implementation is added to the `v0_9/` subdirectory, the top-level exports will be updated to point to the newest stable version. 
-
-**Note:** This side-by-side versioned directory structure is a temporary transition phase. Eventually, the `v0_8` renderer will be deprecated and removed. The package will then revert to a single, unified codebase that natively supports multiple versions of the A2UI specification simultaneously.
-
-### Two-Context Pattern
-
-The React renderer uses a two-context architecture for optimal performance:
-
-```
-┌─────────────────────────────────────────────────────────┐
-│                     A2UIProvider                         │
-├─────────────────────────────────────────────────────────┤
-│  ┌─────────────────────┐  ┌─────────────────────────┐   │
-│  │  A2UIActionsContext │  │   A2UIStateContext      │   │
-│  │  (stable reference) │  │   (triggers re-renders) │   │
-│  │                     │  │                         │   │
-│  │  • processMessages  │  │   • version             │   │
-│  │  • setData          │  │                         │   │
-│  │  • dispatch         │  │                         │   │
-│  │  • getData          │  │                         │   │
-│  │  • getSurface       │  │                         │   │
-│  └─────────────────────┘  └─────────────────────────┘   │
-│                                                          │
-│  ┌────────────────────────────────────────────────────┐ │
-│  │                   ThemeProvider                     │ │
-│  │                                                     │ │
-│  │   ┌─────────────┐    ┌─────────────────────────┐   │ │
-│  │   │ A2UIRenderer│───▶│     ComponentNode       │   │ │
-│  │   │ (surfaceId) │    │  (recursive rendering)  │   │ │
-│  │   └─────────────┘    └─────────────────────────┘   │ │
-│  └────────────────────────────────────────────────────┘ │
-└─────────────────────────────────────────────────────────┘
-```
-
-**Why two contexts?**
-
--   **A2UIActionsContext**: Contains stable action callbacks that never change
-    reference. Components using `useA2UIActions()` won't re-render when data
-    changes.
--   **A2UIStateContext**: Contains a version counter that increments on state
-    changes. Only components that need to react to data changes subscribe to
-    this.
-
-This separation prevents unnecessary re-renders and provides fine-grained
-control over component updates.
-
-### Data Flow
-
-```
-Agent Server                    React App
-     │                              │
-     │  ServerToClientMessage[]     │
-     ├─────────────────────────────▶│ processMessages()
-     │                              │
-     │                              ▼
-     │                     ┌────────────────┐
-     │                     │ MessageProcessor│
-     │                     │   (surfaces)   │
-     │                     └───────┬────────┘
-     │                             │
-     │                             ▼
-     │                     ┌────────────────┐
-     │                     │  A2UIRenderer  │
-     │                     │  (per surface) │
-     │                     └───────┬────────┘
-     │                             │
-     │                             ▼
-     │                     ┌────────────────┐
-     │                     │ ComponentNode  │
-     │                     │  (recursive)   │
-     │                     └───────┬────────┘
-     │                             │
-     │  A2UIClientEventMessage     │ User interaction
-     │◀────────────────────────────┤ dispatch()
-     │                              │
-```
-
-## Components
-
-All components are wrapped with `React.memo()` for performance optimization.
-
-### Content Components
-
-Component     | Description
-------------- | ----------------------------------------
-`Text`        | Renders text with markdown support
-`Image`       | Displays images with various usage hints
-`Icon`        | Renders Material Symbols icons
-`Divider`     | Horizontal or vertical divider
-`Video`       | Video player
-`AudioPlayer` | Audio player
-
-### Layout Components
-
-Component | Description
---------- | ------------------------------------
-`Column`  | Vertical flex container
-`Row`     | Horizontal flex container
-`Card`    | Card container with styling
-`List`    | List container (vertical/horizontal)
-`Tabs`    | Tabbed interface
-`Modal`   | Modal dialog
-
-### Interactive Components
-
-Component        | Description
----------------- | -------------------------------------
-`Button`         | Clickable button with action dispatch
-`TextField`      | Text input (single/multiline)
-`CheckBox`       | Checkbox input
-`Slider`         | Range slider
-`DateTimeInput`  | Date/time picker
-`MultipleChoice` | Radio/checkbox group
-
-### Component Structure
-
-Each component mirrors the Lit renderer's Shadow DOM structure for visual
-parity:
-
-```tsx
-// React component structure
-<div className="a2ui-{component}">    {/* :host equivalent */}
-  <section className="theme-classes"> {/* internal element */}
-    {children}                        {/* ::slotted(*) equivalent */}
-  </section>
-</div>
-```
-
-## Hooks
-
-### useA2UI()
-
-High-level hook for external application use:
-
-```tsx
-import { useA2UI } from '@a2ui/react';
-
-function MyComponent() {
-  const { processMessages, clearSurfaces } = useA2UI();
-
-  const loadUI = async () => {
-    const response = await fetch('/api/agent');
-    const messages = await response.json();
-    processMessages(messages);
-  };
-
-  return <button onClick={loadUI}>Load UI</button>;
-}
-```
-
-### useA2UIActions()
-
-Access stable actions without triggering re-renders:
-
-```tsx
-import { useA2UIActions } from '@a2ui/react';
-
-function ActionButton() {
-  const { dispatch } = useA2UIActions();
-
-  const handleClick = () => {
-    dispatch({
-      event: { action: { name: 'submit' } },
-      sourceComponent: 'button-1',
-      surfaceId: 'main',
-    });
-  };
-
-  return <button onClick={handleClick}>Submit</button>;
-}
-```
-
-### useA2UIState()
-
-Subscribe to state changes (triggers re-renders):
-
-```tsx
-import { useA2UIState } from '@a2ui/react';
-
-function VersionDisplay() {
-  const { version } = useA2UIState();
-  return <span>State version: {version}</span>;
-}
-```
-
-### useA2UIContext()
-
-Combined access to actions and state:
-
-```tsx
-import { useA2UIContext } from '@a2ui/react';
-
-function MyComponent() {
-  const { processMessages, dispatch, version } = useA2UIContext();
+// v0.8 Manual Resolution
+function TextField({ node, surfaceId }) {
+  const { resolveString, setValue } = useA2UIComponent(node, surfaceId);
+  const label = resolveString(node.properties.label);
   // ...
 }
 ```
 
-### useA2UIComponent()
+In v0.9, this is handled by the **Generic Binder** before the component even renders, resulting in cleaner, framework-native view code.
 
-Internal hook for component implementations. Automatically subscribes to state
-changes so components with path bindings re-render when data updates.
+## Security
 
-```tsx
-import { useA2UIComponent } from '@a2ui/react';
+> [!IMPORTANT]
+> The sample code provided is for demonstration purposes and illustrates the mechanics of A2UI. When building production applications, it is critical to treat any agent operating outside of your direct control as a potentially untrusted entity.
 
-function CustomComponent({ node, surfaceId }) {
-  const {
-    theme,
-    resolveString,
-    resolveNumber,
-    resolveBoolean,
-    setValue,
-    getValue,
-    sendAction,
-    getUniqueId,
-  } = useA2UIComponent(node, surfaceId);
+All operational data received from an external agent—including its messages and UI definitions—should be handled as untrusted input. Malicious agents could attempt to spoof legitimate interfaces to deceive users (phishing), inject malicious scripts via property values (XSS), or generate excessive layout complexity to degrade client performance (DoS). If your application supports optional embedded content (such as iframes or web views), additional care must be taken to prevent exposure to malicious external sites.
 
-  const text = resolveString(node.properties.text);
-  // ...
-}
-```
-
-**Path Binding Reactivity**: When a component uses `setValue()` to update the
-data model, all components reading from the same path via `resolveString()`,
-`resolveNumber()`, or `resolveBoolean()` will automatically re-render with the
-new value.
-
-## Theme System
-
-### Using the Default Theme
-
-```tsx
-import { A2UIProvider, litTheme } from '@a2ui/react';
-
-<A2UIProvider theme={litTheme}>
-  {/* components */}
-</A2UIProvider>
-```
-
-### Creating a Custom Theme
-
-```tsx
-import { litTheme } from '@a2ui/react';
-
-const customTheme = {
-  ...litTheme,
-  components: {
-    ...litTheme.components,
-    Button: {
-      ...litTheme.components.Button,
-      all: {
-        'my-button-class': true,
-        'rounded-lg': true,
-      },
-    },
-  },
-};
-
-<A2UIProvider theme={customTheme}>
-  {/* components */}
-</A2UIProvider>
-```
-
-### Theme Structure
-
-```typescript
-interface Theme {
-  components: {
-    [ComponentName]: {
-      all: ClassMap;        // Always applied
-      [variant]: ClassMap;  // Variant-specific (e.g., primary, secondary)
-    };
-  };
-  elements: {
-    [elementName]: ClassMap; // HTML element styling
-  };
-  markdown: {
-    [tagName]: string[];    // Markdown element classes
-  };
-  additionalStyles?: {
-    [ComponentName]: Record<string, string>; // Inline styles
-  };
-}
-```
-
-## Component Registry
-
-### Default Catalog
-
-The default catalog registers all standard A2UI components:
-
-```tsx
-import { initializeDefaultCatalog } from '@a2ui/react';
-
-// Call once at app startup
-initializeDefaultCatalog();
-```
-
-### Custom Components
-
-Register custom components to extend or override the default catalog:
-
-```tsx
-import { ComponentRegistry } from '@a2ui/react';
-
-// Get the singleton registry
-const registry = ComponentRegistry.getInstance();
-
-// Register a custom component
-registry.register('CustomButton', {
-  component: MyCustomButton,
-});
-
-// Override an existing component
-registry.register('Button', {
-  component: MyEnhancedButton,
-});
-```
-
-### Lazy Loading
-
-Components can be lazy-loaded for code splitting:
-
-```tsx
-registry.register('HeavyChart', {
-  component: () => import('./components/HeavyChart'),
-  lazy: true,
-});
-```
-
-> **Note:** Small, commonly-used components (like Tabs, Modal) should be
-> statically imported to avoid Vite cache issues during development.
-
-## Styles
-
-### Injecting Styles
-
-Inject A2UI structural and component styles once at app startup:
-
-```tsx
-import { injectStyles } from '@a2ui/react/styles';
-
-// In your app entry point
-injectStyles();
-```
-
-### Style Architecture
-
-The styles module provides:
-
--   **structuralStyles**: Utility classes from Lit renderer (layout-*,
-    typography-*, color-*)
--   **componentSpecificStyles**: CSS that replicates Lit's Shadow DOM scoped
-    styles
-
-```typescript
-import { structuralStyles, componentSpecificStyles } from '@a2ui/react/styles';
-```
-
-### CSS Variables
-
-CSS color variables must be defined by the host application:
-
-```css
-:root {
-  --n-0: #ffffff;
-  --n-100: #f5f5f5;
-  /* ... other palette variables */
-  --p-500: #3b82f6;
-  /* ... */
-}
-```
-
-### Removing Styles
-
-For cleanup (e.g., in tests):
-
-```tsx
-import { removeStyles } from '@a2ui/react/styles';
-
-removeStyles();
-```
-
-## Development
-
-### Setup
-
-```bash
-cd renderers/react
-npm install
-```
-
-### Build
-
-```bash
-npm run build    # Build the package
-npm run dev      # Watch mode
-```
-
-### Type Check
-
-```bash
-npm run typecheck
-```
-
-### Lint
-
-```bash
-npm run lint
-```
-
-## Testing
-
-### Unit Tests
-
-Uses [Vitest](https://vitest.dev/) +
-[React Testing Library](https://testing-library.com/docs/react-testing-library/intro/).
-
-```bash
-npm test              # Run once
-npm run test:watch    # Watch mode
-```
-
-**Structure:** `tests/ ├── setup.ts # Initializes component catalog ├──
-helpers.tsx # TestWrapper, TestRenderer, message creators └── components/ #
-Component tests (*.test.tsx)`
-
-**Example:** ```tsx import { render, screen, fireEvent } from
-'@testing-library/react'; import { TestWrapper, TestRenderer,
-createSimpleMessages } from '../helpers';
-
-it('should dispatch action on click', () => { const onAction = vi.fn(); const
-messages = createSimpleMessages('btn-1', 'Button', { child: 'text-1', action: {
-name: 'submit' }, });
-
-render( <TestWrapper onAction={onAction}> <TestRenderer messages={messages} />
-</TestWrapper> );
-
-fireEvent.click(screen.getByRole('button'));
-expect(onAction).toHaveBeenCalled(); }); ```
-
-## Visual Parity Testing
-
-The React renderer maintains visual parity with the Lit renderer (reference
-implementation). A comprehensive test suite compares pixel-perfect screenshots
-between both renderers.
-
-### Running Visual Parity Tests
-
-```bash
-cd visual-parity
-npm install
-npm test
-```
-
-### Quick Commands
-
-```bash
-# Run all tests
-npm test
-
-# Run specific component tests
-npm test -- --grep "button"
-
-# Run with UI mode
-npm run test:ui
-
-# Start dev servers for manual inspection
-npm run dev
-# React: http://localhost:5001
-# Lit: http://localhost:5002
-```
-
-### Documentation
-
--   **[visual-parity/README.md](./visual-parity/README.md)** - Test suite usage
-    and fixture creation
--   **[visual-parity/PARITY.md](./visual-parity/PARITY.md)** - CSS
-    transformation approach and implementation status
-
-### Key Concepts
-
-1.  **Structural Mirroring**: React components mirror Lit's Shadow DOM structure
-2.  **CSS Selector Transformation**: `:host` → `.a2ui-surface .a2ui-{component}`
-3.  **Specificity Matching**: Uses `:where()` to match Lit's low specificity
-
-## API Reference
-
-### Core Exports
-
-```typescript
-// Provider and Renderer
-export { A2UIProvider, A2UIRenderer, A2UIViewer, ComponentNode };
-
-// Hooks
-export { useA2UI, useA2UIActions, useA2UIState, useA2UIContext, useA2UIComponent };
-
-// Registry
-export { ComponentRegistry, registerDefaultCatalog, initializeDefaultCatalog };
-
-// Theme
-export { ThemeProvider, useTheme, litTheme, defaultTheme };
-
-// Styles (from '@a2ui/react/styles')
-export { injectStyles, removeStyles, structuralStyles, componentSpecificStyles };
-
-// Utilities
-export { cn, classMapToString, stylesToObject };
-
-// All component exports
-export { Text, Image, Icon, Divider, Video, AudioPlayer };
-export { Row, Column, Card, List, Tabs, Modal };
-export { Button, TextField, CheckBox, Slider, DateTimeInput, MultipleChoice };
-```
-
-### Types
-
-```typescript
-import type {
-  Types,
-  Theme,
-  Surface,
-  SurfaceID,
-  AnyComponentNode,
-  ServerToClientMessage,
-  A2UIClientEventMessage,
-  A2UIComponentProps,
-  A2UIProviderProps,
-  A2UIRendererProps,
-  UseA2UIResult,
-  UseA2UIComponentResult,
-} from '@a2ui/react';
-```
-
-## Contributing
-
-### Code Style
-
--   All components use `React.memo()` for performance
--   Use the two-context pattern for state management
--   Follow the existing component structure for visual parity
-
-### Adding a New Component
-
-1.  Create component in `src/components/{category}/{ComponentName}.tsx`
-2.  Follow wrapper div + section structure (see
-    [Component Structure](#component-structure))
-3.  Register in `src/registry/defaultCatalog.ts`
-4.  Export from `src/index.ts`
-5.  Add unit tests in `tests/components/{ComponentName}.test.tsx`
-6.  Add visual parity fixtures in `visual-parity/fixtures/components/`
+**Developer Responsibility**: Failure to properly validate data and strictly sandbox rendered content can introduce severe vulnerabilities. Developers are responsible for implementing appropriate security measures—such as input sanitization, Content Security Policies (CSP), and secure credential handling—to protect their systems and users.

--- a/renderers/react/README.md
+++ b/renderers/react/README.md
@@ -137,7 +137,7 @@ The Generic Binder is a framework-agnostic engine that transforms raw JSON paylo
 - **Automatic Resolution**: Properties typed as `DynamicString`, `DynamicNumber`, and `DynamicBoolean` are automatically resolved to their current values (strings, numbers, booleans).
 - **Two-Way Binding**: If a schema uses a dynamic type (like `DynamicString`), the binder automatically injects a setter. For a property `username`, it adds `props.setUsername(val: string)`, which updates the underlying data model.
 - **Action Context**: `Action` properties are resolved into ready-to-call functions. When called, they automatically resolve their deep context bindings (e.g., gathering form data from the model) before notifying the server.
-- **Reactive Validation**: If your schema includes `checks`, the binder reactively evaluate the rules and injects `props.isValid` and `props.validationErrors` based on the results of the logic functions.
+- **Reactive Validation**: If your schema includes `checks`, the binder reactively evaluates the rules and injects `props.isValid` and `props.validationErrors` based on the results of the logic functions.
 
 ## Binderless Components
 
@@ -151,11 +151,11 @@ export const RawInspector = createBinderlessComponentImplementation(
   ({ context }) => {
     // Access the raw, unresolved component model and the data model directly
     const rawData = context.componentModel.properties;
-    const surfaceId = context.componentModel.id;
+    const componentId = context.componentModel.id;
     
     return (
       <details>
-        <summary>Raw Component State (ID: {surfaceId})</summary>
+        <summary>Raw Component State (ID: {componentId})</summary>
         <pre>{JSON.stringify(rawData, null, 2)}</pre>
       </details>
     );
@@ -257,3 +257,4 @@ In v0.9, this is handled by the **Generic Binder** before the component even ren
 All operational data received from an external agent—including its messages and UI definitions—should be handled as untrusted input. Malicious agents could attempt to spoof legitimate interfaces to deceive users (phishing), inject malicious scripts via property values (XSS), or generate excessive layout complexity to degrade client performance (DoS). If your application supports optional embedded content (such as iframes or web views), additional care must be taken to prevent exposure to malicious external sites.
 
 **Developer Responsibility**: Failure to properly validate data and strictly sandbox rendered content can introduce severe vulnerabilities. Developers are responsible for implementing appropriate security measures—such as input sanitization, Content Security Policies (CSP), and secure credential handling—to protect their systems and users.
+


### PR DESCRIPTION
**Description of Changes:**
This PR updates the `@a2ui/react` package `README.md` to focus on the newly introduced A2UI v0.9 protocol features and implementation changes.
- Adds instructions for importing and using the v0.9 native `A2uiSurface` component.
- Documents the process of defining custom components using Zod schemas and `createComponentImplementation`.
- Explains the new **Generic Binder** features, including automatic type resolution, two-way data binding, and reactive validation.
- Provides examples of how to define `Catalog`s with custom `Function` implementations.
- Maintains a "Legacy Support (v0.8)" section detailing how to continue using the legacy exports and providing a comparison of the key differences in protocol and data flow.
- Updates security considerations for handling dynamic UI payload configurations.

**Rationale:**
With the transition to A2UI v0.9, the underlying component architecture has been significantly refactored. The new documentation helps developers onboard onto the new `MessageProcessor` and `A2uiSurface` flow, leverage strong typing provided by Zod schemas, and understand the automated features of the generic binder. Keeping v0.8 documentation available ensures backward compatibility for existing users while highlighting the benefits of migrating.

**Testing/Running Instructions:**
- Navigate to the `renderers/react` directory.
- Open `README.md` and verify the content matches the updated v0.9 API surfaces, including the React examples and the comparison chart.
- Ensure formatting remains correct.