### PR TITLE
Increment renderer package versions and ignore specific sample lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ samples/client/angular/projects/mcp_calculator/public/mcp_apps_inner_iframe/
 ## Generated files for a2ui-in-mcpapps
 samples/agent/mcp/a2ui-in-mcpapps/server/apps/dist
 samples/agent/mcp/a2ui-in-mcpapps/server/apps/public
+

--- a/renderers/angular/package-lock.json
+++ b/renderers/angular/package-lock.json
@@ -57,7 +57,7 @@
     },
     "../markdown/markdown-it": {
       "name": "@a2ui/markdown-it",
-      "version": "0.0.2-alpha.3",
+      "version": "0.0.3",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/renderers/angular/package.json
+++ b/renderers/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/angular",
-  "version": "0.9.0-alpha.3",
+  "version": "0.9.1",
   "license": "Apache-2.0",
   "homepage": "https://a2ui.org/",
   "repository": {

--- a/renderers/lit/a2ui_explorer/package-lock.json
+++ b/renderers/lit/a2ui_explorer/package-lock.json
@@ -22,7 +22,7 @@
     },
     "..": {
       "name": "@a2ui/lit",
-      "version": "0.9.2-alpha.3",
+      "version": "0.9.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2ui/web_core": "file:../web_core",
@@ -51,7 +51,7 @@
     },
     "../../markdown/markdown-it": {
       "name": "@a2ui/markdown-it",
-      "version": "0.0.2-alpha.3",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.3.1",

--- a/renderers/lit/package.json
+++ b/renderers/lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/lit",
-  "version": "0.9.2-alpha.3",
+  "version": "0.9.3",
   "description": "A2UI Lit Library",
   "author": "Google",
   "license": "Apache-2.0",

--- a/renderers/markdown/markdown-it/package.json
+++ b/renderers/markdown/markdown-it/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/markdown-it",
-  "version": "0.0.2-alpha.3",
+  "version": "0.0.3",
   "description": "A Markdown renderer using markdown-it and dompurify.",
   "repository": {
     "directory": "renderers/markdown/markdown-it",

--- a/renderers/react/package-lock.json
+++ b/renderers/react/package-lock.json
@@ -72,7 +72,7 @@
     },
     "../markdown/markdown-it": {
       "name": "@a2ui/markdown-it",
-      "version": "0.0.2-alpha.3",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.3.1",

--- a/renderers/react/package.json
+++ b/renderers/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/react",
-  "version": "0.9.0-alpha.3",
+  "version": "0.9.1",
   "description": "React renderer for A2UI (Agent-to-User Interface)",
   "homepage": "https://a2ui.org/",
   "repository": {

--- a/renderers/react/visual-parity/package-lock.json
+++ b/renderers/react/visual-parity/package-lock.json
@@ -33,7 +33,7 @@
     },
     "..": {
       "name": "@a2ui/react",
-      "version": "0.9.0-alpha.3",
+      "version": "0.9.1",
       "dependencies": {
         "@a2ui/markdown-it": "file:../markdown/markdown-it",
         "@a2ui/web_core": "file:../web_core",
@@ -80,7 +80,7 @@
     },
     "../../lit": {
       "name": "@a2ui/lit",
-      "version": "0.9.2-alpha.3",
+      "version": "0.9.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2ui/web_core": "file:../web_core",
@@ -109,7 +109,7 @@
     },
     "../../markdown/markdown-it": {
       "name": "@a2ui/markdown-it",
-      "version": "0.0.2-alpha.3",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.3.1",

--- a/samples/agent/mcp/a2ui-in-mcpapps/server/apps/src/package-lock.json
+++ b/samples/agent/mcp/a2ui-in-mcpapps/server/apps/src/package-lock.json
@@ -48,7 +48,7 @@
     },
     "../../../../../../../renderers/markdown/markdown-it": {
       "name": "@a2ui/markdown-it",
-      "version": "0.0.2-alpha.3",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.3.1",

--- a/samples/client/angular/package-lock.json
+++ b/samples/client/angular/package-lock.json
@@ -71,7 +71,7 @@
     },
     "../../../renderers/markdown/markdown-it": {
       "name": "@a2ui/markdown-it",
-      "version": "0.0.2-alpha.3",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.3.1",
@@ -1492,6 +1492,43 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/samples/client/lit/mcp-apps-in-a2ui-sample/.gitignore
+++ b/samples/client/lit/mcp-apps-in-a2ui-sample/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/samples/client/lit/package-lock.json
+++ b/samples/client/lit/package-lock.json
@@ -28,7 +28,7 @@
     },
     "../../../renderers/lit": {
       "name": "@a2ui/lit",
-      "version": "0.9.2-alpha.3",
+      "version": "0.9.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2ui/web_core": "file:../web_core",
@@ -57,7 +57,7 @@
     },
     "../../../renderers/markdown/markdown-it": {
       "name": "@a2ui/markdown-it",
-      "version": "0.0.2-alpha.3",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.3.1",

--- a/samples/client/react/shell/package-lock.json
+++ b/samples/client/react/shell/package-lock.json
@@ -23,7 +23,7 @@
     },
     "../../../../renderers/react": {
       "name": "@a2ui/react",
-      "version": "0.9.0-alpha.3",
+      "version": "0.9.1",
       "dependencies": {
         "@a2ui/markdown-it": "file:../markdown/markdown-it",
         "@a2ui/web_core": "file:../web_core",

--- a/tools/editor/package-lock.json
+++ b/tools/editor/package-lock.json
@@ -26,7 +26,7 @@
     },
     "../../renderers/lit": {
       "name": "@a2ui/lit",
-      "version": "0.9.2-alpha.3",
+      "version": "0.9.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2ui/web_core": "file:../web_core",

--- a/tools/inspector/package-lock.json
+++ b/tools/inspector/package-lock.json
@@ -25,7 +25,7 @@
     },
     "../../renderers/lit": {
       "name": "@a2ui/lit",
-      "version": "0.9.2-alpha.3",
+      "version": "0.9.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2ui/web_core": "file:../web_core",


### PR DESCRIPTION
### Description of Changes
- Incremented the versions of the following renderer packages to their next patch releases:
  - `@a2ui/markdown-it`: `0.0.2-alpha.3` -> `0.0.3`
  - `@a2ui/lit`: `0.9.2-alpha.3` -> `0.9.3`
  - `@a2ui/angular`: `0.9.0-alpha.3` -> `0.9.1`
  - `@a2ui/react`: `0.9.0-alpha.3` -> `0.9.1`
- Synchronized all internal dependents by updating their `package-lock.json` files via the `increment_version.mjs` script.
- Added a local `.gitignore` file to `samples/client/lit/mcp-apps-in-a2ui-sample/` to ignore its `package-lock.json`, reducing repository noise.

### Rationale
These changes prepare the renderer packages for a new stable release on npm by incrementing their version numbers relative to the currently deployed versions. The automated sync ensures that all samples and tools in the mono-repo are pointing to the correct local versions during development.

### Testing/Running Instructions
1. Navigate to any of the modified package or sample directories (e.g., `renderers/lit` or `samples/client/lit`).
2. Run `npm install` to verify that dependencies are correctly resolved.
3. Verify that `samples/client/lit/mcp-apps-in-a2ui-sample/package-lock.json` is ignored by Git.