### PR TITLE
Refactor: Handle weight in the basic catalog, and centralize boilerplate

### DIFF
--- a/renderers/angular/src/v0_9/catalog/basic/audio-player.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/audio-player.component.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
-import { BoundProperty } from '../../core/types';
+import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
 import { BasicCatalogComponent } from './basic-catalog-component';
 
 /**
@@ -67,18 +66,10 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AudioPlayerComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `url`: The absolute URL of the audio file.
-   * - `description`: Optional text to display above the player.
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>();
 
-  description = computed(() => this.props()['description']?.value());
-  url = computed(() => this.props()['url']?.value());
+
+
+
+  readonly description = computed(() => this.props()['description']?.value());
+  readonly url = computed(() => this.props()['url']?.value());
 }

--- a/renderers/angular/src/v0_9/catalog/basic/audio-player.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/audio-player.component.ts
@@ -66,10 +66,6 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AudioPlayerComponent extends BasicCatalogComponent {
-
-
-
-
   readonly description = computed(() => this.props()['description']?.value());
   readonly url = computed(() => this.props()['url']?.value());
 }

--- a/renderers/angular/src/v0_9/catalog/basic/basic-catalog-component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/basic-catalog-component.ts
@@ -48,7 +48,6 @@ export abstract class BasicCatalogComponent {
    */
   @HostBinding('style.flex')
   get flexStyle() {
-    const w = this.weight();
-    return w ? `${w}` : '';
+    return this.weight() !== null ? `${this.weight()} 1 0%` : null;
   }
 }

--- a/renderers/angular/src/v0_9/catalog/basic/basic-catalog-component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/basic-catalog-component.ts
@@ -14,15 +14,41 @@
  * limitations under the License.
  */
 
-import { injectBasicCatalogStyles } from '@a2ui/web_core/v0_9/basic_catalog';
+import {Directive, computed, HostBinding, input} from '@angular/core';
+import {injectBasicCatalogStyles} from '@a2ui/web_core/v0_9/basic_catalog';
+import {BoundProperty} from '../../core/types';
 
 /**
  * Base class for A2UI basic catalog components in Angular.
  *
  * Automatically injects the basic catalog styles when the component is instantiated.
  */
+@Directive()
 export abstract class BasicCatalogComponent {
+  /**
+   * Reactive properties resolved from the A2UI ComponentModel.
+   */
+  props = input<Record<string, BoundProperty>>({});
+
+  surfaceId = input.required<string>();
+  componentId = input<string>();
+  dataContextPath = input<string>('/');
+
   constructor() {
     injectBasicCatalogStyles();
+  }
+
+  /**
+   * Computes the weight of the component from the properties.
+   */
+  protected readonly weight = computed(() => this.props()['weight']?.value() || null);
+
+  /**
+   * Binds the flex style to the host element based on the weight.
+   */
+  @HostBinding('style.flex')
+  get flexStyle() {
+    const w = this.weight();
+    return w ? `${w}` : '';
   }
 }

--- a/renderers/angular/src/v0_9/catalog/basic/basic-catalog-component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/basic-catalog-component.ts
@@ -15,8 +15,8 @@
  */
 
 import { Directive, computed, HostBinding, input } from '@angular/core';
-import {injectBasicCatalogStyles} from '@a2ui/web_core/v0_9/basic_catalog';
-import {BoundProperty} from '../../core/types';
+import { injectBasicCatalogStyles } from '@a2ui/web_core/v0_9/basic_catalog';
+import { BoundProperty } from '../../core/types';
 
 /**
  * Base class for A2UI basic catalog components in Angular.

--- a/renderers/angular/src/v0_9/catalog/basic/basic-catalog-component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/basic-catalog-component.ts
@@ -48,6 +48,6 @@ export abstract class BasicCatalogComponent {
    */
   @HostBinding('style.flex')
   get flexStyle() {
-    return this.weight() !== null ? `${this.weight()} 1 0%` : null;
+    return this.weight() !== null ? `${this.weight()}` : null;
   }
 }

--- a/renderers/angular/src/v0_9/catalog/basic/basic-catalog-component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/basic-catalog-component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Directive, computed, HostBinding, input} from '@angular/core';
+import { Directive, computed, HostBinding, input } from '@angular/core';
 import {injectBasicCatalogStyles} from '@a2ui/web_core/v0_9/basic_catalog';
 import {BoundProperty} from '../../core/types';
 
@@ -31,7 +31,7 @@ export abstract class BasicCatalogComponent {
   props = input<Record<string, BoundProperty>>({});
 
   surfaceId = input.required<string>();
-  componentId = input<string>();
+  componentId = input.required<string>();
   dataContextPath = input<string>('/');
 
   constructor() {
@@ -41,7 +41,7 @@ export abstract class BasicCatalogComponent {
   /**
    * Computes the weight of the component from the properties.
    */
-  protected readonly weight = computed(() => this.props()['weight']?.value() || null);
+  protected readonly weight = computed(() => this.props()['weight']?.value() ?? null);
 
   /**
    * Binds the flex style to the host element based on the weight.

--- a/renderers/angular/src/v0_9/catalog/basic/button.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/button.component.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  Component,
-  computed,
-  ChangeDetectionStrategy,
-  inject,
-} from '@angular/core';
+import { Component, computed, ChangeDetectionStrategy, inject } from '@angular/core';
 import { ComponentHostComponent } from '../../core/component-host.component';
 import { DataContext } from '@a2ui/web_core/v0_9';
 import { A2uiRendererService } from '../../core/a2ui-renderer.service';
@@ -52,10 +47,7 @@ import { BasicCatalogComponent } from './basic-catalog-component';
       [disabled]="props()['isValid']?.value() === false"
     >
       @if (child()) {
-        <a2ui-v09-component-host
-          [componentKey]="child()!"
-          [surfaceId]="surfaceId()"
-        >
+        <a2ui-v09-component-host [componentKey]="child()!" [surfaceId]="surfaceId()">
         </a2ui-v09-component-host>
       }
     </button>
@@ -63,9 +55,15 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   styles: [
     `
       .a2ui-button {
-        padding: var(--a2ui-button-padding, var(--a2ui-spacing-m, 0.5rem) var(--a2ui-spacing-l, 1rem));
+        padding: var(
+          --a2ui-button-padding,
+          var(--a2ui-spacing-m, 0.5rem) var(--a2ui-spacing-l, 1rem)
+        );
         border-radius: var(--a2ui-button-border-radius, var(--a2ui-spacing-s, 0.25rem));
-        border: var(--a2ui-button-border, var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc));
+        border: var(
+          --a2ui-button-border,
+          var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc)
+        );
         cursor: pointer;
         margin: var(--a2ui-button-margin, var(--a2ui-spacing-m, 0.5rem));
         background: var(--a2ui-button-background, var(--a2ui-color-surface, #fff));
@@ -98,17 +96,11 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ButtonComponent extends BasicCatalogComponent {
-
-
-
-
   private rendererService = inject(A2uiRendererService);
 
   readonly variant = computed(() => this.props()['variant']?.value() ?? 'default');
   readonly child = computed(() => this.props()['child']?.value());
   readonly action = computed(() => this.props()['action']?.value());
-
-
 
   handleClick() {
     const action = this.action();

--- a/renderers/angular/src/v0_9/catalog/basic/button.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/button.component.ts
@@ -16,7 +16,6 @@
 
 import {
   Component,
-  input,
   computed,
   ChangeDetectionStrategy,
   inject,
@@ -24,7 +23,6 @@ import {
 import { ComponentHostComponent } from '../../core/component-host.component';
 import { DataContext } from '@a2ui/web_core/v0_9';
 import { A2uiRendererService } from '../../core/a2ui-renderer.service';
-import { BoundProperty } from '../../core/types';
 import { BasicCatalogComponent } from './basic-catalog-component';
 
 /**
@@ -100,25 +98,15 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ButtonComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `child`: The ID of the component to render inside the button.
-   * - `variant`: Button style variant ('default', 'primary', 'borderless').
-   * - `action`: The A2UI action to dispatch on click.
-   * - `checks`: Optional validation rules.
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input.required<string>();
-  dataContextPath = input<string>('/');
+
+
+
 
   private rendererService = inject(A2uiRendererService);
 
-  variant = computed(() => this.props()['variant']?.value() ?? 'default');
-  child = computed(() => this.props()['child']?.value());
-  action = computed(() => this.props()['action']?.value());
+  readonly variant = computed(() => this.props()['variant']?.value() ?? 'default');
+  readonly child = computed(() => this.props()['child']?.value());
+  readonly action = computed(() => this.props()['action']?.value());
 
 
 
@@ -129,7 +117,7 @@ export class ButtonComponent extends BasicCatalogComponent {
       if (surface) {
         const dataContext = new DataContext(surface, this.dataContextPath());
         const resolvedAction = dataContext.resolveAction(action);
-        surface.dispatchAction(resolvedAction, this.componentId());
+        surface.dispatchAction(resolvedAction, this.componentId()!);
       }
     }
   }

--- a/renderers/angular/src/v0_9/catalog/basic/button.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/button.component.ts
@@ -109,7 +109,7 @@ export class ButtonComponent extends BasicCatalogComponent {
       if (surface) {
         const dataContext = new DataContext(surface, this.dataContextPath());
         const resolvedAction = dataContext.resolveAction(action);
-        surface.dispatchAction(resolvedAction, this.componentId()!);
+        surface.dispatchAction(resolvedAction, this.componentId());
       }
     }
   }

--- a/renderers/angular/src/v0_9/catalog/basic/card.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/card.component.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
-import { ComponentHostComponent } from '../../core/component-host.component';
-import { BoundProperty } from '../../core/types';
-import { BasicCatalogComponent } from './basic-catalog-component';
+import {Component, computed, ChangeDetectionStrategy} from '@angular/core';
+import {ComponentHostComponent} from '../../core/component-host.component';
+import {BasicCatalogComponent} from './basic-catalog-component';
 
 /**
  * Angular implementation of the A2UI Card component (v0.9).
@@ -62,18 +61,7 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CardComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `child`: The component ID to render inside the card.
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>('/');
-
-  child = computed(() => this.props()['child']?.value());
+  readonly child = computed(() => this.props()['child']?.value());
 
 
 }

--- a/renderers/angular/src/v0_9/catalog/basic/card.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/card.component.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {Component, computed, ChangeDetectionStrategy} from '@angular/core';
-import {ComponentHostComponent} from '../../core/component-host.component';
-import {BasicCatalogComponent} from './basic-catalog-component';
+import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
+import { ComponentHostComponent } from '../../core/component-host.component';
+import { BasicCatalogComponent } from './basic-catalog-component';
 
 /**
  * Angular implementation of the A2UI Card component (v0.9).
@@ -38,10 +38,7 @@ import {BasicCatalogComponent} from './basic-catalog-component';
   template: `
     <div class="a2ui-card">
       @if (child()) {
-        <a2ui-v09-component-host
-          [componentKey]="child()!"
-          [surfaceId]="surfaceId()"
-        >
+        <a2ui-v09-component-host [componentKey]="child()!" [surfaceId]="surfaceId()">
         </a2ui-v09-component-host>
       }
     </div>
@@ -51,9 +48,12 @@ import {BasicCatalogComponent} from './basic-catalog-component';
       .a2ui-card {
         padding: var(--a2ui-card-padding, var(--a2ui-spacing-m, 16px));
         border-radius: var(--a2ui-card-border-radius, var(--a2ui-border-radius, 8px));
-        box-shadow: var(--a2ui-card-box-shadow, 0 2px 4px rgba(0,0,0,0.1));
+        box-shadow: var(--a2ui-card-box-shadow, 0 2px 4px rgba(0, 0, 0, 0.1));
         background-color: var(--a2ui-card-background, var(--a2ui-color-surface, #fff));
-        border: var(--a2ui-card-border, var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc));
+        border: var(
+          --a2ui-card-border,
+          var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc)
+        );
         margin: var(--a2ui-card-margin, var(--a2ui-spacing-m, 16px));
       }
     `,
@@ -62,6 +62,4 @@ import {BasicCatalogComponent} from './basic-catalog-component';
 })
 export class CardComponent extends BasicCatalogComponent {
   readonly child = computed(() => this.props()['child']?.value());
-
-
 }

--- a/renderers/angular/src/v0_9/catalog/basic/check-box.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/check-box.component.ts
@@ -69,7 +69,10 @@ import { BasicCatalogComponent } from './basic-catalog-component';
         border-radius: var(--a2ui-checkbox-border-radius, 4px);
       }
       .a2ui-check-box-text {
-        font-size: var(--a2ui-checkbox-label-font-size, var(--a2ui-label-font-size, var(--a2ui-font-size-s, 16px)));
+        font-size: var(
+          --a2ui-checkbox-label-font-size,
+          var(--a2ui-label-font-size, var(--a2ui-font-size-s, 16px))
+        );
         font-weight: var(--a2ui-checkbox-label-font-weight, bold);
       }
     `,
@@ -77,10 +80,6 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CheckBoxComponent extends BasicCatalogComponent {
-
-
-
-
   readonly value = computed(() => this.props()['value']?.value() === true);
   readonly label = computed(() => this.props()['label']?.value());
 

--- a/renderers/angular/src/v0_9/catalog/basic/check-box.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/check-box.component.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
-import { BoundProperty } from '../../core/types';
+import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
 import { BasicCatalogComponent } from './basic-catalog-component';
 
 /**
@@ -78,20 +77,12 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CheckBoxComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `label`: The text to display next to the checkbox.
-   * - `value`: Boolean indicating whether the checkbox is checked.
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>('/');
 
-  value = computed(() => this.props()['value']?.value() === true);
-  label = computed(() => this.props()['label']?.value());
+
+
+
+  readonly value = computed(() => this.props()['value']?.value() === true);
+  readonly label = computed(() => this.props()['label']?.value());
 
   handleChange(event: Event) {
     const checked = (event.target as HTMLInputElement).checked;

--- a/renderers/angular/src/v0_9/catalog/basic/choice-picker.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/choice-picker.component.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
-import { BoundProperty } from '../../core/types';
-import { BasicCatalogComponent } from './basic-catalog-component';
+import {Component, computed, ChangeDetectionStrategy} from '@angular/core';
+import {BasicCatalogComponent} from './basic-catalog-component';
 
 /**
  * Angular implementation of the A2UI ChoicePicker component (v0.9).
@@ -118,26 +117,12 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ChoicePickerComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `value`: The currently selected value(s).
-   * - `choices` or `options`: List of choice objects (label and value).
-   * - `displayStyle`: How to render the choices ('default' or 'chips').
-   * - `variant`: Selection mode ('singleSelection' or 'multipleSelection').
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>('/');
-
-  displayStyle = computed(() => this.props()['displayStyle']?.value());
-  choices = computed(
+  readonly displayStyle = computed(() => this.props()['displayStyle']?.value());
+  readonly choices = computed(
     () => this.props()['choices']?.value() || this.props()['options']?.value() || [],
   );
-  variant = computed(() => this.props()['variant']?.value());
-  selectedValue = computed(() => this.props()['value']?.value());
+  readonly variant = computed(() => this.props()['variant']?.value());
+  readonly selectedValue = computed(() => this.props()['value']?.value());
 
   isMultiple(): boolean {
     return this.variant() === 'multipleSelection';

--- a/renderers/angular/src/v0_9/catalog/basic/choice-picker.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/choice-picker.component.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {Component, computed, ChangeDetectionStrategy} from '@angular/core';
-import {BasicCatalogComponent} from './basic-catalog-component';
+import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
+import { BasicCatalogComponent } from './basic-catalog-component';
 
 /**
  * Angular implementation of the A2UI ChoicePicker component (v0.9).
@@ -100,7 +100,10 @@ import {BasicCatalogComponent} from './basic-catalog-component';
         gap: var(--a2ui-choicepicker-gap, var(--a2ui-spacing-xs, 0.25rem));
       }
       .a2ui-chip {
-        padding: var(--a2ui-choicepicker-chip-padding, var(--a2ui-spacing-s, 0.5rem) var(--a2ui-spacing-m, 1rem));
+        padding: var(
+          --a2ui-choicepicker-chip-padding,
+          var(--a2ui-spacing-s, 0.5rem) var(--a2ui-spacing-m, 1rem)
+        );
         border-radius: var(--a2ui-choicepicker-chip-border-radius, 100px);
         border: var(--a2ui-choicepicker-chip-border, 1px solid var(--a2ui-color-border, #ccc));
         background: var(--a2ui-choicepicker-chip-background, var(--a2ui-color-surface, #fff));
@@ -108,9 +111,15 @@ import {BasicCatalogComponent} from './basic-catalog-component';
         transition: all 0.2s;
       }
       .a2ui-chip.active {
-        background-color: var(--a2ui-choicepicker-chip-background-selected, var(--a2ui-color-primary, #17e));
+        background-color: var(
+          --a2ui-choicepicker-chip-background-selected,
+          var(--a2ui-color-primary, #17e)
+        );
         color: var(--a2ui-color-on-primary, #fff);
-        border-color: var(--a2ui-choicepicker-chip-background-selected, var(--a2ui-color-primary, #17e));
+        border-color: var(
+          --a2ui-choicepicker-chip-background-selected,
+          var(--a2ui-color-primary, #17e)
+        );
       }
     `,
   ],

--- a/renderers/angular/src/v0_9/catalog/basic/column.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/column.component.spec.ts
@@ -134,8 +134,14 @@ describe('ColumnComponent', () => {
 
     const hosts = fixture.debugElement.queryAll(By.css('a2ui-v09-component-host'));
     expect(hosts.length).toBe(2);
-    expect(hosts[0].componentInstance.componentKey()).toEqual({ id: 'template1', basePath: '/items/0' });
-    expect(hosts[1].componentInstance.componentKey()).toEqual({ id: 'template1', basePath: '/items/1' });
+    expect(hosts[0].componentInstance.componentKey()).toEqual({
+      id: 'template1',
+      basePath: '/items/0',
+    });
+    expect(hosts[1].componentInstance.componentKey()).toEqual({
+      id: 'template1',
+      basePath: '/items/1',
+    });
   });
 
   it('should handle non-array children value', () => {
@@ -176,4 +182,3 @@ describe('ColumnComponent', () => {
     expect(div.styles['align-items']).toBeFalsy();
   });
 });
-

--- a/renderers/angular/src/v0_9/catalog/basic/column.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/column.component.spec.ts
@@ -110,6 +110,27 @@ describe('ColumnComponent', () => {
     expect(style.flex).toBe('2 1 0%');
   });
 
+  it('should apply flex style from weight prop when value is 0', () => {
+    fixture.componentRef.setInput('props', {
+      ...component.props(),
+      weight: { value: signal(0), raw: 0, onUpdate: () => {} },
+    });
+    fixture.detectChanges();
+    const style = window.getComputedStyle(fixture.debugElement.nativeElement);
+    expect(style.flex).toBe('0 1 0%');
+  });
+
+  it('should not apply flex style when weight prop is null', () => {
+    fixture.componentRef.setInput('props', {
+      ...component.props(),
+      weight: { value: signal(null), raw: null, onUpdate: () => {} },
+    });
+    fixture.detectChanges();
+    const style = window.getComputedStyle(fixture.debugElement.nativeElement);
+    expect(style.flex).not.toBe('2 1 0%');
+    expect(style.flex).not.toBe('0 1 0%');
+  });
+
   it('should render non-repeating children', () => {
     fixture.detectChanges();
     const hosts = fixture.debugElement.queryAll(By.css('a2ui-v09-component-host'));

--- a/renderers/angular/src/v0_9/catalog/basic/column.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/column.component.spec.ts
@@ -100,6 +100,16 @@ describe('ColumnComponent', () => {
     expect(style.alignItems).toBe('stretch');
   });
 
+  it('should apply flex style from weight prop', () => {
+    fixture.componentRef.setInput('props', {
+      ...component.props(),
+      weight: { value: signal(2), raw: 2, onUpdate: () => {} },
+    });
+    fixture.detectChanges();
+    const style = window.getComputedStyle(fixture.debugElement.nativeElement);
+    expect(style.flex).toBe('2 1 0%');
+  });
+
   it('should render non-repeating children', () => {
     fixture.detectChanges();
     const hosts = fixture.debugElement.queryAll(By.css('a2ui-v09-component-host'));

--- a/renderers/angular/src/v0_9/catalog/basic/column.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/column.component.ts
@@ -40,43 +40,36 @@ import { JUSTIFY_MAP, ALIGN_MAP } from './utils';
     '[style.width]': '"100%"',
     '[style.gap]': '"var(--a2ui-column-gap, var(--a2ui-spacing-m, 16px))"',
     '[style.justify-content]': 'justify()',
-    '[style.align-items]': 'align()'
+    '[style.align-items]': 'align()',
   },
   template: `
-      @if (!isRepeating()) {
-        @for (child of normalizedChildren(); track child.id) {
-          <a2ui-v09-component-host
-            [componentKey]="child"
-            [surfaceId]="surfaceId()"
-          >
-          </a2ui-v09-component-host>
-        }
+    @if (!isRepeating()) {
+      @for (child of normalizedChildren(); track child.id) {
+        <a2ui-v09-component-host [componentKey]="child" [surfaceId]="surfaceId()">
+        </a2ui-v09-component-host>
       }
+    }
 
-      @if (isRepeating()) {
-        @for (item of children(); track item; let i = $index) {
-          <a2ui-v09-component-host
-            [componentKey]="{ id: templateId()!, basePath: getNormalizedPath(i) }"
-            [surfaceId]="surfaceId()"
-          >
-          </a2ui-v09-component-host>
-        }
+    @if (isRepeating()) {
+      @for (item of children(); track item; let i = $index) {
+        <a2ui-v09-component-host
+          [componentKey]="{ id: templateId()!, basePath: getNormalizedPath(i) }"
+          [surfaceId]="surfaceId()"
+        >
+        </a2ui-v09-component-host>
       }
+    }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ColumnComponent extends BasicCatalogComponent {
-
-
-
-
   protected readonly justify = computed(() => {
     const val = this.props()['justify']?.value();
-    return val ? (JUSTIFY_MAP[val] || val) : undefined;
+    return val ? JUSTIFY_MAP[val] || val : undefined;
   });
   protected readonly align = computed(() => {
     const val = this.props()['align']?.value();
-    return val ? (ALIGN_MAP[val] || val) : undefined;
+    return val ? ALIGN_MAP[val] || val : undefined;
   });
 
   protected readonly children = computed(() => {
@@ -94,7 +87,7 @@ export class ColumnComponent extends BasicCatalogComponent {
 
   protected readonly normalizedChildren = computed(() => {
     if (this.isRepeating()) return [];
-    return this.children().map(child => {
+    return this.children().map((child) => {
       if (typeof child === 'object' && child !== null && 'id' in child) {
         return child as { id: string; basePath: string };
       }

--- a/renderers/angular/src/v0_9/catalog/basic/column.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/column.component.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
 import { ComponentHostComponent } from '../../core/component-host.component';
-import { BoundProperty } from '../../core/types';
 
 import { getNormalizedPath } from '../../core/utils';
 import { BasicCatalogComponent } from './basic-catalog-component';
@@ -67,42 +66,33 @@ import { JUSTIFY_MAP, ALIGN_MAP } from './utils';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ColumnComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `children`: A list of component IDs OR a repeating collection definition.
-   * - `justify`: Flexbox justify-content value (e.g., 'flex-start', 'center').
-   * - `align`: Flexbox align-items value (e.g., 'flex-start', 'center').
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>('/');
 
-  protected justify = computed(() => {
+
+
+
+  protected readonly justify = computed(() => {
     const val = this.props()['justify']?.value();
     return val ? (JUSTIFY_MAP[val] || val) : undefined;
   });
-  protected align = computed(() => {
+  protected readonly align = computed(() => {
     const val = this.props()['align']?.value();
     return val ? (ALIGN_MAP[val] || val) : undefined;
   });
 
-  protected children = computed(() => {
+  protected readonly children = computed(() => {
     const raw = this.props()['children']?.value() || [];
     return Array.isArray(raw) ? raw : [];
   });
 
-  protected isRepeating = computed(() => {
+  protected readonly isRepeating = computed(() => {
     return !!this.props()['children']?.raw?.componentId;
   });
 
-  protected templateId = computed(() => {
+  protected readonly templateId = computed(() => {
     return this.props()['children']?.raw?.componentId;
   });
 
-  protected normalizedChildren = computed(() => {
+  protected readonly normalizedChildren = computed(() => {
     if (this.isRepeating()) return [];
     return this.children().map(child => {
       if (typeof child === 'object' && child !== null && 'id' in child) {

--- a/renderers/angular/src/v0_9/catalog/basic/complex-components.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/complex-components.spec.ts
@@ -40,10 +40,19 @@ describe('Complex Components', () => {
           componentsModel: new Map([
             ['child-1', new ComponentModel('child-1', 'Text', { text: { value: 'Child 1' } })],
             ['child-2', new ComponentModel('child-2', 'Text', { text: { value: 'Child 2' } })],
-            ['content-1', new ComponentModel('content-1', 'Text', { text: { value: 'Content 1' } })],
-            ['content-2', new ComponentModel('content-2', 'Text', { text: { value: 'Content 2' } })],
+            [
+              'content-1',
+              new ComponentModel('content-1', 'Text', { text: { value: 'Content 1' } }),
+            ],
+            [
+              'content-2',
+              new ComponentModel('content-2', 'Text', { text: { value: 'Content 2' } }),
+            ],
             ['trigger-btn', new ComponentModel('trigger-btn', 'Text', { text: { value: 'Open' } })],
-            ['modal-content', new ComponentModel('modal-content', 'Text', { text: { value: 'Modal' } })],
+            [
+              'modal-content',
+              new ComponentModel('modal-content', 'Text', { text: { value: 'Modal' } }),
+            ],
           ]),
           catalog: {
             id: 'mock-catalog',
@@ -328,16 +337,14 @@ describe('Complex Components', () => {
         enableTime: createBoundProperty(true),
       });
       fixture.detectChanges();
-      
+
       const dateInput = fixture.nativeElement.querySelector('input[type="date"]');
       const timeInput = fixture.nativeElement.querySelector('input[type="time"]');
-      
+
       expect(dateInput.value).toBe('');
       expect(timeInput.value).toBe('');
     });
   });
-
-
 
   describe('ListComponent', () => {
     let component: ListComponent;
@@ -521,7 +528,10 @@ describe('Complex Components', () => {
       const triggerHost = fixture.debugElement.query(
         By.css('.a2ui-modal-trigger a2ui-v09-component-host'),
       );
-      expect(triggerHost.componentInstance.componentKey()).toEqual({ id: 'trigger-btn', basePath: '/' });
+      expect(triggerHost.componentInstance.componentKey()).toEqual({
+        id: 'trigger-btn',
+        basePath: '/',
+      });
 
       expect(fixture.nativeElement.querySelector('.a2ui-modal-overlay')).toBeFalsy();
 
@@ -533,7 +543,10 @@ describe('Complex Components', () => {
       const contentHost = fixture.debugElement.query(
         By.css('.a2ui-modal-overlay a2ui-v09-component-host'),
       );
-      expect(contentHost.componentInstance.componentKey()).toEqual({ id: 'modal-content', basePath: '/' });
+      expect(contentHost.componentInstance.componentKey()).toEqual({
+        id: 'modal-content',
+        basePath: '/',
+      });
     });
 
     it('should close modal when close button clicked', () => {

--- a/renderers/angular/src/v0_9/catalog/basic/date-time-input.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/date-time-input.component.ts
@@ -72,7 +72,10 @@ import { BasicCatalogComponent } from './basic-catalog-component';
         width: 100%;
       }
       .a2ui-date-time-label {
-        font-size: var(--a2ui-datetimeinput-label-font-size, var(--a2ui-label-font-size, var(--a2ui-font-size-s, 14px)));
+        font-size: var(
+          --a2ui-datetimeinput-label-font-size,
+          var(--a2ui-label-font-size, var(--a2ui-font-size-s, 14px))
+        );
         font-weight: var(--a2ui-datetimeinput-label-font-weight, bold);
         color: var(--a2ui-text-color-text, var(--a2ui-color-on-background, #333));
       }
@@ -95,10 +98,6 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DateTimeInputComponent extends BasicCatalogComponent {
-
-
-
-
   readonly label = computed(() => this.props()['label']?.value());
   readonly enableDate = computed(() => this.props()['enableDate']?.value() ?? true);
   readonly enableTime = computed(() => this.props()['enableTime']?.value() ?? false);

--- a/renderers/angular/src/v0_9/catalog/basic/date-time-input.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/date-time-input.component.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
-import { BoundProperty } from '../../core/types';
+import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
 import { BasicCatalogComponent } from './basic-catalog-component';
 
 /**
@@ -96,33 +95,23 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DateTimeInputComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `value`: The current ISO date/time string.
-   * - `label`: Optional label text.
-   * - `enableDate`: Whether to show the date picker (default: true).
-   * - `enableTime`: Whether to show the time picker (default: false).
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>('/');
 
-  label = computed(() => this.props()['label']?.value());
-  enableDate = computed(() => this.props()['enableDate']?.value() ?? true);
-  enableTime = computed(() => this.props()['enableTime']?.value() ?? false);
 
-  private rawValue = computed(() => this.props()['value']?.value() || '');
 
-  dateValue = computed(() => {
+
+  readonly label = computed(() => this.props()['label']?.value());
+  readonly enableDate = computed(() => this.props()['enableDate']?.value() ?? true);
+  readonly enableTime = computed(() => this.props()['enableTime']?.value() ?? false);
+
+  private readonly rawValue = computed(() => this.props()['value']?.value() || '');
+
+  readonly dateValue = computed(() => {
     const val = this.rawValue();
     if (!val) return '';
     return val.includes('T') ? val.split('T')[0] : val;
   });
 
-  timeValue = computed(() => {
+  readonly timeValue = computed(() => {
     const val = this.rawValue();
     if (!val || !val.includes('T')) return '';
     return val.split('T')[1].substring(0, 5);

--- a/renderers/angular/src/v0_9/catalog/basic/divider.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/divider.component.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
-import { BoundProperty } from '../../core/types';
+import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
 import { BasicCatalogComponent } from './basic-catalog-component';
 
 /**
@@ -62,16 +61,9 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DividerComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `axis`: The orientation of the divider ('horizontal' (default) or 'vertical').
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>('/');
 
-  axis = computed(() => this.props()['axis']?.value() ?? 'horizontal');
+
+
+
+  readonly axis = computed(() => this.props()['axis']?.value() ?? 'horizontal');
 }

--- a/renderers/angular/src/v0_9/catalog/basic/divider.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/divider.component.ts
@@ -45,7 +45,10 @@ import { BasicCatalogComponent } from './basic-catalog-component';
     `
       .a2ui-divider {
         border: 0;
-        border-top: var(--a2ui-divider-border, var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc));
+        border-top: var(
+          --a2ui-divider-border,
+          var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc)
+        );
         margin: var(--a2ui-divider-spacing, var(--a2ui-spacing-m, 16px)) 0;
         width: 100%;
       }
@@ -54,16 +57,15 @@ import { BasicCatalogComponent } from './basic-catalog-component';
         height: 100%;
         margin: 0 var(--a2ui-divider-spacing, var(--a2ui-spacing-m, 16px));
         border-top: 0;
-        border-left: var(--a2ui-divider-border, var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc));
+        border-left: var(
+          --a2ui-divider-border,
+          var(--a2ui-border-width, 1px) solid var(--a2ui-color-border, #ccc)
+        );
       }
     `,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DividerComponent extends BasicCatalogComponent {
-
-
-
-
   readonly axis = computed(() => this.props()['axis']?.value() ?? 'horizontal');
 }

--- a/renderers/angular/src/v0_9/catalog/basic/icon.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/icon.component.ts
@@ -51,8 +51,11 @@ import { BasicCatalogComponent } from './basic-catalog-component';
         height: var(--a2ui-icon-size, 24px);
         font-size: var(--a2ui-icon-size, 24px);
         font-family: var(--a2ui-icon-font-family, 'Material Icons');
-        color: var(--a2ui-icon-color, var(--a2ui-text-color-text, var(--a2ui-color-on-background, #333)));
-        font-variation-settings: var(--a2ui-icon-font-variation-settings, "FILL" 1);
+        color: var(
+          --a2ui-icon-color,
+          var(--a2ui-text-color-text, var(--a2ui-color-on-background, #333))
+        );
+        font-variation-settings: var(--a2ui-icon-font-variation-settings, 'FILL' 1);
         line-height: 1;
         text-transform: none;
         letter-spacing: normal;
@@ -73,10 +76,6 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IconComponent extends BasicCatalogComponent {
-
-
-
-
   readonly color = computed(() => this.props()['color']?.value());
   readonly iconNameRaw = computed(() => this.props()['name']?.value());
 

--- a/renderers/angular/src/v0_9/catalog/basic/icon.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/icon.component.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
-import { BoundProperty } from '../../core/types';
+import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
 import { BasicCatalogComponent } from './basic-catalog-component';
 
 /**
@@ -74,33 +73,24 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IconComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `name`: The name of the icon (e.g., 'home', 'settings') OR an object
-   *           with a `path` property for SVG icons.
-   * - `color`: The CSS color to apply to the icon.
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>('/');
 
-  color = computed(() => this.props()['color']?.value());
-  iconNameRaw = computed(() => this.props()['name']?.value());
 
-  isPath = computed(() => {
+
+
+  readonly color = computed(() => this.props()['color']?.value());
+  readonly iconNameRaw = computed(() => this.props()['name']?.value());
+
+  readonly isPath = computed(() => {
     const name = this.iconNameRaw();
     return typeof name === 'object' && name !== null && 'path' in name;
   });
 
-  path = computed(() => {
+  readonly path = computed(() => {
     const name = this.iconNameRaw();
     return (name as any)?.path || '';
   });
 
-  iconName = computed(() => {
+  readonly iconName = computed(() => {
     const name = this.iconNameRaw();
     if (typeof name !== 'string') return '';
     // Convert camelCase to snake_case for Material Icons

--- a/renderers/angular/src/v0_9/catalog/basic/image.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/image.component.ts
@@ -85,10 +85,6 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ImageComponent extends BasicCatalogComponent {
-
-
-
-
   readonly url = computed(() => this.props()['url']?.value());
   readonly description = computed(() => this.props()['description']?.value() || '');
   readonly fit = computed(() => this.props()['fit']?.value() || 'cover');

--- a/renderers/angular/src/v0_9/catalog/basic/image.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/image.component.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
-import { BoundProperty } from '../../core/types';
+import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
 import { BasicCatalogComponent } from './basic-catalog-component';
 
 /**
@@ -86,22 +85,12 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ImageComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `url`: The absolute URL of the image.
-   * - `description`: Accessibility text for the image.
-   * - `fit`: Object-fit mode ('cover', 'contain', 'fill', 'none', 'scale-down').
-   * - `variant`: Style variant ('default', 'circle', 'rounded', 'icon', 'avatar', 'smallFeature', 'mediumFeature', 'largeFeature', 'header').
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>('/');
 
-  url = computed(() => this.props()['url']?.value());
-  description = computed(() => this.props()['description']?.value() || '');
-  fit = computed(() => this.props()['fit']?.value() || 'cover');
-  variant = computed(() => this.props()['variant']?.value() || 'default');
+
+
+
+  readonly url = computed(() => this.props()['url']?.value());
+  readonly description = computed(() => this.props()['description']?.value() || '');
+  readonly fit = computed(() => this.props()['fit']?.value() || 'cover');
+  readonly variant = computed(() => this.props()['variant']?.value() || 'default');
 }

--- a/renderers/angular/src/v0_9/catalog/basic/list.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/list.component.ts
@@ -39,10 +39,7 @@ import { Child } from '../../core/component-binder.service';
         <ol [class]="'a2ui-list ' + orientation()" [style.list-style-type]="styleType()">
           @for (child of children(); track trackBy($index, child)) {
             <li>
-              <a2ui-v09-component-host
-                [componentKey]="child"
-                [surfaceId]="surfaceId()"
-              >
+              <a2ui-v09-component-host [componentKey]="child" [surfaceId]="surfaceId()">
               </a2ui-v09-component-host>
             </li>
           }
@@ -52,10 +49,7 @@ import { Child } from '../../core/component-binder.service';
         <ul [class]="'a2ui-list ' + orientation()" [style.list-style-type]="styleType()">
           @for (child of children(); track trackBy($index, child)) {
             <li>
-              <a2ui-v09-component-host
-                [componentKey]="child"
-                [surfaceId]="surfaceId()"
-              >
+              <a2ui-v09-component-host [componentKey]="child" [surfaceId]="surfaceId()">
               </a2ui-v09-component-host>
             </li>
           }
@@ -65,10 +59,7 @@ import { Child } from '../../core/component-binder.service';
         <div [class]="'a2ui-list ' + orientation()" style="list-style-type: none;">
           @for (child of children(); track trackBy($index, child)) {
             <div class="a2ui-list-item-none">
-              <a2ui-v09-component-host
-                [componentKey]="child"
-                [surfaceId]="surfaceId()"
-              >
+              <a2ui-v09-component-host [componentKey]="child" [surfaceId]="surfaceId()">
               </a2ui-v09-component-host>
             </div>
           }
@@ -103,10 +94,6 @@ import { Child } from '../../core/component-binder.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ListComponent extends BasicCatalogComponent {
-
-
-
-
   readonly listStyle = computed(() => this.props()['listStyle']?.value());
   readonly orientation = computed(() => this.props()['orientation']?.value() || 'vertical');
   readonly children = computed(() => {

--- a/renderers/angular/src/v0_9/catalog/basic/list.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/list.component.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
 import { ComponentHostComponent } from '../../core/component-host.component';
-import { BoundProperty } from '../../core/types';
 import { BasicCatalogComponent } from './basic-catalog-component';
 import { Child } from '../../core/component-binder.service';
 
@@ -104,34 +103,25 @@ import { Child } from '../../core/component-binder.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ListComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `children`: A list of component IDs to render as list items.
-   * - `listStyle`: The type of list ('ordered', 'unordered', 'none').
-   * - `orientation`: The layout direction ('vertical', 'horizontal').
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>('/');
 
-  listStyle = computed(() => this.props()['listStyle']?.value());
-  orientation = computed(() => this.props()['orientation']?.value() || 'vertical');
-  children = computed(() => {
+
+
+
+  readonly listStyle = computed(() => this.props()['listStyle']?.value());
+  readonly orientation = computed(() => this.props()['orientation']?.value() || 'vertical');
+  readonly children = computed(() => {
     const raw = this.props()['children']?.value();
     return Array.isArray(raw) ? raw : [];
   });
 
-  listTag = computed(() => {
+  readonly listTag = computed(() => {
     const style = this.listStyle();
     if (style === 'ordered') return 'ol';
     if (style === 'unordered') return 'ul';
     return 'div';
   });
 
-  styleType = computed(() => {
+  readonly styleType = computed(() => {
     const style = this.listStyle();
     if (style === 'none') return 'none';
     return '';

--- a/renderers/angular/src/v0_9/catalog/basic/modal.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/modal.component.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy, signal } from '@angular/core';
+import { Component, computed, ChangeDetectionStrategy, signal } from '@angular/core';
 import { ComponentHostComponent } from '../../core/component-host.component';
-import { BoundProperty } from '../../core/types';
 import { BasicCatalogComponent } from './basic-catalog-component';
 
 /**
@@ -112,22 +111,14 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ModalComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `trigger`: The ID of the component that opens the modal.
-   * - `content`: The ID of the component to display inside the modal.
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>('/');
+
+
+
 
   isOpen = signal(false);
 
-  trigger = computed(() => this.props()['trigger']?.value());
-  content = computed(() => this.props()['content']?.value());
+  readonly trigger = computed(() => this.props()['trigger']?.value());
+  readonly content = computed(() => this.props()['content']?.value());
 
 
 

--- a/renderers/angular/src/v0_9/catalog/basic/modal.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/modal.component.ts
@@ -38,10 +38,7 @@ import { BasicCatalogComponent } from './basic-catalog-component';
     <div class="a2ui-modal-wrapper">
       <div (click)="openModal()" class="a2ui-modal-trigger">
         @if (trigger()) {
-          <a2ui-v09-component-host
-            [componentKey]="trigger()!"
-            [surfaceId]="surfaceId()"
-          >
+          <a2ui-v09-component-host [componentKey]="trigger()!" [surfaceId]="surfaceId()">
           </a2ui-v09-component-host>
         }
       </div>
@@ -51,10 +48,7 @@ import { BasicCatalogComponent } from './basic-catalog-component';
           <div class="a2ui-modal-content" (click)="$event.stopPropagation()">
             <button class="a2ui-modal-close" (click)="closeModal()">&times;</button>
             @if (content()) {
-              <a2ui-v09-component-host
-                [componentKey]="content()!"
-                [surfaceId]="surfaceId()"
-              >
+              <a2ui-v09-component-host [componentKey]="content()!" [surfaceId]="surfaceId()">
               </a2ui-v09-component-host>
             }
           </div>
@@ -111,16 +105,10 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ModalComponent extends BasicCatalogComponent {
-
-
-
-
   isOpen = signal(false);
 
   readonly trigger = computed(() => this.props()['trigger']?.value());
   readonly content = computed(() => this.props()['content']?.value());
-
-
 
   openModal() {
     this.isOpen.set(true);

--- a/renderers/angular/src/v0_9/catalog/basic/row.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/row.component.spec.ts
@@ -124,8 +124,14 @@ describe('RowComponent', () => {
 
     const hosts = fixture.debugElement.queryAll(By.css('a2ui-v09-component-host'));
     expect(hosts.length).toBe(2);
-    expect(hosts[0].componentInstance.componentKey()).toEqual({ id: 'template1', basePath: '/items/0' });
-    expect(hosts[1].componentInstance.componentKey()).toEqual({ id: 'template1', basePath: '/items/1' });
+    expect(hosts[0].componentInstance.componentKey()).toEqual({
+      id: 'template1',
+      basePath: '/items/0',
+    });
+    expect(hosts[1].componentInstance.componentKey()).toEqual({
+      id: 'template1',
+      basePath: '/items/1',
+    });
   });
 
   it('should handle non-array children value', () => {
@@ -166,4 +172,3 @@ describe('RowComponent', () => {
     expect(div.styles['align-items']).toBeFalsy();
   });
 });
-

--- a/renderers/angular/src/v0_9/catalog/basic/row.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/row.component.ts
@@ -38,43 +38,36 @@ import { JUSTIFY_MAP, ALIGN_MAP } from './utils';
     '[style.flex-direction]': '"row"',
     '[style.gap]': '"var(--a2ui-row-gap, var(--a2ui-spacing-m, 16px))"',
     '[style.justify-content]': 'justify()',
-    '[style.align-items]': 'align()'
+    '[style.align-items]': 'align()',
   },
   template: `
-      @if (!isRepeating()) {
-        @for (child of normalizedChildren(); track child.id) {
-          <a2ui-v09-component-host
-            [componentKey]="child"
-            [surfaceId]="surfaceId()"
-          >
-          </a2ui-v09-component-host>
-        }
+    @if (!isRepeating()) {
+      @for (child of normalizedChildren(); track child.id) {
+        <a2ui-v09-component-host [componentKey]="child" [surfaceId]="surfaceId()">
+        </a2ui-v09-component-host>
       }
+    }
 
-      @if (isRepeating()) {
-        @for (item of children(); track item; let i = $index) {
-          <a2ui-v09-component-host
-            [componentKey]="{ id: templateId()!, basePath: getNormalizedPath(i) }"
-            [surfaceId]="surfaceId()"
-          >
-          </a2ui-v09-component-host>
-        }
+    @if (isRepeating()) {
+      @for (item of children(); track item; let i = $index) {
+        <a2ui-v09-component-host
+          [componentKey]="{ id: templateId()!, basePath: getNormalizedPath(i) }"
+          [surfaceId]="surfaceId()"
+        >
+        </a2ui-v09-component-host>
       }
+    }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RowComponent extends BasicCatalogComponent {
-
-
-
-
   protected readonly justify = computed(() => {
     const val = this.props()['justify']?.value();
-    return val ? (JUSTIFY_MAP[val] || val) : undefined;
+    return val ? JUSTIFY_MAP[val] || val : undefined;
   });
   protected readonly align = computed(() => {
     const val = this.props()['align']?.value();
-    return val ? (ALIGN_MAP[val] || val) : undefined;
+    return val ? ALIGN_MAP[val] || val : undefined;
   });
 
   protected readonly children = computed(() => {
@@ -92,7 +85,7 @@ export class RowComponent extends BasicCatalogComponent {
 
   protected readonly normalizedChildren = computed(() => {
     if (this.isRepeating()) return [];
-    return this.children().map(child => {
+    return this.children().map((child) => {
       if (typeof child === 'object' && child !== null && 'id' in child) {
         return child as { id: string; basePath: string };
       }

--- a/renderers/angular/src/v0_9/catalog/basic/row.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/row.component.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
 import { ComponentHostComponent } from '../../core/component-host.component';
-import { BoundProperty } from '../../core/types';
 import { getNormalizedPath } from '../../core/utils';
 import { BasicCatalogComponent } from './basic-catalog-component';
 import { JUSTIFY_MAP, ALIGN_MAP } from './utils';
@@ -65,42 +64,33 @@ import { JUSTIFY_MAP, ALIGN_MAP } from './utils';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RowComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `children`: A list of component IDs OR a repeating collection definition.
-   * - `justify`: Flexbox justify-content value (e.g., 'flex-start', 'center').
-   * - `align`: Flexbox align-items value (e.g., 'flex-start', 'center').
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>('/');
 
-  protected justify = computed(() => {
+
+
+
+  protected readonly justify = computed(() => {
     const val = this.props()['justify']?.value();
     return val ? (JUSTIFY_MAP[val] || val) : undefined;
   });
-  protected align = computed(() => {
+  protected readonly align = computed(() => {
     const val = this.props()['align']?.value();
     return val ? (ALIGN_MAP[val] || val) : undefined;
   });
 
-  protected children = computed(() => {
+  protected readonly children = computed(() => {
     const raw = this.props()['children']?.value() || [];
     return Array.isArray(raw) ? raw : [];
   });
 
-  protected isRepeating = computed(() => {
+  protected readonly isRepeating = computed(() => {
     return !!this.props()['children']?.raw?.componentId;
   });
 
-  protected templateId = computed(() => {
+  protected readonly templateId = computed(() => {
     return this.props()['children']?.raw?.componentId;
   });
 
-  protected normalizedChildren = computed(() => {
+  protected readonly normalizedChildren = computed(() => {
     if (this.isRepeating()) return [];
     return this.children().map(child => {
       if (typeof child === 'object' && child !== null && 'id' in child) {

--- a/renderers/angular/src/v0_9/catalog/basic/simple-components.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/simple-components.spec.ts
@@ -39,10 +39,19 @@ describe('Simple Components', () => {
           componentsModel: new Map([
             ['child-1', new ComponentModel('child-1', 'Text', { text: { value: 'Child 1' } })],
             ['child-2', new ComponentModel('child-2', 'Text', { text: { value: 'Child 2' } })],
-            ['content-1', new ComponentModel('content-1', 'Text', { text: { value: 'Content 1' } })],
-            ['content-2', new ComponentModel('content-2', 'Text', { text: { value: 'Content 2' } })],
+            [
+              'content-1',
+              new ComponentModel('content-1', 'Text', { text: { value: 'Content 1' } }),
+            ],
+            [
+              'content-2',
+              new ComponentModel('content-2', 'Text', { text: { value: 'Content 2' } }),
+            ],
             ['trigger-btn', new ComponentModel('trigger-btn', 'Text', { text: { value: 'Open' } })],
-            ['modal-content', new ComponentModel('modal-content', 'Text', { text: { value: 'Modal' } })],
+            [
+              'modal-content',
+              new ComponentModel('modal-content', 'Text', { text: { value: 'Modal' } }),
+            ],
           ]),
           catalog: {
             id: 'mock-catalog',
@@ -170,7 +179,14 @@ describe('Simple Components', () => {
     });
 
     it('should support all specified variants', () => {
-      const variants = ['icon', 'avatar', 'smallFeature', 'mediumFeature', 'largeFeature', 'header'];
+      const variants = [
+        'icon',
+        'avatar',
+        'smallFeature',
+        'mediumFeature',
+        'largeFeature',
+        'header',
+      ];
       for (const variant of variants) {
         fixture.componentRef.setInput('props', {
           url: createBoundProperty('https://example.com/image.png'),
@@ -182,7 +198,6 @@ describe('Simple Components', () => {
       }
     });
   });
-
 
   describe('IconComponent', () => {
     let component: IconComponent;

--- a/renderers/angular/src/v0_9/catalog/basic/slider.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/slider.component.ts
@@ -62,7 +62,10 @@ import { BasicCatalogComponent } from './basic-catalog-component';
       .a2ui-slider-header {
         display: flex;
         justify-content: space-between;
-        font-size: var(--a2ui-slider-label-font-size, var(--a2ui-label-font-size, var(--a2ui-font-size-s, 14px)));
+        font-size: var(
+          --a2ui-slider-label-font-size,
+          var(--a2ui-label-font-size, var(--a2ui-font-size-s, 14px))
+        );
         font-weight: var(--a2ui-slider-label-font-weight, bold);
         color: var(--a2ui-text-color-text, var(--a2ui-color-on-background, #333));
       }
@@ -77,10 +80,6 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SliderComponent extends BasicCatalogComponent {
-
-
-
-
   readonly label = computed(() => this.props()['label']?.value());
   readonly value = computed(() => this.props()['value']?.value());
   readonly min = computed(() => this.props()['min']?.value() ?? 0);

--- a/renderers/angular/src/v0_9/catalog/basic/slider.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/slider.component.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
-import { BoundProperty } from '../../core/types';
+import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
 import { BasicCatalogComponent } from './basic-catalog-component';
 
 /**
@@ -78,26 +77,15 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SliderComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `value`: The current numeric value.
-   * - `label`: Label text to display.
-   * - `min`: Minimum value (default: 0).
-   * - `max`: Maximum value (default: 100).
-   * - `step`: Increment step (default: 1).
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>('/');
 
-  label = computed(() => this.props()['label']?.value());
-  value = computed(() => this.props()['value']?.value());
-  min = computed(() => this.props()['min']?.value() ?? 0);
-  max = computed(() => this.props()['max']?.value() ?? 100);
-  step = computed(() => this.props()['step']?.value() ?? 1);
+
+
+
+  readonly label = computed(() => this.props()['label']?.value());
+  readonly value = computed(() => this.props()['value']?.value());
+  readonly min = computed(() => this.props()['min']?.value() ?? 0);
+  readonly max = computed(() => this.props()['max']?.value() ?? 100);
+  readonly step = computed(() => this.props()['step']?.value() ?? 1);
 
   handleInput(event: Event) {
     const val = Number((event.target as HTMLInputElement).value);

--- a/renderers/angular/src/v0_9/catalog/basic/tabs.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/tabs.component.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy, signal } from '@angular/core';
+import { Component, computed, ChangeDetectionStrategy, signal } from '@angular/core';
 import { ComponentHostComponent } from '../../core/component-host.component';
-import { BoundProperty } from '../../core/types';
 import { BasicCatalogComponent } from './basic-catalog-component';
 
 /**
@@ -96,23 +95,16 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TabsComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `tabs`: A list of tab objects, each containing a `label` and `content` ID.
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>('/');
+
+
+
 
   activeTabIndex = signal(0);
 
-  tabs = computed(() => this.props()['tabs']?.value() || []);
-  activeTab = computed(() => this.tabs()[this.activeTabIndex()]);
+  readonly tabs = computed(() => this.props()['tabs']?.value() || []);
+  readonly activeTab = computed(() => this.tabs()[this.activeTabIndex()]);
 
-  protected normalizedActiveTabContent = computed(() => {
+  protected readonly normalizedActiveTabContent = computed(() => {
     const content = this.activeTab()?.content;
     if (!content) return null;
     if (typeof content === 'object' && content !== null && 'id' in content) {

--- a/renderers/angular/src/v0_9/catalog/basic/tabs.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/tabs.component.ts
@@ -95,10 +95,6 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TabsComponent extends BasicCatalogComponent {
-
-
-
-
   activeTabIndex = signal(0);
 
   readonly tabs = computed(() => this.props()['tabs']?.value() || []);

--- a/renderers/angular/src/v0_9/catalog/basic/text-field.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text-field.component.spec.ts
@@ -128,7 +128,11 @@ describe('TextFieldComponent', () => {
     fixture.componentRef.setInput('props', {
       ...component.props(),
       isValid: { value: signal(false), raw: false, onUpdate: () => {} },
-      validationErrors: { value: signal(['Error 1', 'Error 2']), raw: ['Error 1', 'Error 2'], onUpdate: () => {} },
+      validationErrors: {
+        value: signal(['Error 1', 'Error 2']),
+        raw: ['Error 1', 'Error 2'],
+        onUpdate: () => {},
+      },
     });
 
     fixture.detectChanges();

--- a/renderers/angular/src/v0_9/catalog/basic/text-field.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text-field.component.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
-import { BoundProperty } from '../../core/types';
+import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
 import { BasicCatalogComponent } from './basic-catalog-component';
 
 /**
@@ -92,27 +91,16 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TextFieldComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `value`: The current string value of the input.
-   * - `label`: Optional label text to display above the input.
-   * - `placeholder`: Hint text shown when the input is empty.
-   * - `variant`: Input type variant ('default', 'obscured' (password), 'number').
-   * - `checks`: Optional validation rules.
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>('/');
 
-  label = computed(() => this.props()['label']?.value());
-  value = computed(() => this.props()['value']?.value() || '');
-  placeholder = computed(() => this.props()['placeholder']?.value() || '');
-  variant = computed(() => this.props()['variant']?.value());
 
-  inputType = computed(() => {
+
+
+  readonly label = computed(() => this.props()['label']?.value());
+  readonly value = computed(() => this.props()['value']?.value() || '');
+  readonly placeholder = computed(() => this.props()['placeholder']?.value() || '');
+  readonly variant = computed(() => this.props()['variant']?.value());
+
+  readonly inputType = computed(() => {
     switch (this.variant()) {
       case 'obscured':
         return 'password';

--- a/renderers/angular/src/v0_9/catalog/basic/text-field.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text-field.component.ts
@@ -64,7 +64,10 @@ import { BasicCatalogComponent } from './basic-catalog-component';
         margin: var(--a2ui-spacing-xs, 4px);
       }
       label {
-        font-size: var(--a2ui-textfield-label-font-size, var(--a2ui-label-font-size, var(--a2ui-font-size-s, 14px)));
+        font-size: var(
+          --a2ui-textfield-label-font-size,
+          var(--a2ui-label-font-size, var(--a2ui-font-size-s, 14px))
+        );
         font-weight: var(--a2ui-textfield-label-font-weight, bold);
         color: var(--a2ui-text-color-text, var(--a2ui-color-on-background, #333));
       }
@@ -91,10 +94,6 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TextFieldComponent extends BasicCatalogComponent {
-
-
-
-
   readonly label = computed(() => this.props()['label']?.value());
   readonly value = computed(() => this.props()['value']?.value() || '');
   readonly placeholder = computed(() => this.props()['placeholder']?.value() || '');

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
@@ -31,9 +31,7 @@ describe('TextComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [TextComponent],
-      providers: [
-        { provide: MarkdownRenderer, useValue: mockMarkdownRenderer },
-      ],
+      providers: [{ provide: MarkdownRenderer, useValue: mockMarkdownRenderer }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TextComponent);
@@ -142,4 +140,3 @@ describe('TextComponent', () => {
     expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('');
   });
 });
-

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import { Component, computed, ChangeDetectionStrategy, inject, signal, effect } from '@angular/core';
+import {
+  Component,
+  computed,
+  ChangeDetectionStrategy,
+  inject,
+  signal,
+  effect,
+} from '@angular/core';
 import { MarkdownRenderer } from '../../core/markdown';
 import { BasicCatalogComponent } from './basic-catalog-component';
 
@@ -37,10 +44,7 @@ import { BasicCatalogComponent } from './basic-catalog-component';
 @Component({
   selector: 'a2ui-v09-text',
   standalone: true,
-  template: `
-    <span [class]="'a2ui-text ' + variant()" [innerHTML]="resolvedText()">
-    </span>
-  `,
+  template: ` <span [class]="'a2ui-text ' + variant()" [innerHTML]="resolvedText()"> </span> `,
   // We use :host ::ng-deep because the template content is injected via innerHTML (Markdown).
   // Angular's default view encapsulation cannot target elements injected via innerHTML because they lack the scoping attributes generated at compile time.
   // ::ng-deep allows styles to reach into the injected HTML, while :host keeps them scoped to this component.
@@ -61,7 +65,10 @@ import { BasicCatalogComponent } from './basic-catalog-component';
         margin: var(--_a2ui-text-margin, 0);
       }
       :host ::ng-deep .a2ui-text {
-        color: var(--_a2ui-text-color, var(--a2ui-text-color-text, var(--a2ui-color-on-background)));
+        color: var(
+          --_a2ui-text-color,
+          var(--a2ui-text-color-text, var(--a2ui-color-on-background))
+        );
       }
       :host ::ng-deep .a2ui-text h1,
       :host ::ng-deep .a2ui-text h2,
@@ -72,11 +79,22 @@ import { BasicCatalogComponent } from './basic-catalog-component';
         font-family: var(--a2ui-font-family-title, inherit);
         line-height: var(--a2ui-line-height-headings, 1.2);
       }
-      :host ::ng-deep .a2ui-text h1 { font-size: var(--a2ui-font-size-2xl); }
-      :host ::ng-deep .a2ui-text h2 { font-size: var(--a2ui-font-size-xl); }
-      :host ::ng-deep .a2ui-text h3 { font-size: var(--a2ui-font-size-l); }
-      :host ::ng-deep .a2ui-text p, :host ::ng-deep .a2ui-text h4 { font-size: var(--a2ui-font-size-m); }
-      :host ::ng-deep .a2ui-text h5 { font-size: var(--a2ui-font-size-s); }
+      :host ::ng-deep .a2ui-text h1 {
+        font-size: var(--a2ui-font-size-2xl);
+      }
+      :host ::ng-deep .a2ui-text h2 {
+        font-size: var(--a2ui-font-size-xl);
+      }
+      :host ::ng-deep .a2ui-text h3 {
+        font-size: var(--a2ui-font-size-l);
+      }
+      :host ::ng-deep .a2ui-text p,
+      :host ::ng-deep .a2ui-text h4 {
+        font-size: var(--a2ui-font-size-m);
+      }
+      :host ::ng-deep .a2ui-text h5 {
+        font-size: var(--a2ui-font-size-s);
+      }
       :host ::ng-deep .a2ui-text p {
         line-height: var(--a2ui-line-height-body, 1.5);
       }
@@ -93,10 +111,6 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TextComponent extends BasicCatalogComponent {
-
-
-
-
   private markdownRenderer = inject(MarkdownRenderer);
 
   readonly variant = computed(() => this.props()['variant']?.value() || 'body');
@@ -113,16 +127,28 @@ export class TextComponent extends BasicCatalogComponent {
       let value = text;
 
       switch (variant) {
-        case 'h1': value = `# ${text}`; break;
-        case 'h2': value = `## ${text}`; break;
-        case 'h3': value = `### ${text}`; break;
-        case 'h4': value = `#### ${text}`; break;
-        case 'h5': value = `##### ${text}`; break;
-        case 'caption': value = `*${text}*`; break;
+        case 'h1':
+          value = `# ${text}`;
+          break;
+        case 'h2':
+          value = `## ${text}`;
+          break;
+        case 'h3':
+          value = `### ${text}`;
+          break;
+        case 'h4':
+          value = `#### ${text}`;
+          break;
+        case 'h5':
+          value = `##### ${text}`;
+          break;
+        case 'caption':
+          value = `*${text}*`;
+          break;
       }
 
       const requestId = ++this.renderRequestId;
-      this.markdownRenderer.render(value).then(rendered => {
+      this.markdownRenderer.render(value).then((rendered) => {
         if (requestId === this.renderRequestId) {
           this.resolvedText.set(rendered);
         }

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy, inject, signal, effect } from '@angular/core';
-import { BoundProperty } from '../../core/types';
+import { Component, computed, ChangeDetectionStrategy, inject, signal, effect } from '@angular/core';
 import { MarkdownRenderer } from '../../core/markdown';
 import { BasicCatalogComponent } from './basic-catalog-component';
 
@@ -94,22 +93,14 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TextComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `text`: The string content to display.
-   * - `variant`: A hint for the base text style ('h1', 'h2', 'h3', 'h4', 'h5', 'caption', 'body').
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>('/');
+
+
+
 
   private markdownRenderer = inject(MarkdownRenderer);
 
-  variant = computed(() => this.props()['variant']?.value() || 'body');
-  text = computed(() => this.props()['text']?.value() || '');
+  readonly variant = computed(() => this.props()['variant']?.value() || 'body');
+  readonly text = computed(() => this.props()['text']?.value() || '');
 
   resolvedText = signal<string>('');
   private renderRequestId = 0;

--- a/renderers/angular/src/v0_9/catalog/basic/video.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/video.component.ts
@@ -58,10 +58,6 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class VideoComponent extends BasicCatalogComponent {
-
-
-
-
   readonly url = computed(() => this.props()['url']?.value());
   readonly posterUrl = computed(() => this.props()['posterUrl']?.value());
 }

--- a/renderers/angular/src/v0_9/catalog/basic/video.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/video.component.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
-import { BoundProperty } from '../../core/types';
+import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
 import { BasicCatalogComponent } from './basic-catalog-component';
 
 /**
@@ -59,18 +58,10 @@ import { BasicCatalogComponent } from './basic-catalog-component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class VideoComponent extends BasicCatalogComponent {
-  /**
-   * Reactive properties resolved from the A2UI {@link ComponentModel}.
-   *
-   * Expected properties:
-   * - `url`: The absolute URL of the video file.
-   * - `posterUrl`: The URL of an image to show before the video starts.
-   */
-  props = input<Record<string, BoundProperty>>({});
-  surfaceId = input.required<string>();
-  componentId = input<string>();
-  dataContextPath = input<string>('/');
 
-  url = computed(() => this.props()['url']?.value());
-  posterUrl = computed(() => this.props()['posterUrl']?.value());
+
+
+
+  readonly url = computed(() => this.props()['url']?.value());
+  readonly posterUrl = computed(() => this.props()['posterUrl']?.value());
 }

--- a/renderers/angular/src/v0_9/core/component-host.component.ts
+++ b/renderers/angular/src/v0_9/core/component-host.component.ts
@@ -19,18 +19,16 @@ import {
   ChangeDetectorRef,
   Component,
   DestroyRef,
-  HostBinding,
   OnInit,
   Type,
   inject,
   input,
-  signal,
 } from '@angular/core';
-import { NgComponentOutlet } from '@angular/common';
-import { ComponentContext, ComponentModel, SurfaceModel } from '@a2ui/web_core/v0_9';
-import { A2uiRendererService } from './a2ui-renderer.service';
-import { AngularCatalog } from '../catalog/types';
-import { ComponentBinder } from './component-binder.service';
+import {NgComponentOutlet} from '@angular/common';
+import {ComponentContext, ComponentModel, SurfaceModel} from '@a2ui/web_core/v0_9';
+import {A2uiRendererService} from './a2ui-renderer.service';
+import {AngularCatalog} from '../catalog/types';
+import {ComponentBinder} from './component-binder.service';
 import {BoundProperty} from './types';
 
 /**
@@ -68,7 +66,7 @@ import {BoundProperty} from './types';
 })
 export class ComponentHostComponent implements OnInit {
   /** The key of the component to render, either an ID string or an object with ID and basePath. Defaults to 'root'. */
-  componentKey = input<string | { id: string; basePath: string }>('root');
+  componentKey = input<string | {id: string; basePath: string}>('root');
 
   /** The unique identifier of the surface this component belongs to. */
   surfaceId = input.required<string>();
@@ -81,14 +79,7 @@ export class ComponentHostComponent implements OnInit {
   protected componentType: Type<any> | null = null;
   protected props: Record<string, BoundProperty> = {};
   private context?: ComponentContext;
-  protected weight = signal<string | number | null>(null);
 
-  // TODO(#1199): Move weight handling to the catalog specification.
-  @HostBinding('style.flex')
-  get flexStyle() {
-    const w = this.weight();
-    return w ? `${w}` : '';
-  }
   protected resolvedComponentId: string = '';
   protected resolvedDataContextPath: string = '/';
 
@@ -159,12 +150,8 @@ export class ComponentHostComponent implements OnInit {
     // component to react when a new prop is added after creation.
     const onPropsUpdateSub = componentModel.onUpdated.subscribe(() => {
       this.props = this.binder.bind(this.context!);
-      // TODO(#1199): Move weight handling to the catalog specification.
-      this.weight.set(componentModel.properties['weight'] || null);
       this.cdr.markForCheck();
     });
-
-    this.weight.set(componentModel.properties['weight'] || null);
 
     this.destroyRef.onDestroy(() => {
       // ComponentContext itself doesn't have a dispose, but its inner components might.

--- a/renderers/web_core/package-lock.json
+++ b/renderers/web_core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a2ui/web_core",
-  "version": "0.9.1-alpha.1",
+  "version": "0.9.1-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a2ui/web_core",
-      "version": "0.9.1-alpha.1",
+      "version": "0.9.1-alpha.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@preact/signals-core": "^1.13.0",
@@ -479,7 +479,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -674,7 +673,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1185,7 +1183,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1260,7 +1257,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -2878,7 +2874,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3220,7 +3215,6 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -3491,7 +3485,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3619,7 +3612,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3866,7 +3858,6 @@
       "version": "3.25.76",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Addresses issue #1199.

Changes made:
- Centralized props, surfaceId, componentId, dataContextPath, and weight in BasicCatalogComponent base class.
- Added unit test for weight feature in ColumnComponent.
- Added readonly keyword to computed properties in catalog components.