### PR TITLE
fix: propagate server errors to client in restaurant sample

### DIFF
--- a/samples/client/angular/projects/restaurant/src/server.ts
+++ b/samples/client/angular/projects/restaurant/src/server.ts
@@ -113,9 +113,8 @@ app.post('/a2a', (req, res) => {
       };
     }
 
-    const client = await createOrGetClient();
-
     try {
+      const client = await createOrGetClient();
       if (enableStreaming) {
         await handleStreamingResponse(client, sendParams, res);
       } else {


### PR DESCRIPTION
This PR ensures that errors occurring during API requests in the server middleware are correctly propagated back to the client instead of leaving the connection hanging.