### PR TITLE
Revert Python changes that broke Lit renderer in restaurant sample

### DIFF
--- a/samples/agent/adk/gemini_enterprise/agent_engine/agent.py
+++ b/samples/agent/adk/gemini_enterprise/agent_engine/agent.py
@@ -56,9 +56,7 @@ class ContactAgent:
     self.base_url = base_url
     self._agent_name = "contact_agent"
     self._user_id = "remote_agent"
-    self._text_runner: Optional[Runner] = self._build_runner(
-        self._build_llm_agent()
-    )
+    self._text_runner: Optional[Runner] = self._build_runner(self._build_llm_agent())
 
     self._schema_managers: Dict[str, A2uiSchemaManager] = {}
     self._ui_runners: Dict[str, Runner] = {}
@@ -125,8 +123,7 @@ class ContactAgent:
     return AgentCard(
         name="Contact Lookup Agent",
         description=(
-            "This agent helps find contact info for people in your"
-            " organization."
+            "This agent helps find contact info for people in your organization."
         ),
         url=self.base_url,
         version="1.0.0",
@@ -215,9 +212,7 @@ class ContactAgent:
     current_query_text = query
 
     # Ensure catalog schema was loaded
-    if ui_version and (
-        not selected_catalog or not selected_catalog.catalog_schema
-    ):
+    if ui_version and (not selected_catalog or not selected_catalog.catalog_schema):
       print(
           "--- ContactAgent.fetch_response: A2UI_SCHEMA is not loaded. "
           "Cannot perform UI validation. ---"
@@ -259,14 +254,8 @@ class ContactAgent:
             new_message=current_message,
         ):
           if event.is_final_response():
-            if (
-                event.content
-                and event.content.parts
-                and event.content.parts[0].text
-            ):
-              full_content_list.extend(
-                  [p.text for p in event.content.parts if p.text]
-              )
+            if event.content and event.content.parts and event.content.parts[0].text:
+              full_content_list.extend([p.text for p in event.content.parts if p.text])
       except Exception as e:
         print(
             "--- ContactAgent.fetch_response: Exception caught while running"
@@ -296,8 +285,7 @@ class ContactAgent:
           print("Retries exhausted on no-response")
           # Retries exhausted on no-response
           final_response_content = (
-              "I'm sorry, I encountered an error and couldn't process your"
-              " request."
+              "I'm sorry, I encountered an error and couldn't process your request."
           )
           # Fall through to send this as a text-only error
 
@@ -352,10 +340,7 @@ class ContactAgent:
               f"--- ContactAgent.fetch_response: A2UI validation failed: {e}"
               f" (Attempt {attempt}) ---"
           )
-          print(
-              "--- Failed response content:"
-              f" {final_response_content[:500]}... ---"
-          )
+          print(f"--- Failed response content: {final_response_content[:500]}... ---")
           error_message = f"Validation failed: {e}."
 
       else:  # Not using UI, so text is always "valid"

--- a/samples/agent/adk/gemini_enterprise/agent_engine/agent_executor.py
+++ b/samples/agent/adk/gemini_enterprise/agent_engine/agent_executor.py
@@ -49,9 +49,7 @@ class ContactAgentExecutor(AgentExecutor):
     ui_event_part = None
     action = None
 
-    print(
-        f"--- Client requested extensions: {context.requested_extensions} ---"
-    )
+    print(f"--- Client requested extensions: {context.requested_extensions} ---")
     print(f"--- Agent card: {self._agent.agent_card} ---")
     # active_ui_version = try_activate_a2ui_extension(
     #     context, self._agent.agent_card
@@ -65,10 +63,7 @@ class ContactAgentExecutor(AgentExecutor):
           f" (v{active_ui_version}). Using UI runner. ---"
       )
     else:
-      print(
-          "--- AGENT_EXECUTOR: A2UI extension is not active. Using text"
-          " runner. ---"
-      )
+      print("--- AGENT_EXECUTOR: A2UI extension is not active. Using text runner. ---")
 
     if context.message and context.message.parts:
       print(

--- a/samples/agent/adk/gemini_enterprise/agent_engine/deploy.py
+++ b/samples/agent/adk/gemini_enterprise/agent_engine/deploy.py
@@ -34,9 +34,7 @@ from vertexai.preview.reasoning_engines.templates.a2a import create_agent_card
 def _get_bearer_token():
   """Gets a bearer token for authenticating with Google Cloud."""
   try:
-    credentials, _ = default(
-        scopes=["https://www.googleapis.com/auth/cloud-platform"]
-    )
+    credentials, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
     request = Request()
     credentials.refresh(request)
     return credentials.token
@@ -86,9 +84,7 @@ def _register_agent_on_gemini_enterprise(
   }
 
   if agent_authorization:
-    payload["authorization_config"] = {
-        "agent_authorization": agent_authorization
-    }
+    payload["authorization_config"] = {"agent_authorization": agent_authorization}
 
   # Get access token
   bearer_token = _get_bearer_token()
@@ -215,9 +211,7 @@ def main():
   remote_engine_resource = remote_agent.api_resource.name
   print(f"✓ Remote agent created. {remote_engine_resource}")
 
-  a2a_endpoint = (
-      f"https://{api_endpoint}/v1beta1/{remote_engine_resource}/a2a/v1/card"
-  )
+  a2a_endpoint = f"https://{api_endpoint}/v1beta1/{remote_engine_resource}/a2a/v1/card"
   bearer_token = _get_bearer_token()
   headers = {
       "Authorization": f"Bearer {bearer_token}",
@@ -256,9 +250,7 @@ def main():
       agent_card=a2ui_agent_card_str,
       agent_name="a2ui_contact_card_agent",
       display_name="A2UI Contact Card Agent",
-      description=(
-          "A helpful assistant agent that uses A2UI to render contact cards."
-      ),
+      description="A helpful assistant agent that uses A2UI to render contact cards.",
       agent_authorization=os.environ.get("AGENT_AUTHORIZATION"),
   )
 

--- a/samples/agent/adk/gemini_enterprise/agent_engine/tools.py
+++ b/samples/agent/adk/gemini_enterprise/agent_engine/tools.py
@@ -46,17 +46,13 @@ def get_contact_info(name: str = None, department: str = "") -> str:
 
     # Filter by name
     results = [
-        contact
-        for contact in all_contacts
-        if name_lower in contact["name"].lower()
+        contact for contact in all_contacts if name_lower in contact["name"].lower()
     ]
 
     # If department is provided, filter results further
     if dept_lower:
       results = [
-          contact
-          for contact in results
-          if dept_lower in contact["department"].lower()
+          contact for contact in results if dept_lower in contact["department"].lower()
       ]
 
     logger.info(f"  - Success: Found {len(results)} matching contacts.")

--- a/samples/agent/adk/gemini_enterprise/cloud_run/agent.py
+++ b/samples/agent/adk/gemini_enterprise/cloud_run/agent.py
@@ -58,9 +58,7 @@ class ContactAgent:
     self.base_url = base_url
     self._agent_name = "contact_agent"
     self._user_id = "remote_agent"
-    self._text_runner: Optional[Runner] = self._build_runner(
-        self._build_llm_agent()
-    )
+    self._text_runner: Optional[Runner] = self._build_runner(self._build_llm_agent())
 
     self._schema_managers: Dict[str, A2uiSchemaManager] = {}
     self._ui_runners: Dict[str, Runner] = {}
@@ -126,8 +124,7 @@ class ContactAgent:
     return AgentCard(
         name="Contact Lookup Agent",
         description=(
-            "This agent helps find contact info for people in your"
-            " organization."
+            "This agent helps find contact info for people in your organization."
         ),
         url=self.base_url,
         version="1.0.0",
@@ -215,9 +212,7 @@ class ContactAgent:
     current_query_text = query
 
     # Ensure catalog schema was loaded
-    if ui_version and (
-        not selected_catalog or not selected_catalog.catalog_schema
-    ):
+    if ui_version and (not selected_catalog or not selected_catalog.catalog_schema):
       logger.error(
           "--- ContactAgent.fetch_response: A2UI_SCHEMA is not loaded. "
           "Cannot perform UI validation. ---"
@@ -253,14 +248,8 @@ class ContactAgent:
           new_message=current_message,
       ):
         if event.is_final_response():
-          if (
-              event.content
-              and event.content.parts
-              and event.content.parts[0].text
-          ):
-            full_content_list.extend(
-                [p.text for p in event.content.parts if p.text]
-            )
+          if event.content and event.content.parts and event.content.parts[0].text:
+            full_content_list.extend([p.text for p in event.content.parts if p.text])
 
       final_response_content = "".join(full_content_list)
 
@@ -280,8 +269,7 @@ class ContactAgent:
           logger.info("Retries exhausted on no-response")
           # Retries exhausted on no-response
           final_response_content = (
-              "I'm sorry, I encountered an error and couldn't process your"
-              " request."
+              "I'm sorry, I encountered an error and couldn't process your request."
           )
           # Fall through to send this as a text-only error
 
@@ -340,8 +328,7 @@ class ContactAgent:
               f" (Attempt {attempt}) ---"
           )
           logger.warning(
-              "--- Failed response content:"
-              f" {final_response_content[:500]}... ---"
+              f"--- Failed response content: {final_response_content[:500]}... ---"
           )
           error_message = f"Validation failed: {e}."
 

--- a/samples/agent/adk/gemini_enterprise/cloud_run/agent_executor.py
+++ b/samples/agent/adk/gemini_enterprise/cloud_run/agent_executor.py
@@ -51,12 +51,8 @@ class ContactAgentExecutor(AgentExecutor):
     ui_event_part = None
     action = None
 
-    logger.info(
-        f"--- Client requested extensions: {context.requested_extensions} ---"
-    )
-    active_ui_version = try_activate_a2ui_extension(
-        context, self._agent.agent_card
-    )
+    logger.info(f"--- Client requested extensions: {context.requested_extensions} ---")
+    active_ui_version = try_activate_a2ui_extension(context, self._agent.agent_card)
 
     if active_ui_version:
       logger.info(
@@ -65,8 +61,7 @@ class ContactAgentExecutor(AgentExecutor):
       )
     else:
       logger.info(
-          "--- AGENT_EXECUTOR: A2UI extension is not active. Using text"
-          " runner. ---"
+          "--- AGENT_EXECUTOR: A2UI extension is not active. Using text runner. ---"
       )
 
     if context.message and context.message.parts:

--- a/samples/agent/adk/gemini_enterprise/cloud_run/tools.py
+++ b/samples/agent/adk/gemini_enterprise/cloud_run/tools.py
@@ -46,17 +46,13 @@ def get_contact_info(name: str = None, department: str = "") -> str:
 
     # Filter by name
     results = [
-        contact
-        for contact in all_contacts
-        if name_lower in contact["name"].lower()
+        contact for contact in all_contacts if name_lower in contact["name"].lower()
     ]
 
     # If department is provided, filter results further
     if dept_lower:
       results = [
-          contact
-          for contact in results
-          if dept_lower in contact["department"].lower()
+          contact for contact in results if dept_lower in contact["department"].lower()
       ]
 
     logger.info(f"  - Success: Found {len(results)} matching contacts.")

--- a/samples/agent/adk/restaurant_finder/agent.py
+++ b/samples/agent/adk/restaurant_finder/agent.py
@@ -52,25 +52,6 @@ from a2ui.a2a.parts import parse_response_to_parts, stream_response_to_parts
 
 logger = logging.getLogger(__name__)
 
-from google.adk.utils import instructions_utils
-
-# Monkey patch to work around ADK issue where it tries to interpolate A2UI
-# syntax (like ${...}) as session state.
-# Bug filed against ADK: https://github.com/google/adk-python/issues/5179
-original_inject = instructions_utils.inject_session_state
-
-
-async def custom_inject_session_state(template: str, context: Any) -> str:
-  # Protect A2UI interpolation syntax from ADK
-  protected = template.replace("${", "__PROTECTED_BRACE__")
-  # Run original ADK injection
-  result = await original_inject(protected, context)
-  # Restore syntax for the model
-  return result.replace("__PROTECTED_BRACE__", "${")
-
-
-# Apply the monkeypatch
-instructions_utils.inject_session_state = custom_inject_session_state
 
 
 class RestaurantAgent:
@@ -178,19 +159,7 @@ class RestaurantAgent:
         else get_text_prompt()
     )
 
-    if schema_manager:
-      instruction += (
-          "\n\nMANDATORY: Every single response from you MUST start with a"
-          " `createSurface` message followed by an `updateComponents` message, before"
-          " any `updateDataModel` messages. The client requires them to render the"
-          " interface on every turn.\nCRITICAL: You MUST ALWAYS use an ARRAY for"
-          " `items` in a list, do NOT use an object with keys like `item1`.\nCRITICAL:"
-          " When updating the list of restaurants, use `updateDataModel` with `path:"
-          ' "/items"` so that you do not overwrite the `title` property at the'
-          " root.\nCRITICAL: You MUST output the entire `updateDataModel` message with"
-          " all items at once at the end of your response. Do NOT output partial lists"
-          " or stream items one by one."
-      )
+
 
     return LlmAgent(
         model=LiteLlm(model=LITELLM_MODEL),
@@ -270,7 +239,6 @@ class RestaurantAgent:
       )
 
       full_content_list = []
-      parts_streamed = False
 
       async def token_stream():
         async for event in runner.run_async(
@@ -297,7 +265,6 @@ class RestaurantAgent:
           if len(self._parsers) > self._max_parsers:
             self._parsers.popitem(last=False)
 
-        parts_streamed = True
         async for part in stream_response_to_parts(
             self._parsers[session_id],
             token_stream(),
@@ -375,7 +342,7 @@ class RestaurantAgent:
 
         yield {
             "is_task_complete": True,
-            "parts": [] if parts_streamed else final_parts,
+            "parts": final_parts,
         }
         return  # We're done, exit the generator
 

--- a/samples/agent/adk/restaurant_finder/agent.py
+++ b/samples/agent/adk/restaurant_finder/agent.py
@@ -53,7 +53,6 @@ from a2ui.a2a.parts import parse_response_to_parts, stream_response_to_parts
 logger = logging.getLogger(__name__)
 
 
-
 class RestaurantAgent:
   """An agent that finds restaurants based on user criteria."""
 
@@ -158,8 +157,6 @@ class RestaurantAgent:
         if schema_manager
         else get_text_prompt()
     )
-
-
 
     return LlmAgent(
         model=LiteLlm(model=LITELLM_MODEL),


### PR DESCRIPTION
This PR reverts the changes to agent.py in PR #1189 that enforced a flat array schema and altered the streaming logic. These changes broke the Lit renderer which expected a different structure or handling. Reverting these fixes the Lit renderer and allows running both samples against the same agent for comparison. Verification: Confirmed both Lit and Angular samples run and render correctly after this revert.