### PR TITLE
fix(react,v0.9): wire `@a2ui/markdown-it` as default `MarkdownContext` value

### DIFF
--- a/.github/workflows/composer_build_and_test.yml
+++ b/.github/workflows/composer_build_and_test.yml
@@ -51,6 +51,10 @@ jobs:
         working-directory: ./renderers/web_core
         run: npm ci && npm run build
 
+      - name: Build markdown-it (dependency of @a2ui/react)
+        working-directory: ./renderers/markdown/markdown-it
+        run: npm ci && npm run build
+
       - name: Build React renderer (local file dependency)
         working-directory: ./renderers/react
         run: npm ci && npm run build

--- a/renderers/react/CHANGELOG.md
+++ b/renderers/react/CHANGELOG.md
@@ -5,6 +5,8 @@
 - **BREAKING CHANGE**: Removed `minimalCatalog`.
 - (v0_9) Re-style the v0_9 catalog components using the default theme from
   `web_core`. [#1205](https://github.com/google/A2UI/pull/1205)
+- (v0_9) Use `@a2ui/markdown-it` as the default `MarkdownContext` value so
+  `Text` renders markdown out of the box. [#1227](https://github.com/google/A2UI/pull/1227)
 
 ## 0.8.1
 

--- a/renderers/react/src/v0_9/catalog/basic/hooks/useMarkdown.ts
+++ b/renderers/react/src/v0_9/catalog/basic/hooks/useMarkdown.ts
@@ -16,30 +16,17 @@
 
 import {useState, useEffect} from 'react';
 import {useMarkdownRenderer} from '../context/MarkdownContext';
+import {renderMarkdown as defaultRenderer} from '@a2ui/markdown-it';
 import type {MarkdownRendererOptions} from '@a2ui/web_core/types/types';
 
-let warningLogged = false;
-
 export function useMarkdown(text: string, options?: MarkdownRendererOptions) {
-  const renderer = useMarkdownRenderer();
+  const contextRenderer = useMarkdownRenderer();
+  const renderer = contextRenderer ?? defaultRenderer;
   const [html, setHtml] = useState<string | null>(null);
 
   const optionsKey = JSON.stringify(options);
 
   useEffect(() => {
-    if (!renderer) {
-      if (!warningLogged) {
-        console.warn(
-          '[useMarkdown]',
-          "can't render markdown because no markdown renderer is configured.\n",
-          'Use `@a2ui/markdown-it`, or your own markdown renderer.'
-        );
-        warningLogged = true;
-      }
-      setHtml(null);
-      return;
-    }
-
     let active = true;
     const parsedOptions = optionsKey ? JSON.parse(optionsKey) : undefined;
 

--- a/renderers/react/tests/v0_9/markdown-default.test.tsx
+++ b/renderers/react/tests/v0_9/markdown-default.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { renderA2uiComponent } from '../utils';
+import { Text } from '../../src/v0_9/catalog/basic';
+import { MarkdownContext } from '../../src/v0_9/catalog/basic/context/MarkdownContext';
+
+describe('Markdown rendering defaults', () => {
+  it('renders markdown by default without an explicit MarkdownContext provider', async () => {
+    const { view } = renderA2uiComponent(Text, 't1', { text: 'Hello', variant: 'h1' });
+
+    await waitFor(() => {
+      const h1 = view.container.querySelector('h1');
+      expect(h1).not.toBeNull();
+      expect(h1?.textContent).toBe('Hello');
+    });
+  });
+
+  it('does not render literal markdown syntax in the fallback', async () => {
+    const { view } = renderA2uiComponent(Text, 't1', { text: 'Hello', variant: 'h1' });
+
+    await waitFor(() => {
+      expect(view.container.textContent).not.toContain('# Hello');
+    });
+  });
+
+  it('uses a custom renderer when MarkdownContext is overridden', async () => {
+    const customRenderer = vi.fn(async (text: string) => `<p>CUSTOM: ${text}</p>`);
+
+    const { context } = renderA2uiComponent(Text, 't1', { text: 'Hello' });
+    const ComponentToRender = Text.render;
+    const { container } = render(
+      <MarkdownContext.Provider value={customRenderer}>
+        <ComponentToRender context={context} buildChild={() => null} />
+      </MarkdownContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(customRenderer).toHaveBeenCalled();
+      expect(container.textContent).toContain('CUSTOM:');
+    });
+  });
+});


### PR DESCRIPTION
@a2ui/markdown-it is already a dependency of @a2ui/react but was not wired as the default renderer.

Set renderMarkdown from @a2ui/markdown-it as the default context value. Users can still override via MarkdownContext.Provider. Remove the warning/fallback code path in useMarkdown since a renderer is now always available.

Fixes #1226.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
