### PR TITLE
docs: feature quickstarts and add AG-UI guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Pick the path that matches where you want to start:
 
 | Path | What you get | Time |
 |------|--------------|------|
-| 🍜 **[Restaurant Finder demo](docs/quickstart.md)** | Full-stack A2UI running locally with a Gemini agent and Lit renderer. Best for learning the protocol end-to-end. | ~5 min |
-| ⚛️ **[A2UI + AG-UI (CopilotKit)](docs/guides/a2ui-with-any-agent-framework.md)** | Set up CopilotKit with your agent framework of choice, then enable A2UI rendering. Best for shipping A2UI in a React app. | ~5 min |
+| 🍜 **[Quickstart Restaurant Finder Demo](https://a2ui.org/quickstart/)** | Full-stack A2UI running locally with a Gemini powered ADK agent and Lit renderer. Learn A2UI end-to-end and customize to your use case. | ~5 min |
+| ⚛️ **[A2UI + AG-UI (CopilotKit)](docs/guides/a2ui-with-any-agent-framework.md)** | Set up CopilotKit with your agent framework of choice, then enable A2UI rendering. Ready to ship A2UI in a React app. | ~5 min |
 | 🎨 **[A2UI Composer](https://a2ui-composer.ag-ui.com/)** · **[Widget Builder](https://go.copilotkit.ai/A2UI-widget-builder)** | Generate A2UI JSON from a visual editor and paste it into any agent prompt — no install required. | ~1 min |
 
 ### Restaurant Finder demo — TL;DR

--- a/README.md
+++ b/README.md
@@ -100,66 +100,41 @@ A2UI is designed to be a lightweight format, but it fits into a larger ecosystem
 
 ## Getting started
 
-The best way to understand A2UI is to run the samples.
+Pick the path that matches where you want to start:
 
-### Prerequisites
+| Path | What you get | Time |
+|------|--------------|------|
+| 🍜 **[Restaurant Finder demo](docs/quickstart.md)** | Full-stack A2UI running locally with a Gemini agent and Lit renderer. Best for learning the protocol end-to-end. | ~5 min |
+| ⚛️ **[A2UI + AG-UI quickstart (CopilotKit)](docs/guides/a2ui-with-any-agent-framework.md)** | React/Next.js scaffold with an A2UI catalog and any agent framework behind AG-UI. Best for shipping A2UI in a React app. | ~5 min |
+| 🎨 **[A2UI Composer](https://a2ui-composer.ag-ui.com/)** · **[Widget Builder](https://go.copilotkit.ai/A2UI-widget-builder)** | Generate A2UI JSON from a visual editor and paste it into any agent prompt — no install required. | ~1 min |
 
-* Node.js (for web clients)
-* Python (for agent samples)
-* A valid [Gemini API Key](https://aistudio.google.com/) is required for the samples.
+### Restaurant Finder demo — TL;DR
 
-### Running the Restaurant Finder demo
+Prerequisites: Node.js 18+, [uv](https://docs.astral.sh/uv/), and a [Gemini API key](https://aistudio.google.com/apikey).
 
-1. **Clone the repository:**
+```bash
+git clone https://github.com/google/A2UI.git
+cd A2UI
+export GEMINI_API_KEY="your_gemini_api_key"
+cd samples/client/lit
+npm run demo:restaurant
+```
 
-    ```bash
-    git clone https://github.com/google/A2UI.git
-    cd A2UI
-    ```
+This one command installs dependencies, builds the renderers, starts the Python agent, and opens the client at `http://localhost:5173`. For step-by-step instructions, alternative demos, and troubleshooting see the **[full Quickstart](docs/quickstart.md)**.
 
-2. **Set your API key:**
+### A2UI + AG-UI — TL;DR
 
-    ```bash
-    export GEMINI_API_KEY="your_gemini_api_key"
-    ```
+```bash
+npx copilotkit@latest create my-app --framework a2ui
+cd my-app
+pnpm install && pnpm dev
+```
 
-3. **Run the Agent (Backend):**
+Pairs a Next.js frontend (with a typed A2UI catalog) against the agent framework of your choice. See **[Use A2UI with Any Agent Framework (Using AG-UI)](docs/guides/a2ui-with-any-agent-framework.md)** for the catalog wiring, message shapes, and fixed-vs-dynamic schema patterns.
 
-    ```bash
-    cd samples/agent/adk/restaurant_finder
-    uv run .
-    ```
+### Other renderers
 
-4. **Run the Client (Frontend):**
-    Open a new terminal window:
-
-    ```bash
-    # Install and build the Markdown renderer
-    cd renderers/markdown/markdown-it
-    npm install
-    npm run build
-
-    # Install and build the Web Core library
-    cd ../../web_core
-    npm install
-    npm run build
-
-    # Install and build the Lit renderer
-    cd ../lit
-    npm install
-    npm run build
-
-    # Install and run the shell client
-    cd ../../samples/client/lit/shell
-    npm install
-    npm run dev
-    ```
-
-For Flutter developers, check out the [GenUI SDK](https://github.com/flutter/genui),
-which uses A2UI under the hood.
-
-CopilotKit has a public [A2UI Widget Builder](https://go.copilotkit.ai/A2UI-widget-builder)
-to try out as well.
+For Flutter, check out the [GenUI SDK](https://github.com/flutter/genui), which uses A2UI under the hood. See [docs/reference/renderers.md](docs/reference/renderers.md) for the full list of client implementations.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Pick the path that matches where you want to start:
 | Path | What you get | Time |
 |------|--------------|------|
 | 🍜 **[Restaurant Finder demo](docs/quickstart.md)** | Full-stack A2UI running locally with a Gemini agent and Lit renderer. Best for learning the protocol end-to-end. | ~5 min |
-| ⚛️ **[A2UI + AG-UI quickstart (CopilotKit)](docs/guides/a2ui-with-any-agent-framework.md)** | React/Next.js scaffold with an A2UI catalog and any agent framework behind AG-UI. Best for shipping A2UI in a React app. | ~5 min |
+| ⚛️ **[A2UI + AG-UI (CopilotKit)](docs/guides/a2ui-with-any-agent-framework.md)** | Set up CopilotKit with your agent framework of choice, then enable A2UI rendering. Best for shipping A2UI in a React app. | ~5 min |
 | 🎨 **[A2UI Composer](https://a2ui-composer.ag-ui.com/)** · **[Widget Builder](https://go.copilotkit.ai/A2UI-widget-builder)** | Generate A2UI JSON from a visual editor and paste it into any agent prompt — no install required. | ~1 min |
 
 ### Restaurant Finder demo — TL;DR
@@ -125,12 +125,10 @@ This one command installs dependencies, builds the renderers, starts the Python 
 ### A2UI + AG-UI — TL;DR
 
 ```bash
-npx copilotkit@latest create my-app --framework a2ui
-cd my-app
-pnpm install && pnpm dev
+npx copilotkit@latest init
 ```
 
-Pairs a Next.js frontend (with a typed A2UI catalog) against the agent framework of your choice. See **[Use A2UI with Any Agent Framework (Using AG-UI)](docs/guides/a2ui-with-any-agent-framework.md)** for the catalog wiring, message shapes, and fixed-vs-dynamic schema patterns.
+Set up CopilotKit with your framework of choice (ADK, LangGraph, CrewAI, Mastra, …), then follow the **[AG-UI guide](docs/guides/a2ui-with-any-agent-framework.md)** to enable A2UI rendering. CopilotKit's [quickstart](https://docs.copilotkit.ai/quickstart) covers the initial install for any supported agent framework.
 
 ### Other renderers
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Pick the path that matches where you want to start:
 | 🍜 **[Quickstart Restaurant Finder Demo](https://a2ui.org/quickstart/)** | Full-stack A2UI running locally with a Gemini powered ADK agent and Lit renderer. Learn A2UI end-to-end and customize to your use case. | ~5 min |
 | ⚛️ **[A2UI + AG-UI (CopilotKit)](docs/guides/a2ui-with-any-agent-framework.md)** | Set up CopilotKit with your agent framework of choice, then enable A2UI rendering. Ready to ship A2UI in a React app. | ~5 min |
 | 🎨 **[A2UI Composer](https://a2ui-composer.ag-ui.com/)** · **[Widget Builder](https://go.copilotkit.ai/A2UI-widget-builder)** | Generate A2UI JSON from a visual editor and paste it into any agent prompt — no install required. | ~1 min |
+| 🎬 **[A2UI Theater](https://a2ui-composer.ag-ui.com/theater)** | Step through pre-built A2UI streaming scenarios across Lit, React, and Angular renderers — no install required. | ~1 min |
 
 ### Restaurant Finder demo — TL;DR
 

--- a/docs/concepts/transports.md
+++ b/docs/concepts/transports.md
@@ -43,11 +43,9 @@ TODO: Add a detailed guide.
 
 ## AG UI
 
-[AG UI](https://ag-ui.com/) translates from A2UI messages to AG UI messages, and handles transport and state sync automatically.
+[AG UI](https://ag-ui.com/) translates A2UI messages to AG UI events and handles transport and state sync automatically. It is the recommended transport for React / Next.js clients.
 
-If you are using AG UI, this should be automatic.
-
-TODO: Add a detailed guide.
+**See:** [Use A2UI with Any Agent Framework (Using AG-UI)](../guides/a2ui-with-any-agent-framework.md) — end-to-end guide covering catalog setup, A2UI operations, and fixed vs dynamic schema patterns.
 
 ## Custom Transports
 

--- a/docs/concepts/transports.md
+++ b/docs/concepts/transports.md
@@ -45,7 +45,7 @@ TODO: Add a detailed guide.
 
 [AG UI](https://ag-ui.com/) translates A2UI messages to AG UI events and handles transport and state sync automatically. It is the recommended transport for React / Next.js clients.
 
-**See:** [Use A2UI with Any Agent Framework (Using AG-UI)](../guides/a2ui-with-any-agent-framework.md) — end-to-end guide covering catalog setup, A2UI operations, and fixed vs dynamic schema patterns.
+**See:** [Use A2UI with Any Agent Framework (Using AG-UI)](../guides/a2ui-with-any-agent-framework.md) — guide to setting up CopilotKit with your agent framework of choice and enabling A2UI rendering.
 
 ## Custom Transports
 

--- a/docs/guides/a2ui-with-any-agent-framework.md
+++ b/docs/guides/a2ui-with-any-agent-framework.md
@@ -62,10 +62,124 @@ import { myCustomTheme } from "@copilotkit/a2ui-renderer";
 
 ### Custom components (BYOC)
 
-To extend the built-in A2UI catalog with your own React components, see
-CopilotKit's [Custom Components (BYOC) section](https://docs.copilotkit.ai/adk/generative-ui/a2ui#custom-components-byoc)
-— define Zod schemas, map them to React renderers, and pass the catalog
-through the provider's `a2ui` prop.
+A2UI ships with a built-in catalog (Text, Image, Card, …) that gets you a
+working surface immediately. The real power is extending it with _your_
+React components — your design system, your data shapes — so the agent
+can compose interfaces from primitives you already trust. A catalog has
+three pieces:
+
+1. **Definitions** — Zod schemas plus a natural-language description. This
+   is what the agent sees in its system prompt.
+2. **Renderers** — typed React components, one per definition. This is
+   what the user sees.
+3. **Registration** — pass the catalog through the provider so the A2UI
+   renderer knows how to draw your components.
+
+#### 1. Define component schemas
+
+Create platform-agnostic definitions with Zod. The `description` field
+gets injected into the agent's prompt so the LLM knows when to reach for
+each component; the schema validates the props the agent sends.
+
+```ts title="lib/a2ui/definitions.ts"
+import { z } from "zod";
+
+export const myDefinitions = {
+  StatusBadge: {
+    description: "A colored status badge.",
+    props: z.object({
+      text: z.string(),
+      variant: z.enum(["success", "warning", "error"]).optional(),
+    }),
+  },
+  Metric: {
+    description: "A key metric with label and value.",
+    props: z.object({
+      label: z.string(),
+      value: z.string(),
+      trend: z.enum(["up", "down"]).optional(),
+    }),
+  },
+};
+
+export type MyDefinitions = typeof myDefinitions;
+```
+
+#### 2. Create React renderers
+
+Map each definition to a React component. `createCatalog` is generic over
+the definitions type, so the props your renderer receives are type-checked
+against the Zod schema — a typo in `props.text` is a compile error.
+
+{% raw %}
+```tsx title="lib/a2ui/renderers.tsx"
+"use client";
+
+import { createCatalog, type CatalogRenderers } from "@copilotkit/a2ui-renderer";
+import { myDefinitions, type MyDefinitions } from "./definitions";
+
+const myRenderers: CatalogRenderers<MyDefinitions> = {
+  StatusBadge: ({ props }) => {
+    const colors = {
+      success: { bg: "#dcfce7", text: "#166534" },
+      warning: { bg: "#fef3c7", text: "#92400e" },
+      error: { bg: "#fee2e2", text: "#991b1b" },
+    };
+    const c = colors[props.variant ?? "success"];
+    return (
+      <span style={{ padding: "2px 8px", borderRadius: 9999, fontSize: "0.75rem", background: c.bg, color: c.text }}>
+        {props.text}
+      </span>
+    );
+  },
+
+  Metric: ({ props }) => (
+    <div>
+      <div style={{ fontSize: "0.75rem", color: "#6b7280" }}>{props.label}</div>
+      <div style={{ fontSize: "1.5rem", fontWeight: 700 }}>
+        {props.value} {props.trend === "up" ? "↑" : props.trend === "down" ? "↓" : ""}
+      </div>
+    </div>
+  ),
+};
+
+export const myCatalog = createCatalog(myDefinitions, myRenderers, {
+  catalogId: "my-app-catalog",
+  includeBasicCatalog: true, // merges with built-in components
+});
+```
+{% endraw %}
+
+`catalogId` is the stable handle the agent uses to target this catalog;
+`includeBasicCatalog: true` keeps the built-in components available
+alongside your own (omit it to render _only_ your components).
+
+#### 3. Pass the catalog to CopilotKit
+
+{% raw %}
+```tsx title="app/layout.tsx"
+"use client";
+
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+import "@copilotkit/react-core/v2/styles.css";
+import { myCatalog } from "@/lib/a2ui/renderers";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <CopilotKitProvider runtimeUrl="/api/copilotkit" a2ui={{ catalog: myCatalog }}>
+      {children}
+    </CopilotKitProvider>
+  );
+}
+```
+{% endraw %}
+
+Agents will now see your custom components alongside the built-ins and
+can use them in any A2UI surface they emit.
+
+For the full BYOC reference (multiple catalogs, theming hooks, advanced
+patterns), see CopilotKit's
+[Custom Components (BYOC) section](https://docs.copilotkit.ai/adk/generative-ui/a2ui#custom-components-byoc).
 
 ## 3. Advanced usage
 

--- a/docs/guides/a2ui-with-any-agent-framework.md
+++ b/docs/guides/a2ui-with-any-agent-framework.md
@@ -1,342 +1,80 @@
 # Use A2UI with Any Agent Framework (Using AG-UI)
 
-A2UI describes _what_ the UI should look like. [AG-UI](https://ag-ui.com/) is a thin,
-framework-neutral transport that moves messages between an agent and a web client.
-Together they let any agent — LangGraph, CrewAI, Mastra, ADK, a custom Python
-service, a Next.js API route — speak A2UI to a React frontend without writing
-transport glue yourself.
+A2UI is a declarative UI format. [AG-UI](https://ag-ui.com/) is the transport
+that carries A2UI messages between an agent and the browser. CopilotKit's
+AG-UI implementation is the fastest path to putting A2UI in front of users
+today — any agent framework CopilotKit supports (ADK, LangGraph, CrewAI,
+Mastra, custom Python/TS services, etc.) can emit A2UI and render it in a
+React app with no transport glue.
 
-This guide walks through the end-to-end picture: where A2UI sits in an AG-UI
-pipeline, how to wire up the catalog on the frontend, how to emit A2UI
-operations from the backend, and two patterns (fixed vs. dynamic schemas) for
-choosing which layouts the agent can produce.
+!!! info "Source of truth"
 
-## When to use this
+    This guide mirrors the key steps from CopilotKit's
+    [ADK + A2UI docs](https://docs.copilotkit.ai/adk/generative-ui/a2ui).
+    Refer to the CopilotKit docs for the latest API surface.
 
-Pick A2UI + AG-UI when you want:
+## 1. Set up CopilotKit
 
-- **One agent, many renderers.** The same A2UI payload can render in React
-  (AG-UI), Lit, Flutter, Angular, or anywhere else A2UI is supported.
-- **Safe generative UI.** The agent can only render components that your
-  frontend has registered in a [catalog](../concepts/catalogs.md). No arbitrary
-  code, no arbitrary markup.
-- **A framework-agnostic agent.** You are not tied to a specific agent SDK.
-  Anything that can emit JSON over the AG-UI event stream can speak A2UI.
-
-If your agent already talks [A2A](../concepts/transports.md#a2a-protocol),
-prefer the [A2A extension](../specification/v0.8-a2a-extension.md). AG-UI is the
-right choice when your frontend is a React app and you want streaming UI
-updates with minimal wiring.
-
-## How A2UI and AG-UI fit together
-
-```
-┌──────────────┐   AG-UI events    ┌─────────────────┐   A2UI ops    ┌────────────┐
-│  Your Agent  │ ────────────────> │  AG-UI runtime  │ ────────────> │  Catalog   │
-│ (any fwk.)   │                   │ (Next.js route) │               │ renderers  │
-└──────────────┘ <──────────────── └─────────────────┘ <──────────── └────────────┘
-       ▲           tool events /          ▲      │                     (your
-       │           actions                │      │                      React
-       │                                  │      ▼                      comps)
-       │                            ┌─────────────────┐
-       └───── user input ────────── │  React client   │
-                                    │  (CopilotKit)   │
-                                    └─────────────────┘
-```
-
-Roles:
-
-- **Agent.** Produces A2UI operations (`createSurface`, `updateComponents`,
-  `updateDataModel`). The operations are just JSON — the agent framework is
-  an implementation detail.
-- **AG-UI runtime.** Bridges the agent and the browser. A2UI operations ride on
-  the AG-UI event stream as activity messages; AG-UI handles reconnection,
-  backpressure, and state sync.
-- **Catalog + renderers.** A typed registry on the frontend mapping component
-  names (e.g. `DashboardCard`) to the React components that render them. The
-  agent can only render components the catalog declares.
-
-The key invariant: **the agent never ships React, HTML, or CSS**. It ships A2UI
-operations naming components your app already trusts.
-
-## Quickstart (CopilotKit)
-
-The fastest path today is CopilotKit's AG-UI implementation. This takes you
-from zero to a running A2UI surface in two commands.
-
-### 1. Scaffold the starter
+Install CopilotKit into a React/Next.js app with the framework of your
+choice (ADK, LangGraph, CrewAI, Mastra, etc.):
 
 ```bash
-npx copilotkit@latest create my-app --framework a2ui
-cd my-app
+npx copilotkit@latest init
 ```
 
-The `a2ui` framework scaffolds a Next.js app paired with an agent backend,
-preconfigured with an A2UI catalog and the AG-UI middleware. `-f a2ui` works
-as a shorthand.
+Or follow the [CopilotKit quickstart](https://docs.copilotkit.ai/quickstart)
+to wire it into an existing project. This is the standard CopilotKit setup —
+no A2UI-specific scaffold.
 
-### 2. Install and run
+## 2. Enable A2UI
 
-```bash
-pnpm install
-cp .env.example .env   # add your model provider API key
-pnpm dev
+### Backend
+
+Turn on A2UI in `CopilotRuntime` and inject the `render_a2ui` tool so your
+agent can produce A2UI surfaces:
+
+```ts title="app/api/copilotkit/route.ts"
+import { CopilotRuntime } from "@copilotkit/runtime";
+
+const runtime = new CopilotRuntime({
+  agents: { default: myAgent },
+  a2ui: { injectA2UITool: true },
+});
 ```
 
-`pnpm dev` starts the Next.js UI and the agent concurrently. Open
-<http://localhost:3000> and send a message — the agent responds with an A2UI
-surface rendered from your catalog.
+Scope to specific agents with `a2ui: { injectA2UITool: true, agents: ["my-agent"] }`.
 
-!!! tip "Try it without installing anything"
+### Frontend
 
-    CopilotKit also hosts a public [A2UI Widget Builder](https://go.copilotkit.ai/A2UI-widget-builder)
-    and the [A2UI Composer](https://a2ui-composer.ag-ui.com/) — both let you
-    generate A2UI JSON visually and paste it into any agent prompt.
+The A2UI renderer activates automatically. Optionally pass a theme:
 
-## Register a catalog on the frontend
-
-The catalog is the contract between your agent and your UI. It has two files:
-
-- **Definitions** — Zod schemas plus a natural-language description. This is
-  what the agent sees.
-- **Renderers** — React components, type-checked against the schemas. This is
-  what the user sees.
-
-### Definitions
-
-```ts title="src/app/catalog/definitions.ts"
-import { z } from "zod";
-
-export const demonstrationCatalogDefinitions = {
-  Metric: {
-    description:
-      "A key metric display with label, value, and optional trend indicator. Great for KPIs and stats.",
-    props: z.object({
-      label: z.string(),
-      value: z.string(),
-      trend: z.enum(["up", "down", "neutral"]).optional(),
-      trendValue: z.string().optional(),
-    }),
-  },
-  DashboardCard: {
-    description:
-      "A card container with title and optional subtitle. Has a 'child' slot for content.",
-    props: z.object({
-      title: z.string(),
-      subtitle: z.string().optional(),
-      child: z.string().optional(),
-    }),
-  },
-};
-
-export type DemonstrationCatalogDefinitions =
-  typeof demonstrationCatalogDefinitions;
-```
-
-The `description` field matters — it is injected into the agent's system prompt
-so the LLM knows when to reach for each component.
-
-### Renderers
-
-```tsx title="src/app/catalog/renderers.tsx"
-"use client";
-import {
-  createCatalog,
-  type CatalogRenderers,
-} from "@copilotkit/a2ui-renderer";
-import {
-  demonstrationCatalogDefinitions,
-  type DemonstrationCatalogDefinitions,
-} from "./definitions";
-
-const renderers: CatalogRenderers<DemonstrationCatalogDefinitions> = {
-  Metric: ({ props }) => (
-    <div className="flex flex-col">
-      <span className="text-sm opacity-70">{props.label}</span>
-      <strong className="text-2xl">{props.value}</strong>
-      {props.trend && <span>{props.trendValue}</span>}
-    </div>
-  ),
-  DashboardCard: ({ props, children }) => (
-    <div className="rounded-xl border p-5">
-      <h3>{props.title}</h3>
-      {props.subtitle && <p className="opacity-70">{props.subtitle}</p>}
-      {props.child && children(props.child)}
-    </div>
-  ),
-};
-
-export const demonstrationCatalog = createCatalog(
-  demonstrationCatalogDefinitions,
-  renderers,
-  { catalogId: "copilotkit://app-dashboard-catalog" },
-);
-```
-
-### Mount the provider
-
-Register the catalog once, at the root of the React tree:
-
-```tsx title="src/app/layout.tsx"
-"use client";
+{% raw %}
+```tsx
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
 import "@copilotkit/react-core/v2/styles.css";
-import { CopilotKit } from "@copilotkit/react-core/v2";
-import { demonstrationCatalog } from "./catalog/renderers";
+import { myCustomTheme } from "@copilotkit/a2ui-renderer";
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return (
-    <html lang="en">
-      <body>
-        <CopilotKit
-          runtimeUrl="/api/copilotkit"
-          a2ui={{ catalog: demonstrationCatalog }}
-        >
-          {children}
-        </CopilotKit>
-      </body>
-    </html>
-  );
-}
+<CopilotKitProvider runtimeUrl="/api/copilotkit" a2ui={{ theme: myCustomTheme }}>
+  {children}
+</CopilotKitProvider>
 ```
+{% endraw %}
 
-!!! info "A2UI lives on the v2 runtime"
+### Custom components (BYOC)
 
-    The import path is `@copilotkit/react-core/v2`. A2UI surfaces render
-    through the v2 runtime — the classic (v1) runtime does not include the
-    A2UI renderer.
+To extend the built-in A2UI catalog with your own React components, see
+CopilotKit's [Custom Components (BYOC) section](https://docs.copilotkit.ai/adk/generative-ui/a2ui#custom-components-byoc)
+— define Zod schemas, map them to React renderers, and pass the catalog
+through the provider's `a2ui` prop.
 
-## Emitting A2UI from the agent
+## 3. Advanced usage
 
-The agent's job is to stream three kinds of operation, in order:
-
-| Operation         | What it does                                           |
-| ----------------- | ------------------------------------------------------ |
-| `createSurface`   | Opens a new surface bound to a catalog.                |
-| `updateComponents`| Sends (or replaces) the component tree on the surface. |
-| `updateDataModel` | Writes values into the surface's data model.           |
-
-### Minimal v0.9 payload
-
-```json
-{"version": "v0.9", "createSurface": {
-  "surfaceId": "main",
-  "catalogId": "copilotkit://app-dashboard-catalog"
-}}
-
-{"version": "v0.9", "updateComponents": {
-  "surfaceId": "main",
-  "components": [
-    {"id": "card",   "component": "DashboardCard", "title": "Revenue",
-     "subtitle": "This quarter", "child": "metric"},
-    {"id": "metric", "component": "Metric",
-     "label": "MRR", "value": {"path": "/metrics/mrr"},
-     "trend": "up", "trendValue": "+12%"}
-  ]
-}}
-
-{"version": "v0.9", "updateDataModel": {
-  "surfaceId": "main",
-  "path": "/metrics",
-  "value": {"mrr": "$42,500"}
-}}
-```
-
-Each line is a complete A2UI message. Stream them as they are produced — the
-renderer applies updates incrementally.
-
-!!! note "v0.8 vs v0.9"
-
-    These snippets use the [v0.9 draft](../specification/v0.9-a2ui.md) format
-    (`createSurface`, flat component shape, plain JSON data model). If you
-    are pinned to v0.8, swap in `surfaceUpdate` / `beginRendering` and the
-    wrapped-key data model. See the [evolution guide](../specification/v0.9-evolution-guide.md)
-    for a side-by-side diff.
-
-### Where these messages come from
-
-There are two patterns for generating the component tree. They share the
-same frontend catalog.
-
-| Pattern           | Who builds the tree                     | Best for                                                  |
-| ----------------- | --------------------------------------- | --------------------------------------------------------- |
-| **Fixed schema**  | You. Agent provides data only.          | Known layouts (product cards, flight itineraries).        |
-| **Dynamic schema**| A secondary LLM call per turn.          | Open-ended UI that changes with the conversation.         |
-
-**Fixed schema** trades flexibility for determinism — you hand-write
-`updateComponents` once and the agent only fills in `updateDataModel`. Cheaper,
-faster, easier to test.
-
-**Dynamic schema** asks an LLM to author both the tree and the data. More
-expressive, slower, and requires good examples and validation in the agent
-prompt. The restaurant finder samples in this repo use this pattern — see
-[samples/agent/adk/restaurant_finder](https://github.com/google/A2UI/tree/main/samples/agent/adk/restaurant_finder)
-for a full walkthrough.
-
-## Handling user actions
-
-Interactive components (buttons, inputs) emit AG-UI tool events when the user
-interacts. Define the tool on the agent; AG-UI wires the component's `action`
-to a tool call automatically.
-
-```json
-{"id": "book-btn", "component": "Button", "child": "book-label",
- "variant": "primary",
- "action": {"event": {"name": "book_restaurant",
-                      "context": [{"key": "restaurantId",
-                                   "value": {"path": "/selection/id"}}]}}}
-```
-
-When the user clicks, the agent receives a `book_restaurant` tool call with
-`restaurantId` as an argument. Respond by calling back with more
-A2UI operations (e.g. a confirmation surface) or with plain text.
-
-## Bringing your own agent framework
-
-AG-UI is a thin wrapper — any framework that can stream JSON can produce
-A2UI. Integration boils down to two responsibilities:
-
-1. **Emit the three operations** (`createSurface`, `updateComponents`,
-   `updateDataModel`) as AG-UI activity events.
-2. **Handle tool calls** when the user interacts with rendered components.
-
-Community integrations exist for several popular frameworks (LangGraph,
-Mastra, CrewAI, and more) — see the
-[AG-UI documentation](https://docs.ag-ui.com/) for the current list. For a
-custom agent, the AG-UI SDK provides the event types you need; emit A2UI
-operations as `ACTIVITY` events and let CopilotKit's renderer do the rest.
-
-## Troubleshooting
-
-### The surface never appears
-
-- Confirm the catalog is passed to `<CopilotKit a2ui={{ catalog }}>` and that
-  you are importing from `@copilotkit/react-core/v2`.
-- Check the browser devtools network tab for the AG-UI stream. If the stream
-  is open but no `createSurface` arrives, the agent is likely not emitting
-  A2UI messages.
-
-### Components render blank
-
-- Every component referenced in `updateComponents` must exist in the catalog
-  you registered. A missing component is skipped silently — check the browser
-  console for a warning listing the unknown name.
-
-### Data bindings show literal paths (e.g. `/metrics/mrr`)
-
-- The `updateDataModel` call must reach the surface _after_ `updateComponents`.
-  Stream order matters. Re-check the agent's emission order.
+For the full A2UI integration surface (custom catalogs, fine-grained control,
+advanced patterns), see CopilotKit's
+[A2UI docs](https://docs.copilotkit.ai/generative-ui/a2ui).
 
 ## What's next
 
-- **[Catalogs](../concepts/catalogs.md)** — the reference for catalog authoring,
-  component schemas, and custom props.
-- **[Transports](../concepts/transports.md)** — compare AG-UI with A2A and
-  raw HTTP.
-- **[v0.9 specification](../specification/v0.9-a2ui.md)** — the full message
-  shape, including `createSurface`, client-side functions, and extensions.
-- **[CopilotKit A2UI Widget Builder](https://go.copilotkit.ai/A2UI-widget-builder)**
-  — generate A2UI JSON from a visual editor.
+- **[A2UI Composer](https://a2ui-composer.ag-ui.com/)** — build widgets visually.
+- **[Concepts › Transports](../concepts/transports.md)** — how A2UI maps onto AG-UI.
+- **[v0.9 specification](../specification/v0.9-a2ui.md)** — the underlying protocol.

--- a/docs/guides/a2ui-with-any-agent-framework.md
+++ b/docs/guides/a2ui-with-any-agent-framework.md
@@ -1,0 +1,342 @@
+# Use A2UI with Any Agent Framework (Using AG-UI)
+
+A2UI describes _what_ the UI should look like. [AG-UI](https://ag-ui.com/) is a thin,
+framework-neutral transport that moves messages between an agent and a web client.
+Together they let any agent — LangGraph, CrewAI, Mastra, ADK, a custom Python
+service, a Next.js API route — speak A2UI to a React frontend without writing
+transport glue yourself.
+
+This guide walks through the end-to-end picture: where A2UI sits in an AG-UI
+pipeline, how to wire up the catalog on the frontend, how to emit A2UI
+operations from the backend, and two patterns (fixed vs. dynamic schemas) for
+choosing which layouts the agent can produce.
+
+## When to use this
+
+Pick A2UI + AG-UI when you want:
+
+- **One agent, many renderers.** The same A2UI payload can render in React
+  (AG-UI), Lit, Flutter, Angular, or anywhere else A2UI is supported.
+- **Safe generative UI.** The agent can only render components that your
+  frontend has registered in a [catalog](../concepts/catalogs.md). No arbitrary
+  code, no arbitrary markup.
+- **A framework-agnostic agent.** You are not tied to a specific agent SDK.
+  Anything that can emit JSON over the AG-UI event stream can speak A2UI.
+
+If your agent already talks [A2A](../concepts/transports.md#a2a-protocol),
+prefer the [A2A extension](../specification/v0.8-a2a-extension.md). AG-UI is the
+right choice when your frontend is a React app and you want streaming UI
+updates with minimal wiring.
+
+## How A2UI and AG-UI fit together
+
+```
+┌──────────────┐   AG-UI events    ┌─────────────────┐   A2UI ops    ┌────────────┐
+│  Your Agent  │ ────────────────> │  AG-UI runtime  │ ────────────> │  Catalog   │
+│ (any fwk.)   │                   │ (Next.js route) │               │ renderers  │
+└──────────────┘ <──────────────── └─────────────────┘ <──────────── └────────────┘
+       ▲           tool events /          ▲      │                     (your
+       │           actions                │      │                      React
+       │                                  │      ▼                      comps)
+       │                            ┌─────────────────┐
+       └───── user input ────────── │  React client   │
+                                    │  (CopilotKit)   │
+                                    └─────────────────┘
+```
+
+Roles:
+
+- **Agent.** Produces A2UI operations (`createSurface`, `updateComponents`,
+  `updateDataModel`). The operations are just JSON — the agent framework is
+  an implementation detail.
+- **AG-UI runtime.** Bridges the agent and the browser. A2UI operations ride on
+  the AG-UI event stream as activity messages; AG-UI handles reconnection,
+  backpressure, and state sync.
+- **Catalog + renderers.** A typed registry on the frontend mapping component
+  names (e.g. `DashboardCard`) to the React components that render them. The
+  agent can only render components the catalog declares.
+
+The key invariant: **the agent never ships React, HTML, or CSS**. It ships A2UI
+operations naming components your app already trusts.
+
+## Quickstart (CopilotKit)
+
+The fastest path today is CopilotKit's AG-UI implementation. This takes you
+from zero to a running A2UI surface in two commands.
+
+### 1. Scaffold the starter
+
+```bash
+npx copilotkit@latest create my-app --framework a2ui
+cd my-app
+```
+
+The `a2ui` framework scaffolds a Next.js app paired with an agent backend,
+preconfigured with an A2UI catalog and the AG-UI middleware. `-f a2ui` works
+as a shorthand.
+
+### 2. Install and run
+
+```bash
+pnpm install
+cp .env.example .env   # add your model provider API key
+pnpm dev
+```
+
+`pnpm dev` starts the Next.js UI and the agent concurrently. Open
+<http://localhost:3000> and send a message — the agent responds with an A2UI
+surface rendered from your catalog.
+
+!!! tip "Try it without installing anything"
+
+    CopilotKit also hosts a public [A2UI Widget Builder](https://go.copilotkit.ai/A2UI-widget-builder)
+    and the [A2UI Composer](https://a2ui-composer.ag-ui.com/) — both let you
+    generate A2UI JSON visually and paste it into any agent prompt.
+
+## Register a catalog on the frontend
+
+The catalog is the contract between your agent and your UI. It has two files:
+
+- **Definitions** — Zod schemas plus a natural-language description. This is
+  what the agent sees.
+- **Renderers** — React components, type-checked against the schemas. This is
+  what the user sees.
+
+### Definitions
+
+```ts title="src/app/catalog/definitions.ts"
+import { z } from "zod";
+
+export const demonstrationCatalogDefinitions = {
+  Metric: {
+    description:
+      "A key metric display with label, value, and optional trend indicator. Great for KPIs and stats.",
+    props: z.object({
+      label: z.string(),
+      value: z.string(),
+      trend: z.enum(["up", "down", "neutral"]).optional(),
+      trendValue: z.string().optional(),
+    }),
+  },
+  DashboardCard: {
+    description:
+      "A card container with title and optional subtitle. Has a 'child' slot for content.",
+    props: z.object({
+      title: z.string(),
+      subtitle: z.string().optional(),
+      child: z.string().optional(),
+    }),
+  },
+};
+
+export type DemonstrationCatalogDefinitions =
+  typeof demonstrationCatalogDefinitions;
+```
+
+The `description` field matters — it is injected into the agent's system prompt
+so the LLM knows when to reach for each component.
+
+### Renderers
+
+```tsx title="src/app/catalog/renderers.tsx"
+"use client";
+import {
+  createCatalog,
+  type CatalogRenderers,
+} from "@copilotkit/a2ui-renderer";
+import {
+  demonstrationCatalogDefinitions,
+  type DemonstrationCatalogDefinitions,
+} from "./definitions";
+
+const renderers: CatalogRenderers<DemonstrationCatalogDefinitions> = {
+  Metric: ({ props }) => (
+    <div className="flex flex-col">
+      <span className="text-sm opacity-70">{props.label}</span>
+      <strong className="text-2xl">{props.value}</strong>
+      {props.trend && <span>{props.trendValue}</span>}
+    </div>
+  ),
+  DashboardCard: ({ props, children }) => (
+    <div className="rounded-xl border p-5">
+      <h3>{props.title}</h3>
+      {props.subtitle && <p className="opacity-70">{props.subtitle}</p>}
+      {props.child && children(props.child)}
+    </div>
+  ),
+};
+
+export const demonstrationCatalog = createCatalog(
+  demonstrationCatalogDefinitions,
+  renderers,
+  { catalogId: "copilotkit://app-dashboard-catalog" },
+);
+```
+
+### Mount the provider
+
+Register the catalog once, at the root of the React tree:
+
+```tsx title="src/app/layout.tsx"
+"use client";
+import "@copilotkit/react-core/v2/styles.css";
+import { CopilotKit } from "@copilotkit/react-core/v2";
+import { demonstrationCatalog } from "./catalog/renderers";
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <CopilotKit
+          runtimeUrl="/api/copilotkit"
+          a2ui={{ catalog: demonstrationCatalog }}
+        >
+          {children}
+        </CopilotKit>
+      </body>
+    </html>
+  );
+}
+```
+
+!!! info "A2UI lives on the v2 runtime"
+
+    The import path is `@copilotkit/react-core/v2`. A2UI surfaces render
+    through the v2 runtime — the classic (v1) runtime does not include the
+    A2UI renderer.
+
+## Emitting A2UI from the agent
+
+The agent's job is to stream three kinds of operation, in order:
+
+| Operation         | What it does                                           |
+| ----------------- | ------------------------------------------------------ |
+| `createSurface`   | Opens a new surface bound to a catalog.                |
+| `updateComponents`| Sends (or replaces) the component tree on the surface. |
+| `updateDataModel` | Writes values into the surface's data model.           |
+
+### Minimal v0.9 payload
+
+```json
+{"version": "v0.9", "createSurface": {
+  "surfaceId": "main",
+  "catalogId": "copilotkit://app-dashboard-catalog"
+}}
+
+{"version": "v0.9", "updateComponents": {
+  "surfaceId": "main",
+  "components": [
+    {"id": "card",   "component": "DashboardCard", "title": "Revenue",
+     "subtitle": "This quarter", "child": "metric"},
+    {"id": "metric", "component": "Metric",
+     "label": "MRR", "value": {"path": "/metrics/mrr"},
+     "trend": "up", "trendValue": "+12%"}
+  ]
+}}
+
+{"version": "v0.9", "updateDataModel": {
+  "surfaceId": "main",
+  "path": "/metrics",
+  "value": {"mrr": "$42,500"}
+}}
+```
+
+Each line is a complete A2UI message. Stream them as they are produced — the
+renderer applies updates incrementally.
+
+!!! note "v0.8 vs v0.9"
+
+    These snippets use the [v0.9 draft](../specification/v0.9-a2ui.md) format
+    (`createSurface`, flat component shape, plain JSON data model). If you
+    are pinned to v0.8, swap in `surfaceUpdate` / `beginRendering` and the
+    wrapped-key data model. See the [evolution guide](../specification/v0.9-evolution-guide.md)
+    for a side-by-side diff.
+
+### Where these messages come from
+
+There are two patterns for generating the component tree. They share the
+same frontend catalog.
+
+| Pattern           | Who builds the tree                     | Best for                                                  |
+| ----------------- | --------------------------------------- | --------------------------------------------------------- |
+| **Fixed schema**  | You. Agent provides data only.          | Known layouts (product cards, flight itineraries).        |
+| **Dynamic schema**| A secondary LLM call per turn.          | Open-ended UI that changes with the conversation.         |
+
+**Fixed schema** trades flexibility for determinism — you hand-write
+`updateComponents` once and the agent only fills in `updateDataModel`. Cheaper,
+faster, easier to test.
+
+**Dynamic schema** asks an LLM to author both the tree and the data. More
+expressive, slower, and requires good examples and validation in the agent
+prompt. The restaurant finder samples in this repo use this pattern — see
+[samples/agent/adk/restaurant_finder](https://github.com/google/A2UI/tree/main/samples/agent/adk/restaurant_finder)
+for a full walkthrough.
+
+## Handling user actions
+
+Interactive components (buttons, inputs) emit AG-UI tool events when the user
+interacts. Define the tool on the agent; AG-UI wires the component's `action`
+to a tool call automatically.
+
+```json
+{"id": "book-btn", "component": "Button", "child": "book-label",
+ "variant": "primary",
+ "action": {"event": {"name": "book_restaurant",
+                      "context": [{"key": "restaurantId",
+                                   "value": {"path": "/selection/id"}}]}}}
+```
+
+When the user clicks, the agent receives a `book_restaurant` tool call with
+`restaurantId` as an argument. Respond by calling back with more
+A2UI operations (e.g. a confirmation surface) or with plain text.
+
+## Bringing your own agent framework
+
+AG-UI is a thin wrapper — any framework that can stream JSON can produce
+A2UI. Integration boils down to two responsibilities:
+
+1. **Emit the three operations** (`createSurface`, `updateComponents`,
+   `updateDataModel`) as AG-UI activity events.
+2. **Handle tool calls** when the user interacts with rendered components.
+
+Community integrations exist for several popular frameworks (LangGraph,
+Mastra, CrewAI, and more) — see the
+[AG-UI documentation](https://docs.ag-ui.com/) for the current list. For a
+custom agent, the AG-UI SDK provides the event types you need; emit A2UI
+operations as `ACTIVITY` events and let CopilotKit's renderer do the rest.
+
+## Troubleshooting
+
+### The surface never appears
+
+- Confirm the catalog is passed to `<CopilotKit a2ui={{ catalog }}>` and that
+  you are importing from `@copilotkit/react-core/v2`.
+- Check the browser devtools network tab for the AG-UI stream. If the stream
+  is open but no `createSurface` arrives, the agent is likely not emitting
+  A2UI messages.
+
+### Components render blank
+
+- Every component referenced in `updateComponents` must exist in the catalog
+  you registered. A missing component is skipped silently — check the browser
+  console for a warning listing the unknown name.
+
+### Data bindings show literal paths (e.g. `/metrics/mrr`)
+
+- The `updateDataModel` call must reach the surface _after_ `updateComponents`.
+  Stream order matters. Re-check the agent's emission order.
+
+## What's next
+
+- **[Catalogs](../concepts/catalogs.md)** — the reference for catalog authoring,
+  component schemas, and custom props.
+- **[Transports](../concepts/transports.md)** — compare AG-UI with A2A and
+  raw HTTP.
+- **[v0.9 specification](../specification/v0.9-a2ui.md)** — the full message
+  shape, including `createSurface`, client-side functions, and extensions.
+- **[CopilotKit A2UI Widget Builder](https://go.copilotkit.ai/A2UI-widget-builder)**
+  — generate A2UI JSON from a visual editor.

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,11 +72,11 @@ This repository contains:
 
 <div class="grid cards" markdown>
 
-- :material-clock-fast:{ .lg .middle } **[Restaurant Finder Demo](quickstart.md)**
+- :material-clock-fast:{ .lg .middle } **[Quickstart Restaurant Finder Demo](quickstart.md)**
 
     ---
 
-    Run the full-stack demo locally with a Gemini agent and Lit renderer. Best for learning the protocol end-to-end.
+    Run the full-stack demo locally with a Gemini powered ADK agent and Lit renderer. Learn A2UI end-to-end and customize to your use case.
 
     [:octicons-arrow-right-24: Run the demo](quickstart.md)
 
@@ -84,7 +84,7 @@ This repository contains:
 
     ---
 
-    Scaffold a Next.js app wired to any agent framework via AG-UI. Best for shipping A2UI in a React application.
+    Scaffold a Next.js app wired to any agent framework via AG-UI. This is a React + A2UI app, ready to ship.
 
     [:octicons-arrow-right-24: Use with any agent](guides/a2ui-with-any-agent-framework.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,6 +96,14 @@ This repository contains:
 
     [:octicons-arrow-right-24: Open the composer](https://a2ui-composer.ag-ui.com/)
 
+- :material-play-circle-outline:{ .lg .middle } **[A2UI Theater](https://a2ui-composer.ag-ui.com/theater)**
+
+    ---
+
+    Step through pre-built A2UI streaming scenarios across Lit, React, and Angular renderers. See the protocol in motion before writing code.
+
+    [:octicons-arrow-right-24: Open the playground](https://a2ui-composer.ag-ui.com/theater)
+
 - :material-book-open-variant:{ .lg .middle } **[Core Concepts](concepts/overview.md)**
 
     ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,13 +72,29 @@ This repository contains:
 
 <div class="grid cards" markdown>
 
-- :material-clock-fast:{ .lg .middle } **[Quickstart Guide](quickstart.md)**
+- :material-clock-fast:{ .lg .middle } **[Restaurant Finder Demo](quickstart.md)**
 
     ---
 
-    Run the restaurant finder demo and see A2UI in action with Gemini-powered agents.
+    Run the full-stack demo locally with a Gemini agent and Lit renderer. Best for learning the protocol end-to-end.
 
-    [:octicons-arrow-right-24: Get started](quickstart.md)
+    [:octicons-arrow-right-24: Run the demo](quickstart.md)
+
+- :material-react:{ .lg .middle } **[A2UI + AG-UI (React)](guides/a2ui-with-any-agent-framework.md)**
+
+    ---
+
+    Scaffold a Next.js app wired to any agent framework via AG-UI. Best for shipping A2UI in a React application.
+
+    [:octicons-arrow-right-24: Use with any agent](guides/a2ui-with-any-agent-framework.md)
+
+- :material-palette-outline:{ .lg .middle } **[A2UI Composer](https://a2ui-composer.ag-ui.com/)**
+
+    ---
+
+    Generate A2UI JSON from a visual editor — no install required. Paste the output into any agent prompt.
+
+    [:octicons-arrow-right-24: Open the composer](https://a2ui-composer.ag-ui.com/)
 
 - :material-book-open-variant:{ .lg .middle } **[Core Concepts](concepts/overview.md)**
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -51,6 +51,7 @@ nav:
   - Guides:
       - Client Setup: guides/client-setup.md
       - Agent Development: guides/agent-development.md
+      - Use A2UI with Any Agent Framework (AG-UI): guides/a2ui-with-any-agent-framework.md
       - Renderer Development: guides/renderer-development.md
       - Defining Your Own Catalog: guides/defining-your-own-catalog.md
       - Authoring Custom Components: guides/authoring-components.md


### PR DESCRIPTION
## Summary

- Surface two onboarding paths (Restaurant Finder demo and A2UI + AG-UI via CopilotKit) plus the A2UI Composer in `README.md` and `docs/index.md`, so new users can pick the entry point that matches their stack.
- Add `docs/guides/a2ui-with-any-agent-framework.md` — a short guide titled **"Use A2UI with Any Agent Framework (Using AG-UI)"** that defers to CopilotKit's docs as the source of truth.
- Wire the new guide into `mkdocs.yaml` under Guides, and replace the `TODO: Add a detailed guide` placeholder under the AG UI section of `docs/concepts/transports.md` with a link to the new page.

## Guide shape

Per review feedback from [@ataibarkai](https://github.com/ataibarkai), the guide is intentionally thin — it points to CopilotKit's docs rather than duplicating A2UI / CopilotKit content that already lives elsewhere:

1. **Set up CopilotKit** with the framework of your choice via `npx copilotkit@latest init` (generic CopilotKit setup, not an A2UI-specific starter). Links to <https://docs.copilotkit.ai/quickstart>.
2. **Enable A2UI** — mirrors the Backend / Frontend / BYOC snippets from <https://docs.copilotkit.ai/adk/generative-ui/a2ui>.
3. **Advanced usage** — links to <https://docs.copilotkit.ai/generative-ui/a2ui>.

No protocol explanations (the existing Concepts pages cover that), no fixed-schema framing.

## Test plan

- [ ] Run `mkdocs serve` locally and walk the new nav entry under Guides → **Use A2UI with Any Agent Framework (AG-UI)**.
- [ ] Click through the "Get Started in 5 Minutes" cards on the docs home page — all three should resolve (Restaurant Finder, AG-UI guide, A2UI Composer).
- [ ] Verify the README's "Pick the path" table renders correctly on GitHub and the TL;DR shows `npx copilotkit@latest init` (no `--framework a2ui`).
- [ ] Verify the `transports.md` AG UI section now links to the new guide (no dangling TODO).

No code changes; docs-only.