### PR TITLE
(Python) Bump google-adk version to 1.28.1

### DIFF
--- a/agent_sdks/python/pyproject.toml
+++ b/agent_sdks/python/pyproject.toml
@@ -20,7 +20,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "a2a-sdk>=0.3.0",
-  "google-adk>=1.28.0",
+  "google-adk>=1.28.1",
   "google-genai>=1.27.0",
   "jsonschema>=4.0.0"
 ]

--- a/samples/agent/adk/custom-components-example/pyproject.toml
+++ b/samples/agent/adk/custom-components-example/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.13"
 dependencies = [
     "a2a-sdk>=0.3.0",
     "click>=8.1.8",
-    "google-adk>=1.28.0",
+    "google-adk>=1.28.1",
     "google-genai>=1.27.0",
     "python-dotenv>=1.1.0",
     "litellm",

--- a/samples/agent/adk/gemini_enterprise/cloud_run/pyproject.toml
+++ b/samples/agent/adk/gemini_enterprise/cloud_run/pyproject.toml
@@ -20,7 +20,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "a2a-sdk>=0.3.4",
-    "google-adk>=1.28.0",
+    "google-adk>=1.28.1",
     "google-genai>=1.27.0",
     "python-dotenv>=1.1.0",
     "uvicorn",

--- a/samples/agent/adk/mcp-apps-in-a2ui-sample/pyproject.toml
+++ b/samples/agent/adk/mcp-apps-in-a2ui-sample/pyproject.toml
@@ -20,7 +20,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "a2a-sdk>=0.3.0",
-    "google-adk>=1.28.0",
+    "google-adk>=1.28.1",
     "google-genai>=1.27.0",
     "python-dotenv>=1.1.0",
     "fastapi>=0.123.10",

--- a/samples/agent/adk/mcp_app_proxy/pyproject.toml
+++ b/samples/agent/adk/mcp_app_proxy/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.12"
 dependencies = [
     "a2a-sdk>=0.3.0",
     "click>=8.1.8",
-    "google-adk>=1.28.0",
+    "google-adk>=1.28.1",
     "google-genai>=1.27.0",
     "python-dotenv>=1.1.0",
     "litellm",

--- a/samples/agent/adk/orchestrator/pyproject.toml
+++ b/samples/agent/adk/orchestrator/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.13"
 dependencies = [
     "a2a-sdk>=0.3.0",
     "click>=8.1.8",
-    "google-adk>=1.28.0",
+    "google-adk>=1.28.1",
     "google-genai>=1.27.0",
     "python-dotenv>=1.1.0",
     "litellm",

--- a/samples/agent/adk/restaurant_finder/pyproject.toml
+++ b/samples/agent/adk/restaurant_finder/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.13"
 dependencies = [
     "a2a-sdk>=0.3.0",
     "click>=8.1.8",
-    "google-adk>=1.28.0",
+    "google-adk>=1.28.1",
     "google-genai>=1.27.0",
     "python-dotenv>=1.1.0",
     "litellm",

--- a/samples/agent/adk/rizzcharts/python/pyproject.toml
+++ b/samples/agent/adk/rizzcharts/python/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.13"
 dependencies = [
     "a2a-sdk>=0.3.0",
     "click>=8.1.8",
-    "google-adk>=1.28.0",
+    "google-adk>=1.28.1",
     "google-genai>=1.27.0",
     "python-dotenv>=1.1.0",
     "litellm",

--- a/samples/agent/adk/uv.lock
+++ b/samples/agent/adk/uv.lock
@@ -50,7 +50,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.3.0" },
-    { name = "google-adk", specifier = ">=1.28.0" },
+    { name = "google-adk", specifier = ">=1.28.1" },
     { name = "google-genai", specifier = ">=1.27.0" },
     { name = "jsonschema", specifier = ">=4.0.0" },
 ]
@@ -87,7 +87,7 @@ requires-dist = [
     { name = "a2ui-agent-sdk", editable = "../../../agent_sdks/python" },
     { name = "click", specifier = ">=8.1.8" },
     { name = "fastapi", specifier = ">=0.123.10" },
-    { name = "google-adk", specifier = ">=1.28.0" },
+    { name = "google-adk", specifier = ">=1.28.1" },
     { name = "google-genai", specifier = ">=1.27.0" },
     { name = "jsonschema", specifier = ">=4.0.0" },
     { name = "litellm" },
@@ -117,7 +117,7 @@ requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.3.0" },
     { name = "a2ui-agent-sdk", editable = "../../../agent_sdks/python" },
     { name = "click", specifier = ">=8.1.8" },
-    { name = "google-adk", specifier = ">=1.28.0" },
+    { name = "google-adk", specifier = ">=1.28.1" },
     { name = "google-genai", specifier = ">=1.27.0" },
     { name = "jsonschema", specifier = ">=4.0.0" },
     { name = "litellm" },
@@ -649,7 +649,7 @@ wheels = [
 
 [[package]]
 name = "google-adk"
-version = "1.28.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
@@ -698,9 +698,9 @@ dependencies = [
     { name = "watchdog" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/2b/6f3e87faa3d3b11d585524ee8e1c088472f9d3783879b360db32b96bd2de/google_adk-1.28.0.tar.gz", hash = "sha256:3c7ef1a518296641b992cc68ae4795987da48765f9788af37da1acc39db0f362", size = 2317884, upload-time = "2026-03-26T22:48:26.755Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/bd/ce670dca7a32b1bc46410edece7781d8db06aa5a48d7323f1c2aa30384b6/google_adk-1.28.1.tar.gz", hash = "sha256:76e6ec4a13f981bd9c2c7782e8b37b0e973b570b699b750a52444998e8886ced", size = 2318960, upload-time = "2026-04-02T22:21:02.796Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/1a/a76004c1660118a37836bf6355628506601f9fa27b7490c47160b723465e/google_adk-1.28.0-py3-none-any.whl", hash = "sha256:8470c2e5a97bcef9a54283148be9f4ffaa88b3eefe3f55f269183f715d8830b6", size = 2728054, upload-time = "2026-03-26T22:48:24.947Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/51/1926ef771b3223fcd0ff0568c9f5429d45239cdc6f09d9ecbb7a4cc69c1f/google_adk-1.28.1-py3-none-any.whl", hash = "sha256:ee7cdf90ba05737be3a2aa4867804324a02f2918bd810e746fe6416184e11511", size = 2729150, upload-time = "2026-04-02T22:21:01.096Z" },
 ]
 
 [[package]]
@@ -1676,7 +1676,7 @@ requires-dist = [
     { name = "a2ui-agent-sdk", editable = "../../../agent_sdks/python" },
     { name = "anyio" },
     { name = "click", specifier = ">=8.1.8" },
-    { name = "google-adk", specifier = ">=1.28.0" },
+    { name = "google-adk", specifier = ">=1.28.1" },
     { name = "google-genai", specifier = ">=1.27.0" },
     { name = "jsonschema", specifier = ">=4.0.0" },
     { name = "litellm" },
@@ -2030,7 +2030,7 @@ requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.3.0" },
     { name = "a2ui-agent-sdk", editable = "../../../agent_sdks/python" },
     { name = "click", specifier = ">=8.1.8" },
-    { name = "google-adk", specifier = ">=1.28.0" },
+    { name = "google-adk", specifier = ">=1.28.1" },
     { name = "google-genai", specifier = ">=1.27.0" },
     { name = "jsonschema", specifier = ">=4.0.0" },
     { name = "litellm" },
@@ -2631,7 +2631,7 @@ requires-dist = [
     { name = "a2a-sdk", specifier = ">=0.3.0" },
     { name = "a2ui-agent-sdk", editable = "../../../agent_sdks/python" },
     { name = "click", specifier = ">=8.1.8" },
-    { name = "google-adk", specifier = ">=1.28.0" },
+    { name = "google-adk", specifier = ">=1.28.1" },
     { name = "google-genai", specifier = ">=1.27.0" },
     { name = "jsonschema", specifier = ">=4.0.0" },
     { name = "litellm" },

--- a/samples/personalized_learning/agent/pyproject.toml
+++ b/samples/personalized_learning/agent/pyproject.toml
@@ -18,7 +18,7 @@ version = "0.1.0"
 description = "A2A Agent for generating personalized A2UI learning materials"
 requires-python = ">=3.11"
 dependencies = [
-    "google-adk>=1.28.0",
+    "google-adk>=1.28.1",
     "google-genai>=1.27.0",
     "google-cloud-storage>=2.10.0",
     "python-dotenv>=1.0.0",

--- a/samples/personalized_learning/agent/requirements.txt
+++ b/samples/personalized_learning/agent/requirements.txt
@@ -1,4 +1,4 @@
-google-adk>=1.28.0
+google-adk>=1.28.1
 google-genai>=1.27.0
 google-cloud-storage>=2.10.0
 certifi>=2023.0.0

--- a/samples/personalized_learning/quickstart_setup.sh
+++ b/samples/personalized_learning/quickstart_setup.sh
@@ -92,7 +92,7 @@ if [ "$SKIP_PIP" = false ]; then
         --index-url https://pypi.org/simple/ \
         --trusted-host pypi.org \
         --trusted-host files.pythonhosted.org \
-        "google-adk>=1.28.0" \
+        "google-adk>=1.28.1" \
         "google-genai>=1.27.0" \
         "google-cloud-storage>=2.10.0" \
         "python-dotenv>=1.0.0" \


### PR DESCRIPTION
# Description

Bumps google-adk version to 1.28.1 in the python sdk.

(Addresses [CVE-2026-4810](https://nvd.nist.gov/vuln/detail/CVE-2026-4810))

## Tests

* Tested by running the restaurant finder sample.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
