### PR TITLE
fix(lit): remove dead ICON_MAP after v0.9 icon override cleanup

### DIFF
--- a/renderers/lit/src/v0_9/catalogs/basic/components/Icon.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Icon.ts
@@ -22,13 +22,6 @@ import { A2uiController } from "@a2ui/lit/v0_9";
 
 import { classMap } from "lit/directives/class-map.js";
 
-const ICON_MAP: Record<string, string> = {
-  favoriteOff: "favorite_border",
-  play: "play_arrow",
-  rewind: "fast_rewind",
-  starOff: "star_border",
-};
-
 const ICON_NAME_OVERRIDES: Record<string, string> = {
   "play": "play_arrow",
   "rewind": "fast_rewind",
@@ -72,11 +65,6 @@ export class A2uiIconElement extends BasicCatalogA2uiLitElement<typeof IconApi> 
       font-variation-settings: var(--a2ui-icon-font-variation-settings, "FILL" 1);
     }
   `;
-
-  private getIconName(rawName: string): string {
-    if (ICON_MAP[rawName]) return ICON_MAP[rawName];
-    return rawName.replace(/[A-Z]/g, (letter: string) => `_${letter.toLowerCase()}`);
-  }
 
   protected createController() {
     return new A2uiController(this, IconApi);


### PR DESCRIPTION
## Description

Follow-up to #1146. That PR introduced `ICON_NAME_OVERRIDES` and `toMaterialSymbol()` in the Lit v0.9 `Icon` component but left the previous `ICON_MAP` constant and `getIconName()` method in place. Both were unreferenced after `render()` switched to `toMaterialSymbol`, so this PR removes them.

No behavior change. Lit build and test suite (70 tests) pass locally.

Addresses https://github.com/google/A2UI/pull/1146#pullrequestreview-4122755873.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

<!-- Links -->
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[Style Guide]: ../STYLE_GUIDE.md
[CHANGELOG]: ../CHANGELOG.md