### PR TITLE
add web analogy to renderers and separate web from mobile

### DIFF
--- a/docs/reference/renderers.md
+++ b/docs/reference/renderers.md
@@ -6,7 +6,7 @@ The [agents](agents.md) are responsible for generating the A2UI messages,
 and the [transports](../concepts/transports.md) are responsible for delivering the messages to the client.
 The client renderer library must buffer and handle A2UI messages, implement the A2UI lifecycle, render widgets, and route user actions back to the agent.
 
-Let's use the web as an analogy. The A2UI protocol is like HTML. It provides a language and the semantics of the UI model. The agent is like the server that serves HTML to the client. The renderer is like a browser. It talks to the agents, interprets the A2UI protocol, and renders the UI. Just like there are multiple browser engines for HTML, there are multiple different renderers for A2UI.
+Let's use the web as an analogy. The A2UI protocol is like HTML. It provides a language and the semantics of the UI model. The agent is like the server that serves HTML to the client. The renderer is like a browser. It talks to the agent, interprets the A2UI protocol, and renders the UI. Just like there are multiple browser engines for HTML, there are multiple different renderers for A2UI.
 
 You have a lot of flexibility, to bring custom components to a renderer, or build your own renderer to support your UI component framework.
 

--- a/docs/reference/renderers.md
+++ b/docs/reference/renderers.md
@@ -19,6 +19,7 @@ You have a lot of flexibility, to bring custom components to a renderer, or buil
 | **React** | Web | ✅ Stable | ❌ | [Code](https://github.com/google/A2UI/tree/main/renderers/react) |
 | **Lit (Web Components)** | Web | ✅ Stable | ✅ Stable | [Code](https://github.com/google/A2UI/tree/main/renderers/lit) |
 | **Angular** | Web | ✅ Stable | ✅ Stable | [Code](https://github.com/google/A2UI/tree/main/renderers/angular) |
+| **Flutter (GenUI SDK)** | Mobile/Desktop/Web | ✅ Stable | ✅ Stable | [Docs](https://docs.flutter.dev/ai/genui) · [Code](https://github.com/flutter/genui) |
 
 Mobile:
 

--- a/docs/reference/renderers.md
+++ b/docs/reference/renderers.md
@@ -12,7 +12,7 @@ You have a lot of flexibility, to bring custom components to a renderer, or buil
 
 ## Maintained Renderers
 
-Web:
+### Web
 
 | Renderer | Platform | v0.8 | v0.9 | Links |
 |----------|----------|------|------|-------|

--- a/docs/reference/renderers.md
+++ b/docs/reference/renderers.md
@@ -21,7 +21,7 @@ You have a lot of flexibility, to bring custom components to a renderer, or buil
 | **Angular** | Web | ✅ Stable | ✅ Stable | [Code](https://github.com/google/A2UI/tree/main/renderers/angular) |
 | **Flutter (GenUI SDK)** | Mobile/Desktop/Web | ✅ Stable | ✅ Stable | [Docs](https://docs.flutter.dev/ai/genui) · [Code](https://github.com/flutter/genui) |
 
-Mobile:
+### Mobile
 
 | Renderer | Platform | v0.8 | v0.9 | Links |
 |----------|----------|------|------|-------|

--- a/docs/reference/renderers.md
+++ b/docs/reference/renderers.md
@@ -4,17 +4,26 @@ Renderers convert A2UI JSON messages into native UI components for different pla
 
 The [agents](agents.md) are responsible for generating the A2UI messages,
 and the [transports](../concepts/transports.md) are responsible for delivering the messages to the client.
-The client renderer library must buffer and handle A2UI messages, implement the A2UI lifecycle, and render surfaces (widgets).
+The client renderer library must buffer and handle A2UI messages, implement the A2UI lifecycle, render widgets, and route user actions back to the agent.
+
+Let's use the web as an analogy. The A2UI protocol is like HTML. It provides a language and the semantics of the UI model. The agent is like the server that serves HTML to the client. The renderer is like a browser. It talks to the agents, interprets the A2UI protocol, and renders the UI. Just like there are multiple browser engines for HTML, there are multiple different renderers for A2UI.
 
 You have a lot of flexibility, to bring custom components to a renderer, or build your own renderer to support your UI component framework.
 
 ## Maintained Renderers
+
+Web:
 
 | Renderer | Platform | v0.8 | v0.9 | Links |
 |----------|----------|------|------|-------|
 | **React** | Web | ✅ Stable | ❌ | [Code](https://github.com/google/A2UI/tree/main/renderers/react) |
 | **Lit (Web Components)** | Web | ✅ Stable | ✅ Stable | [Code](https://github.com/google/A2UI/tree/main/renderers/lit) |
 | **Angular** | Web | ✅ Stable | ✅ Stable | [Code](https://github.com/google/A2UI/tree/main/renderers/angular) |
+
+Mobile:
+
+| Renderer | Platform | v0.8 | v0.9 | Links |
+|----------|----------|------|------|-------|
 | **Flutter (GenUI SDK)** | Mobile/Desktop/Web | ✅ Stable | ✅ Stable | [Docs](https://docs.flutter.dev/ai/genui) · [Code](https://github.com/flutter/genui) |
 | **SwiftUI** | iOS/macOS | — | 🚧 Planned Q2 | — |
 | **Jetpack Compose** | Android | — | 🚧 Planned Q2 | — |


### PR DESCRIPTION
# Description

A couple of changes in `renderers.md`:

* Explain the HTML-browser analogy for A2UI-renderer.
* Separate the renderer table into two tables, one for web and one for mobile.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
