### PR TITLE
fix(react,v0.9): honor the schema's `weight` property in basic catalog

### DIFF
--- a/renderers/react/src/v0_9/catalog/basic/components/Card.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Card.tsx
@@ -17,11 +17,12 @@
 import React from 'react';
 import {createComponentImplementation} from '../../../adapter';
 import {CardApi} from '@a2ui/web_core/v0_9/basic_catalog';
-import {getBaseContainerStyle} from '../utils';
+import {getBaseContainerStyle, getWeightStyle} from '../utils';
 
 export const Card = createComponentImplementation(CardApi, ({props, buildChild}) => {
   const style: React.CSSProperties = {
     ...getBaseContainerStyle(),
+    ...getWeightStyle(props.weight),
     backgroundColor: '#fff',
     boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
     width: '100%',

--- a/renderers/react/src/v0_9/catalog/basic/components/Column.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Column.tsx
@@ -17,7 +17,7 @@
 import {createComponentImplementation} from '../../../adapter';
 import {ColumnApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {ChildList} from './ChildList';
-import {mapJustify, mapAlign} from '../utils';
+import {mapJustify, mapAlign, getWeightStyle} from '../utils';
 
 export const Column = createComponentImplementation(ColumnApi, ({props, buildChild, context}) => {
   return (
@@ -30,6 +30,7 @@ export const Column = createComponentImplementation(ColumnApi, ({props, buildChi
         width: '100%',
         margin: 0,
         padding: 0,
+        ...getWeightStyle(props.weight),
       }}
     >
       <ChildList childList={props.children} buildChild={buildChild} context={context} />

--- a/renderers/react/src/v0_9/catalog/basic/components/Image.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Image.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import {createComponentImplementation} from '../../../adapter';
 import {ImageApi} from '@a2ui/web_core/v0_9/basic_catalog';
-import {getBaseLeafStyle} from '../utils';
+import {getBaseLeafStyle, getWeightStyle} from '../utils';
 
 export const Image = createComponentImplementation(ImageApi, ({props}) => {
   const mapFit = (fit?: string): React.CSSProperties['objectFit'] => {
@@ -27,6 +27,7 @@ export const Image = createComponentImplementation(ImageApi, ({props}) => {
 
   const style: React.CSSProperties = {
     ...getBaseLeafStyle(),
+    ...getWeightStyle(props.weight),
     objectFit: mapFit(props.fit),
     width: '100%',
     height: 'auto',

--- a/renderers/react/src/v0_9/catalog/basic/components/Row.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Row.tsx
@@ -17,7 +17,7 @@
 import {createComponentImplementation} from '../../../adapter';
 import {RowApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {ChildList} from './ChildList';
-import {mapJustify, mapAlign} from '../utils';
+import {mapJustify, mapAlign, getWeightStyle} from '../utils';
 
 export const Row = createComponentImplementation(RowApi, ({props, buildChild, context}) => {
   return (
@@ -30,6 +30,7 @@ export const Row = createComponentImplementation(RowApi, ({props, buildChild, co
         width: '100%',
         margin: 0,
         padding: 0,
+        ...getWeightStyle(props.weight),
       }}
     >
       <ChildList childList={props.children} buildChild={buildChild} context={context} />

--- a/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import {createComponentImplementation} from '../../../adapter';
 import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
-import {getBaseLeafStyle} from '../utils';
+import {getBaseLeafStyle, getWeightStyle} from '../utils';
 import {useMarkdown} from '../hooks/useMarkdown';
 
 export const Text = createComponentImplementation(TextApi, ({props}) => {
@@ -48,6 +48,7 @@ export const Text = createComponentImplementation(TextApi, ({props}) => {
   const renderedHtml = useMarkdown(markdownText);
   const style: React.CSSProperties = {
     ...getBaseLeafStyle(),
+    ...getWeightStyle(props.weight),
     display: 'inline-block',
   };
 

--- a/renderers/react/src/v0_9/catalog/basic/utils.ts
+++ b/renderers/react/src/v0_9/catalog/basic/utils.ts
@@ -83,5 +83,5 @@ export const getBaseContainerStyle = (): React.CSSProperties => ({
 // proportions honored when the row needs to shrink, not just when it grows.
 export const getWeightStyle = (weight?: number): React.CSSProperties => {
   if (typeof weight !== 'number') return {};
-  return {flex: `${weight} ${weight} 0`, minWidth: 0};
+  return {flex: `${weight} ${weight} 0px`, minWidth: 0};
 };

--- a/renderers/react/src/v0_9/catalog/basic/utils.ts
+++ b/renderers/react/src/v0_9/catalog/basic/utils.ts
@@ -76,3 +76,12 @@ export const getBaseContainerStyle = (): React.CSSProperties => ({
   borderRadius: STANDARD_RADIUS,
   boxSizing: 'border-box',
 });
+
+// `min-width: 0` lets weighted children shrink below their intrinsic content
+// width. Without it, a Text with a long string would force the row to
+// overflow. Setting both grow and shrink (rather than just grow) keeps the
+// proportions honored when the row needs to shrink, not just when it grows.
+export const getWeightStyle = (weight?: number): React.CSSProperties => {
+  if (typeof weight !== 'number') return {};
+  return {flex: `${weight} ${weight} 0`, minWidth: 0};
+};

--- a/renderers/react/src/v0_9/catalog/basic/utils.ts
+++ b/renderers/react/src/v0_9/catalog/basic/utils.ts
@@ -77,11 +77,10 @@ export const getBaseContainerStyle = (): React.CSSProperties => ({
   boxSizing: 'border-box',
 });
 
-// `min-width: 0` lets weighted children shrink below their intrinsic content
-// width. Without it, a Text with a long string would force the row to
-// overflow. Setting both grow and shrink (rather than just grow) keeps the
-// proportions honored when the row needs to shrink, not just when it grows.
+// `min-width: 0` / `min-height: 0` let weighted children shrink below their
+// intrinsic content size. Without them, a component with large content would
+// force the container to overflow.
 export const getWeightStyle = (weight?: number): React.CSSProperties => {
   if (typeof weight !== 'number') return {};
-  return {flex: `${weight} ${weight} 0px`, minWidth: 0};
+  return {flex: `${weight}`, minWidth: 0, minHeight: 0};
 };

--- a/renderers/react/tests/v0_9/weight.test.tsx
+++ b/renderers/react/tests/v0_9/weight.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderA2uiComponent } from '../utils';
+import { getWeightStyle } from '../../src/v0_9/catalog/basic/utils';
+import {
+  Image,
+  Text,
+  Card,
+  Row,
+  Column,
+} from '../../src/v0_9/catalog/basic';
+
+describe('getWeightStyle', () => {
+  it('returns empty object when weight is undefined', () => {
+    expect(getWeightStyle(undefined)).toEqual({});
+  });
+
+  it('returns flex and minWidth when weight is set', () => {
+    expect(getWeightStyle(2)).toEqual({ flex: '2 2 0px', minWidth: 0 });
+  });
+
+  it('handles fractional weights', () => {
+    expect(getWeightStyle(1.5)).toEqual({ flex: '1.5 1.5 0px', minWidth: 0 });
+  });
+
+  it('treats weight: 0 as a valid value (a child that does not grow)', () => {
+    // Per spec, weight is "similar to flex-grow"; 0 is a meaningful value.
+    expect(getWeightStyle(0)).toEqual({ flex: '0 0 0px', minWidth: 0 });
+  });
+});
+
+describe('weight property is honored on basic catalog components', () => {
+  const cases: Array<{ name: string; impl: any; props: Record<string, any> }> = [
+    { name: 'Image', impl: Image, props: { url: 'https://example.com/x.png' } },
+    { name: 'Text', impl: Text, props: { text: 'hello' } },
+    { name: 'Card', impl: Card, props: { child: 'unknown-child' } },
+    { name: 'Row', impl: Row, props: { children: [] } },
+    { name: 'Column', impl: Column, props: { children: [] } },
+  ];
+
+  for (const { name, impl, props } of cases) {
+    it(`${name} applies flex when weight is set`, () => {
+      const { view } = renderA2uiComponent(impl, 'c1', { ...props, weight: 2 });
+      const root = view.container.firstChild as HTMLElement;
+      expect(root.style.flex).toBe('2 2 0px');
+      expect(root.style.minWidth).toBe('0');
+    });
+
+    it(`${name} does not apply flex when weight is unset`, () => {
+      const { view } = renderA2uiComponent(impl, 'c1', props);
+      const root = view.container.firstChild as HTMLElement;
+      expect(root.style.flex).toBe('');
+    });
+  }
+});

--- a/renderers/react/tests/v0_9/weight.test.tsx
+++ b/renderers/react/tests/v0_9/weight.test.tsx
@@ -30,17 +30,17 @@ describe('getWeightStyle', () => {
     expect(getWeightStyle(undefined)).toEqual({});
   });
 
-  it('returns flex and minWidth when weight is set', () => {
-    expect(getWeightStyle(2)).toEqual({ flex: '2 2 0px', minWidth: 0 });
+  it('returns flex, minWidth, and minHeight when weight is set', () => {
+    expect(getWeightStyle(2)).toEqual({ flex: '2', minWidth: 0, minHeight: 0 });
   });
 
   it('handles fractional weights', () => {
-    expect(getWeightStyle(1.5)).toEqual({ flex: '1.5 1.5 0px', minWidth: 0 });
+    expect(getWeightStyle(1.5)).toEqual({ flex: '1.5', minWidth: 0, minHeight: 0 });
   });
 
   it('treats weight: 0 as a valid value (a child that does not grow)', () => {
     // Per spec, weight is "similar to flex-grow"; 0 is a meaningful value.
-    expect(getWeightStyle(0)).toEqual({ flex: '0 0 0px', minWidth: 0 });
+    expect(getWeightStyle(0)).toEqual({ flex: '0', minWidth: 0, minHeight: 0 });
   });
 });
 
@@ -57,7 +57,7 @@ describe('weight property is honored on basic catalog components', () => {
     it(`${name} applies flex when weight is set`, () => {
       const { view } = renderA2uiComponent(impl, 'c1', { ...props, weight: 2 });
       const root = view.container.firstChild as HTMLElement;
-      expect(root.style.flex).toBe('2 2 0px');
+      expect(root.style.flexGrow).toBe('2');
       expect(root.style.minWidth).toBe('0');
     });
 


### PR DESCRIPTION
The `weight` property on `CommonProps` (basic_catalog) is documented in the schema as "similar to the CSS flex-grow property" and applies when the component is a direct descendant of a Row or Column. It was not implemented in any v0.9 React component: agents emitting per-spec proportional layouts (e.g. `weight: 1` for an image, `weight: 2` for its sibling details column) saw no effect.

This adds a small `getWeightStyle(weight?)` helper in utils.ts that returns `{flex: '<w> <w> 0', minWidth: 0}` when weight is set, and spreads it into the inline styles of every basic-catalog component that can be a Row/Column child:

  - Image, Text (leaf components)
  - Card (single-child container)
  - Row, Column  (multi-child containers, since they can themselves  be children of an outer Row/Column)

Non-weighted children fall back to default flex behavior (no behavior change). Verified visually against the explorer's
`33_financial-data-grid` example (the only spec example with asymmetric weights) and the restaurant-finder agent demo (real-world 1:2 image/details split).

### Spec example: `33_financial-data-grid` (asymmetric weights `2, 1, 1, 1.5`)

| Before (main) | After (this PR) |
|---|---|
| <img width="798" height="962" alt="image" src="https://github.com/user-attachments/assets/0de5a32f-1fbb-482b-a475-0ea17a5d183d" />| <img width="764" height="940" alt="image" src="https://github.com/user-attachments/assets/de0ff659-ca1f-413a-99e4-579098109b22" /> |

(last tested at: initial commit)

Note: after the fix, you see some numbers get clipped in the body, which is unfortunate but correct. We may want to consider better support for proper tables in the future rather than the agent MacGyvering one out of weighted rows+columns.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
