### PR TITLE
docs: clarify createSurface is an error for existing surfaces

### DIFF
--- a/specification/v0_10/docs/a2ui_protocol.md
+++ b/specification/v0_10/docs/a2ui_protocol.md
@@ -173,7 +173,7 @@ The envelope defines several message types, and every message streamed by the se
 
 ### `createSurface`
 
-This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated. One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
+This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated. It is an error to send `createSurface` for a `surfaceId` that already exists without first deleting it. One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 
 **Properties:**
 

--- a/specification/v0_10/json/server_to_client.json
+++ b/specification/v0_10/json/server_to_client.json
@@ -21,7 +21,7 @@
         },
         "createSurface": {
           "type": "object",
-          "description": "Signals the client to create a new surface and begin rendering it. When this message is sent, the client will expect 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId that define the component tree.",
+          "description": "Signals the client to create a new surface and begin rendering it. It is an error to send createSurface for a surfaceId that already exists. When this message is sent, the client will expect 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId that define the component tree.",
           "properties": {
             "surfaceId": {
               "type": "string",

--- a/specification/v0_10/json/server_to_client.json
+++ b/specification/v0_10/json/server_to_client.json
@@ -21,7 +21,7 @@
         },
         "createSurface": {
           "type": "object",
-          "description": "Signals the client to create a new surface and begin rendering it. It is an error to send createSurface for a surfaceId that already exists. When this message is sent, the client will expect 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId that define the component tree.",
+          "description": "Signals the client to create a new surface and begin rendering it. It is an error to send 'createSurface' for a surfaceId that already exists without first deleting it. When this message is sent, the client will expect 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId that define the component tree.",
           "properties": {
             "surfaceId": {
               "type": "string",

--- a/specification/v0_9/docs/a2ui_protocol.md
+++ b/specification/v0_9/docs/a2ui_protocol.md
@@ -176,7 +176,7 @@ The envelope defines four primary message types, and every message streamed by t
 
 ### `createSurface`
 
-This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated. One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
+This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated. It is an error to send `createSurface` for a `surfaceId` that already exists without first deleting it. One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 
 **Properties:**
 

--- a/specification/v0_9/docs/renderer_guide.md
+++ b/specification/v0_9/docs/renderer_guide.md
@@ -318,7 +318,7 @@ When a surface is created with `sendDataModel: true`, the client is responsible 
 3.  The **Transport Layer** (e.g., A2A, MCP) calls `getClientDataModel()` before sending any message to the server.
 4.  If a non-empty data model map is returned, it is included in the transport's metadata field (e.g., `a2uiClientDataModel` in A2A metadata).
 
-*   **Surface Lifecycle**: It is an error to receive a `createSurface` message for a `surfaceId` that is already active. The processor SHOULD throw an error or report a validation failure if this occurs.
+*   **Surface Lifecycle**: It is an error to receive a `createSurface` message for a `surfaceId` that is already active. The processor MUST throw an error or report a validation failure if this occurs.
 *   **Component Lifecycle**: If an `updateComponents` message provides an existing `id` but a *different* `type`, the processor MUST remove the old component and create a fresh one to ensure framework renderers correctly reset their internal state.
 
 #### Generating Client Capabilities and Schema Types

--- a/specification/v0_9/docs/renderer_guide.md
+++ b/specification/v0_9/docs/renderer_guide.md
@@ -318,6 +318,7 @@ When a surface is created with `sendDataModel: true`, the client is responsible 
 3.  The **Transport Layer** (e.g., A2A, MCP) calls `getClientDataModel()` before sending any message to the server.
 4.  If a non-empty data model map is returned, it is included in the transport's metadata field (e.g., `a2uiClientDataModel` in A2A metadata).
 
+*   **Surface Lifecycle**: It is an error to receive a `createSurface` message for a `surfaceId` that is already active. The processor SHOULD throw an error or report a validation failure if this occurs.
 *   **Component Lifecycle**: If an `updateComponents` message provides an existing `id` but a *different* `type`, the processor MUST remove the old component and create a fresh one to ensure framework renderers correctly reset their internal state.
 
 #### Generating Client Capabilities and Schema Types

--- a/specification/v0_9/json/server_to_client.json
+++ b/specification/v0_9/json/server_to_client.json
@@ -19,7 +19,7 @@
         },
         "createSurface": {
           "type": "object",
-          "description": "Signals the client to create a new surface and begin rendering it. It is an error to send createSurface for a surfaceId that already exists. When this message is sent, the client will expect 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId that define the component tree.",
+          "description": "Signals the client to create a new surface and begin rendering it. It is an error to send 'createSurface' for a surfaceId that already exists without first deleting it. When this message is sent, the client will expect 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId that define the component tree.",
           "properties": {
             "surfaceId": {
               "type": "string",

--- a/specification/v0_9/json/server_to_client.json
+++ b/specification/v0_9/json/server_to_client.json
@@ -19,7 +19,7 @@
         },
         "createSurface": {
           "type": "object",
-          "description": "Signals the client to create a new surface and begin rendering it. When this message is sent, the client will expect 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId that define the component tree.",
+          "description": "Signals the client to create a new surface and begin rendering it. It is an error to send createSurface for a surfaceId that already exists. When this message is sent, the client will expect 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId that define the component tree.",
           "properties": {
             "surfaceId": {
               "type": "string",


### PR DESCRIPTION
## Description of Changes
- Updated `specification/v0_9/docs/a2ui_protocol.md` and `specification/v0_10/docs/a2ui_protocol.md` to state that sending `createSurface` for an existing `surfaceId` is an error.
- Updated `specification/v0_9/json/server_to_client.json` and `specification/v0_10/json/server_to_client.json` schemas with the same clarification in the `createSurface` description.
- Added a "Surface Lifecycle" note to `specification/v0_9/docs/renderer_guide.md` advising renderer implementations to handle duplicate `createSurface` messages as errors.

## Rationale
The A2UI specification intended for `createSurface` to be a one-time initialization per surface. Re-creating a surface without deleting it first leads to ambiguous state in renderers. This change codifies that behavior as an error to ensure protocol consistency across different agent and renderer implementations.

## Testing/Running Instructions
Review the updated documentation and JSON schema files to ensure the language is clear and consistent with existing protocol documentation.
- `specification/v0_9/docs/a2ui_protocol.md`
- `specification/v0_10/docs/a2ui_protocol.md`
- `specification/v0_9/json/server_to_client.json`
- `specification/v0_10/json/server_to_client.json`
- `specification/v0_9/docs/renderer_guide.md`