### PR TITLE
fix(python-sdk): support relative data binding paths in v0.9 streaming parser

### DIFF
--- a/agent_sdks/python/src/a2ui/parser/streaming.py
+++ b/agent_sdks/python/src/a2ui/parser/streaming.py
@@ -76,6 +76,7 @@ class A2uiStreamParser:
     return super().__new__(cls)
 
   def __init__(self, catalog: "A2uiCatalog" = None):
+    self._version = getattr(catalog, "version", None) if catalog else None
     self._ref_fields_map = extract_component_ref_fields(catalog) if catalog else {}
     self._required_fields_map = (
         extract_component_required_fields(catalog) if catalog else {}
@@ -1010,8 +1011,8 @@ class A2uiStreamParser:
           if "componentId" not in obj:
             obj.clear()
           obj.update({"path": "/" + key})
-        else:
-          # If not in data model, still ensure path has leading slash if it's a bindable object
+        elif self._version != VERSION_0_9:
+          # If not in data model, still ensure path has leading slash if it's a bindable object (v0.8 only)
           current_path = obj.get("path")
           if current_path is not None:
             if not isinstance(current_path, str) or not current_path.startswith("/"):

--- a/agent_sdks/python/src/a2ui/parser/streaming.py
+++ b/agent_sdks/python/src/a2ui/parser/streaming.py
@@ -1008,9 +1008,10 @@ class A2uiStreamParser:
         ):
           path = obj["path"]
           key = path.lstrip("/")
-          if "componentId" not in obj:
-            obj.clear()
-          obj.update({"path": "/" + key})
+          if self._version != VERSION_0_9:
+            if "componentId" not in obj:
+              obj.clear()
+            obj.update({"path": "/" + key})
         elif self._version != VERSION_0_9:
           # If not in data model, still ensure path has leading slash if it's a bindable object (v0.8 only)
           current_path = obj.get("path")

--- a/agent_sdks/python/tests/parser/test_streaming_v08.py
+++ b/agent_sdks/python/tests/parser/test_streaming_v08.py
@@ -273,3 +273,36 @@ def test_streaming_msg_type_deduplication(mock_catalog):
 
   # After completion, msg_types is reset
   assert parser.msg_types == []
+
+
+def test_v08_path_heuristic_adds_slash(mock_catalog):
+  """Tests that v0.8 adds a leading slash to relative paths."""
+  parser = A2uiStreamParser(catalog=mock_catalog)
+  # Disable validation for simplicity
+  parser._validator = None
+
+  # 1. Send beginRendering first to avoid buffering
+  chunk_br = (
+      A2UI_OPEN_TAG
+      + '[{"beginRendering": {"surfaceId": "s1", "root": "root"}}]'
+      + A2UI_CLOSE_TAG
+  )
+  list(parser.process_chunk(chunk_br))
+
+  # 2. Send surfaceUpdate with a relative path
+  chunk_su = (
+      A2UI_OPEN_TAG
+      + '[{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root",'
+      ' "component": {"Text": {"text": {"path": "some/relative/path"}}}}]}}]'
+      + A2UI_CLOSE_TAG
+  )
+
+  messages = []
+  for part in parser.process_chunk(chunk_su):
+    if part.a2ui_json:
+      messages.extend(part.a2ui_json)
+
+  # The path should have been prefixed with a slash
+  assert len(messages) > 0
+  comp = messages[0][MSG_TYPE_SURFACE_UPDATE]["components"][0]
+  assert comp["component"]["Text"]["text"]["path"] == "/some/relative/path"

--- a/agent_sdks/python/tests/parser/test_streaming_v09.py
+++ b/agent_sdks/python/tests/parser/test_streaming_v09.py
@@ -408,7 +408,8 @@ def test_v09_path_heuristic_relative_path(mock_catalog):
   chunk_uc = (
       A2UI_OPEN_TAG
       + '[{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components":'
-      ' [{"id": "root", "component": "Text", "text": {"path": "some/relative/path"}}]}}]'
+      ' [{"id": "root", "component": "Text", "text": {"path":'
+      ' "some/relative/path"}}]}}]'
       + A2UI_CLOSE_TAG
   )
 

--- a/agent_sdks/python/tests/parser/test_streaming_v09.py
+++ b/agent_sdks/python/tests/parser/test_streaming_v09.py
@@ -388,3 +388,66 @@ def test_streaming_msg_type_deduplication(mock_catalog):
 
   # After completion, msg_types is reset
   assert not parser.msg_types
+
+
+def test_v09_path_heuristic_relative_path(mock_catalog):
+  """Tests that v0.9 allows relative paths (no leading slash)."""
+  parser = A2uiStreamParser(catalog=mock_catalog)
+  # Disable validation to avoid needing full catalog for this test
+  parser._validator = None
+
+  # 1. Create surface
+  chunk_cs = (
+      A2UI_OPEN_TAG
+      + '[{"version": "v0.9", "createSurface": {"surfaceId": "s1", "catalogId": "c1"}}]'
+      + A2UI_CLOSE_TAG
+  )
+  list(parser.process_chunk(chunk_cs))
+
+  # 2. Update components with a relative path
+  chunk_uc = (
+      A2UI_OPEN_TAG
+      + '[{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components":'
+      ' [{"id": "root", "component": "Text", "text": {"path": "some/relative/path"}}]}}]'
+      + A2UI_CLOSE_TAG
+  )
+
+  messages = []
+  for part in parser.process_chunk(chunk_uc):
+    if part.a2ui_json:
+      messages.extend(part.a2ui_json)
+
+  assert len(messages) > 0
+  comp = messages[0][MSG_TYPE_UPDATE_COMPONENTS]["components"][0]
+  assert comp["text"]["path"] == "some/relative/path"
+
+
+def test_v09_path_heuristic_absolute_path(mock_catalog):
+  """Tests that v0.9 still supports absolute paths (leading slash)."""
+  parser = A2uiStreamParser(catalog=mock_catalog)
+  parser._validator = None
+
+  # 1. Create surface
+  chunk_cs = (
+      A2UI_OPEN_TAG
+      + '[{"version": "v0.9", "createSurface": {"surfaceId": "s1", "catalogId": "c1"}}]'
+      + A2UI_CLOSE_TAG
+  )
+  list(parser.process_chunk(chunk_cs))
+
+  # 2. Update components with an absolute path
+  chunk_uc = (
+      A2UI_OPEN_TAG
+      + '[{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components":'
+      ' [{"id": "root", "component": "Text", "text": {"path": "/absolute/path"}}]}}]'
+      + A2UI_CLOSE_TAG
+  )
+
+  messages = []
+  for part in parser.process_chunk(chunk_uc):
+    if part.a2ui_json:
+      messages.extend(part.a2ui_json)
+
+  assert len(messages) > 0
+  comp = messages[0][MSG_TYPE_UPDATE_COMPONENTS]["components"][0]
+  assert comp["text"]["path"] == "/absolute/path"


### PR DESCRIPTION
## Description of Changes
Modified the `A2uiStreamParser` in the Python SDK to conditionally skip the heuristic that automatically prepends a leading slash (`/`) to data binding `path` strings. This heuristic is now restricted to `v0.8` catalogs. For `v0.9`, the parser accurately preserves relative paths (no leading slash) and absolute paths (leading slash). 

Also added comprehensive test coverage:
* `test_v08_path_heuristic_adds_slash`: Ensures v0.8 still receives the auto-prefixed slash.
* `test_v09_path_heuristic_relative_path`: Ensures v0.9 preserves relative paths natively.
* `test_v09_path_heuristic_absolute_path`: Ensures v0.9 still supports explicit absolute paths.

## Rationale
A2UI Protocol v0.9 introduces relative path resolution for components inside collection scopes (such as templates inside `List`, `Column`, etc.). The previous streaming parser heuristic aggressively forced all paths to be absolute, which broke this core v0.9 feature. This fix properly aligns the streaming parser with the v0.9 specification.

## Testing/Running Instructions
Reviewers can verify these changes locally by running the test suite:
1. Navigate to the Python SDK directory: `cd agent_sdks/python`
2. Run the parser tests via `uv`: `export PYTHONPATH=$PYTHONPATH:$(pwd)/src && uv run pytest tests/parser/`
3. Verify that all tests pass, specifically the new path heuristic tests in `test_streaming_v08.py` and `test_streaming_v09.py`.