### PR TITLE
feat(react): Add markdown rendering support to basic Text component (v0.9)

### DIFF
--- a/.github/workflows/react_renderer.yml
+++ b/.github/workflows/react_renderer.yml
@@ -47,6 +47,12 @@ jobs:
           npm ci
           npm run build
 
+      - name: Build markdown-it dependency
+        working-directory: ./renderers/markdown/markdown-it
+        run: |
+          npm ci
+          npm run build
+
       - name: Install React renderer deps
         working-directory: ./renderers/react
         run: npm ci
@@ -76,6 +82,12 @@ jobs:
           npm ci
           npm run build
 
+      - name: Build markdown-it dependency
+        working-directory: ./renderers/markdown/markdown-it
+        run: |
+          npm ci
+          npm run build
+
       - name: Install React renderer deps
         working-directory: ./renderers/react
         run: npm ci
@@ -101,6 +113,12 @@ jobs:
 
       - name: Build web_core dependency
         working-directory: ./renderers/web_core
+        run: |
+          npm ci
+          npm run build
+
+      - name: Build markdown-it dependency
+        working-directory: ./renderers/markdown/markdown-it
         run: |
           npm ci
           npm run build

--- a/renderers/react/a2ui_explorer/src/App.tsx
+++ b/renderers/react/a2ui_explorer/src/App.tsx
@@ -205,13 +205,14 @@ export default function App() {
                     padding: '1rem',
                     borderRadius: '8px',
                     background: '#fff',
-                    }}
-                    >
-                    <MarkdownContext.Provider value={renderMarkdown}>
+                  }}
+                >
+                  <MarkdownContext.Provider value={renderMarkdown}>
                     <A2uiSurface surface={surface} />
-                    </MarkdownContext.Provider>
-                    </div>
-                    </div>            );
+                  </MarkdownContext.Provider>
+                </div>
+              </div>
+            );
           })}
         </div>
 

--- a/renderers/react/a2ui_explorer/src/App.tsx
+++ b/renderers/react/a2ui_explorer/src/App.tsx
@@ -16,8 +16,9 @@
 
 import {useState, useEffect, useSyncExternalStore, useCallback} from 'react';
 import {MessageProcessor, SurfaceModel} from '@a2ui/web_core/v0_9';
-import {minimalCatalog, basicCatalog, A2uiSurface, type ReactComponentImplementation} from '@a2ui/react/v0_9';
+import {minimalCatalog, basicCatalog, A2uiSurface, MarkdownContext, type ReactComponentImplementation} from '@a2ui/react/v0_9';
 import {exampleFiles, getMessages} from './examples';
+import {renderMarkdown} from '@a2ui/markdown-it';
 
 const DataModelViewer = ({surface}: {surface: SurfaceModel<any>}) => {
   const subscribeHook = useCallback(
@@ -204,12 +205,13 @@ export default function App() {
                     padding: '1rem',
                     borderRadius: '8px',
                     background: '#fff',
-                  }}
-                >
-                  <A2uiSurface surface={surface} />
-                </div>
-              </div>
-            );
+                    }}
+                    >
+                    <MarkdownContext.Provider value={renderMarkdown}>
+                    <A2uiSurface surface={surface} />
+                    </MarkdownContext.Provider>
+                    </div>
+                    </div>            );
           })}
         </div>
 

--- a/renderers/react/package-lock.json
+++ b/renderers/react/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@a2ui/react",
       "version": "0.9.0-alpha.0",
       "dependencies": {
+        "@a2ui/markdown-it": "file:../markdown/markdown-it",
         "@a2ui/web_core": "file:../web_core",
         "clsx": "^2.1.0",
         "markdown-it": "^14.0.0",
@@ -69,6 +70,29 @@
         "wireit": "^0.15.0-pre.2"
       }
     },
+    "../markdown/markdown-it": {
+      "name": "@a2ui/markdown-it",
+      "version": "0.0.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dompurify": "^3.3.1",
+        "markdown-it": "^14.1.0"
+      },
+      "devDependencies": {
+        "@a2ui/web_core": "file:../../web_core",
+        "@types/dompurify": "^3.0.5",
+        "@types/jsdom": "^28.0.0",
+        "@types/markdown-it": "^14.1.2",
+        "@types/node": "^24.10.1",
+        "jsdom": "^28.1.0",
+        "prettier": "^3.4.2",
+        "typescript": "^5.8.3",
+        "wireit": "^0.15.0-pre.2"
+      },
+      "peerDependencies": {
+        "@a2ui/web_core": "file:../../web_core"
+      }
+    },
     "../web_core": {
       "name": "@a2ui/web_core",
       "version": "0.9.1-alpha.0",
@@ -89,6 +113,10 @@
         "typescript": "^5.9.3",
         "wireit": "^0.15.0-pre.2"
       }
+    },
+    "node_modules/@a2ui/markdown-it": {
+      "resolved": "../markdown/markdown-it",
+      "link": true
     },
     "node_modules/@a2ui/web_core": {
       "resolved": "../web_core",

--- a/renderers/react/package.json
+++ b/renderers/react/package.json
@@ -90,6 +90,7 @@
     "test:demo": "cd a2ui_explorer && vitest run src"
   },
   "dependencies": {
+    "@a2ui/markdown-it": "file:../markdown/markdown-it",
     "@a2ui/web_core": "file:../web_core",
     "clsx": "^2.1.0",
     "markdown-it": "^14.0.0",

--- a/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
@@ -53,9 +53,9 @@ export const Text = createComponentImplementation(TextApi, ({props}) => {
 
   if (renderedHtml === null) {
     return (
-      <span className={`a2ui-text ${props.variant || 'body'} no-markdown-renderer`} style={style}>
+      <div className={`a2ui-text ${props.variant || 'body'} no-markdown-renderer`} style={style}>
         {markdownText}
-      </span>
+      </div>
     );
   }
 
@@ -63,14 +63,14 @@ export const Text = createComponentImplementation(TextApi, ({props}) => {
     return (
       <span
         className="a2ui-caption"
-        style={{...style, color: '#666', textAlign: 'left'}}
+        style={{...style, color: '#666', textAlign: 'left', display: 'inline-block'}}
         dangerouslySetInnerHTML={{__html: renderedHtml}}
       />
     );
   }
 
   return (
-    <span
+    <div
       className={`a2ui-text ${props.variant || 'body'}`}
       style={style}
       dangerouslySetInnerHTML={{__html: renderedHtml}}

--- a/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
@@ -18,29 +18,62 @@ import React from 'react';
 import {createComponentImplementation} from '../../../adapter';
 import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {getBaseLeafStyle} from '../utils';
+import {useMarkdown} from '../hooks/useMarkdown';
 
 export const Text = createComponentImplementation(TextApi, ({props}) => {
   const text = props.text ?? '';
+  let markdownText = text;
+
+  switch (props.variant) {
+    case 'h1':
+      markdownText = `# ${text}`;
+      break;
+    case 'h2':
+      markdownText = `## ${text}`;
+      break;
+    case 'h3':
+      markdownText = `### ${text}`;
+      break;
+    case 'h4':
+      markdownText = `#### ${text}`;
+      break;
+    case 'h5':
+      markdownText = `##### ${text}`;
+      break;
+    case 'caption':
+      markdownText = `*${text}*`;
+      break;
+  }
+
+  const renderedHtml = useMarkdown(markdownText);
   const style: React.CSSProperties = {
     ...getBaseLeafStyle(),
     display: 'inline-block',
   };
 
-  switch (props.variant) {
-    case 'h1':
-      return <h1 style={style}>{text}</h1>;
-    case 'h2':
-      return <h2 style={style}>{text}</h2>;
-    case 'h3':
-      return <h3 style={style}>{text}</h3>;
-    case 'h4':
-      return <h4 style={style}>{text}</h4>;
-    case 'h5':
-      return <h5 style={style}>{text}</h5>;
-    case 'caption':
-      return <caption style={{...style, color: '#666', textAlign: 'left'}}>{text}</caption>;
-    case 'body':
-    default:
-      return <span style={style}>{text}</span>;
+  if (renderedHtml === null) {
+    return (
+      <span className={`a2ui-text ${props.variant || 'body'} no-markdown-renderer`} style={style}>
+        {markdownText}
+      </span>
+    );
   }
+
+  if (props.variant === 'caption') {
+    return (
+      <span
+        className="a2ui-caption"
+        style={{...style, color: '#666', textAlign: 'left'}}
+        dangerouslySetInnerHTML={{__html: renderedHtml}}
+      />
+    );
+  }
+
+  return (
+    <span
+      className={`a2ui-text ${props.variant || 'body'}`}
+      style={style}
+      dangerouslySetInnerHTML={{__html: renderedHtml}}
+    />
+  );
 });

--- a/renderers/react/src/v0_9/catalog/basic/context/MarkdownContext.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/context/MarkdownContext.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { createContext, useContext } from 'react';
-import type { MarkdownRenderer } from '@a2ui/web_core/types/types';
+import {createContext, useContext} from 'react';
+import type {MarkdownRenderer} from '@a2ui/web_core/types/types';
 
 export const MarkdownContext = createContext<MarkdownRenderer | undefined>(undefined);
 

--- a/renderers/react/src/v0_9/catalog/basic/context/MarkdownContext.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/context/MarkdownContext.tsx
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, useContext } from 'react';
+import type { MarkdownRenderer } from '@a2ui/web_core/types/types';
+
+export const MarkdownContext = createContext<MarkdownRenderer | undefined>(undefined);
+
+export const useMarkdownRenderer = () => useContext(MarkdownContext);

--- a/renderers/react/src/v0_9/catalog/basic/hooks/useMarkdown.ts
+++ b/renderers/react/src/v0_9/catalog/basic/hooks/useMarkdown.ts
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
-import { useState, useEffect } from 'react';
-import { useMarkdownRenderer } from '../context/MarkdownContext';
-import type { MarkdownRendererOptions } from '@a2ui/web_core/types/types';
+import {useState, useEffect} from 'react';
+import {useMarkdownRenderer} from '../context/MarkdownContext';
+import type {MarkdownRendererOptions} from '@a2ui/web_core/types/types';
 
 let warningLogged = false;
 
 export function useMarkdown(text: string, options?: MarkdownRendererOptions) {
   const renderer = useMarkdownRenderer();
   const [html, setHtml] = useState<string | null>(null);
+
+  const optionsKey = JSON.stringify(options);
 
   useEffect(() => {
     if (!renderer) {
@@ -39,16 +41,22 @@ export function useMarkdown(text: string, options?: MarkdownRendererOptions) {
     }
 
     let active = true;
-    renderer(text, options).then((result) => {
-      if (active) {
-        setHtml(result);
-      }
-    });
+    const parsedOptions = optionsKey ? JSON.parse(optionsKey) : undefined;
+
+    renderer(text, parsedOptions)
+      .then((result) => {
+        if (active) {
+          setHtml(result);
+        }
+      })
+      .catch((err) => {
+        console.error('[useMarkdown] Render failed:', err);
+      });
 
     return () => {
       active = false;
     };
-  }, [text, renderer, JSON.stringify(options)]);
+  }, [text, renderer, optionsKey]);
 
   return html;
 }

--- a/renderers/react/src/v0_9/catalog/basic/hooks/useMarkdown.ts
+++ b/renderers/react/src/v0_9/catalog/basic/hooks/useMarkdown.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useEffect } from 'react';
+import { useMarkdownRenderer } from '../context/MarkdownContext';
+import type { MarkdownRendererOptions } from '@a2ui/web_core/types/types';
+
+let warningLogged = false;
+
+export function useMarkdown(text: string, options?: MarkdownRendererOptions) {
+  const renderer = useMarkdownRenderer();
+  const [html, setHtml] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!renderer) {
+      if (!warningLogged) {
+        console.warn(
+          '[useMarkdown]',
+          "can't render markdown because no markdown renderer is configured.\n",
+          'Use `@a2ui/markdown-it`, or your own markdown renderer.'
+        );
+        warningLogged = true;
+      }
+      setHtml(null);
+      return;
+    }
+
+    let active = true;
+    renderer(text, options).then((result) => {
+      if (active) {
+        setHtml(result);
+      }
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [text, renderer, options]);
+
+  return html;
+}

--- a/renderers/react/src/v0_9/catalog/basic/hooks/useMarkdown.ts
+++ b/renderers/react/src/v0_9/catalog/basic/hooks/useMarkdown.ts
@@ -48,7 +48,7 @@ export function useMarkdown(text: string, options?: MarkdownRendererOptions) {
     return () => {
       active = false;
     };
-  }, [text, renderer, options]);
+  }, [text, renderer, JSON.stringify(options)]);
 
   return html;
 }

--- a/renderers/react/src/v0_9/catalog/basic/index.ts
+++ b/renderers/react/src/v0_9/catalog/basic/index.ts
@@ -37,6 +37,8 @@ import {ChoicePicker} from './components/ChoicePicker';
 import {Slider} from './components/Slider';
 import {DateTimeInput} from './components/DateTimeInput';
 
+export * from './context/MarkdownContext';
+
 const basicComponents: ReactComponentImplementation[] = [
   Text,
   Image,

--- a/renderers/react/tests/v0_9/basic_catalog.test.tsx
+++ b/renderers/react/tests/v0_9/basic_catalog.test.tsx
@@ -66,7 +66,7 @@ describe('Basic Catalog Components', () => {
 
     it('renders with correct heading tag based on variant', () => {
       const { view } = renderA2uiComponent(Text, 't1', { text: 'Title', variant: 'h1' });
-      const h1 = view.container.querySelector('span.h1');
+      const h1 = view.container.querySelector('div.h1');
       expect(h1).not.toBeNull();
       expect(h1?.textContent).toBe('# Title');
     });

--- a/renderers/react/tests/v0_9/basic_catalog.test.tsx
+++ b/renderers/react/tests/v0_9/basic_catalog.test.tsx
@@ -66,9 +66,9 @@ describe('Basic Catalog Components', () => {
 
     it('renders with correct heading tag based on variant', () => {
       const { view } = renderA2uiComponent(Text, 't1', { text: 'Title', variant: 'h1' });
-      const h1 = view.container.querySelector('h1');
+      const h1 = view.container.querySelector('span.h1');
       expect(h1).not.toBeNull();
-      expect(h1?.textContent).toBe('Title');
+      expect(h1?.textContent).toBe('# Title');
     });
   });
 

--- a/renderers/web_core/src/v0_8/types/types.ts
+++ b/renderers/web_core/src/v0_8/types/types.ts
@@ -576,7 +576,10 @@ export declare interface Surface {
 // Markdown rendering
 /**
  * Renders `markdown` using `options`.
- * @returns A promise that resolves to the rendered HTML as a string.
+ *
+ * Implementations MUST sanitize the resulting HTML to prevent XSS vulnerabilities.
+ *
+ * @returns A promise that resolves to the rendered, sanitized HTML as a string.
  */
 export declare type MarkdownRenderer = (
   markdown: string,


### PR DESCRIPTION
### Description of Changes
This PR introduces Markdown rendering support specifically for the `Text` component in the React `basic` catalog (v0.9). To keep the core React renderer framework-agnostic and free of markdown-specific dependencies, the implementation has been completely encapsulated within the basic catalog.

Key changes:
- Added `MarkdownContext.tsx` and an asynchronous `useMarkdown.ts` hook within the `basic` catalog to optionally inject a markdown renderer (like `@a2ui/markdown-it`).
- Refactored the `Text` component to utilize the new `useMarkdown` hook. Variants (e.g. `h1`, `h2`, `caption`) are transparently translated into markdown syntax before rendering.
- If a `MarkdownRenderer` is not provided via the context, the `useMarkdown` hook will gracefully fall back to rendering raw text inside a `<span class="no-markdown-renderer">`, accompanied by a one-time console warning.
- Updated `a2ui_explorer` application to consume the `MarkdownContext.Provider`, injecting `renderMarkdown` from the newly linked local `@a2ui/markdown-it` package.
- Updated corresponding React tests to expect the new span-based Markdown fallback structures.

### Rationale
The primary goal is to provide rich text formatting capabilities for A2UI textual content natively using the `@a2ui/markdown-it` utility, but in a completely decoupled way. This architectural choice aligns exactly with the pattern established in the Lit renderer, ensuring that applications that don't need markdown (or are using minimal/custom catalogs) don't have to pay the dependency payload cost for it.

### Testing/Running Instructions
1. Navigate to the React explorer app: `cd renderers/react/a2ui_explorer`
2. Install dependencies: `npm install`
3. Run the demo application locally: `npm run dev`
4. Open the application in your browser (usually `http://localhost:5173`) and browse through the samples to verify that `Text` components render successfully with parsed Markdown HTML output.
5. In addition, you can run the React test suite using `npm test` from `renderers/react/` to verify that the plain-text fallbacks work as expected when no Markdown context is provided.