### PR TITLE
chore(license): fix license header formatting in mcp_app.html

### DIFF
--- a/samples/agent/adk/mcp-apps-in-a2ui-sample/mcp_app.html
+++ b/samples/agent/adk/mcp-apps-in-a2ui-sample/mcp_app.html
@@ -6,7 +6,7 @@
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+      https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
### Description of Changes
Updates the Apache 2.0 license header in `samples/agent/adk/mcp-apps-in-a2ui-sample/mcp_app.html`. Specifically, it updates the license URL from `http` to `https` and adjusts its indentation to 6 spaces.

### Rationale
The `addlicense` check in CI was failing for this specific file. The tool is highly sensitive to exact boilerplate formatting. Aligning this header to match known-passing files (such as `tools/editor/index.html`) successfully resolves the validation failure.

### Testing/Running Instructions
Reviewers can verify the fix by running the license check locally:
```bash
go install github.com/google/addlicense@latest
$(go env GOPATH)/bin/addlicense -check -l apache -c "Google LLC" samples/agent/adk/mcp-apps-in-a2ui-sample/mcp_app.html
```
The command should complete successfully with no output.