### PR TITLE
Don't use z.infer to fix closure compiler issues

### DIFF
--- a/.github/workflows/web_build_and_test.yml
+++ b/.github/workflows/web_build_and_test.yml
@@ -32,6 +32,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Check for z.infer usage
+        run: |
+          RESULTS=$(grep -r --include="*.ts" --exclude-dir="node_modules" "z\.infer" renderers | grep -v "v0_9/catalog/types" || true)
+          if [ -n "$RESULTS" ]; then
+            echo "Error: z.infer found in codebase! Use manual interfaces instead to ensure Closure Compiler compatibility."
+            echo "Instead of: type Foo = z.infer<typeof Schema>;"
+            echo "Do: interface Foo { ... } AND const Schema: z.ZodType<Foo> = z.object({ ... });"
+            echo "$RESULTS"
+            exit 1
+          fi
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/renderers/react/src/v0_8/components/content/Image.tsx
+++ b/renderers/react/src/v0_8/components/content/Image.tsx
@@ -34,9 +34,7 @@ export const Image = memo(function Image({node, surfaceId}: A2UIComponentProps<T
   const props = node.properties;
 
   const url = resolveString(props.url);
-  const altText = resolveString(
-    (props as Record<string, unknown>).altText as Types.StringValue | undefined
-  );
+  const altText = resolveString(props.altText);
   const usageHint = props.usageHint as UsageHint | undefined;
   const fit = (props.fit as FitMode) ?? 'fill';
 

--- a/renderers/react/src/v0_8/components/interactive/TextField.tsx
+++ b/renderers/react/src/v0_8/components/interactive/TextField.tsx
@@ -38,8 +38,7 @@ export const TextField = memo(function TextField({
   const label = resolveString(props.label);
   const textPath = props.text?.path;
   const initialValue = resolveString(props.text) ?? '';
-  const propsRecord = props as Record<string, unknown>;
-  const fieldType = (propsRecord.textFieldType || propsRecord.type) as TextFieldType;
+  const fieldType = (props.textFieldType || (props as any).type) as TextFieldType;
   const validationRegexp = props.validationRegexp;
 
   const [value, setLocalValue] = useState(initialValue);

--- a/renderers/web_core/src/v0_8/schema/common-types.ts
+++ b/renderers/web_core/src/v0_8/schema/common-types.ts
@@ -30,7 +30,13 @@ const exactlyOneKey = (val: any, ctx: z.RefinementCtx) => {
   }
 };
 
-export const StringValueSchema = z
+export interface StringValue {
+  path?: string;
+  literalString?: string;
+  literal?: string;
+}
+
+export const StringValueSchema: z.ZodType<StringValue> = z
   .object({
     path: z.string().optional(),
     literalString: z.string().optional(),
@@ -38,9 +44,16 @@ export const StringValueSchema = z
   })
   .strict()
   .superRefine(exactlyOneKey);
-export type StringValue = z.infer<typeof StringValueSchema>;
 
-const DataValueMapItemSchema: z.ZodType<any> = z.lazy(() =>
+export interface DataValue {
+  key: string;
+  valueString?: string;
+  valueNumber?: number;
+  valueBoolean?: boolean;
+  valueMap?: DataValue[];
+}
+
+const DataValueMapItemSchema: z.ZodType<DataValue> = z.lazy(() =>
   z
     .object({
       key: z.string(),
@@ -65,7 +78,7 @@ const DataValueMapItemSchema: z.ZodType<any> = z.lazy(() =>
     }),
 );
 
-export const DataValueSchema = z
+export const DataValueSchema: z.ZodType<DataValue> = z
   .object({
     key: z.string(),
     valueString: z.string().optional(),
@@ -105,7 +118,13 @@ export const DataValueSchema = z
     checkDepth(val, 1);
   });
 
-export const NumberValueSchema = z
+export interface NumberValue {
+  path?: string;
+  literalNumber?: number;
+  literal?: number;
+}
+
+export const NumberValueSchema: z.ZodType<NumberValue> = z
   .object({
     path: z.string().optional(),
     literalNumber: z.number().optional(),
@@ -113,9 +132,14 @@ export const NumberValueSchema = z
   })
   .strict()
   .superRefine(exactlyOneKey);
-export type NumberValue = z.infer<typeof NumberValueSchema>;
 
-export const BooleanValueSchema = z
+export interface BooleanValue {
+  path?: string;
+  literalBoolean?: boolean;
+  literal?: boolean;
+}
+
+export const BooleanValueSchema: z.ZodType<BooleanValue> = z
   .object({
     path: z.string().optional(),
     literalBoolean: z.boolean().optional(),
@@ -123,12 +147,24 @@ export const BooleanValueSchema = z
   })
   .strict()
   .superRefine(exactlyOneKey);
-export type BooleanValue = z.infer<typeof BooleanValueSchema>;
 
 /**
  * Action Schema for components that trigger user actions
  */
-export const ActionSchema = z.object({
+export interface Action {
+  name: string;
+  context?: Array<{
+    key: string;
+    value: {
+      path?: string;
+      literalString?: string;
+      literalNumber?: number;
+      literalBoolean?: boolean;
+    };
+  }>;
+}
+
+export const ActionSchema: z.ZodType<Action> = z.object({
   name: z
     .string()
     .describe("A unique name identifying the action (e.g., 'submitForm')."),
@@ -168,45 +204,85 @@ export const ActionSchema = z.object({
  * Component Properties Schemas
  */
 
-export const TextSchema = z.object({
+const TEXT_USAGE_HINT_VALUES = ["h1", "h2", "h3", "h4", "h5", "caption", "body"] as const;
+type TextUsageHint = typeof TEXT_USAGE_HINT_VALUES[number];
+
+export interface Text {
+  text: StringValue;
+  usageHint?: TextUsageHint;
+}
+
+export const TextSchema: z.ZodType<Text> = z.object({
   text: StringValueSchema,
-  usageHint: z
-    .enum(["h1", "h2", "h3", "h4", "h5", "caption", "body"])
-    .optional(),
+  usageHint: z.enum(TEXT_USAGE_HINT_VALUES).optional(),
 });
 
-export const ImageSchema = z.object({
+const IMAGE_USAGE_HINT_VALUES = [
+  "icon",
+  "avatar",
+  "smallFeature",
+  "mediumFeature",
+  "largeFeature",
+  "header",
+] as const;
+type ImageUsageHint = typeof IMAGE_USAGE_HINT_VALUES[number];
+
+const IMAGE_FIT_VALUES = ["contain", "cover", "fill", "none", "scale-down"] as const;
+type ImageFit = typeof IMAGE_FIT_VALUES[number];
+
+export interface Image {
+  url: StringValue;
+  usageHint?: ImageUsageHint;
+  fit?: ImageFit;
+  altText?: StringValue;
+}
+
+export const ImageSchema: z.ZodType<Image> = z.object({
   url: StringValueSchema,
-  usageHint: z
-    .enum([
-      "icon",
-      "avatar",
-      "smallFeature",
-      "mediumFeature",
-      "largeFeature",
-      "header",
-    ])
-    .optional(),
-  fit: z.enum(["contain", "cover", "fill", "none", "scale-down"]).optional(),
+  usageHint: z.enum(IMAGE_USAGE_HINT_VALUES).optional(),
+  fit: z.enum(IMAGE_FIT_VALUES).optional(),
   altText: StringValueSchema.optional(),
 });
 
-export const IconSchema = z.object({
+export interface Icon {
+  name: StringValue;
+}
+
+export const IconSchema: z.ZodType<Icon> = z.object({
   name: StringValueSchema,
 });
 
-export const VideoSchema = z.object({
+export interface Video {
+  url: StringValue;
+}
+
+export const VideoSchema: z.ZodType<Video> = z.object({
   url: StringValueSchema,
 });
 
-export const AudioPlayerSchema = z.object({
+export interface AudioPlayer {
+  url: StringValue;
+  description?: StringValue;
+}
+
+export const AudioPlayerSchema: z.ZodType<AudioPlayer> = z.object({
   url: StringValueSchema,
   description: StringValueSchema.optional().describe(
     "A label, title, or placeholder text.",
   ),
 });
 
-export const TabsSchema = z.object({
+export interface Tabs {
+  tabItems: Array<{
+    title: {
+      path?: string;
+      literalString?: string;
+    };
+    child: string;
+  }>;
+}
+
+export const TabsSchema: z.ZodType<Tabs> = z.object({
   tabItems: z
     .array(
       z
@@ -249,9 +325,18 @@ export const TabsSchema = z.object({
     .describe("A list of tabs, each with a title and a child component ID."),
 });
 
-export const DividerSchema = z.object({
+const DIVIDER_AXIS_VALUES = ["horizontal", "vertical"] as const;
+type DividerAxis = typeof DIVIDER_AXIS_VALUES[number];
+
+export interface Divider {
+  axis?: DividerAxis;
+  color?: string;
+  thickness?: number;
+}
+
+export const DividerSchema: z.ZodType<Divider> = z.object({
   axis: z
-    .enum(["horizontal", "vertical"])
+    .enum(DIVIDER_AXIS_VALUES)
     .optional()
     .describe("The orientation."),
   color: z
@@ -261,7 +346,12 @@ export const DividerSchema = z.object({
   thickness: z.number().optional().describe("The thickness of the divider."),
 });
 
-export const ModalSchema = z.object({
+export interface Modal {
+  entryPointChild: string;
+  contentChild: string;
+}
+
+export const ModalSchema: z.ZodType<Modal> = z.object({
   entryPointChild: z
     .string()
     .describe(
@@ -272,7 +362,13 @@ export const ModalSchema = z.object({
     .describe("The ID of the component to display as the modal's content."),
 });
 
-export const ButtonSchema = z.object({
+export interface Button {
+  child: string;
+  action: Action;
+  primary?: boolean;
+}
+
+export const ButtonSchema: z.ZodType<Button> = z.object({
   child: z
     .string()
     .describe("The ID of the component to display as the button's content."),
@@ -285,7 +381,15 @@ export const ButtonSchema = z.object({
     ),
 });
 
-export const CheckboxSchema = z.object({
+export interface Checkbox {
+  label: StringValue;
+  value: {
+    path?: string;
+    literalBoolean?: boolean;
+  };
+}
+
+export const CheckboxSchema: z.ZodType<Checkbox> = z.object({
   label: StringValueSchema,
   value: z
     .object({
@@ -301,17 +405,34 @@ export const CheckboxSchema = z.object({
     .superRefine(exactlyOneKey),
 });
 
-export const TextFieldSchema = z.object({
+const TEXT_FIELD_TYPE_VALUES = ["shortText", "number", "date", "longText"] as const;
+type TextFieldType = typeof TEXT_FIELD_TYPE_VALUES[number];
+
+export interface TextField {
+  text?: StringValue;
+  label: StringValue;
+  textFieldType?: TextFieldType;
+  validationRegexp?: string;
+}
+
+export const TextFieldSchema: z.ZodType<TextField> = z.object({
   text: StringValueSchema.optional(),
   label: StringValueSchema.describe("A label, title, or placeholder text."),
-  textFieldType: z.enum(["shortText", "number", "date", "longText"]).optional(),
+  textFieldType: z.enum(TEXT_FIELD_TYPE_VALUES).optional(),
   validationRegexp: z
     .string()
     .optional()
     .describe("A regex string to validate the input."),
 });
 
-export const DateTimeInputSchema = z.object({
+export interface DateTimeInput {
+  value: StringValue;
+  enableDate?: boolean;
+  enableTime?: boolean;
+  outputFormat?: string;
+}
+
+export const DateTimeInputSchema: z.ZodType<DateTimeInput> = z.object({
   value: StringValueSchema,
   enableDate: z.boolean().optional(),
   enableTime: z.boolean().optional(),
@@ -321,7 +442,27 @@ export const DateTimeInputSchema = z.object({
     .describe("The string format for the output (e.g., 'YYYY-MM-DD')."),
 });
 
-export const MultipleChoiceSchema = z.object({
+const MULTIPLE_CHOICE_TYPE_VALUES = ["checkbox", "chips"] as const;
+type MultipleChoiceType = typeof MULTIPLE_CHOICE_TYPE_VALUES[number];
+
+export interface MultipleChoice {
+  selections: {
+    path?: string;
+    literalArray?: string[];
+  };
+  options?: Array<{
+    label: {
+      path?: string;
+      literalString?: string;
+    };
+    value: string;
+  }>;
+  maxAllowedSelections?: number;
+  type?: MultipleChoiceType;
+  filterable?: boolean;
+}
+
+export const MultipleChoiceSchema: z.ZodType<MultipleChoice> = z.object({
   selections: z
     .object({
       path: z
@@ -357,11 +498,21 @@ export const MultipleChoiceSchema = z.object({
     )
     .optional(),
   maxAllowedSelections: z.number().optional(),
-  type: z.enum(["checkbox", "chips"]).optional(),
+  type: z.enum(MULTIPLE_CHOICE_TYPE_VALUES).optional(),
   filterable: z.boolean().optional(),
 });
 
-export const SliderSchema = z.object({
+export interface Slider {
+  value: {
+    path?: string;
+    literalNumber?: number;
+  };
+  minValue?: number;
+  maxValue?: number;
+  label?: StringValue;
+}
+
+export const SliderSchema: z.ZodType<Slider> = z.object({
   value: z
     .object({
       path: z
@@ -379,12 +530,22 @@ export const SliderSchema = z.object({
   label: StringValueSchema.optional(),
 });
 
-export const ComponentArrayTemplateSchema = z.object({
+export interface ComponentArrayTemplate {
+  componentId: string;
+  dataBinding: string;
+}
+
+export const ComponentArrayTemplateSchema: z.ZodType<ComponentArrayTemplate> = z.object({
   componentId: z.string(),
   dataBinding: z.string(),
 });
 
-export const ComponentArrayReferenceSchema = z
+export interface ComponentArrayReference {
+  explicitList?: string[];
+  template?: ComponentArrayTemplate;
+}
+
+export const ComponentArrayReferenceSchema: z.ZodType<ComponentArrayReference> = z
   .object({
     explicitList: z.array(z.string()).optional(),
     template: ComponentArrayTemplateSchema.describe(
@@ -394,43 +555,63 @@ export const ComponentArrayReferenceSchema = z
   .strict()
   .superRefine(exactlyOneKey);
 
-export const RowSchema = z.object({
+const COMPONENT_DISTRIBUTION_VALUES = [
+  "start",
+  "center",
+  "end",
+  "spaceBetween",
+  "spaceAround",
+  "spaceEvenly",
+] as const;
+type ComponentDistribution = typeof COMPONENT_DISTRIBUTION_VALUES[number];
+
+const COMPONENT_ALIGNMENT_VALUES = ["start", "center", "end", "stretch"] as const;
+type ComponentAlignment = typeof COMPONENT_ALIGNMENT_VALUES[number];
+
+export interface Row {
+  children: ComponentArrayReference;
+  distribution?: ComponentDistribution;
+  alignment?: ComponentAlignment;
+}
+
+export const RowSchema: z.ZodType<Row> = z.object({
   children: ComponentArrayReferenceSchema,
-  distribution: z
-    .enum([
-      "start",
-      "center",
-      "end",
-      "spaceBetween",
-      "spaceAround",
-      "spaceEvenly",
-    ])
-    .optional(),
-  alignment: z.enum(["start", "center", "end", "stretch"]).optional(),
+  distribution: z.enum(COMPONENT_DISTRIBUTION_VALUES).optional(),
+  alignment: z.enum(COMPONENT_ALIGNMENT_VALUES).optional(),
 });
 
-export const ColumnSchema = z.object({
+export interface Column {
+  children: ComponentArrayReference;
+  distribution?: ComponentDistribution;
+  alignment?: ComponentAlignment;
+}
+
+export const ColumnSchema: z.ZodType<Column> = z.object({
   children: ComponentArrayReferenceSchema,
-  distribution: z
-    .enum([
-      "start",
-      "center",
-      "end",
-      "spaceBetween",
-      "spaceAround",
-      "spaceEvenly",
-    ])
-    .optional(),
-  alignment: z.enum(["start", "center", "end", "stretch"]).optional(),
+  distribution: z.enum(COMPONENT_DISTRIBUTION_VALUES).optional(),
+  alignment: z.enum(COMPONENT_ALIGNMENT_VALUES).optional(),
 });
 
-export const ListSchema = z.object({
+const LIST_DIRECTION_VALUES = ["vertical", "horizontal"] as const;
+type ListDirection = typeof LIST_DIRECTION_VALUES[number];
+
+export interface List {
+  children: ComponentArrayReference;
+  direction?: ListDirection;
+  alignment?: ComponentAlignment;
+}
+
+export const ListSchema: z.ZodType<List> = z.object({
   children: ComponentArrayReferenceSchema,
-  direction: z.enum(["vertical", "horizontal"]).optional(),
-  alignment: z.enum(["start", "center", "end", "stretch"]).optional(),
+  direction: z.enum(LIST_DIRECTION_VALUES).optional(),
+  alignment: z.enum(COMPONENT_ALIGNMENT_VALUES).optional(),
 });
 
-export const CardSchema = z.object({
+export interface Card {
+  child: string;
+}
+
+export const CardSchema: z.ZodType<Card> = z.object({
   child: z
     .string()
     .describe("The ID of the component to be rendered inside the card."),

--- a/renderers/web_core/src/v0_8/schema/server-to-client.ts
+++ b/renderers/web_core/src/v0_8/schema/server-to-client.ts
@@ -16,25 +16,25 @@
 
 import { z } from "zod";
 import {
-  AudioPlayerSchema,
-  ButtonSchema,
-  CardSchema,
-  CheckboxSchema,
-  ColumnSchema,
-  DateTimeInputSchema,
-  DividerSchema,
-  IconSchema,
-  ImageSchema,
-  ListSchema,
-  ModalSchema,
-  MultipleChoiceSchema,
-  RowSchema,
-  SliderSchema,
-  TabsSchema,
-  TextFieldSchema,
-  TextSchema,
-  VideoSchema,
-  DataValueSchema,
+  AudioPlayerSchema, AudioPlayer,
+  ButtonSchema, Button,
+  CardSchema, Card,
+  CheckboxSchema, Checkbox,
+  ColumnSchema, Column,
+  DateTimeInputSchema, DateTimeInput,
+  DividerSchema, Divider,
+  IconSchema, Icon,
+  ImageSchema, Image,
+  ListSchema, List,
+  ModalSchema, Modal,
+  MultipleChoiceSchema, MultipleChoice,
+  RowSchema, Row,
+  SliderSchema, Slider,
+  TabsSchema, Tabs,
+  TextFieldSchema, TextField,
+  TextSchema, Text,
+  VideoSchema, Video,
+  DataValueSchema, DataValue,
 } from "./common-types.js";
 
 const validateValueProperty = (val: any, ctx: z.RefinementCtx) => {
@@ -55,7 +55,29 @@ export const ValueMapSchema = DataValueSchema.describe(
   "A single data entry. Exactly one 'value*' property should be provided alongside the key.",
 );
 
-export const AnyComponentSchema = z
+export interface AnyComponent {
+  Text?: Text;
+  Image?: Image;
+  Icon?: Icon;
+  Video?: Video;
+  AudioPlayer?: AudioPlayer;
+  Row?: Row;
+  Column?: Column;
+  List?: List;
+  Card?: Card;
+  Tabs?: Tabs;
+  Divider?: Divider;
+  Modal?: Modal;
+  Button?: Button;
+  Checkbox?: Checkbox;
+  TextField?: TextField;
+  DateTimeInput?: DateTimeInput;
+  MultipleChoice?: MultipleChoice;
+  Slider?: Slider;
+  [key: string]: any;
+}
+
+export const AnyComponentSchema: z.ZodType<AnyComponent> = z
   .object({
     Text: TextSchema.optional(),
     Image: ImageSchema.optional(),
@@ -80,7 +102,13 @@ export const AnyComponentSchema = z
 
 export const ComponentPropertiesSchema = AnyComponentSchema;
 
-export const ComponentInstanceSchema = z
+export interface ComponentInstance {
+  id: string;
+  weight?: number;
+  component: AnyComponent;
+}
+
+export const ComponentInstanceSchema: z.ZodType<ComponentInstance> = z
   .object({
     id: z.string().describe("The unique identifier for this component."),
     weight: z
@@ -98,7 +126,17 @@ export const ComponentInstanceSchema = z
     "Represents a *single* component in a UI widget tree. This component could be one of many supported types.",
   );
 
-export const BeginRenderingMessageSchema = z
+export interface BeginRenderingMessage {
+  surfaceId: string;
+  catalogId?: string;
+  root: string;
+  styles?: {
+    font?: string;
+    primaryColor?: string;
+  };
+}
+
+export const BeginRenderingMessageSchema: z.ZodType<BeginRenderingMessage> = z
   .object({
     surfaceId: z
       .string()
@@ -130,7 +168,12 @@ export const BeginRenderingMessageSchema = z
     "Signals the client to begin rendering a surface with a root component and specific styles.",
   );
 
-export const SurfaceUpdateMessageSchema = z
+export interface SurfaceUpdateMessage {
+  surfaceId: string;
+  components: ComponentInstance[];
+}
+
+export const SurfaceUpdateMessageSchema: z.ZodType<SurfaceUpdateMessage> = z
   .object({
     surfaceId: z
       .string()
@@ -227,7 +270,13 @@ export const SurfaceUpdateMessageSchema = z
   })
   .describe("Updates a surface with a new set of components.");
 
-export const DataModelUpdateMessageSchema = z
+export interface DataModelUpdateMessage {
+  surfaceId: string;
+  path?: string;
+  contents: DataValue[];
+}
+
+export const DataModelUpdateMessageSchema: z.ZodType<DataModelUpdateMessage> = z
   .object({
     surfaceId: z
       .string()
@@ -249,7 +298,11 @@ export const DataModelUpdateMessageSchema = z
   .strict()
   .describe("Updates the data model for a surface.");
 
-export const DeleteSurfaceMessageSchema = z
+export interface DeleteSurfaceMessage {
+  surfaceId: string;
+}
+
+export const DeleteSurfaceMessageSchema: z.ZodType<DeleteSurfaceMessage> = z
   .object({
     surfaceId: z
       .string()
@@ -260,7 +313,14 @@ export const DeleteSurfaceMessageSchema = z
     "Signals the client to delete the surface identified by 'surfaceId'.",
   );
 
-export const A2uiMessageSchema = z
+export interface A2uiMessage {
+  beginRendering?: BeginRenderingMessage;
+  surfaceUpdate?: SurfaceUpdateMessage;
+  dataModelUpdate?: DataModelUpdateMessage;
+  deleteSurface?: DeleteSurfaceMessage;
+}
+
+export const A2uiMessageSchema: z.ZodType<A2uiMessage> = z
   .object({
     beginRendering: BeginRenderingMessageSchema.optional(),
     surfaceUpdate: SurfaceUpdateMessageSchema.optional(),
@@ -288,5 +348,3 @@ export const A2uiMessageSchema = z
   .describe(
     "Describes a JSON payload for an A2UI (Agent to UI) message, which is used to dynamically construct and update user interfaces. A message MUST contain exactly ONE of the action properties: 'beginRendering', 'surfaceUpdate', 'dataModelUpdate', or 'deleteSurface'.",
   );
-
-export type A2uiMessage = z.infer<typeof A2uiMessageSchema>;

--- a/renderers/web_core/src/v0_8/types/components.ts
+++ b/renderers/web_core/src/v0_8/types/components.ts
@@ -14,45 +14,44 @@
  * limitations under the License.
  */
 
-import type { z } from "zod";
 import type {
-  ActionSchema,
-  AudioPlayerSchema,
-  ButtonSchema,
-  CardSchema,
-  CheckboxSchema,
-  ColumnSchema,
-  DateTimeInputSchema,
-  DividerSchema,
-  IconSchema,
-  ImageSchema,
-  ListSchema,
-  ModalSchema,
-  MultipleChoiceSchema,
-  RowSchema,
-  SliderSchema,
-  TabsSchema,
-  TextFieldSchema,
-  TextSchema,
-  VideoSchema,
+  Action as IAction,
+  AudioPlayer as IAudioPlayer,
+  Button as IButton,
+  Card as ICard,
+  Checkbox as ICheckbox,
+  Column as IColumn,
+  DateTimeInput as IDateTimeInput,
+  Divider as IDivider,
+  Icon as IIcon,
+  Image as IImage,
+  List as IList,
+  Modal as IModal,
+  MultipleChoice as IMultipleChoice,
+  Row as IRow,
+  Slider as ISlider,
+  Tabs as ITabs,
+  TextField as ITextField,
+  Text as IText,
+  Video as IVideo,
 } from "../schema/common-types.js";
 
-export declare interface Action extends z.infer<typeof ActionSchema> {}
-export declare interface Text extends z.infer<typeof TextSchema> {}
-export declare interface Image extends z.infer<typeof ImageSchema> {}
-export declare interface Icon extends z.infer<typeof IconSchema> {}
-export declare interface Video extends z.infer<typeof VideoSchema> {}
-export declare interface AudioPlayer extends z.infer<typeof AudioPlayerSchema> {}
-export declare interface Tabs extends z.infer<typeof TabsSchema> {}
-export declare interface Row extends z.infer<typeof RowSchema> {}
-export declare interface Column extends z.infer<typeof ColumnSchema> {}
-export declare interface List extends z.infer<typeof ListSchema> {}
-export declare interface Button extends z.infer<typeof ButtonSchema> {}
-export declare interface Modal extends z.infer<typeof ModalSchema> {}
-export declare interface Card extends z.infer<typeof CardSchema> {}
-export declare interface Divider extends z.infer<typeof DividerSchema> {}
-export declare interface TextField extends z.infer<typeof TextFieldSchema> {}
-export declare interface Checkbox extends z.infer<typeof CheckboxSchema> {}
-export declare interface DateTimeInput extends z.infer<typeof DateTimeInputSchema> {}
-export declare interface MultipleChoice extends z.infer<typeof MultipleChoiceSchema> {}
-export declare interface Slider extends z.infer<typeof SliderSchema> {}
+export declare interface Action extends IAction {}
+export declare interface Text extends IText {}
+export declare interface Image extends IImage {}
+export declare interface Icon extends IIcon {}
+export declare interface Video extends IVideo {}
+export declare interface AudioPlayer extends IAudioPlayer {}
+export declare interface Tabs extends ITabs {}
+export declare interface Row extends IRow {}
+export declare interface Column extends IColumn {}
+export declare interface List extends IList {}
+export declare interface Button extends IButton {}
+export declare interface Modal extends IModal {}
+export declare interface Card extends ICard {}
+export declare interface Divider extends IDivider {}
+export declare interface TextField extends ITextField {}
+export declare interface Checkbox extends ICheckbox {}
+export declare interface DateTimeInput extends IDateTimeInput {}
+export declare interface MultipleChoice extends IMultipleChoice {}
+export declare interface Slider extends ISlider {}

--- a/renderers/web_core/src/v0_8/types/primitives.ts
+++ b/renderers/web_core/src/v0_8/types/primitives.ts
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-import type { z } from "zod";
 import type {
-  StringValueSchema,
-  NumberValueSchema,
-  BooleanValueSchema,
+  StringValue as IStringValue,
+  NumberValue as INumberValue,
+  BooleanValue as IBooleanValue,
 } from "../schema/common-types.js";
 
-export declare interface StringValue extends z.infer<typeof StringValueSchema> {}
-export declare interface NumberValue extends z.infer<typeof NumberValueSchema> {}
-export declare interface BooleanValue extends z.infer<typeof BooleanValueSchema> {}
+export declare interface StringValue extends IStringValue {}
+export declare interface NumberValue extends INumberValue {}
+export declare interface BooleanValue extends IBooleanValue {}

--- a/renderers/web_core/src/v0_8/types/types.ts
+++ b/renderers/web_core/src/v0_8/types/types.ts
@@ -43,18 +43,18 @@ import {
 
 import type { z } from "zod";
 import type {
-  A2uiMessageSchema,
-  BeginRenderingMessageSchema,
-  ComponentInstanceSchema,
-  ComponentPropertiesSchema,
-  DataModelUpdateMessageSchema,
-  DeleteSurfaceMessageSchema,
-  SurfaceUpdateMessageSchema,
-  ValueMapSchema,
+  A2uiMessage,
+  BeginRenderingMessage as IBeginRenderingMessage,
+  ComponentInstance as IComponentInstance,
+  AnyComponent,
+  DataModelUpdateMessage as IDataModelUpdateMessage,
+  DeleteSurfaceMessage as IDeleteSurfaceMessage,
+  SurfaceUpdateMessage as ISurfaceUpdateMessage,
 } from "../schema/server-to-client.js";
 import type {
-  ComponentArrayReferenceSchema,
-  ComponentArrayTemplateSchema,
+  ComponentArrayReference as IComponentArrayReference,
+  ComponentArrayTemplate as IComponentArrayTemplate,
+  DataValue as IDataValue,
 } from "../schema/common-types.js";
 import { StringValue, NumberValue, BooleanValue } from "./primitives";
 export type { StringValue, NumberValue, BooleanValue };
@@ -257,21 +257,13 @@ export declare type DataMap = Map<string, DataValue>;
 export declare type DataArray = DataValue[];
 
 /** A template for creating components from a list in the data model. */
-export declare interface ComponentArrayTemplate
-  extends z.infer<typeof ComponentArrayTemplateSchema> {
-  componentId: string;
-  dataBinding: string;
-}
+export declare interface ComponentArrayTemplate extends IComponentArrayTemplate {}
 
 /** Defines a list of child components, either explicitly or via a template. */
-export declare interface ComponentArrayReference
-  extends z.infer<typeof ComponentArrayReferenceSchema> {
-  explicitList?: string[];
-  template?: ComponentArrayTemplate;
-}
+export declare interface ComponentArrayReference extends IComponentArrayReference {}
 
 /** Represents the general shape of a component's properties. */
-export declare interface ComponentProperties extends z.infer<typeof ComponentPropertiesSchema> {
+export declare interface ComponentProperties extends AnyComponent {
   Text?: Text;
   Image?: Image;
   Icon?: Icon;
@@ -293,46 +285,28 @@ export declare interface ComponentProperties extends z.infer<typeof ComponentPro
 }
 
 /** A raw component instance from a SurfaceUpdate message. */
-export declare interface ComponentInstance extends z.infer<typeof ComponentInstanceSchema> {
-  id: string;
-  weight?: number;
+export declare interface ComponentInstance extends IComponentInstance {
   component: ComponentProperties;
 }
 
-export declare interface BeginRenderingMessage extends z.infer<typeof BeginRenderingMessageSchema> {
-  surfaceId: string;
-  root: string;
-  styles?: {
-    font?: string;
-    primaryColor?: string;
-  };
-}
+export declare interface BeginRenderingMessage extends IBeginRenderingMessage {}
 
-export declare interface SurfaceUpdateMessage extends z.infer<typeof SurfaceUpdateMessageSchema> {
-  surfaceId: string;
+export declare interface SurfaceUpdateMessage extends ISurfaceUpdateMessage {
   components: ComponentInstance[];
 }
 
-export declare interface DataModelUpdate extends z.infer<typeof DataModelUpdateMessageSchema> {
-  surfaceId: string;
-  path?: string;
+export declare interface DataModelUpdate extends IDataModelUpdateMessage {
   contents: ValueMap[];
 }
 
 // ValueMap is a type of DataObject for passing to the data model.
-export declare interface ValueMap extends z.infer<typeof ValueMapSchema> {
-  key: string;
-  valueString?: string;
-  valueNumber?: number;
-  valueBoolean?: boolean;
+export declare interface ValueMap extends IDataValue {
   valueMap?: ValueMap[];
 }
 
-export declare interface DeleteSurfaceMessage extends z.infer<typeof DeleteSurfaceMessageSchema> {
-  surfaceId: string;
-}
+export declare interface DeleteSurfaceMessage extends IDeleteSurfaceMessage {}
 
-export declare interface ServerToClientMessage extends z.infer<typeof A2uiMessageSchema> {
+export declare interface ServerToClientMessage extends A2uiMessage {
   beginRendering?: BeginRenderingMessage;
   surfaceUpdate?: SurfaceUpdateMessage;
   dataModelUpdate?: DataModelUpdate;

--- a/renderers/web_core/src/v0_9/basic_catalog/components/basic_components.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/basic_components.ts
@@ -24,7 +24,7 @@ import {
   ComponentIdSchema,
   ActionSchema,
   AccessibilityAttributesSchema,
-  CheckableSchema,
+  ChecksSchema,
 } from '../../schema/common-types.js';
 import {ComponentApi} from '../../catalog/types.js';
 
@@ -368,7 +368,7 @@ export const ButtonApi = {
         )
         .optional(),
       action: ActionSchema,
-      checks: CheckableSchema.shape.checks,
+      checks: ChecksSchema,
     })
     .strict(),
 } satisfies ComponentApi;
@@ -395,7 +395,7 @@ export const TextFieldApi = {
           'A regular expression used for client-side validation of the input.',
         )
         .optional(),
-      checks: CheckableSchema.shape.checks,
+      checks: ChecksSchema,
     })
     .strict(),
 } satisfies ComponentApi;
@@ -411,7 +411,7 @@ export const CheckBoxApi = {
       value: DynamicBooleanSchema.describe(
         'The current state of the checkbox (true for checked, false for unchecked).',
       ),
-      checks: CheckableSchema.shape.checks,
+      checks: ChecksSchema,
     })
     .strict(),
 } satisfies ComponentApi;
@@ -458,7 +458,7 @@ export const ChoicePickerApi = {
         .default(false)
         .describe('If true, displays a search input to filter the options.')
         .optional(),
-      checks: CheckableSchema.shape.checks,
+      checks: ChecksSchema,
     })
     .strict()
     .describe(
@@ -481,7 +481,7 @@ export const SliderApi = {
         .optional(),
       max: z.number().describe('The maximum value of the slider.'),
       value: DynamicNumberSchema.describe('The current value of the slider.'),
-      checks: CheckableSchema.shape.checks,
+      checks: ChecksSchema,
     })
     .strict(),
 } satisfies ComponentApi;
@@ -525,7 +525,7 @@ export const DateTimeInputApi = {
       label: DynamicStringSchema.describe(
         'The text label for the input field.',
       ).optional(),
-      checks: CheckableSchema.shape.checks,
+      checks: ChecksSchema,
     })
     .strict(),
 } satisfies ComponentApi;

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
@@ -55,7 +55,7 @@ describe('GenericBinder Checkable Trait', () => {
 
     const schema = z.object({
       value: CommonSchemas.DynamicString,
-      checks: CommonSchemas.Checkable.shape.checks,
+      checks: CommonSchemas.Checks,
     });
 
     return {surface, schema};

--- a/renderers/web_core/src/v0_9/schema/client-to-server.ts
+++ b/renderers/web_core/src/v0_9/schema/client-to-server.ts
@@ -20,7 +20,15 @@ import {z} from 'zod';
  * Reports a user-initiated action from a component.
  * Matches 'action' in specification/v0_9/json/client_to_server.json.
  */
-export const A2uiClientActionSchema = z
+export interface A2uiClientAction {
+  name: string;
+  surfaceId: string;
+  sourceComponentId: string;
+  timestamp: string;
+  context: Record<string, any>;
+}
+
+export const A2uiClientActionSchema: z.ZodType<A2uiClientAction> = z
   .object({
     name: z
       .string()
@@ -45,32 +53,47 @@ export const A2uiClientActionSchema = z
   })
   .strict();
 
+export interface A2uiValidationErrorData {
+  code: 'VALIDATION_FAILED';
+  surfaceId: string;
+  path: string;
+  message: string;
+}
+
 /**
  * Reports a client-side validation failure.
  */
-export const A2uiValidationErrorSchema = z
-  .object({
-    code: z.literal('VALIDATION_FAILED'),
-    surfaceId: z
-      .string()
-      .describe('The id of the surface where the error occurred.'),
-    path: z
-      .string()
-      .describe(
-        "The JSON pointer to the field that failed validation (e.g. '/components/0/text').",
-      ),
-    message: z
-      .string()
-      .describe(
-        'A short one or two sentence description of why validation failed.',
-      ),
-  })
-  .strict();
+export const A2uiValidationErrorDataSchema: z.ZodType<A2uiValidationErrorData> =
+  z
+    .object({
+      code: z.literal('VALIDATION_FAILED'),
+      surfaceId: z
+        .string()
+        .describe('The id of the surface where the error occurred.'),
+      path: z
+        .string()
+        .describe(
+          "The JSON pointer to the field that failed validation (e.g. '/components/0/text').",
+        ),
+      message: z
+        .string()
+        .describe(
+          'A short one or two sentence description of why validation failed.',
+        ),
+    })
+    .strict();
+
+export interface A2uiGenericError {
+  code: string;
+  message: string;
+  surfaceId: string;
+  [key: string]: any;
+}
 
 /**
  * Reports a generic client-side error.
  */
-export const A2uiGenericErrorSchema = z
+export const A2uiGenericErrorSchema: z.ZodType<A2uiGenericError> = z
   .object({
     code: z.string().refine(c => c !== 'VALIDATION_FAILED'),
     message: z
@@ -84,12 +107,14 @@ export const A2uiGenericErrorSchema = z
   })
   .passthrough();
 
+export type A2uiClientError = A2uiValidationErrorData | A2uiGenericError;
+
 /**
  * Reports a client-side error.
  * Matches 'error' in specification/v0_9/json/client_to_server.json.
  */
-export const A2uiClientErrorSchema = z.union([
-  A2uiValidationErrorSchema,
+export const A2uiClientErrorSchema: z.ZodType<A2uiClientError> = z.union([
+  A2uiValidationErrorDataSchema,
   A2uiGenericErrorSchema,
 ]);
 
@@ -97,7 +122,11 @@ export const A2uiClientErrorSchema = z.union([
  * A message sent from the A2UI client to the server.
  * Matches specification/v0_9/json/client_to_server.json.
  */
-export const A2uiClientMessageSchema = z
+export type A2uiClientMessage = {
+  version: 'v0.9';
+} & ({action: A2uiClientAction} | {error: A2uiClientError});
+
+export const A2uiClientMessageSchema: z.ZodType<A2uiClientMessage> = z
   .object({
     version: z.literal('v0.9'),
   })
@@ -108,11 +137,16 @@ export const A2uiClientMessageSchema = z
     ]),
   );
 
+export interface A2uiClientDataModel {
+  version: 'v0.9';
+  surfaces: Record<string, Record<string, any>>;
+}
+
 /**
  * Schema for the client data model synchronization.
  * Matches specification/v0_9/json/client_data_model.json.
  */
-export const A2uiClientDataModelSchema = z
+export const A2uiClientDataModelSchema: z.ZodType<A2uiClientDataModel> = z
   .object({
     version: z.literal('v0.9'),
     surfaces: z
@@ -121,24 +155,20 @@ export const A2uiClientDataModelSchema = z
   })
   .strict();
 
-export type A2uiClientAction = z.infer<typeof A2uiClientActionSchema>;
-export type A2uiClientError = z.infer<typeof A2uiClientErrorSchema>;
-export type A2uiClientMessage = z.infer<typeof A2uiClientMessageSchema>;
-export type A2uiClientDataModel = z.infer<typeof A2uiClientDataModelSchema>;
+export type A2uiClientMessageList = A2uiClientMessage[];
 
-export const A2uiClientMessageListSchema = z
+export const A2uiClientMessageListSchema: z.ZodType<A2uiClientMessageList> = z
   .array(A2uiClientMessageSchema)
   .describe('A list of client messages.');
 
-export type A2uiClientMessageList = z.infer<typeof A2uiClientMessageListSchema>;
+export interface A2uiClientMessageListWrapper {
+  messages: A2uiClientMessageList;
+}
 
-export const A2uiClientMessageListWrapperSchema = z
-  .object({
-    messages: A2uiClientMessageListSchema,
-  })
-  .strict()
-  .describe('An object wrapping a list of client messages.');
-
-export type A2uiClientMessageListWrapper = z.infer<
-  typeof A2uiClientMessageListWrapperSchema
->;
+export const A2uiClientMessageListWrapperSchema: z.ZodType<A2uiClientMessageListWrapper> =
+  z
+    .object({
+      messages: A2uiClientMessageListSchema,
+    })
+    .strict()
+    .describe('An object wrapping a list of client messages.');

--- a/renderers/web_core/src/v0_9/schema/common-types.ts
+++ b/renderers/web_core/src/v0_9/schema/common-types.ts
@@ -16,7 +16,11 @@
 
 import {z} from 'zod';
 
-export const DataBindingSchema = z
+export interface DataBinding {
+  path: string;
+}
+
+export const DataBindingSchema: z.ZodType<DataBinding> = z
   .object({
     path: z
       .string()
@@ -26,46 +30,72 @@ export const DataBindingSchema = z
     'REF:common_types.json#/$defs/DataBinding|A JSON Pointer path to a value in the data model.',
   );
 
-export const FunctionCallSchema = z
+const FUNCTION_CALL_RETURN_TYPE_VALUES = [
+  'string',
+  'number',
+  'boolean',
+  'array',
+  'object',
+  'any',
+  'void',
+] as const;
+type FunctionCallReturnType = (typeof FUNCTION_CALL_RETURN_TYPE_VALUES)[number];
+
+export interface FunctionCall {
+  call: string;
+  args: Record<string, any>;
+  returnType?: FunctionCallReturnType;
+}
+
+export const FunctionCallSchema: z.ZodType<FunctionCall> = z
   .object({
     call: z.string().describe('The name of the function to call.'),
     args: z.record(z.any()).describe('Arguments passed to the function.'),
-    returnType: z
-      .enum(['string', 'number', 'boolean', 'array', 'object', 'any', 'void'])
-      .default('boolean'),
+    returnType: z.enum(FUNCTION_CALL_RETURN_TYPE_VALUES).default('boolean'),
   })
   .describe(
     'REF:common_types.json#/$defs/FunctionCall|Invokes a named function on the client.',
   );
 
-export const DynamicBooleanSchema = z
+export type DynamicBoolean = boolean | DataBinding | FunctionCall;
+
+export const DynamicBooleanSchema: z.ZodType<DynamicBoolean> = z
   .union([z.boolean(), DataBindingSchema, FunctionCallSchema])
   .describe(
     'REF:common_types.json#/$defs/DynamicBoolean|A boolean value that can be a literal, a path, or a function call returning a boolean.',
   );
 
-export const DynamicStringSchema = z
-  .union([
-    z.string(),
-    DataBindingSchema,
-    // FunctionCall returning string (simplified schema for Zod, stricter in JSON Schema)
-    FunctionCallSchema,
-  ])
+export type DynamicString = string | DataBinding | FunctionCall;
+
+export const DynamicStringSchema: z.ZodType<DynamicString> = z
+  .union([z.string(), DataBindingSchema, FunctionCallSchema])
   .describe('REF:common_types.json#/$defs/DynamicString|Represents a string');
 
-export const DynamicNumberSchema = z
+export type DynamicNumber = number | DataBinding | FunctionCall;
+
+export const DynamicNumberSchema: z.ZodType<DynamicNumber> = z
   .union([z.number(), DataBindingSchema, FunctionCallSchema])
   .describe(
     'REF:common_types.json#/$defs/DynamicNumber|Represents a value that can be either a literal number, a path to a number in the data model, or a function call returning a number.',
   );
 
-export const DynamicStringListSchema = z
+export type DynamicStringList = string[] | DataBinding | FunctionCall;
+
+export const DynamicStringListSchema: z.ZodType<DynamicStringList> = z
   .union([z.array(z.string()), DataBindingSchema, FunctionCallSchema])
   .describe(
     'REF:common_types.json#/$defs/DynamicStringList|Represents a value that can be either a literal array of strings, a path to a string array in the data model, or a function call returning a string array.',
   );
 
-export const DynamicValueSchema = z
+export type DynamicValue =
+  | string
+  | number
+  | boolean
+  | any[]
+  | DataBinding
+  | FunctionCall;
+
+export const DynamicValueSchema: z.ZodType<DynamicValue> = z
   .union([
     z.string(),
     z.number(),
@@ -78,30 +108,22 @@ export const DynamicValueSchema = z
     'REF:common_types.json#/$defs/DynamicValue|A value that can be a literal, a path, or a function call returning any type.',
   );
 
-/** A JSON Pointer path to a value in the data model. */
-export type DataBinding = z.infer<typeof DataBindingSchema>;
-/** A function call representation. */
-export type FunctionCall = z.infer<typeof FunctionCallSchema>;
-/** A dynamic string that can be a literal, a data binding, or a function call. */
-export type DynamicString = z.infer<typeof DynamicStringSchema>;
-/** A dynamic number that can be a literal, a data binding, or a function call. */
-export type DynamicNumber = z.infer<typeof DynamicNumberSchema>;
-/** A dynamic boolean that can be a literal, a path, or a function call returning a boolean. */
-export type DynamicBoolean = z.infer<typeof DynamicBooleanSchema>;
-/** A dynamic list of strings that can be a literal array, a data binding, or a function call. */
-export type DynamicStringList = z.infer<typeof DynamicStringListSchema>;
-/** A dynamic value that can be a literal, a path, or a function call returning any type. */
-export type DynamicValue = z.infer<typeof DynamicValueSchema>;
+export type ComponentId = string;
 
-export const ComponentIdSchema = z
+export const ComponentIdSchema: z.ZodType<ComponentId> = z
   .string()
   .describe(
     'REF:common_types.json#/$defs/ComponentId|The unique identifier for a component.',
   );
-/** The unique identifier for a component. */
-export type ComponentId = z.infer<typeof ComponentIdSchema>;
 
-export const ChildListSchema = z
+export type ChildList =
+  | ComponentId[]
+  | {
+      componentId: ComponentId;
+      path: string;
+    };
+
+export const ChildListSchema: z.ZodType<ChildList> = z
   .union([
     z
       .array(ComponentIdSchema)
@@ -118,10 +140,19 @@ export const ChildListSchema = z
       .describe('A template for generating a dynamic list of children.'),
   ])
   .describe('REF:common_types.json#/$defs/ChildList');
-/** A static list of child component IDs or a dynamic list template. */
-export type ChildList = z.infer<typeof ChildListSchema>;
 
-export const ActionSchema = z
+export type Action =
+  | {
+      event: {
+        name: string;
+        context?: Record<string, DynamicValue>;
+      };
+    }
+  | {
+      functionCall: FunctionCall;
+    };
+
+export const ActionSchema: z.ZodType<Action> = z
   .union([
     z
       .object({
@@ -138,10 +169,13 @@ export const ActionSchema = z
       .describe('Executes a local client-side function.'),
   ])
   .describe('REF:common_types.json#/$defs/Action');
-/** Triggers a server-side event or a local client-side function. */
-export type Action = z.infer<typeof ActionSchema>;
 
-export const CheckRuleSchema = z
+export interface CheckRule {
+  condition: DynamicBoolean;
+  message: string;
+}
+
+export const CheckRuleSchema: z.ZodType<CheckRule> = z
   .object({
     condition: DynamicBooleanSchema,
     message: z
@@ -151,41 +185,51 @@ export const CheckRuleSchema = z
   .describe(
     'REF:common_types.json#/$defs/CheckRule|A check rule consisting of a condition and an error message.',
   );
-/** A check rule consisting of a condition and an error message. */
-export type CheckRule = z.infer<typeof CheckRuleSchema>;
 
-export const CheckableSchema = z
+export interface Checkable {
+  checks?: CheckRule[];
+}
+
+export const ChecksSchema = z
+  .array(CheckRuleSchema)
+  .optional()
+  .describe('A list of checks to perform.');
+
+export const CheckableSchema: z.ZodType<Checkable> = z
   .object({
-    checks: z
-      .array(CheckRuleSchema)
-      .optional()
-      .describe('A list of checks to perform.'),
+    checks: ChecksSchema,
   })
   .describe(
     'REF:common_types.json#/$defs/Checkable|Properties for components that support client-side checks.',
   );
-/** An object that contains checks. */
-export type Checkable = z.infer<typeof CheckableSchema>;
 
-export const AccessibilityAttributesSchema = z
-  .object({
-    label: DynamicStringSchema.optional().describe(
-      'REF:common_types.json#/$defs/DynamicString|A short string used by assistive technologies to convey the purpose of an element.',
-    ),
-    description: DynamicStringSchema.optional().describe(
-      'REF:common_types.json#/$defs/DynamicString|Additional information provided by assistive technologies about an element.',
-    ),
-  })
-  .describe(
-    'REF:common_types.json#/$defs/AccessibilityAttributes|Attributes to enhance accessibility.',
-  );
+export interface AccessibilityAttributes {
+  label?: DynamicString;
+  description?: DynamicString;
+}
 
-/** Accessibility attributes like label and description. */
-export type AccessibilityAttributes = z.infer<
-  typeof AccessibilityAttributesSchema
->;
+export const AccessibilityAttributesSchema: z.ZodType<AccessibilityAttributes> =
+  z
+    .object({
+      label: DynamicStringSchema.optional().describe(
+        'REF:common_types.json#/$defs/DynamicString|A short string used by assistive technologies to convey the purpose of an element.',
+      ),
+      description: DynamicStringSchema.optional().describe(
+        'REF:common_types.json#/$defs/DynamicString|Additional information provided by assistive technologies about an element.',
+      ),
+    })
+    .describe(
+      'REF:common_types.json#/$defs/AccessibilityAttributes|Attributes to enhance accessibility.',
+    );
 
-export const AnyComponentSchema = z
+export interface AnyComponent {
+  component: string;
+  id?: ComponentId;
+  weight?: number;
+  [key: string]: any;
+}
+
+export const AnyComponentSchema: z.ZodType<AnyComponent> = z
   .object({
     component: z.string().describe('The type name of the component.'),
     id: ComponentIdSchema.optional(),
@@ -193,9 +237,6 @@ export const AnyComponentSchema = z
   })
   .passthrough()
   .describe('A generic A2UI component definition.');
-
-/** A generic A2UI component definition. */
-export type AnyComponent = z.infer<typeof AnyComponentSchema>;
 
 export const CommonSchemas = {
   ComponentId: ComponentIdSchema,
@@ -209,6 +250,7 @@ export const CommonSchemas = {
   FunctionCall: FunctionCallSchema,
   CheckRule: CheckRuleSchema,
   Checkable: CheckableSchema,
+  Checks: ChecksSchema,
   Action: ActionSchema,
   AccessibilityAttributes: AccessibilityAttributesSchema,
   AnyComponent: AnyComponentSchema,

--- a/renderers/web_core/src/v0_9/schema/server-to-client.ts
+++ b/renderers/web_core/src/v0_9/schema/server-to-client.ts
@@ -15,9 +15,19 @@
  */
 
 import {z} from 'zod';
-import {AnyComponentSchema} from './common-types.js';
+import {AnyComponentSchema, AnyComponent} from './common-types.js';
 
-export const CreateSurfaceMessageSchema = z
+export interface CreateSurfaceMessage {
+  version: 'v0.9';
+  createSurface: {
+    surfaceId: string;
+    catalogId: string;
+    theme?: any;
+    sendDataModel?: boolean;
+  };
+}
+
+export const CreateSurfaceMessageSchema: z.ZodType<CreateSurfaceMessage> = z
   .object({
     version: z.literal('v0.9'),
     createSurface: z
@@ -38,24 +48,44 @@ export const CreateSurfaceMessageSchema = z
   })
   .strict();
 
-export const UpdateComponentsMessageSchema = z
-  .object({
-    version: z.literal('v0.9'),
-    updateComponents: z
-      .object({
-        surfaceId: z
-          .string()
-          .describe('The unique identifier for the UI surface to be updated.'),
-        components: z
-          .array(AnyComponentSchema)
-          .min(1)
-          .describe('A list containing all UI components for the surface.'),
-      })
-      .strict(),
-  })
-  .strict();
+export interface UpdateComponentsMessage {
+  version: 'v0.9';
+  updateComponents: {
+    surfaceId: string;
+    components: AnyComponent[];
+  };
+}
 
-export const UpdateDataModelMessageSchema = z
+export const UpdateComponentsMessageSchema: z.ZodType<UpdateComponentsMessage> =
+  z
+    .object({
+      version: z.literal('v0.9'),
+      updateComponents: z
+        .object({
+          surfaceId: z
+            .string()
+            .describe(
+              'The unique identifier for the UI surface to be updated.',
+            ),
+          components: z
+            .array(AnyComponentSchema)
+            .min(1)
+            .describe('A list containing all UI components for the surface.'),
+        })
+        .strict(),
+    })
+    .strict();
+
+export interface UpdateDataModelMessage {
+  version: 'v0.9';
+  updateDataModel: {
+    surfaceId: string;
+    path?: string;
+    value?: any;
+  };
+}
+
+export const UpdateDataModelMessageSchema: z.ZodType<UpdateDataModelMessage> = z
   .object({
     version: z.literal('v0.9'),
     updateDataModel: z
@@ -78,7 +108,14 @@ export const UpdateDataModelMessageSchema = z
   })
   .strict();
 
-export const DeleteSurfaceMessageSchema = z
+export interface DeleteSurfaceMessage {
+  version: 'v0.9';
+  deleteSurface: {
+    surfaceId: string;
+  };
+}
+
+export const DeleteSurfaceMessageSchema: z.ZodType<DeleteSurfaceMessage> = z
   .object({
     version: z.literal('v0.9'),
     deleteSurface: z
@@ -91,51 +128,16 @@ export const DeleteSurfaceMessageSchema = z
   })
   .strict();
 
-export declare interface CreateSurfaceMessage extends z.infer<
-  typeof CreateSurfaceMessageSchema
-> {
-  version: 'v0.9';
-  createSurface: {
-    surfaceId: string;
-    catalogId: string;
-    theme?: any;
-    sendDataModel?: boolean;
-  };
-}
-export declare interface UpdateComponentsMessage extends z.infer<
-  typeof UpdateComponentsMessageSchema
-> {
-  version: 'v0.9';
-  updateComponents: {
-    surfaceId: string;
-    components: any[];
-  };
-}
-export declare interface UpdateDataModelMessage extends z.infer<
-  typeof UpdateDataModelMessageSchema
-> {
-  version: 'v0.9';
-  updateDataModel: {
-    surfaceId: string;
-    path?: string;
-    value?: any;
-  };
-}
-export declare interface DeleteSurfaceMessage extends z.infer<
-  typeof DeleteSurfaceMessageSchema
-> {
-  version: 'v0.9';
-  deleteSurface: {
-    surfaceId: string;
-  };
-}
-
-export const A2uiMessageSchema = z.union([
-  CreateSurfaceMessageSchema,
-  UpdateComponentsMessageSchema,
-  UpdateDataModelMessageSchema,
-  DeleteSurfaceMessageSchema,
-]);
+export const A2uiMessageSchema: z.ZodType<A2uiMessage> = z
+  .union([
+    CreateSurfaceMessageSchema,
+    UpdateComponentsMessageSchema,
+    UpdateDataModelMessageSchema,
+    DeleteSurfaceMessageSchema,
+  ])
+  .describe(
+    'Describes a JSON payload for an A2UI (Agent to UI) message in v0.9. It is a union of CreateSurface, UpdateComponents, UpdateDataModel, and DeleteSurface messages.',
+  );
 
 /** A message sent from the A2UI server to the client. */
 export type A2uiMessage =
@@ -144,19 +146,19 @@ export type A2uiMessage =
   | UpdateDataModelMessage
   | DeleteSurfaceMessage;
 
-export const A2uiMessageListSchema = z
+export type A2uiMessageList = A2uiMessage[];
+
+export const A2uiMessageListSchema: z.ZodType<A2uiMessageList> = z
   .array(A2uiMessageSchema)
   .describe('A list of messages.');
 
-export type A2uiMessageList = z.infer<typeof A2uiMessageListSchema>;
+export interface A2uiMessageListWrapper {
+  messages: A2uiMessageList;
+}
 
-export const A2uiMessageListWrapperSchema = z
+export const A2uiMessageListWrapperSchema: z.ZodType<A2uiMessageListWrapper> = z
   .object({
     messages: A2uiMessageListSchema,
   })
   .strict()
   .describe('An object wrapping a list of messages.');
-
-export type A2uiMessageListWrapper = z.infer<
-  typeof A2uiMessageListWrapperSchema
->;


### PR DESCRIPTION
# Description

- The Closure Compiler renames properties and variables to minimize code size.
- `z.infer` Relies on Type Names and works by inspecting the shape of the schema definition at compile time to create a TypeScript type. However, the runtime validation logic within Zod likely relies on the property names defined in the schema.

The two are mutually exclusive. To fix this, introduce some duplication of the types. The duplication should be mostly okay as if they are changed to not match, typescript will fail the typecheck except if there are optional fields introduced in the schema.

Coding agents can easily address this duplication. Also added a github actions to check for `z.infer`.

### API changes

•  renderers/web_core/src/v0_9/schema/common-types.ts : Added  ChecksSchema  as a new top-level
export (to avoid using  .shape.checks  on strictly typed schemas).
•  renderers/web_core/src/v0_9/schema/client-to-server.ts : The interface  A2uiValidationError  and
its schema  A2uiValidationErrorSchema  were renamed to  A2uiValidationErrorData  and
A2uiValidationErrorDataSchema  respectively (to resolve the duplicate export clash with  errors.ts
in  index.ts ).

Related: b/502243995
Fixes b/495161036
Fixes https://github.com/google/A2UI/issues/896
## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
