### PR TITLE
feat: improve React Basic Catalog layout and update samples

### DIFF
--- a/renderers/react/src/v0_9/catalog/basic/components/Column.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Column.tsx
@@ -17,7 +17,7 @@
 import {createComponentImplementation} from '../../../adapter';
 import {ColumnApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {ChildList} from './ChildList';
-import {mapJustify, mapAlign} from '../utils';
+import {mapJustify, mapAlign, STANDARD_GAP} from '../utils';
 
 export const Column = createComponentImplementation(ColumnApi, ({props, buildChild, context}) => {
   return (
@@ -27,6 +27,7 @@ export const Column = createComponentImplementation(ColumnApi, ({props, buildChi
         flexDirection: 'column',
         justifyContent: mapJustify(props.justify),
         alignItems: mapAlign(props.align),
+        gap: STANDARD_GAP,
         width: '100%',
         margin: 0,
         padding: 0,

--- a/renderers/react/src/v0_9/catalog/basic/components/Row.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Row.tsx
@@ -17,7 +17,7 @@
 import {createComponentImplementation} from '../../../adapter';
 import {RowApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {ChildList} from './ChildList';
-import {mapJustify, mapAlign} from '../utils';
+import {mapJustify, mapAlign, STANDARD_GAP} from '../utils';
 
 export const Row = createComponentImplementation(RowApi, ({props, buildChild, context}) => {
   return (
@@ -27,6 +27,7 @@ export const Row = createComponentImplementation(RowApi, ({props, buildChild, co
         flexDirection: 'row',
         justifyContent: mapJustify(props.justify),
         alignItems: mapAlign(props.align),
+        gap: STANDARD_GAP,
         width: '100%',
         margin: 0,
         padding: 0,

--- a/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
@@ -26,21 +26,40 @@ export const Text = createComponentImplementation(TextApi, ({props}) => {
     display: 'inline-block',
   };
 
+  const headerReset: React.CSSProperties = {
+    margin: 0,
+    fontWeight: 600,
+    lineHeight: 1.2,
+  };
+
   switch (props.variant) {
     case 'h1':
-      return <h1 style={style}>{text}</h1>;
+      return <h1 style={{...style, ...headerReset, fontSize: '2.25rem'}}>{text}</h1>;
     case 'h2':
-      return <h2 style={style}>{text}</h2>;
+      return <h2 style={{...style, ...headerReset, fontSize: '1.5rem'}}>{text}</h2>;
     case 'h3':
-      return <h3 style={style}>{text}</h3>;
+      return <h3 style={{...style, ...headerReset, fontSize: '1.25rem'}}>{text}</h3>;
     case 'h4':
-      return <h4 style={style}>{text}</h4>;
+      return <h4 style={{...style, ...headerReset, fontSize: '1.1rem'}}>{text}</h4>;
     case 'h5':
-      return <h5 style={style}>{text}</h5>;
+      return <h5 style={{...style, ...headerReset, fontSize: '1rem'}}>{text}</h5>;
     case 'caption':
-      return <caption style={{...style, color: '#666', textAlign: 'left'}}>{text}</caption>;
+      return (
+        <span
+          style={{
+            ...style,
+            color: '#666',
+            fontSize: '0.75rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.05em',
+            fontWeight: 500,
+          }}
+        >
+          {text}
+        </span>
+      );
     case 'body':
     default:
-      return <span style={style}>{text}</span>;
+      return <span style={{...style, lineHeight: 1.5}}>{text}</span>;
   }
 });

--- a/renderers/react/src/v0_9/catalog/basic/utils.ts
+++ b/renderers/react/src/v0_9/catalog/basic/utils.ts
@@ -16,17 +16,23 @@
 
 import type React from 'react';
 
-/** Standard leaf margin from the implementation guide. */
-export const LEAF_MARGIN = '8px';
+/** 
+ * Standard leaf margin. 
+ * We set this to 0px and prefer 'gap' on containers for more predictable layouts.
+ */
+export const LEAF_MARGIN = '0px';
 
 /** Standard internal padding for visually bounded containers. */
 export const CONTAINER_PADDING = '16px';
 
 /** Standard border for cards and inputs. */
-export const STANDARD_BORDER = '1px solid #ccc';
+export const STANDARD_BORDER = '1px solid #f0f0f0';
 
 /** Standard border radius. */
-export const STANDARD_RADIUS = '8px';
+export const STANDARD_RADIUS = '12px';
+
+/** Standard gap for Rows and Columns */
+export const STANDARD_GAP = '12px';
 
 export const mapJustify = (j?: string) => {
   switch (j) {
@@ -74,5 +80,7 @@ export const getBaseContainerStyle = (): React.CSSProperties => ({
   padding: CONTAINER_PADDING,
   border: STANDARD_BORDER,
   borderRadius: STANDARD_RADIUS,
+  boxShadow: '0 4px 12px rgba(0, 0, 0, 0.05), 0 1px 2px rgba(0, 0, 0, 0.1)',
   boxSizing: 'border-box',
+  backgroundColor: '#fff',
 });

--- a/specification/v0_9/json/catalogs/basic/examples/02_email-compose.json
+++ b/specification/v0_9/json/catalogs/basic/examples/02_email-compose.json
@@ -30,7 +30,8 @@
               "divider",
               "message",
               "actions"
-            ]
+            ],
+            "align": "stretch"
           },
           {
             "id": "from-row",
@@ -39,8 +40,7 @@
               "from-label",
               "from-value"
             ],
-            "align": "center"
-          },
+            "align": "center"},
           {
             "id": "from-label",
             "component": "Text",
@@ -62,8 +62,7 @@
               "to-label",
               "to-value"
             ],
-            "align": "center"
-          },
+            "align": "center"},
           {
             "id": "to-label",
             "component": "Text",
@@ -85,8 +84,7 @@
               "subject-label",
               "subject-value"
             ],
-            "align": "center"
-          },
+            "align": "center"},
           {
             "id": "subject-label",
             "component": "Text",

--- a/specification/v0_9/json/catalogs/basic/examples/04_weather-current.json
+++ b/specification/v0_9/json/catalogs/basic/examples/04_weather-current.json
@@ -35,10 +35,26 @@
             "id": "temp-row",
             "component": "Row",
             "children": [
-              "temp-high",
-              "temp-low"
+              "high-group",
+              "low-group"
             ],
-            "align": "start"
+            "align": "center",
+            "justify": "center"
+          },
+          {
+            "id": "high-group",
+            "component": "Column",
+            "children": [
+              "high-label",
+              "temp-high"
+            ],
+            "align": "center"
+          },
+          {
+            "id": "high-label",
+            "component": "Text",
+            "text": "High",
+            "variant": "caption"
           },
           {
             "id": "temp-high",
@@ -53,6 +69,21 @@
             "variant": "h1"
           },
           {
+            "id": "low-group",
+            "component": "Column",
+            "children": [
+              "low-label",
+              "temp-low"
+            ],
+            "align": "center"
+          },
+          {
+            "id": "low-label",
+            "component": "Text",
+            "text": "Low",
+            "variant": "caption"
+          },
+          {
             "id": "temp-low",
             "component": "Text",
             "text": {
@@ -62,7 +93,7 @@
               },
               "returnType": "string"
             },
-            "variant": "h2"
+            "variant": "h1"
           },
           {
             "id": "location",
@@ -78,7 +109,7 @@
             "text": {
               "path": "/description"
             },
-            "variant": "caption"
+            "variant": "body"
           },
           {
             "id": "forecast-row",
@@ -87,7 +118,8 @@
               "path": "/forecast",
               "componentId": "forecast-day-template"
             },
-            "justify": "spaceAround"
+            "justify": "spaceAround",
+            "align": "center"
           },
           {
             "id": "forecast-day-template",
@@ -132,7 +164,7 @@
               },
               "returnType": "string"
             },
-            "variant": "caption"
+            "variant": "body"
           }
         ]
       }

--- a/specification/v0_9/json/catalogs/basic/examples/07_task-card.json
+++ b/specification/v0_9/json/catalogs/basic/examples/07_task-card.json
@@ -28,8 +28,7 @@
               "content",
               "priority"
             ],
-            "align": "start"
-          },
+            "align": "start"},
           {
             "id": "status-checkbox",
             "component": "CheckBox",
@@ -70,12 +69,11 @@
               "due-date-input",
               "project"
             ],
-            "align": "center"
-          },
+            "align": "center"},
           {
             "id": "due-date-input",
             "component": "DateTimeInput",
-            "label": "Due",
+            "label": "DUE DATE",
             "value": {
               "path": "/dueDate"
             },
@@ -108,7 +106,7 @@
           "completed": false,
           "title": "Review pull request",
           "description": "Review and approve the authentication module changes.",
-          "dueDate": "2025-12-15T17:00:00Z",
+          "dueDate": "2025-12-15T17:00",
           "project": "Backend",
           "priorityIcon": "priority_high"
         }

--- a/specification/v0_9/json/catalogs/basic/examples/09_login-form.json
+++ b/specification/v0_9/json/catalogs/basic/examples/09_login-form.json
@@ -173,8 +173,8 @@
             "id": "signup-text",
             "component": "Row",
             "children": ["no-account", "signup-link"],
-            "justify": "center"
-          },
+            "justify": "center",
+            "align": "center"},
           {
             "id": "no-account",
             "component": "Text",
@@ -190,6 +190,7 @@
             "id": "signup-link",
             "component": "Button",
             "child": "signup-link-text",
+            "variant": "borderless",
             "action": {
               "event": {
                 "name": "signup",


### PR DESCRIPTION
## Description of Changes
This PR improves the visual quality and layout consistency of the React Basic Catalog renderer and updates several A2UI samples.

### Renderer Changes (Basic Catalog)
- **Gap-based Spacing**: Transitioned from a margin-based model to a gap-based model (`gap: 12px`) in `Row` and `Column` components.
- **Typography Reset**: Implemented a reset for `h1`-`h5` margins in `Text.tsx` to prevent inconsistent vertical spacing caused by browser defaults.
- **Improved Captions**: Refined the `caption` variant with uppercase styling, better letter spacing, and reduced font size for better hierarchy.
- **Aesthetic Refinement**: Updated `Card` shadows and `STANDARD_BORDER` for a more modern, professional look.

### Sample Improvements
- **Weather Current**: Re-architected the layout to use vertical groupings for High/Low temperatures, unified font sizes, and centered alignment.
- **Email Compose**: Updated labels to use the `caption` variant and ensured the main column stretches to fill the viewport.
- **Task Card**: Improved label formatting and fixed a date string format issue that caused browser console warnings.
- **Login Form**: Centered the footer elements vertically and updated the sign-up link to use a `borderless` button variant.

## Rationale
The previous margin-based approach led to 'doubled' spacing between adjacent components. Moving to a centralized `gap` model on containers and resetting child margins ensures clean alignment and consistent whitespace. The typography and aesthetic refinements bring the Basic Catalog output closer to a production-ready design system.

## Testing/Running Instructions
1. Run the React Gallery App to see the updated samples:
   ```bash
   cd renderers/react/a2ui_explorer
   npm install && npm run dev
   ```
2. (Optional) Use the new snapshot tool (if installed) to verify layouts:
   ```bash
   cd renderers/react/react_snapshot
   node dist/cli.js --sample "basic/04_weather-current" --width 400
   ```