### PR TITLE
Fix quickstart guide to refer to restaurant finder and remove contact demo

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -38,7 +38,9 @@ Export your Gemini API key as an environment variable:
 export GEMINI_API_KEY="your_gemini_api_key_here"
 ```
 
-## Step 3: Navigate to the Lit Client
+## Step 3: Navigate to the Lit Client Samples Directory
+
+The client application source code is located in `samples/client/lit/shell`. Navigate to the parent samples directory to run the demo:
 
 ```bash
 cd samples/client/lit
@@ -49,8 +51,7 @@ cd samples/client/lit
 Run the one-command demo launcher:
 
 ```bash
-npm install
-npm run demo:all
+npm run demo:restaurant
 ```
 
 This command will:
@@ -186,15 +187,13 @@ npm start -- gallery
 
 This runs a client-only demo showcasing every standard component (Card, Button, TextField, Timeline, etc.) with live examples and code samples.
 
-### Contact Lookup Demo
+### Other Languages and Frameworks
 
-Try a different agent use case:
+While this guide uses the Lit client as an example, A2UI provides samples for other popular frameworks in the `samples/client` directory:
+- **Angular**: `samples/client/angular`
+- **React**: `samples/client/react`
 
-```bash
-npm run demo:contact
-```
-
-This demonstrates a contact lookup agent that generates search forms and result lists.
+Explore the [samples/client](../samples/client) directory to see all available client implementations.
 
 ## What's Next?
 


### PR DESCRIPTION
This PR updates the quickstart guide to remove references to the deprecated contact finder demo and instead refer to the restaurant finder agent. It also clarifies the client source code location and mentions samples in other languages.\n\nDependent on PR #1138 for code changes defaulting to restaurant finder.