### PR TITLE
Ignore .angular/ directory in root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 .idx
 .idea/
 *.pyc
+.angular/
 
 # MkDocs build output
 site/


### PR DESCRIPTION
This PR adds .angular/ to the root .gitignore file to ignore build artifacts from Angular apps.