### PR TITLE
chore: increment renderer versions to alpha.4

### DIFF
--- a/renderers/angular/package-lock.json
+++ b/renderers/angular/package-lock.json
@@ -57,7 +57,7 @@
     },
     "../markdown/markdown-it": {
       "name": "@a2ui/markdown-it",
-      "version": "0.0.2-alpha.3",
+      "version": "0.0.2-alpha.4",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -81,7 +81,7 @@
     },
     "../web_core": {
       "name": "@a2ui/web_core",
-      "version": "0.9.1-alpha.3",
+      "version": "0.9.1-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@preact/signals-core": "^1.13.0",

--- a/renderers/angular/package.json
+++ b/renderers/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/angular",
-  "version": "0.9.0-alpha.3",
+  "version": "0.9.0-alpha.4",
   "license": "Apache-2.0",
   "homepage": "https://a2ui.org/",
   "repository": {

--- a/renderers/docs/web_publishing.md
+++ b/renderers/docs/web_publishing.md
@@ -15,7 +15,7 @@ To increment a package version and automatically sync all internal dependents (u
 renderers/scripts/increment_version.mjs web_core
 
 # Set a specific version (e.g. including pre-releases)
-renderers/scripts/increment_version.mjs lit 0.9.2-beta.1
+renderers/scripts/increment_version.mjs lit 0.9.2-alpha.4
 ```
 
 This script will:
@@ -83,7 +83,7 @@ npm run publish:package
 **What happens during `npm run publish:package`?**
 Before publishing, the script runs the necessary `build` command which processes the code. Then, a preparation script (usually `prepare-publish.mjs`) runs, which:
 1. Copies `package.json`, `README.md`, and `LICENSE` to the `dist/` folder.
-2. If it's a renderer, it reads the `version` from `@a2ui/web_core` and updates the `file:` dependency in the `dist/package.json` to the actual core version (e.g., `^0.9.0`).
+2. If it's a renderer, it reads the `version` from `@a2ui/web_core` and updates the `file:` dependency in the `dist/package.json` to the actual core version (e.g., `^0.23.0`).
 3. Adjusts exports and paths (removing the `./dist/` prefix) so they are correct when consumed from the package root.
 4. Removes any build scripts (`prepublishOnly`, `scripts`, `wireit`) so they don't interfere with the publish process.
 

--- a/renderers/lit/a2ui_explorer/package-lock.json
+++ b/renderers/lit/a2ui_explorer/package-lock.json
@@ -22,7 +22,7 @@
     },
     "..": {
       "name": "@a2ui/lit",
-      "version": "0.9.2-alpha.3",
+      "version": "0.9.2-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2ui/web_core": "file:../web_core",
@@ -51,7 +51,7 @@
     },
     "../../markdown/markdown-it": {
       "name": "@a2ui/markdown-it",
-      "version": "0.0.2-alpha.3",
+      "version": "0.0.2-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.3.1",
@@ -74,7 +74,7 @@
     },
     "../../web_core": {
       "name": "@a2ui/web_core",
-      "version": "0.9.1-alpha.3",
+      "version": "0.9.1-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@preact/signals-core": "^1.13.0",

--- a/renderers/lit/a2ui_explorer/package.json
+++ b/renderers/lit/a2ui_explorer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@a2ui/lit-explorer",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1-alpha.4",
   "description": "A2UI Lit Explorer",
   "type": "module",
   "scripts": {

--- a/renderers/lit/package-lock.json
+++ b/renderers/lit/package-lock.json
@@ -35,7 +35,7 @@
     },
     "../web_core": {
       "name": "@a2ui/web_core",
-      "version": "0.9.1-alpha.3",
+      "version": "0.9.1-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@preact/signals-core": "^1.13.0",

--- a/renderers/lit/package.json
+++ b/renderers/lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/lit",
-  "version": "0.9.2-alpha.3",
+  "version": "0.9.2-alpha.4",
   "description": "A2UI Lit Library",
   "author": "Google",
   "license": "Apache-2.0",

--- a/renderers/markdown/markdown-it/package-lock.json
+++ b/renderers/markdown/markdown-it/package-lock.json
@@ -29,7 +29,7 @@
     },
     "../../web_core": {
       "name": "@a2ui/web_core",
-      "version": "0.9.1-alpha.3",
+      "version": "0.9.1-alpha.4",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/renderers/markdown/markdown-it/package.json
+++ b/renderers/markdown/markdown-it/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/markdown-it",
-  "version": "0.0.2-alpha.3",
+  "version": "0.0.2-alpha.4",
   "description": "A Markdown renderer using markdown-it and dompurify.",
   "repository": {
     "directory": "renderers/markdown/markdown-it",

--- a/renderers/react/package-lock.json
+++ b/renderers/react/package-lock.json
@@ -72,7 +72,7 @@
     },
     "../markdown/markdown-it": {
       "name": "@a2ui/markdown-it",
-      "version": "0.0.2-alpha.3",
+      "version": "0.0.2-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.3.1",
@@ -95,7 +95,7 @@
     },
     "../web_core": {
       "name": "@a2ui/web_core",
-      "version": "0.9.1-alpha.3",
+      "version": "0.9.1-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@preact/signals-core": "^1.13.0",

--- a/renderers/react/package.json
+++ b/renderers/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/react",
-  "version": "0.9.0-alpha.3",
+  "version": "0.9.0-alpha.4",
   "description": "React renderer for A2UI (Agent-to-User Interface)",
   "homepage": "https://a2ui.org/",
   "repository": {

--- a/renderers/react/visual-parity/package-lock.json
+++ b/renderers/react/visual-parity/package-lock.json
@@ -33,7 +33,7 @@
     },
     "..": {
       "name": "@a2ui/react",
-      "version": "0.9.0-alpha.3",
+      "version": "0.9.0-alpha.4",
       "dependencies": {
         "@a2ui/markdown-it": "file:../markdown/markdown-it",
         "@a2ui/web_core": "file:../web_core",
@@ -80,7 +80,7 @@
     },
     "../../lit": {
       "name": "@a2ui/lit",
-      "version": "0.9.2-alpha.3",
+      "version": "0.9.2-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2ui/web_core": "file:../web_core",
@@ -109,7 +109,7 @@
     },
     "../../markdown/markdown-it": {
       "name": "@a2ui/markdown-it",
-      "version": "0.0.2-alpha.3",
+      "version": "0.0.2-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.3.1",

--- a/renderers/react/visual-parity/package.json
+++ b/renderers/react/visual-parity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/visual-parity",
-  "version": "0.8.0",
+  "version": "0.8.1-alpha.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/renderers/scripts/lib/workspace.mjs
+++ b/renderers/scripts/lib/workspace.mjs
@@ -100,7 +100,7 @@ export function getPackageGraph() {
 
 /**
  * Increments a version string.
- * Supports: 0.9.2 -> 0.9.3, 0.9.2-beta.1 -> 0.9.2-beta.2
+ * Supports: 0.9.2 -> 0.9.3, 0.9.1-alpha.3 -> 0.9.1-alpha.4
  */
 export function incrementVersion(version) {
   const parts = version.split('.');

--- a/renderers/web_core/package.json
+++ b/renderers/web_core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/web_core",
-  "version": "0.9.1-alpha.3",
+  "version": "0.9.1-alpha.4",
   "description": "A2UI Core Library",
   "homepage": "https://a2ui.org/",
   "repository": {

--- a/samples/agent/mcp/a2ui-in-mcpapps/server/apps/src/package-lock.json
+++ b/samples/agent/mcp/a2ui-in-mcpapps/server/apps/src/package-lock.json
@@ -48,7 +48,7 @@
     },
     "../../../../../../../renderers/markdown/markdown-it": {
       "name": "@a2ui/markdown-it",
-      "version": "0.0.2-alpha.3",
+      "version": "0.0.2-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.3.1",

--- a/samples/client/angular/package-lock.json
+++ b/samples/client/angular/package-lock.json
@@ -71,7 +71,7 @@
     },
     "../../../renderers/markdown/markdown-it": {
       "name": "@a2ui/markdown-it",
-      "version": "0.0.2-alpha.3",
+      "version": "0.0.2-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.3.1",
@@ -94,7 +94,7 @@
     },
     "../../../renderers/web_core": {
       "name": "@a2ui/web_core",
-      "version": "0.9.1-alpha.3",
+      "version": "0.9.1-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@preact/signals-core": "^1.13.0",

--- a/samples/client/lit/package-lock.json
+++ b/samples/client/lit/package-lock.json
@@ -28,7 +28,7 @@
     },
     "../../../renderers/lit": {
       "name": "@a2ui/lit",
-      "version": "0.9.2-alpha.3",
+      "version": "0.9.2-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2ui/web_core": "file:../web_core",
@@ -57,7 +57,7 @@
     },
     "../../../renderers/markdown/markdown-it": {
       "name": "@a2ui/markdown-it",
-      "version": "0.0.2-alpha.3",
+      "version": "0.0.2-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.3.1",
@@ -80,7 +80,7 @@
     },
     "../../../renderers/web_core": {
       "name": "@a2ui/web_core",
-      "version": "0.9.1-alpha.3",
+      "version": "0.9.1-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@preact/signals-core": "^1.13.0",

--- a/samples/client/react/shell/package-lock.json
+++ b/samples/client/react/shell/package-lock.json
@@ -23,7 +23,7 @@
     },
     "../../../../renderers/react": {
       "name": "@a2ui/react",
-      "version": "0.9.0-alpha.3",
+      "version": "0.9.0-alpha.4",
       "dependencies": {
         "@a2ui/markdown-it": "file:../markdown/markdown-it",
         "@a2ui/web_core": "file:../web_core",

--- a/tools/editor/package-lock.json
+++ b/tools/editor/package-lock.json
@@ -26,7 +26,7 @@
     },
     "../../renderers/lit": {
       "name": "@a2ui/lit",
-      "version": "0.9.2-alpha.3",
+      "version": "0.9.2-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2ui/web_core": "file:../web_core",
@@ -966,7 +966,7 @@
     },
     "../../renderers/web_core": {
       "name": "@a2ui/web_core",
-      "version": "0.9.1-alpha.3",
+      "version": "0.9.1-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@preact/signals-core": "^1.13.0",

--- a/tools/inspector/package-lock.json
+++ b/tools/inspector/package-lock.json
@@ -25,7 +25,7 @@
     },
     "../../renderers/lit": {
       "name": "@a2ui/lit",
-      "version": "0.9.2-alpha.3",
+      "version": "0.9.2-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2ui/web_core": "file:../web_core",
@@ -965,7 +965,7 @@
     },
     "../../renderers/web_core": {
       "name": "@a2ui/web_core",
-      "version": "0.9.1-alpha.3",
+      "version": "0.9.1-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@preact/signals-core": "^1.13.0",


### PR DESCRIPTION
## Description of Changes
This pull request increments the version of several A2UI packages from `alpha.3` to `alpha.4`. This includes updates to:
- `@a2ui/angular`
- `@a2ui/lit`
- `@a2ui/markdown-it`
- `@a2ui/react`
- `@a2ui/web_core`
- Related tools and samples (`a2ui_explorer`, `visual-parity`).

The `package-lock.json` files have been updated accordingly to ensure consistency across the workspace. Additionally, documentation in `renderers/docs/web_publishing.md` and comments in `renderers/scripts/lib/workspace.mjs` were updated to reflect the current versioning scheme.

## Rationale
These changes are part of a routine version bump for the alpha release cycle, ensuring all packages and their dependents are synchronized before further development or publishing.

## Testing/Running Instructions
Reviewers can verify the changes by:
1. Checking that all `package.json` files in the `renderers/` directory reflect the new `alpha.4` version.
2. Running `npm install` in the root or relevant subdirectories to confirm that dependencies are correctly resolved.
3. Verifying that the build script still works correctly (e.g., by running `renderers/scripts/increment_version.mjs`).