### PR TITLE
[Angular] Remove Types namespace from v0.8 renderer.

### DIFF
--- a/renderers/angular/.gitignore
+++ b/renderers/angular/.gitignore
@@ -1,1 +1,3 @@
+.angular
+.npm-cache
 a2ui_explorer/src/app/generated

--- a/renderers/angular/package-lock.json
+++ b/renderers/angular/package-lock.json
@@ -596,7 +596,6 @@
       "integrity": "sha512-QloEsknGqLvmr+ED7QShDt7SoMY9mipV+gVnwn4hBI5sbl+TOBfYWXIaJMnxseFwSqjXTSCVGckfylIlynNcFg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -609,7 +608,6 @@
       "integrity": "sha512-Ox3vz6KAM7i47ujR/3M3NCOeCRn6vrC9yV1SHZRhSrYg6CWWcOMveavEEwtNjYtn3hOzrktO4CnuVwtDbU8pLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.29.0",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -641,7 +639,6 @@
       "version": "21.2.5",
       "integrity": "sha512-JgHU134Adb1wrpyGC9ozcv3hiRAgaFTvJFn1u9OU/AVXyxu4meMmVh2hp5QhAvPnv8XQdKWWIkAY+dbpPE6zKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -762,7 +759,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1106,7 +1102,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1153,7 +1148,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1922,7 +1916,6 @@
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
         "@inquirer/confirm": "^5.1.21",
@@ -4084,7 +4077,6 @@
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4796,7 +4788,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5060,7 +5051,6 @@
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -6190,7 +6180,6 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -7254,7 +7243,6 @@
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7864,8 +7852,7 @@
       "version": "5.9.0",
       "integrity": "sha512-OMUvF1iI6+gSRYOhMrH4QYothVLN9C3EJ6wm4g7zLJlnaTl8zbaPOr0bTw70l7QxkoM7sVFOWo83u9B2Fe2Zng==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jose": {
       "version": "6.2.2",
@@ -8103,7 +8090,6 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -8437,7 +8423,6 @@
       "integrity": "sha512-OJmO5+HxZLLw0RLzkqaNHzcgEAQG7C0y3aMbwtCzIUFZsLMNNq/1IdAdHEycQ58CwUO3jPTHmoN+tE5I7FQxNg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^3.0.5",
         "parse-node-version": "^1.0.1"
@@ -8520,7 +8505,6 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -9257,7 +9241,6 @@
       "integrity": "sha512-rk0aL0wWkC+FTA4wyzJIfjcUgAKMAEB19ULvP0QkAoAkzjS+3SBEf0n3MS6z7gcOW8SRU9rw1BmsouEAXD+SCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@rollup/plugin-json": "^6.1.0",
@@ -10132,7 +10115,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10460,7 +10442,6 @@
       "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10551,7 +10532,6 @@
       "version": "7.8.2",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -11497,8 +11477,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tuf-js": {
       "version": "4.1.0",
@@ -11585,7 +11564,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11747,7 +11725,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11822,7 +11799,6 @@
       "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.1",
         "@vitest/mocker": "4.1.1",
@@ -12187,7 +12163,6 @@
       "version": "3.25.76",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/renderers/angular/src/v0_8/components/audio.spec.ts
+++ b/renderers/angular/src/v0_8/components/audio.spec.ts
@@ -16,7 +16,7 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AudioPlayer } from './audio';
-import { Types } from '../types';
+import type { AudioPlayerNode } from '../types';
 import { Theme } from '../rendering/theming';
 import { ChangeDetectionStrategy } from '@angular/core';
 import { MessageProcessor } from '../data/processor';
@@ -28,7 +28,7 @@ describe('AudioPlayer Component', () => {
   let mockTheme: Theme;
   let mockProcessor: jasmine.SpyObj<MessageProcessor>;
 
-  const mockAudioNode: Types.AudioPlayerNode = {
+  const mockAudioNode: AudioPlayerNode = {
     id: 'audio-1',
     type: 'AudioPlayer',
     weight: 1,

--- a/renderers/angular/src/v0_8/components/audio.ts
+++ b/renderers/angular/src/v0_8/components/audio.ts
@@ -16,7 +16,7 @@
 
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { DynamicComponent } from '../rendering/dynamic-component';
-import { Types } from '../types';
+import type { AudioPlayerNode, StringValue } from '../types';
 
 @Component({
   selector: 'a2ui-audio',
@@ -33,7 +33,7 @@ import { Types } from '../types';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AudioPlayer extends DynamicComponent<Types.AudioPlayerNode> {
-  readonly url = input.required<Types.StringValue | null>();
+export class AudioPlayer extends DynamicComponent<AudioPlayerNode> {
+  readonly url = input.required<StringValue | null>();
   protected readonly resolvedUrl = computed(() => this.resolvePrimitive(this.url()));
 }

--- a/renderers/angular/src/v0_8/components/button.spec.ts
+++ b/renderers/angular/src/v0_8/components/button.spec.ts
@@ -20,7 +20,7 @@ import { MessageProcessor } from '../data/processor';
 import { Theme } from '../rendering/theming';
 import { Catalog } from '../rendering/catalog';
 import { Renderer } from '../rendering/renderer';
-import { Types } from '../types';
+import type { Action, ButtonNode, A2UIClientEventMessage } from '../types';
 import { Directive, Input } from '@angular/core';
 
 // Mock Renderer directive to avoid full tree rendering issues for isolated unit tests
@@ -39,12 +39,12 @@ describe('Button Component', () => {
   let mockProcessor: jasmine.SpyObj<MessageProcessor>;
   let mockTheme: Theme;
 
-  const mockAction: Types.Action = {
+  const mockAction: Action = {
     name: 'testAction',
     context: [],
   };
 
-  const mockButtonNode: Types.ButtonNode = {
+  const mockButtonNode: ButtonNode = {
     id: 'btn-1',
     type: 'Button',
     weight: 1,
@@ -109,8 +109,7 @@ describe('Button Component', () => {
     buttonEl.click();
 
     expect(mockProcessor.dispatch).toHaveBeenCalled();
-    const message = mockProcessor.dispatch.calls.mostRecent()
-      .args[0] as Types.A2UIClientEventMessage;
+    const message = mockProcessor.dispatch.calls.mostRecent().args[0] as A2UIClientEventMessage;
     expect(message.userAction!.name).toBe('testAction');
     expect(message.userAction!.sourceComponentId).toBe('btn-1');
   });

--- a/renderers/angular/src/v0_8/components/button.ts
+++ b/renderers/angular/src/v0_8/components/button.ts
@@ -15,7 +15,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
-import { Types } from '../types';
+import type { ButtonNode, Action, AnyComponentNode } from '../types';
 import { DynamicComponent } from '../rendering/dynamic-component';
 import { Renderer } from '../rendering/renderer';
 
@@ -46,9 +46,9 @@ import { Renderer } from '../rendering/renderer';
     }
   `,
 })
-export class Button extends DynamicComponent<Types.ButtonNode> {
-  readonly action = input<Types.Action | null>(null);
-  readonly child = input<Types.AnyComponentNode | null>(null);
+export class Button extends DynamicComponent<ButtonNode> {
+  readonly action = input<Action | null>(null);
+  readonly child = input<AnyComponentNode | null>(null);
   // This is currently not handled by the template.
   readonly primary = input<boolean | null>(false);
 

--- a/renderers/angular/src/v0_8/components/card.spec.ts
+++ b/renderers/angular/src/v0_8/components/card.spec.ts
@@ -19,7 +19,7 @@ import { Card } from './card';
 import { MessageProcessor } from '../data/processor';
 import { Theme } from '../rendering/theming';
 import { Catalog } from '../rendering/catalog';
-import { Types } from '../types';
+import type { CardNode } from '../types';
 import { Directive, Input, ChangeDetectionStrategy } from '@angular/core';
 
 @Directive({
@@ -41,7 +41,7 @@ describe('Card Component', () => {
   let fixture: ComponentFixture<Card>;
   let mockTheme: Theme;
 
-  const mockNode: Types.CardNode = {
+  const mockNode: CardNode = {
     id: 'card-1',
     type: 'Card',
     weight: 1,

--- a/renderers/angular/src/v0_8/components/card.ts
+++ b/renderers/angular/src/v0_8/components/card.ts
@@ -17,7 +17,7 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { DynamicComponent } from '../rendering/dynamic-component';
 import { Renderer } from '../rendering/renderer';
-import { Types } from '../types';
+import type { AnyComponentNode, CardNode } from '../types';
 
 @Component({
   selector: 'a2ui-card',
@@ -40,7 +40,7 @@ import { Types } from '../types';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class Card extends DynamicComponent<Types.CardNode> {
-  readonly child = input<Types.AnyComponentNode | null>(null);
-  readonly children = input<Types.AnyComponentNode[]>([]);
+export class Card extends DynamicComponent<CardNode> {
+  readonly child = input<AnyComponentNode | null>(null);
+  readonly children = input<AnyComponentNode[]>([]);
 }

--- a/renderers/angular/src/v0_8/components/checkbox.spec.ts
+++ b/renderers/angular/src/v0_8/components/checkbox.spec.ts
@@ -18,14 +18,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Checkbox } from './checkbox';
 import { MessageProcessor } from '../data/processor';
 import { Theme } from '../rendering/theming';
-import { Types } from '../types';
+import type { A2UIClientEventMessage, CheckboxNode } from '../types';
 
 describe('Checkbox Component', () => {
   let component: Checkbox;
   let fixture: ComponentFixture<Checkbox>;
   let mockProcessor: jasmine.SpyObj<MessageProcessor>;
 
-  const mockNode: Types.CheckboxNode = {
+  const mockNode: CheckboxNode = {
     id: 'chk-1',
     type: 'CheckBox',
     weight: 1,
@@ -87,8 +87,7 @@ describe('Checkbox Component', () => {
     inputEl.dispatchEvent(new Event('change'));
 
     expect(mockProcessor.dispatch).toHaveBeenCalled();
-    const message = mockProcessor.dispatch.calls.mostRecent()
-      .args[0] as Types.A2UIClientEventMessage;
+    const message = mockProcessor.dispatch.calls.mostRecent().args[0] as A2UIClientEventMessage;
     expect(message.userAction!.name).toBe('toggle');
     expect(message.userAction!.context!['checked']).toBeTrue();
   });

--- a/renderers/angular/src/v0_8/components/checkbox.ts
+++ b/renderers/angular/src/v0_8/components/checkbox.ts
@@ -16,7 +16,7 @@
 
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { DynamicComponent } from '../rendering/dynamic-component';
-import { Types } from '../types';
+import type { BooleanValue, CheckboxNode, StringValue } from '../types';
 
 @Component({
   selector: 'a2ui-checkbox',
@@ -40,9 +40,9 @@ import { Types } from '../types';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class Checkbox extends DynamicComponent<Types.CheckboxNode> {
-  readonly label = input.required<Types.StringValue | null>();
-  readonly checked = input.required<Types.BooleanValue | null>();
+export class Checkbox extends DynamicComponent<CheckboxNode> {
+  readonly label = input.required<StringValue | null>();
+  readonly checked = input.required<BooleanValue | null>();
 
   protected inputChecked = computed(() => super.resolvePrimitive(this.checked()) ?? false);
   protected resolvedLabel = computed(() => super.resolvePrimitive(this.label()));
@@ -51,15 +51,25 @@ export class Checkbox extends DynamicComponent<Types.CheckboxNode> {
   onToggle(event: Event) {
     const checked = (event.target as HTMLInputElement).checked;
     const checkedNode = this.checked();
-    if (checkedNode && typeof checkedNode === 'object' && 'path' in checkedNode && checkedNode.path) {
+    if (
+      checkedNode &&
+      typeof checkedNode === 'object' &&
+      'path' in checkedNode &&
+      checkedNode.path
+    ) {
       // Update the local data model directly to ensure immediate UI feedback and avoid unnecessary network requests.
-      this.processor.processMessages([{
-        dataModelUpdate: {
-          surfaceId: this.surfaceId()!,
-          path: this.processor.resolvePath(checkedNode.path as string, this.component().dataContextPath),
-          contents: [{ key: '.', valueBoolean: checked }],
+      this.processor.processMessages([
+        {
+          dataModelUpdate: {
+            surfaceId: this.surfaceId()!,
+            path: this.processor.resolvePath(
+              checkedNode.path as string,
+              this.component().dataContextPath,
+            ),
+            contents: [{ key: '.', valueBoolean: checked }],
+          },
         },
-      }]);
+      ]);
     } else {
       this.sendAction({
         name: 'toggle',

--- a/renderers/angular/src/v0_8/components/column.spec.ts
+++ b/renderers/angular/src/v0_8/components/column.spec.ts
@@ -19,7 +19,7 @@ import { Column } from './column';
 import { MessageProcessor } from '../data/processor';
 import { Theme } from '../rendering/theming';
 import { Catalog } from '../rendering/catalog';
-import { Types } from '../types';
+import type { ColumnNode } from '../types';
 import { Directive, Input, ChangeDetectionStrategy } from '@angular/core';
 
 @Directive({
@@ -41,7 +41,7 @@ describe('Column Component', () => {
   let fixture: ComponentFixture<Column>;
   let mockTheme: Theme;
 
-  const mockNode: Types.ColumnNode = {
+  const mockNode: ColumnNode = {
     id: 'col-1',
     type: 'Column',
     weight: 1,

--- a/renderers/angular/src/v0_8/components/column.ts
+++ b/renderers/angular/src/v0_8/components/column.ts
@@ -15,7 +15,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
-import { Types } from '../types';
+import type { AnyComponentNode, ColumnNode, ResolvedColumn } from '../types';
 import { DynamicComponent } from '../rendering/dynamic-component';
 import { Renderer } from '../rendering/renderer';
 
@@ -87,10 +87,10 @@ import { Renderer } from '../rendering/renderer';
     </section>
   `,
 })
-export class Column extends DynamicComponent<Types.ColumnNode> {
-  readonly alignment = input<Types.ResolvedColumn['alignment']>('stretch');
-  readonly distribution = input<Types.ResolvedColumn['distribution']>('start');
-  readonly children = input<Types.AnyComponentNode[] | null>();
+export class Column extends DynamicComponent<ColumnNode> {
+  readonly alignment = input<ResolvedColumn['alignment']>('stretch');
+  readonly distribution = input<ResolvedColumn['distribution']>('start');
+  readonly children = input<AnyComponentNode[] | null>();
 
   protected readonly classes = computed(() => ({
     ...this.theme.components.Column,

--- a/renderers/angular/src/v0_8/components/datetime-input.spec.ts
+++ b/renderers/angular/src/v0_8/components/datetime-input.spec.ts
@@ -16,7 +16,7 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DateTimeInput } from './datetime-input';
-import { Types } from '../types';
+import type { A2UIClientEventMessage, DateTimeInputNode } from '../types';
 import { Theme } from '../rendering/theming';
 import { ChangeDetectionStrategy } from '@angular/core';
 import { MessageProcessor } from '../data/processor';
@@ -28,7 +28,7 @@ describe('DateTimeInput Component', () => {
   let mockTheme: Theme;
   let mockProcessor: jasmine.SpyObj<MessageProcessor>;
 
-  const mockDatetimeNode: Types.DateTimeInputNode = {
+  const mockDatetimeNode: DateTimeInputNode = {
     id: 'dt-1',
     type: 'DateTimeInput',
     weight: 1,
@@ -114,8 +114,7 @@ describe('DateTimeInput Component', () => {
     inputEl.dispatchEvent(new Event('change'));
 
     expect(mockProcessor.dispatch).toHaveBeenCalled();
-    const message = mockProcessor.dispatch.calls.mostRecent()
-      .args[0] as Types.A2UIClientEventMessage;
+    const message = mockProcessor.dispatch.calls.mostRecent().args[0] as A2UIClientEventMessage;
     expect(message.userAction!.name).toBe('change');
 
     // Verify context

--- a/renderers/angular/src/v0_8/components/datetime-input.ts
+++ b/renderers/angular/src/v0_8/components/datetime-input.ts
@@ -16,7 +16,7 @@
 
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { DynamicComponent } from '../rendering/dynamic-component';
-import { Types } from '../types';
+import type { DateTimeInputNode, StringValue } from '../types';
 
 @Component({
   selector: 'a2ui-datetime-input',
@@ -44,9 +44,9 @@ import { Types } from '../types';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DateTimeInput extends DynamicComponent<Types.DateTimeInputNode> {
-  readonly label = input<Types.StringValue | null>(null);
-  readonly value = input.required<Types.StringValue | null>();
+export class DateTimeInput extends DynamicComponent<DateTimeInputNode> {
+  readonly label = input<StringValue | null>(null);
+  readonly value = input.required<StringValue | null>();
   readonly enableDate = input<boolean>(true);
   readonly enableTime = input<boolean>(false);
 
@@ -66,13 +66,18 @@ export class DateTimeInput extends DynamicComponent<Types.DateTimeInputNode> {
     const valueNode = this.value();
     if (valueNode && typeof valueNode === 'object' && 'path' in valueNode && valueNode.path) {
       // Update the local data model directly to ensure immediate UI feedback and avoid unnecessary network requests.
-      this.processor.processMessages([{
-        dataModelUpdate: {
-          surfaceId: this.surfaceId()!,
-          path: this.processor.resolvePath(valueNode.path as string, this.component().dataContextPath),
-          contents: [{ key: '.', valueString: value }],
+      this.processor.processMessages([
+        {
+          dataModelUpdate: {
+            surfaceId: this.surfaceId()!,
+            path: this.processor.resolvePath(
+              valueNode.path as string,
+              this.component().dataContextPath,
+            ),
+            contents: [{ key: '.', valueString: value }],
+          },
         },
-      }]);
+      ]);
     } else {
       this.handleAction('change', { value });
     }

--- a/renderers/angular/src/v0_8/components/divider.spec.ts
+++ b/renderers/angular/src/v0_8/components/divider.spec.ts
@@ -18,14 +18,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Divider } from './divider';
 import { Theme } from '../rendering/theming';
 import { MessageProcessor } from '../data/processor';
-import { Types } from '../types';
+import type { DividerNode } from '../types';
 
 describe('Divider Component', () => {
   let component: Divider;
   let fixture: ComponentFixture<Divider>;
   let mockTheme: Theme;
 
-  const mockNode: Types.DividerNode = {
+  const mockNode: DividerNode = {
     id: 'div-1',
     type: 'Divider',
     weight: 1,

--- a/renderers/angular/src/v0_8/components/divider.ts
+++ b/renderers/angular/src/v0_8/components/divider.ts
@@ -15,7 +15,7 @@
  */
 
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { Types } from '../types';
+import type { DividerNode } from '../types';
 import { DynamicComponent } from '../rendering/dynamic-component';
 
 @Component({
@@ -36,4 +36,4 @@ import { DynamicComponent } from '../rendering/dynamic-component';
     }
   `,
 })
-export class Divider extends DynamicComponent<Types.DividerNode> {}
+export class Divider extends DynamicComponent<DividerNode> {}

--- a/renderers/angular/src/v0_8/components/icon.ts
+++ b/renderers/angular/src/v0_8/components/icon.ts
@@ -16,7 +16,7 @@
 
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { DynamicComponent } from '../rendering/dynamic-component';
-import { Types } from '../types';
+import type { IconNode, StringValue } from '../types';
 
 @Component({
   selector: 'a2ui-icon',
@@ -43,7 +43,7 @@ import { Types } from '../types';
     }
   `,
 })
-export class Icon extends DynamicComponent<Types.IconNode> {
-  readonly name = input<Types.StringValue | null>(null);
+export class Icon extends DynamicComponent<IconNode> {
+  readonly name = input<StringValue | null>(null);
   protected readonly resolvedName = computed(() => this.resolvePrimitive(this.name()));
 }

--- a/renderers/angular/src/v0_8/components/image.ts
+++ b/renderers/angular/src/v0_8/components/image.ts
@@ -17,7 +17,7 @@
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import * as Primitives from '@a2ui/web_core/types/primitives';
 import * as Styles from '@a2ui/web_core/styles/index';
-import { Types } from '../types';
+import type { ImageNode, ResolvedImage } from '../types';
 import { DynamicComponent } from '../rendering/dynamic-component';
 
 @Component({
@@ -49,10 +49,10 @@ import { DynamicComponent } from '../rendering/dynamic-component';
     }
   `,
 })
-export class Image extends DynamicComponent<Types.ImageNode> {
+export class Image extends DynamicComponent<ImageNode> {
   readonly url = input<Primitives.StringValue | null>(null);
-  readonly usageHint = input<Types.ResolvedImage['usageHint'] | null>(null);
-  readonly fit = input<Types.ResolvedImage['fit'] | null>(null);
+  readonly usageHint = input<ResolvedImage['usageHint'] | null>(null);
+  readonly fit = input<ResolvedImage['fit'] | null>(null);
   readonly altText = input<Primitives.StringValue | null>(null);
 
   protected readonly resolvedUrl = computed(() => this.resolvePrimitive(this.url()));

--- a/renderers/angular/src/v0_8/components/list.spec.ts
+++ b/renderers/angular/src/v0_8/components/list.spec.ts
@@ -19,7 +19,7 @@ import { List } from './list';
 import { MessageProcessor } from '../data/processor';
 import { Theme } from '../rendering/theming';
 import { Catalog } from '../rendering/catalog';
-import { Types } from '../types';
+import type { ListNode } from '../types';
 import { Directive, Input, ChangeDetectionStrategy } from '@angular/core';
 import { By } from '@angular/platform-browser';
 
@@ -42,7 +42,7 @@ describe('List Component', () => {
   let fixture: ComponentFixture<List>;
   let mockTheme: Theme;
 
-  const mockNode: Types.ListNode = {
+  const mockNode: ListNode = {
     id: 'list-1',
     type: 'List',
     weight: 1,

--- a/renderers/angular/src/v0_8/components/list.ts
+++ b/renderers/angular/src/v0_8/components/list.ts
@@ -15,7 +15,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
-import { Types } from '../types';
+import type { AnyComponentNode, ListNode, ResolvedList } from '../types';
 import { DynamicComponent } from '../rendering/dynamic-component';
 import { Renderer } from '../rendering/renderer';
 
@@ -66,8 +66,8 @@ import { Renderer } from '../rendering/renderer';
     </section>
   `,
 })
-export class List extends DynamicComponent<Types.ListNode> {
-  readonly alignment = input<Types.ResolvedList['alignment']>('stretch');
-  readonly direction = input<Types.ResolvedList['direction']>('vertical');
-  readonly children = input<Types.AnyComponentNode[] | null>(null);
+export class List extends DynamicComponent<ListNode> {
+  readonly alignment = input<ResolvedList['alignment']>('stretch');
+  readonly direction = input<ResolvedList['direction']>('vertical');
+  readonly children = input<AnyComponentNode[] | null>(null);
 }

--- a/renderers/angular/src/v0_8/components/modal.spec.ts
+++ b/renderers/angular/src/v0_8/components/modal.spec.ts
@@ -19,7 +19,7 @@ import { Modal } from './modal';
 import { MessageProcessor } from '../data/processor';
 import { Theme } from '../rendering/theming';
 import { Catalog } from '../rendering/catalog';
-import { Types } from '../types';
+import type { AnyComponentNode } from '../types';
 import { Directive, Input, ChangeDetectionStrategy } from '@angular/core';
 import { By } from '@angular/platform-browser';
 
@@ -42,12 +42,12 @@ describe('Modal Component', () => {
   let fixture: ComponentFixture<Modal>;
   let mockTheme: Theme;
 
-  const mockEntryPoint: Types.AnyComponentNode = {
+  const mockEntryPoint: AnyComponentNode = {
     id: 'btn-1',
     type: 'Button',
     properties: { text: 'Open' },
   };
-  const mockContent: Types.AnyComponentNode = {
+  const mockContent: AnyComponentNode = {
     id: 'text-1',
     type: 'Text',
     properties: { text: 'Hello' },

--- a/renderers/angular/src/v0_8/components/modal.ts
+++ b/renderers/angular/src/v0_8/components/modal.ts
@@ -17,7 +17,7 @@
 import { ChangeDetectionStrategy, Component, input, signal } from '@angular/core';
 import { DynamicComponent } from '../rendering/dynamic-component';
 import { Renderer } from '../rendering/renderer';
-import { Types } from '../types';
+import type { AnyComponentNode, ModalNode } from '../types';
 
 @Component({
   selector: 'a2ui-modal',
@@ -25,11 +25,7 @@ import { Types } from '../types';
   template: `
     <div class="a2ui-modal-entry-point" (click)="openModal()">
       @if (entryPointChild()) {
-        <ng-container
-          a2ui-renderer
-          [surfaceId]="surfaceId()!"
-          [component]="entryPointChild()!"
-        />
+        <ng-container a2ui-renderer [surfaceId]="surfaceId()!" [component]="entryPointChild()!" />
       }
     </div>
 
@@ -37,11 +33,7 @@ import { Types } from '../types';
       <div [class]="theme.components.Modal.backdrop" (click)="closeModal()">
         <div [class]="theme.components.Modal.element" (click)="$event.stopPropagation()">
           @if (contentChild()) {
-            <ng-container
-              a2ui-renderer
-              [surfaceId]="surfaceId()!"
-              [component]="contentChild()!"
-            />
+            <ng-container a2ui-renderer [surfaceId]="surfaceId()!" [component]="contentChild()!" />
           }
         </div>
       </div>
@@ -57,9 +49,9 @@ import { Types } from '../types';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class Modal extends DynamicComponent<Types.ModalNode> {
-  readonly entryPointChild = input.required<Types.AnyComponentNode>();
-  readonly contentChild = input.required<Types.AnyComponentNode>();
+export class Modal extends DynamicComponent<ModalNode> {
+  readonly entryPointChild = input.required<AnyComponentNode>();
+  readonly contentChild = input.required<AnyComponentNode>();
 
   protected readonly isOpen = signal(false);
 

--- a/renderers/angular/src/v0_8/components/multiple-choice.ts
+++ b/renderers/angular/src/v0_8/components/multiple-choice.ts
@@ -16,7 +16,7 @@
 
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { DynamicComponent } from '../rendering/dynamic-component';
-import { Types } from '../types';
+import type { AnyComponentNode, MultipleChoiceNode, StringValue } from '../types';
 
 @Component({
   selector: 'a2ui-multiple-choice',
@@ -47,10 +47,10 @@ import { Types } from '../types';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MultipleChoice extends DynamicComponent<Types.MultipleChoiceNode> {
-  readonly label = input<Types.StringValue | null>(null);
-  readonly options = input.required<{ label: Types.StringValue; value: string }[]>();
-  readonly selections = input.required<Types.AnyComponentNode | null>();
+export class MultipleChoice extends DynamicComponent<MultipleChoiceNode> {
+  readonly label = input<StringValue | null>(null);
+  readonly options = input.required<{ label: StringValue; value: string }[]>();
+  readonly selections = input.required<AnyComponentNode | null>();
 
   protected readonly selectId = super.getUniqueId('a2ui-multiple-choice');
 
@@ -74,15 +74,25 @@ export class MultipleChoice extends DynamicComponent<Types.MultipleChoiceNode> {
   onChange(event: Event) {
     const value = (event.target as HTMLSelectElement).value;
     const selectionsNode = this.selections();
-    if (selectionsNode && typeof selectionsNode === 'object' && 'path' in selectionsNode && selectionsNode.path) {
+    if (
+      selectionsNode &&
+      typeof selectionsNode === 'object' &&
+      'path' in selectionsNode &&
+      selectionsNode.path
+    ) {
       // Update the local data model directly to ensure immediate UI feedback and avoid unnecessary network requests.
-      this.processor.processMessages([{
-        dataModelUpdate: {
-          surfaceId: this.surfaceId()!,
-          path: this.processor.resolvePath(selectionsNode.path as string, this.component().dataContextPath),
-          contents: [{ key: '.', valueString: JSON.stringify({ literalArray: [value] }) }],
+      this.processor.processMessages([
+        {
+          dataModelUpdate: {
+            surfaceId: this.surfaceId()!,
+            path: this.processor.resolvePath(
+              selectionsNode.path as string,
+              this.component().dataContextPath,
+            ),
+            contents: [{ key: '.', valueString: JSON.stringify({ literalArray: [value] }) }],
+          },
         },
-      }]);
+      ]);
     } else {
       this.handleAction('change', { value });
     }

--- a/renderers/angular/src/v0_8/components/row-integration.spec.ts
+++ b/renderers/angular/src/v0_8/components/row-integration.spec.ts
@@ -42,7 +42,12 @@ describe('Row Component Integration (Real Renderer)', () => {
   let processor: jasmine.SpyObj<MessageProcessor>;
 
   beforeEach(async () => {
-    processor = jasmine.createSpyObj('MessageProcessor', ['getData', 'dispatch', 'resolvePath', 'version']);
+    processor = jasmine.createSpyObj('MessageProcessor', [
+      'getData',
+      'dispatch',
+      'resolvePath',
+      'version',
+    ]);
 
     await TestBed.configureTestingModule({
       imports: [TestHost],

--- a/renderers/angular/src/v0_8/components/row.spec.ts
+++ b/renderers/angular/src/v0_8/components/row.spec.ts
@@ -19,7 +19,7 @@ import { Row } from './row';
 import { MessageProcessor } from '../data/processor';
 import { Theme } from '../rendering/theming';
 import { Catalog } from '../rendering/catalog';
-import { Types } from '../types';
+import type { RowNode } from '../types';
 import { Directive, Input, ChangeDetectionStrategy } from '@angular/core';
 
 @Directive({
@@ -41,7 +41,7 @@ describe('Row Component', () => {
   let fixture: ComponentFixture<Row>;
   let mockTheme: Theme;
 
-  const mockNode: Types.RowNode = {
+  const mockNode: RowNode = {
     id: 'row-1',
     type: 'Row',
     weight: 1,

--- a/renderers/angular/src/v0_8/components/row.ts
+++ b/renderers/angular/src/v0_8/components/row.ts
@@ -17,7 +17,7 @@
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { DynamicComponent } from '../rendering/dynamic-component';
 import { Renderer } from '../rendering/renderer';
-import { Types } from '../types';
+import type { AnyComponentNode, ResolvedRow, RowNode } from '../types';
 
 @Component({
   selector: 'a2ui-row',
@@ -91,10 +91,10 @@ import { Types } from '../types';
     </section>
   `,
 })
-export class Row extends DynamicComponent<Types.RowNode> {
-  readonly alignment = input<Types.ResolvedRow['alignment']>('stretch');
-  readonly distribution = input<Types.ResolvedRow['distribution']>('start');
-  readonly children = input<Types.AnyComponentNode[] | null>();
+export class Row extends DynamicComponent<RowNode> {
+  readonly alignment = input<ResolvedRow['alignment']>('stretch');
+  readonly distribution = input<ResolvedRow['distribution']>('start');
+  readonly children = input<AnyComponentNode[] | null>();
 
   protected readonly classes = computed(() => ({
     ...this.theme.components.Row,

--- a/renderers/angular/src/v0_8/components/slider.ts
+++ b/renderers/angular/src/v0_8/components/slider.ts
@@ -15,7 +15,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
-import { Types } from '../types';
+import type { NumberValue, SliderNode, StringValue } from '../types';
 import { DynamicComponent } from '../rendering/dynamic-component';
 
 @Component({
@@ -44,9 +44,9 @@ import { DynamicComponent } from '../rendering/dynamic-component';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class Slider extends DynamicComponent<Types.SliderNode> {
-  readonly label = input<Types.StringValue | null>(null);
-  readonly value = input.required<Types.NumberValue | null>();
+export class Slider extends DynamicComponent<SliderNode> {
+  readonly label = input<StringValue | null>(null);
+  readonly value = input.required<NumberValue | null>();
   readonly minValue = input<number>(0);
   readonly maxValue = input<number>(100);
 
@@ -61,13 +61,18 @@ export class Slider extends DynamicComponent<Types.SliderNode> {
     const valueNode = this.value();
     if (valueNode && typeof valueNode === 'object' && 'path' in valueNode && valueNode.path) {
       // Update the local data model directly to ensure immediate UI feedback and avoid unnecessary network requests.
-      this.processor.processMessages([{
-        dataModelUpdate: {
-          surfaceId: this.surfaceId()!,
-          path: this.processor.resolvePath(valueNode.path as string, this.component().dataContextPath),
-          contents: [{ key: '.', valueNumber: value }],
+      this.processor.processMessages([
+        {
+          dataModelUpdate: {
+            surfaceId: this.surfaceId()!,
+            path: this.processor.resolvePath(
+              valueNode.path as string,
+              this.component().dataContextPath,
+            ),
+            contents: [{ key: '.', valueNumber: value }],
+          },
         },
-      }]);
+      ]);
     } else {
       this.handleAction('change', { value });
     }

--- a/renderers/angular/src/v0_8/components/surface.spec.ts
+++ b/renderers/angular/src/v0_8/components/surface.spec.ts
@@ -17,7 +17,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Surface } from './surface';
 import { MessageProcessor } from '../data/processor';
-import { Types } from '../types';
+import type { AnyComponentNode, Surface as SurfaceType } from '../types';
 import { Directive, Input, ChangeDetectionStrategy } from '@angular/core';
 
 @Directive({
@@ -38,14 +38,14 @@ describe('Surface Component', () => {
   let component: Surface;
   let fixture: ComponentFixture<Surface>;
   let mockProcessor: jasmine.SpyObj<MessageProcessor>;
-  let surfacesMap: Map<string, Types.Surface>;
+  let surfacesMap: Map<string, SurfaceType>;
 
-  const mockRootComponent: Types.AnyComponentNode = {
+  const mockRootComponent: AnyComponentNode = {
     id: 'root-1',
     type: 'Column',
     properties: {},
   };
-  const mockSurfaceData: Types.Surface = {
+  const mockSurfaceData: SurfaceType = {
     id: 'surface-1',
     componentTree: mockRootComponent,
   } as any;

--- a/renderers/angular/src/v0_8/components/surface.ts
+++ b/renderers/angular/src/v0_8/components/surface.ts
@@ -17,7 +17,7 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { MessageProcessor } from '../data';
 import { Renderer } from '../rendering/renderer';
-import { Types } from '../types';
+import type { Surface as SurfaceType, SurfaceID } from '../types';
 
 @Component({
   selector: 'a2ui-surface',
@@ -38,8 +38,8 @@ import { Types } from '../types';
 })
 export class Surface {
   private readonly processor = inject(MessageProcessor);
-  readonly surfaceId = input.required<Types.SurfaceID>();
-  readonly surfaceInput = input<Types.Surface | null>(null, { alias: 'surface' });
+  readonly surfaceId = input.required<SurfaceID>();
+  readonly surfaceInput = input<SurfaceType | null>(null, { alias: 'surface' });
 
   protected readonly surface = computed(() => {
     this.processor.version(); // Track dependency on in-place mutations

--- a/renderers/angular/src/v0_8/components/tabs.ts
+++ b/renderers/angular/src/v0_8/components/tabs.ts
@@ -17,7 +17,7 @@
 import { ChangeDetectionStrategy, Component, input, signal } from '@angular/core';
 import { DynamicComponent } from '../rendering/dynamic-component';
 import { Renderer } from '../rendering/renderer';
-import { Types } from '../types';
+import type { ResolvedTabs, TabsNode } from '../types';
 
 @Component({
   selector: 'a2ui-tabs',
@@ -52,8 +52,8 @@ import { Types } from '../types';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class Tabs extends DynamicComponent<Types.TabsNode> {
-  readonly tabItems = input.required<Types.ResolvedTabs['tabItems']>();
+export class Tabs extends DynamicComponent<TabsNode> {
+  readonly tabItems = input.required<ResolvedTabs['tabItems']>();
   protected readonly selectedIndex = signal(0);
 
   protected selectTab(index: number) {

--- a/renderers/angular/src/v0_8/components/text-field.ts
+++ b/renderers/angular/src/v0_8/components/text-field.ts
@@ -16,7 +16,7 @@
 
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { DynamicComponent } from '../rendering/dynamic-component';
-import { Types } from '../types';
+import type { ResolvedTextField, StringValue, TextFieldNode } from '../types';
 
 @Component({
   selector: 'a2ui-text-field',
@@ -41,10 +41,10 @@ import { Types } from '../types';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TextField extends DynamicComponent<Types.TextFieldNode> {
-  readonly label = input.required<Types.StringValue | null>();
-  readonly text = input<Types.StringValue | null>(null);
-  readonly textFieldType = input<Types.ResolvedTextField['textFieldType']>('shortText');
+export class TextField extends DynamicComponent<TextFieldNode> {
+  readonly label = input.required<StringValue | null>();
+  readonly text = input<StringValue | null>(null);
+  readonly textFieldType = input<ResolvedTextField['textFieldType']>('shortText');
 
   protected readonly inputId = super.getUniqueId('a2ui-text-field');
 
@@ -67,13 +67,18 @@ export class TextField extends DynamicComponent<Types.TextFieldNode> {
     const textNode = this.text();
     if (textNode && typeof textNode === 'object' && 'path' in textNode && textNode.path) {
       // Update the local data model directly to ensure immediate UI feedback and avoid unnecessary network requests.
-      this.processor.processMessages([{
-        dataModelUpdate: {
-          surfaceId: this.surfaceId()!,
-          path: this.processor.resolvePath(textNode.path as string, this.component().dataContextPath),
-          contents: [{ key: '.', valueString: value }],
+      this.processor.processMessages([
+        {
+          dataModelUpdate: {
+            surfaceId: this.surfaceId()!,
+            path: this.processor.resolvePath(
+              textNode.path as string,
+              this.component().dataContextPath,
+            ),
+            contents: [{ key: '.', valueString: value }],
+          },
         },
-      }]);
+      ]);
     } else {
       this.handleAction('input', { value });
     }

--- a/renderers/angular/src/v0_8/components/text.ts
+++ b/renderers/angular/src/v0_8/components/text.ts
@@ -26,7 +26,7 @@ import { AsyncPipe } from '@angular/common';
 import { DynamicComponent } from '../rendering/dynamic-component';
 import * as Primitives from '@a2ui/web_core/types/primitives';
 import * as Styles from '@a2ui/web_core/styles/index';
-import { Types } from '../types';
+import type { ResolvedText, TextNode } from '../types';
 import { MarkdownRenderer } from '../data/markdown';
 
 interface HintedStyles {
@@ -67,10 +67,10 @@ interface HintedStyles {
     }
   `,
 })
-export class Text extends DynamicComponent<Types.TextNode> {
+export class Text extends DynamicComponent<TextNode> {
   private markdownRenderer = inject(MarkdownRenderer);
   readonly text = input.required<Primitives.StringValue | null>();
-  readonly usageHint = input<Types.ResolvedText['usageHint'] | null>(null);
+  readonly usageHint = input<ResolvedText['usageHint'] | null>(null);
 
   protected resolvedText = computed(() => {
     const usageHint = this.usageHint();

--- a/renderers/angular/src/v0_8/components/video.spec.ts
+++ b/renderers/angular/src/v0_8/components/video.spec.ts
@@ -16,7 +16,7 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Video } from './video';
-import { Types } from '../types';
+import type { VideoNode } from '../types';
 import { Theme } from '../rendering/theming';
 import { ChangeDetectionStrategy } from '@angular/core';
 import { MessageProcessor } from '../data/processor';
@@ -28,7 +28,7 @@ describe('Video Component', () => {
   let mockTheme: Theme;
   let mockProcessor: jasmine.SpyObj<MessageProcessor>;
 
-  const mockVideoNode: Types.VideoNode = {
+  const mockVideoNode: VideoNode = {
     id: 'video-1',
     type: 'Video',
     weight: 1,

--- a/renderers/angular/src/v0_8/components/video.ts
+++ b/renderers/angular/src/v0_8/components/video.ts
@@ -16,7 +16,7 @@
 
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { DynamicComponent } from '../rendering/dynamic-component';
-import { Types } from '../types';
+import type { StringValue, VideoNode } from '../types';
 
 @Component({
   selector: 'a2ui-video',
@@ -45,7 +45,7 @@ import { Types } from '../types';
     }
   `,
 })
-export class Video extends DynamicComponent<Types.VideoNode> {
-  readonly url = input.required<Types.StringValue | null>();
+export class Video extends DynamicComponent<VideoNode> {
+  readonly url = input.required<StringValue | null>();
   protected readonly resolvedUrl = computed(() => this.resolvePrimitive(this.url()));
 }

--- a/renderers/angular/src/v0_8/config.ts
+++ b/renderers/angular/src/v0_8/config.ts
@@ -16,12 +16,9 @@
 
 import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
 import { Catalog, Theme } from './rendering';
-import { Types } from './types';
+import type { Theme as ThemeType } from './types';
 
-export function provideA2UI(config: {
-  catalog: Catalog;
-  theme: Types.Theme;
-}): EnvironmentProviders {
+export function provideA2UI(config: { catalog: Catalog; theme: ThemeType }): EnvironmentProviders {
   return makeEnvironmentProviders([
     { provide: Catalog, useValue: config.catalog },
     {

--- a/renderers/angular/src/v0_8/data/markdown.ts
+++ b/renderers/angular/src/v0_8/data/markdown.ts
@@ -15,13 +15,13 @@
  */
 
 import { Injectable } from '@angular/core';
-import { Types } from '../types';
+import type { MarkdownRenderer as MarkdownRendererType, MarkdownRendererOptions } from '../types';
 
 @Injectable({
   providedIn: 'root',
 })
 export abstract class MarkdownRenderer {
-  abstract render(markdown: string, options?: Types.MarkdownRendererOptions): Promise<string>;
+  abstract render(markdown: string, options?: MarkdownRendererOptions): Promise<string>;
 }
 
 @Injectable({
@@ -30,17 +30,16 @@ export abstract class MarkdownRenderer {
 export class DefaultMarkdownRenderer extends MarkdownRenderer {
   private static warningLogged = false;
 
-  override async render(
-    markdown: string,
-    options?: Types.MarkdownRendererOptions,
-  ): Promise<string> {
+  override async render(markdown: string, options?: MarkdownRendererOptions): Promise<string> {
     try {
       // @ts-ignore - optional peer dependency
       const { renderMarkdown } = await import('@a2ui/markdown-it');
       return await renderMarkdown(markdown, options);
     } catch (e) {
       if (!DefaultMarkdownRenderer.warningLogged) {
-        console.warn("[DefaultMarkdownRenderer] Failed to load optional `@a2ui/markdown-it` renderer. Using fallback regex.");
+        console.warn(
+          '[DefaultMarkdownRenderer] Failed to load optional `@a2ui/markdown-it` renderer. Using fallback regex.',
+        );
         DefaultMarkdownRenderer.warningLogged = true;
       }
       // Basic implementation for v0.8
@@ -49,7 +48,7 @@ export class DefaultMarkdownRenderer extends MarkdownRenderer {
   }
 }
 
-export function provideMarkdownRenderer(renderFn?: Types.MarkdownRenderer) {
+export function provideMarkdownRenderer(renderFn?: MarkdownRendererType) {
   if (renderFn) {
     return {
       provide: MarkdownRenderer,

--- a/renderers/angular/src/v0_8/data/processor.spec.ts
+++ b/renderers/angular/src/v0_8/data/processor.spec.ts
@@ -17,7 +17,7 @@
 import { TestBed } from '@angular/core/testing';
 import { MessageProcessor, A2UIClientEvent } from './processor';
 import { Catalog } from '../rendering/catalog';
-import { Types } from '../types';
+import type { A2UIClientEventMessage, AnyComponentNode, ServerToClientMessage } from '../types';
 import * as WebCore from '@a2ui/web_core/v0_8';
 
 describe('MessageProcessor', () => {
@@ -41,14 +41,14 @@ describe('MessageProcessor', () => {
     const baseProcessor = (service as any).baseProcessor;
     spyOn(baseProcessor, 'processMessages');
 
-    const messages: Types.ServerToClientMessage[] = [];
+    const messages: ServerToClientMessage[] = [];
     service.processMessages(messages);
 
     expect(baseProcessor.processMessages).toHaveBeenCalledWith(messages);
   });
 
   it('should dispatch events and emit to observable', (done) => {
-    const mockMessage: Types.A2UIClientEventMessage = {
+    const mockMessage: A2UIClientEventMessage = {
       userAction: {
         name: 'click',
         sourceComponentId: 'btn-1',
@@ -67,11 +67,11 @@ describe('MessageProcessor', () => {
   });
 
   it('should resolve dispatch promise when completion is triggered', async () => {
-    const mockMessage: Types.A2UIClientEventMessage = {
+    const mockMessage: A2UIClientEventMessage = {
       userAction: { name: 'click', sourceComponentId: '1', surfaceId: '1', timestamp: '' },
     };
 
-    const replyMessages: Types.ServerToClientMessage[] = [{ type: 'UpdateSurface' } as any];
+    const replyMessages: ServerToClientMessage[] = [{ type: 'UpdateSurface' } as any];
 
     // Setup subscription to trigger completion
     service.events.subscribe((event: A2UIClientEvent) => {
@@ -86,7 +86,7 @@ describe('MessageProcessor', () => {
     const baseProcessor = (service as any).baseProcessor;
     spyOn(baseProcessor, 'getData').and.returnValue('mock-value');
 
-    const node = { id: '1', type: 'Text' } as any as Types.AnyComponentNode;
+    const node = { id: '1', type: 'Text' } as any as AnyComponentNode;
     const result = service.getData(node, 'path/to/data', 'surf-1');
 
     expect(baseProcessor.getData).toHaveBeenCalledWith(node, 'path/to/data', 'surf-1');
@@ -97,7 +97,7 @@ describe('MessageProcessor', () => {
     const baseProcessor = (service as any).baseProcessor;
     spyOn(baseProcessor, 'setData');
 
-    const node = { id: '1', type: 'Text' } as any as Types.AnyComponentNode;
+    const node = { id: '1', type: 'Text' } as any as AnyComponentNode;
     service.setData(node, 'path/to/data', 'new-value', 'surf-1');
 
     expect(baseProcessor.setData).toHaveBeenCalledWith(node, 'path/to/data', 'new-value', 'surf-1');
@@ -135,7 +135,7 @@ describe('MessageProcessor', () => {
         type: 'Text',
         properties: {
           text: { literalString: 'Ready to render' },
-        }
+        },
       },
       dataModel: new Map(),
       components: new Map(),

--- a/renderers/angular/src/v0_8/data/processor.ts
+++ b/renderers/angular/src/v0_8/data/processor.ts
@@ -18,11 +18,11 @@ import { Injectable, signal } from '@angular/core';
 import { Subject, Observable } from 'rxjs';
 import * as WebCore from '@a2ui/web_core/v0_8';
 
-import { Types } from '../types';
+import type { A2UIClientEventMessage, AnyComponentNode, ServerToClientMessage } from '../types';
 
 export interface A2UIClientEvent {
-  message: Types.A2UIClientEventMessage;
-  completion: Subject<Types.ServerToClientMessage[]>;
+  message: A2UIClientEventMessage;
+  completion: Subject<ServerToClientMessage[]>;
 }
 
 export type DispatchedEvent = A2UIClientEvent;
@@ -35,8 +35,8 @@ export class MessageProcessor {
 
   private readonly eventsSubject = new Subject<A2UIClientEvent>();
   readonly events: Observable<A2UIClientEvent> = this.eventsSubject.asObservable();
-  // Signal to track the version of the data in the MessageProcessor. Since the base processor updates 
-  // surfaces in-place (mutating the Map), we use this to force Angular's change detection to 
+  // Signal to track the version of the data in the MessageProcessor. Since the base processor updates
+  // surfaces in-place (mutating the Map), we use this to force Angular's change detection to
   // re-evaluate any components or effects that depend on getSurfaces().
   private readonly versionSignal = signal(0);
   readonly version = this.versionSignal.asReadonly();
@@ -53,14 +53,14 @@ export class MessageProcessor {
     this.versionSignal.update((v) => v + 1);
   }
 
-  processMessages(messages: Types.ServerToClientMessage[]) {
+  processMessages(messages: ServerToClientMessage[]) {
     this.baseProcessor.processMessages(messages as WebCore.ServerToClientMessage[]);
     this.notify();
   }
 
-  dispatch(message: Types.A2UIClientEventMessage): Promise<Types.ServerToClientMessage[]> {
-    const completion = new Subject<Types.ServerToClientMessage[]>();
-    const promise = new Promise<Types.ServerToClientMessage[]>((resolve, reject) => {
+  dispatch(message: A2UIClientEventMessage): Promise<ServerToClientMessage[]> {
+    const completion = new Subject<ServerToClientMessage[]>();
+    const promise = new Promise<ServerToClientMessage[]>((resolve, reject) => {
       completion.subscribe({
         next: (msgs) => resolve(msgs),
         error: (err) => reject(err),
@@ -71,7 +71,7 @@ export class MessageProcessor {
     return promise;
   }
 
-  getData(node: Types.AnyComponentNode, path: string, surfaceId?: string | null): unknown {
+  getData(node: AnyComponentNode, path: string, surfaceId?: string | null): unknown {
     return this.baseProcessor.getData(
       node as WebCore.AnyComponentNode,
       path,
@@ -79,7 +79,7 @@ export class MessageProcessor {
     );
   }
 
-  setData(node: Types.AnyComponentNode | null, path: string, value: any, surfaceId: string) {
+  setData(node: AnyComponentNode | null, path: string, value: any, surfaceId: string) {
     this.baseProcessor.setData(node as WebCore.AnyComponentNode | null, path, value, surfaceId);
     this.notify();
   }

--- a/renderers/angular/src/v0_8/data/types.ts
+++ b/renderers/angular/src/v0_8/data/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Types } from '../types';
+import type { ServerToClientMessage } from '../types';
 
 export interface A2TextPayload {
   kind: 'text';
@@ -23,7 +23,7 @@ export interface A2TextPayload {
 
 export interface A2DataPayload {
   kind: 'data';
-  data: Types.ServerToClientMessage;
+  data: ServerToClientMessage;
 }
 
 export type A2AServerPayload = Array<A2DataPayload | A2TextPayload> | { error: string };

--- a/renderers/angular/src/v0_8/public-api.ts
+++ b/renderers/angular/src/v0_8/public-api.ts
@@ -37,4 +37,4 @@ export * from './components/video';
 export * from './config';
 export * from './data/index';
 export * from './rendering/index';
-export * from './types';
+export * as Types from './types';

--- a/renderers/angular/src/v0_8/rendering/catalog.ts
+++ b/renderers/angular/src/v0_8/rendering/catalog.ts
@@ -16,13 +16,13 @@
 
 import { Binding, InjectionToken, Type } from '@angular/core';
 import { DynamicComponent } from './dynamic-component';
-import { Types } from '../types';
+import type { AnyComponentNode } from '../types';
 
 export type CatalogLoader = () =>
   | Promise<Type<DynamicComponent<any>>>
   | Type<DynamicComponent<any>>;
 
-export type CatalogEntry<T extends Types.AnyComponentNode> =
+export type CatalogEntry<T extends AnyComponentNode> =
   | CatalogLoader
   | {
       type: CatalogLoader;
@@ -30,7 +30,7 @@ export type CatalogEntry<T extends Types.AnyComponentNode> =
     };
 
 export interface Catalog {
-  [key: string]: CatalogEntry<Types.AnyComponentNode>;
+  [key: string]: CatalogEntry<AnyComponentNode>;
 }
 
 export const Catalog = new InjectionToken<Catalog>('Catalog');

--- a/renderers/angular/src/v0_8/rendering/dynamic-component.ts
+++ b/renderers/angular/src/v0_8/rendering/dynamic-component.ts
@@ -17,7 +17,16 @@
 import { Directive, inject, input } from '@angular/core';
 import { MessageProcessor } from '../data';
 import { Theme } from './theming';
-import { Types } from '../types';
+import type {
+  A2UIClientEventMessage,
+  Action,
+  AnyComponentNode,
+  BooleanValue,
+  NumberValue,
+  ServerToClientMessage,
+  StringValue,
+  SurfaceID,
+} from '../types';
 
 let idCounter = 0;
 
@@ -26,15 +35,15 @@ let idCounter = 0;
     '[style.--weight]': 'weight()',
   },
 })
-export abstract class DynamicComponent<T extends Types.AnyComponentNode = Types.AnyComponentNode> {
+export abstract class DynamicComponent<T extends AnyComponentNode = AnyComponentNode> {
   protected readonly processor = inject(MessageProcessor);
   protected readonly theme = inject(Theme);
 
-  readonly surfaceId = input.required<Types.SurfaceID | null>();
+  readonly surfaceId = input.required<SurfaceID | null>();
   readonly component = input.required<T>();
   readonly weight = input.required<string | number>();
 
-  protected sendAction(action: Types.Action): Promise<Types.ServerToClientMessage[]> {
+  protected sendAction(action: Action): Promise<ServerToClientMessage[]> {
     const component = this.component();
     const surfaceId = this.surfaceId() ?? undefined;
     const context: Record<string, unknown> = {};
@@ -55,7 +64,7 @@ export abstract class DynamicComponent<T extends Types.AnyComponentNode = Types.
       }
     }
 
-    const message: Types.A2UIClientEventMessage = {
+    const message: A2UIClientEventMessage = {
       userAction: {
         name: action.name,
         sourceComponentId: component.id,
@@ -68,12 +77,10 @@ export abstract class DynamicComponent<T extends Types.AnyComponentNode = Types.
     return this.processor.dispatch(message);
   }
 
-  protected resolvePrimitive(value: Types.StringValue | null): string | null;
-  protected resolvePrimitive(value: Types.BooleanValue | null): boolean | null;
-  protected resolvePrimitive(value: Types.NumberValue | null): number | null;
-  protected resolvePrimitive(
-    value: Types.StringValue | Types.BooleanValue | Types.NumberValue | null,
-  ) {
+  protected resolvePrimitive(value: StringValue | null): string | null;
+  protected resolvePrimitive(value: BooleanValue | null): boolean | null;
+  protected resolvePrimitive(value: NumberValue | null): number | null;
+  protected resolvePrimitive(value: StringValue | BooleanValue | NumberValue | null) {
     const component = this.component();
     const surfaceId = this.surfaceId();
 

--- a/renderers/angular/src/v0_8/rendering/renderer.ts
+++ b/renderers/angular/src/v0_8/rendering/renderer.ts
@@ -28,7 +28,7 @@ import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { structuralStyles } from '@a2ui/web_core/styles/index';
 import { Catalog } from './catalog';
 import { MessageProcessor } from '../data';
-import { Types } from '../types';
+import type { AnyComponentNode, SurfaceID } from '../types';
 import { DynamicComponent } from './dynamic-component';
 
 @Directive({
@@ -42,12 +42,12 @@ export class Renderer {
   private readonly container = inject(ViewContainerRef);
   private readonly processor: MessageProcessor = inject(MessageProcessor);
 
-  readonly surfaceId = input.required<Types.SurfaceID>();
-  readonly component = input.required<Types.AnyComponentNode>();
+  readonly surfaceId = input.required<SurfaceID>();
+  readonly component = input.required<AnyComponentNode>();
 
   private currentId: string | null = null;
   private currentType: string | null = null;
-  private currentComponentRef: ComponentRef<DynamicComponent<Types.AnyComponentNode>> | null = null;
+  private currentComponentRef: ComponentRef<DynamicComponent<AnyComponentNode>> | null = null;
 
   constructor() {
     const platformId = inject(PLATFORM_ID);
@@ -61,8 +61,8 @@ export class Renderer {
     }
 
     effect(() => {
-      // Explicitly depend on the MessageProcessor's version signal. This ensures that the effect re-runs 
-      // whenever data model changes occur, even if the node's object reference remains identical 
+      // Explicitly depend on the MessageProcessor's version signal. This ensures that the effect re-runs
+      // whenever data model changes occur, even if the node's object reference remains identical
       // (as in the case of in-place mutations from local updates).
       this.processor.version();
 
@@ -87,7 +87,7 @@ export class Renderer {
 
       // Focus Loss Prevention:
       // If we have an existing component and its unique identity (ID and Type) hasn't changed,
-      // we update its @Input() values in-place. This preserves the underlying DOM element, 
+      // we update its @Input() values in-place. This preserves the underlying DOM element,
       // maintaining focus, text selection, and cursor position.
       if (this.currentComponentRef && this.currentId === id && this.currentType === type) {
         this.updateInputs(this.currentComponentRef, node, surfaceId);
@@ -113,7 +113,7 @@ export class Renderer {
 
   private render(
     container: ViewContainerRef,
-    node: Types.AnyComponentNode,
+    node: AnyComponentNode,
     surfaceId: string,
     config: any,
   ) {
@@ -123,13 +123,17 @@ export class Renderer {
       componentTypeOrPromise.then((componentType) => {
         // Ensure we are still supposed to render this component
         if (this.currentId === node.id && this.currentType === node.type) {
-          const componentRef = container.createComponent(componentType) as ComponentRef<DynamicComponent<Types.AnyComponentNode>>;
+          const componentRef = container.createComponent(componentType) as ComponentRef<
+            DynamicComponent<AnyComponentNode>
+          >;
           this.currentComponentRef = componentRef;
           this.updateInputs(componentRef, node, surfaceId);
         }
       });
     } else if (componentTypeOrPromise) {
-      const componentRef = container.createComponent(componentTypeOrPromise) as ComponentRef<DynamicComponent<Types.AnyComponentNode>>;
+      const componentRef = container.createComponent(componentTypeOrPromise) as ComponentRef<
+        DynamicComponent<AnyComponentNode>
+      >;
       this.currentComponentRef = componentRef;
       this.updateInputs(componentRef, node, surfaceId);
     }
@@ -148,13 +152,13 @@ export class Renderer {
     return null;
   }
 
-  /** 
+  /**
    * Updates the inputs of an existing component instance with the latest data from the node.
    * This is called during component reuse to keep the UI in sync without losing DOM state (like focus).
    */
   private updateInputs(
-    componentRef: ComponentRef<DynamicComponent<Types.AnyComponentNode>>,
-    node: Types.AnyComponentNode,
+    componentRef: ComponentRef<DynamicComponent<AnyComponentNode>>,
+    node: AnyComponentNode,
     surfaceId: string,
   ) {
     componentRef.setInput('surfaceId', surfaceId);

--- a/renderers/angular/src/v0_8/rendering/theming.ts
+++ b/renderers/angular/src/v0_8/rendering/theming.ts
@@ -15,15 +15,15 @@
  */
 
 import { Injectable } from '@angular/core';
-import { Types } from '../types';
+import type { Theme as ThemeType } from '../types';
 
 @Injectable({
   providedIn: 'root',
 })
 export class Theme {
-  components: Types.Theme['components'] = {} as Types.Theme['components'];
-  elements: Types.Theme['elements'] = {} as Types.Theme['elements'];
-  markdown: Types.Theme['markdown'] = {
+  components: ThemeType['components'] = {} as ThemeType['components'];
+  elements: ThemeType['elements'] = {} as ThemeType['elements'];
+  markdown: ThemeType['markdown'] = {
     p: [],
     h1: [],
     h2: [],
@@ -37,9 +37,9 @@ export class Theme {
     strong: [],
     em: [],
   };
-  additionalStyles?: Types.Theme['additionalStyles'];
+  additionalStyles?: ThemeType['additionalStyles'];
 
-  update(theme: Types.Theme) {
+  update(theme: ThemeType) {
     this.components = theme.components;
     this.elements = theme.elements;
     this.markdown = theme.markdown;

--- a/renderers/angular/src/v0_8/types.ts
+++ b/renderers/angular/src/v0_8/types.ts
@@ -14,80 +14,79 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview Reexports v0.8 renderer types.
+ *
+ * These types are aliases or re-exports of core types from `@a2ui/web_core/v0_8`.
+ * Documentation for each type is available in the web core package.
+ */
+
 import * as WebCore from '@a2ui/web_core/v0_8';
 
-/**
- * Centralized namespace for v0.8 renderer types.
- * Standardizes on the `...Node` suffix for component types and provides
- * resolved variants for property binding.
- */
-export namespace Types {
-  // Messages & Infrastructure
-  export type Action = WebCore.Action;
-  export type FunctionCall = unknown; // v0.8 might not have FunctionCall or structure differs
-  export type SurfaceID = string;
-  export type StringValue = WebCore.StringValue;
-  export type BooleanValue = WebCore.BooleanValue;
-  export type NumberValue = WebCore.NumberValue;
-  export type Surface = WebCore.Surface;
+// Messages & Infrastructure
+export type Action = WebCore.Action;
+export type FunctionCall = unknown;
+export type SurfaceID = string;
+export type StringValue = WebCore.StringValue;
+export type BooleanValue = WebCore.BooleanValue;
+export type NumberValue = WebCore.NumberValue;
+export type Surface = WebCore.Surface;
 
-  export type A2UIClientEventMessage = WebCore.A2UIClientEventMessage;
-  export type ClientToServerMessage = A2UIClientEventMessage;
-  export type ServerToClientMessage = WebCore.ServerToClientMessage;
+export type A2UIClientEventMessage = WebCore.A2UIClientEventMessage;
+export type ClientToServerMessage = A2UIClientEventMessage;
+export type ServerToClientMessage = WebCore.ServerToClientMessage;
 
-  // Components & Interfaces
-  export interface Component<P = Record<string, unknown>> {
-    id: string;
-    type: string;
-    properties: P;
-  }
-
-  export type AnyComponentNode = WebCore.AnyComponentNode;
-  export type CustomNode = WebCore.CustomNode;
-
-  export type Theme = WebCore.Theme;
-
-  // Node Types (Explicit suffix)
-  export type RowNode = WebCore.RowNode;
-  export type ColumnNode = WebCore.ColumnNode;
-  export type TextNode = WebCore.TextNode;
-  export type ListNode = WebCore.ListNode;
-  export type ImageNode = WebCore.ImageNode;
-  export type IconNode = WebCore.IconNode;
-  export type VideoNode = WebCore.VideoNode;
-  export type AudioPlayerNode = WebCore.AudioPlayerNode;
-  export type ButtonNode = WebCore.ButtonNode;
-  export type DividerNode = WebCore.DividerNode;
-  export type MultipleChoiceNode = WebCore.MultipleChoiceNode;
-  export type TextFieldNode = WebCore.TextFieldNode;
-  export type CheckboxNode = WebCore.CheckboxNode;
-  export type SliderNode = WebCore.SliderNode;
-  export type DateTimeInputNode = WebCore.DateTimeInputNode;
-  export type TabsNode = WebCore.TabsNode;
-  export type ModalNode = WebCore.ModalNode;
-  export type CardNode = WebCore.CardNode;
-
-  // Resolved Property Types
-  export type ResolvedRow = WebCore.ResolvedRow;
-  export type ResolvedColumn = WebCore.ResolvedColumn;
-  export type ResolvedText = WebCore.ResolvedText;
-  export type ResolvedList = WebCore.ResolvedList;
-  export type ResolvedImage = WebCore.ResolvedImage;
-  export type ResolvedIcon = WebCore.ResolvedIcon;
-  export type ResolvedVideo = WebCore.ResolvedVideo;
-  export type ResolvedAudioPlayer = WebCore.ResolvedAudioPlayer;
-  export type ResolvedButton = WebCore.ResolvedButton;
-  export type ResolvedDivider = WebCore.ResolvedDivider;
-  export type ResolvedMultipleChoice = WebCore.ResolvedMultipleChoice;
-  export type ResolvedTextField = WebCore.ResolvedTextField;
-  export type ResolvedCheckbox = WebCore.ResolvedCheckbox;
-  export type ResolvedSlider = WebCore.ResolvedSlider;
-  export type ResolvedDateTimeInput = WebCore.ResolvedDateTimeInput;
-  export type ResolvedTabs = WebCore.ResolvedTabs;
-  export type ResolvedModal = WebCore.ResolvedModal;
-  export type ResolvedCard = WebCore.ResolvedCard;
-
-  // Markdown
-  export type MarkdownRenderer = WebCore.MarkdownRenderer;
-  export type MarkdownRendererOptions = WebCore.MarkdownRendererOptions;
+// Components & Interfaces
+export interface Component<P = Record<string, unknown>> {
+  id: string;
+  type: string;
+  properties: P;
 }
+
+export type AnyComponentNode = WebCore.AnyComponentNode;
+export type CustomNode = WebCore.CustomNode;
+export type Theme = WebCore.Theme;
+
+// Node Types (Explicit suffix)
+export type RowNode = WebCore.RowNode;
+export type ColumnNode = WebCore.ColumnNode;
+export type TextNode = WebCore.TextNode;
+export type ListNode = WebCore.ListNode;
+export type ImageNode = WebCore.ImageNode;
+export type IconNode = WebCore.IconNode;
+export type VideoNode = WebCore.VideoNode;
+export type AudioPlayerNode = WebCore.AudioPlayerNode;
+export type ButtonNode = WebCore.ButtonNode;
+export type DividerNode = WebCore.DividerNode;
+export type MultipleChoiceNode = WebCore.MultipleChoiceNode;
+export type TextFieldNode = WebCore.TextFieldNode;
+export type CheckboxNode = WebCore.CheckboxNode;
+export type SliderNode = WebCore.SliderNode;
+export type DateTimeInputNode = WebCore.DateTimeInputNode;
+export type TabsNode = WebCore.TabsNode;
+export type ModalNode = WebCore.ModalNode;
+export type CardNode = WebCore.CardNode;
+
+// Resolved Property Types
+export type ResolvedRow = WebCore.ResolvedRow;
+export type ResolvedColumn = WebCore.ResolvedColumn;
+export type ResolvedText = WebCore.ResolvedText;
+export type ResolvedList = WebCore.ResolvedList;
+export type ResolvedImage = WebCore.ResolvedImage;
+export type ResolvedIcon = WebCore.ResolvedIcon;
+export type ResolvedVideo = WebCore.ResolvedVideo;
+export type ResolvedAudioPlayer = WebCore.ResolvedAudioPlayer;
+export type ResolvedButton = WebCore.ResolvedButton;
+export type ResolvedDivider = WebCore.ResolvedDivider;
+export type ResolvedMultipleChoice = WebCore.ResolvedMultipleChoice;
+export type ResolvedTextField = WebCore.ResolvedTextField;
+export type ResolvedCheckbox = WebCore.ResolvedCheckbox;
+export type ResolvedSlider = WebCore.ResolvedSlider;
+export type ResolvedDateTimeInput = WebCore.ResolvedDateTimeInput;
+export type ResolvedTabs = WebCore.ResolvedTabs;
+export type ResolvedModal = WebCore.ResolvedModal;
+export type ResolvedCard = WebCore.ResolvedCard;
+
+// Markdown
+export type MarkdownRenderer = WebCore.MarkdownRenderer;
+export type MarkdownRendererOptions = WebCore.MarkdownRendererOptions;

--- a/renderers/angular/src/v0_8/v0_8_integration.spec.ts
+++ b/renderers/angular/src/v0_8/v0_8_integration.spec.ts
@@ -94,7 +94,12 @@ describe('v0.8 Angular Renderer Integration', () => {
   let processor: jasmine.SpyObj<MessageProcessor>;
 
   beforeEach(async () => {
-    processor = jasmine.createSpyObj('MessageProcessor', ['getData', 'dispatch', 'resolvePath', 'version']);
+    processor = jasmine.createSpyObj('MessageProcessor', [
+      'getData',
+      'dispatch',
+      'resolvePath',
+      'version',
+    ]);
     // Default mock behavior for getData
     processor.getData.and.callFake((node: any, path: string, surfaceId?: string) => {
       if (path === '/name') return 'The Italian Kitchen';

--- a/renderers/markdown/markdown-it/package-lock.json
+++ b/renderers/markdown/markdown-it/package-lock.json
@@ -189,7 +189,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -236,7 +235,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }

--- a/renderers/web_core/package-lock.json
+++ b/renderers/web_core/package-lock.json
@@ -479,7 +479,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -674,7 +673,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1185,7 +1183,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1260,7 +1257,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -2878,7 +2874,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3220,7 +3215,6 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -3491,7 +3485,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3619,7 +3612,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3866,7 +3858,6 @@
       "version": "3.25.76",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/samples/client/angular/package-lock.json
+++ b/samples/client/angular/package-lock.json
@@ -575,7 +575,6 @@
       "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -669,7 +668,6 @@
       "version": "20.2.14",
       "integrity": "sha512-7bZxc01URbiPiIBWThQ69XwOxVduqEKN4PhpbF2AAyfMc/W8Hcr4VoIJOwL0O1Nkq5beS8pCAqoOeIgFyXd/kg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
@@ -767,7 +765,6 @@
       "version": "21.2.8",
       "integrity": "sha512-ZvgcxsLPkSG0B1jc2ZXshAWIFBoQ0U9uwIX/zG/RGcfMpoKyEDNAebli6FTIpxIlz/35rtBNV7EGPhinjPTJFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -783,7 +780,6 @@
       "version": "21.2.8",
       "integrity": "sha512-Il9KlT6qX8rWmun5jY6wMLx56bCQZpOVIFEyHM4ai2wmxvbqyxgRFKDs4iMRNn1h04Tgupl6cKSqP9lecIvH6w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -796,7 +792,6 @@
       "integrity": "sha512-S0W+6QazCsn/4xWZu0V5VmU9zmKIlqFR2FJSsAQUPReVmpA40SuQSP6A/cyMVIMYaHvO/cAXSHJVgpxBzBSL/Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.29.0",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -828,7 +823,6 @@
       "version": "21.2.8",
       "integrity": "sha512-hI7n4t8qgFJaVV55LIaNuzcdP+/IeuqQRu3huSLo47Gf6uZAD0Acj4Ye9SC8YNmhUu5/RiImngm9NOlcI2oCJA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -853,7 +847,6 @@
       "version": "21.2.8",
       "integrity": "sha512-tyQAHjfMHcqETRkKQaZHjYqIK9W8uRenPpY2DF/Jl+S7CwcaX4T8t8TKgzvTynNzQW9QGiLg0pqVosVMKzBXJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "tslib": "^2.3.0"
@@ -902,7 +895,6 @@
       "version": "21.2.8",
       "integrity": "sha512-4fwmGf7GCuIsjFqx1gqqWC92YjlN9SmGJO17TPPsOm5zUOnDx+h3Bj9XjdXxlcBtugTb2xHk6Auqyv3lzWGlkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -924,7 +916,6 @@
       "version": "21.2.8",
       "integrity": "sha512-dIbw8NsDGiKkA388AM8eq2IpsQcpTKUSGXyNCv6HlJi6BULF3zAAH9eeGXrbibrcKru2p02Vs8lxnLzo+5tkLw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0",
         "xhr2": "^0.2.0"
@@ -944,7 +935,6 @@
       "version": "21.2.8",
       "integrity": "sha512-KSlUbFHHKY84G6iKlB2FDMmh+lLmGjmpyT1p/kx8qZm1BuxJGOOU+oNgkCfaPJT1R2/muDXuxQ51uc/la6y28g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -962,7 +952,6 @@
       "version": "21.2.7",
       "integrity": "sha512-NhrkeD32s3H/jU9yJLqDy2JBNNatFyzqNkwieJw0waEvBRNbxXlcg5+g6rilcg2nHlH5hyzMQUzs7ZwZH9wCqg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1056,7 +1045,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1400,7 +1388,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1447,7 +1434,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1507,17 +1493,6 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2226,7 +2201,6 @@
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
         "@inquirer/confirm": "^5.1.21",
@@ -5200,7 +5174,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5459,7 +5432,6 @@
       "version": "4.5.1",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -5480,7 +5452,6 @@
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -6688,7 +6659,6 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -6988,7 +6958,6 @@
       "version": "5.2.1",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7662,7 +7631,6 @@
       "version": "4.12.12",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8264,8 +8232,7 @@
       "version": "5.9.0",
       "integrity": "sha512-OMUvF1iI6+gSRYOhMrH4QYothVLN9C3EJ6wm4g7zLJlnaTl8zbaPOr0bTw70l7QxkoM7sVFOWo83u9B2Fe2Zng==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jose": {
       "version": "6.2.2",
@@ -8485,7 +8452,6 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -8819,7 +8785,6 @@
       "integrity": "sha512-OJmO5+HxZLLw0RLzkqaNHzcgEAQG7C0y3aMbwtCzIUFZsLMNNq/1IdAdHEycQ58CwUO3jPTHmoN+tE5I7FQxNg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^3.0.5",
         "parse-node-version": "^1.0.1"
@@ -8910,7 +8875,6 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -9691,7 +9655,6 @@
       "integrity": "sha512-VO0y7RU3Ik8E14QdrryVyVbTAyqO2MK9W9GrG4e/4N8+ti+DWiBSQmw0tIhnV67lEjQwCccPA3ZBoIn3B1vJ1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@rollup/plugin-json": "^6.1.0",
@@ -10579,7 +10542,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10941,7 +10903,6 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11031,7 +10992,6 @@
       "version": "7.8.2",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -11974,8 +11934,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tuf-js": {
       "version": "4.1.0",
@@ -12059,7 +12018,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12226,7 +12184,6 @@
       "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -12758,7 +12715,6 @@
       "integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.3",
         "@vitest/mocker": "4.1.3",
@@ -13144,7 +13100,6 @@
       "version": "3.25.76",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -13160,8 +13115,7 @@
     "node_modules/zone.js": {
       "version": "0.15.1",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "projects/a2a-chat-canvas": {
       "version": "0.0.1",


### PR DESCRIPTION
# Description

`namespace`s are typescript-only syntax that, for what we need, can be achieved with standard `import`/`export`s.

This PR removes the `Types` namespace and replaces it by a named export in the public API of the package. Internally, tightens the imports of v0.8 types to be explicit about the imports.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG]. - n/a. This change should be totally transparent to the users of the package.
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes. - n/a. Not a flutter change.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
