### PR TITLE
(Lit) Fix Text widget inside Row.

### DIFF
--- a/renderers/lit/package-lock.json
+++ b/renderers/lit/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a2ui/lit",
-  "version": "0.9.2-alpha.0",
+  "version": "0.9.2-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a2ui/lit",
-      "version": "0.9.2-alpha.0",
+      "version": "0.9.2-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2ui/web_core": "file:../web_core",

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Column.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Column.ts
@@ -52,9 +52,6 @@ export class A2uiBasicColumnElement extends BasicCatalogA2uiLitElement<typeof Co
       flex-direction: column;
       gap: var(--a2ui-column-gap, var(--a2ui-spacing-m));
     }
-    :host > * {
-      display: flex;
-    }
   `;
 
   protected createController() {

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Row.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Row.ts
@@ -52,9 +52,6 @@ export class A2uiBasicRowElement extends BasicCatalogA2uiLitElement<typeof RowAp
       flex-direction: row;
       gap: var(--a2ui-row-gap, var(--a2ui-spacing-m));
     }
-    :host > * {
-      display: flex;
-    }
   `;
 
   protected createController() {

--- a/renderers/web_core/package-lock.json
+++ b/renderers/web_core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a2ui/web_core",
-  "version": "0.9.1-alpha.0",
+  "version": "0.9.1-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a2ui/web_core",
-      "version": "0.9.1-alpha.0",
+      "version": "0.9.1-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@preact/signals-core": "^1.13.0",


### PR DESCRIPTION
# Description

This fixes multiline Text widgets inside Rows in the Lit renderer (and probably other widgets) by removing a CSS rule that was setting every child of a Row/Column as display:flex.

This was flagged by gemini in an earlier PR, but I didn't notice the broken Text widget until I compared its output with the one in the Angular renderer!

(Tested by looking at the a2ui_explorer app for Lit)

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
