### PR TITLE
fix: Add the missing "obscured" enum type in the v0_8 common types zod

### DIFF
--- a/renderers/web_core/src/v0_8/schema/common-types.ts
+++ b/renderers/web_core/src/v0_8/schema/common-types.ts
@@ -304,7 +304,7 @@ export const CheckboxSchema = z.object({
 export const TextFieldSchema = z.object({
   text: StringValueSchema.optional(),
   label: StringValueSchema.describe("A label, title, or placeholder text."),
-  textFieldType: z.enum(["shortText", "number", "date", "longText"]).optional(),
+  textFieldType: z.enum(["shortText", "number", "date", "longText", "obscured"]).optional(),
   validationRegexp: z
     .string()
     .optional()


### PR DESCRIPTION
interface.

# Description

The "obscured" enum type was missing resulting in A2UI response that included the enum type to throw a run time exception on the renderer execution.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
