### PR TITLE
feat: implement node layer architecture

### DIFF
--- a/renderers/markdown/markdown-it/package-lock.json
+++ b/renderers/markdown/markdown-it/package-lock.json
@@ -189,7 +189,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -236,7 +235,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }

--- a/renderers/react/a2ui_explorer/src/Integration.test.tsx
+++ b/renderers/react/a2ui_explorer/src/Integration.test.tsx
@@ -42,7 +42,7 @@ describe('A2UI React Integration', () => {
     const surface = processor.model.getSurface('s1');
     expect(surface).toBeDefined();
     
-    const { rerender } = render(<A2uiSurface surface={surface as any} />);
+    render(<A2uiSurface surface={surface as any} />);
 
     // 2. Add components
     await act(async () => {

--- a/renderers/react/a2ui_explorer/src/Integration.test.tsx
+++ b/renderers/react/a2ui_explorer/src/Integration.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MessageProcessor } from '@a2ui/web_core/v0_9';
+import { basicCatalog, A2uiSurface } from '@a2ui/react/v0_9';
+
+describe('A2UI React Integration', () => {
+  it('renders a reactive node tree from messages', async () => {
+    const processor = new MessageProcessor([basicCatalog]);
+    
+    render(<A2uiSurface surface={processor.model.getSurface('s1') as any} />);
+    
+    // 1. Create surface
+    await act(async () => {
+      processor.processMessages([
+        {
+          version: 'v0.9',
+          createSurface: {
+            surfaceId: 's1',
+            catalogId: 'https://a2ui.org/specification/v0_9/basic_catalog.json'
+          }
+        }
+      ]);
+    });
+
+    // Re-render with the new surface
+    const surface = processor.model.getSurface('s1');
+    expect(surface).toBeDefined();
+    
+    const { rerender } = render(<A2uiSurface surface={surface as any} />);
+
+    // 2. Add components
+    await act(async () => {
+      processor.processMessages([
+        {
+          version: 'v0.9',
+          updateComponents: {
+            surfaceId: 's1',
+            components: [
+              {
+                id: 'root',
+                component: 'Card',
+                child: 'title'
+              },
+              {
+                id: 'title',
+                component: 'Text',
+                text: { path: '/title' }
+              }
+            ]
+          }
+        }
+      ]);
+    });
+
+    // Should show loading or empty initially as data is missing
+    expect(screen.queryByText('Hello World')).toBeNull();
+
+    // 3. Update data
+    await act(async () => {
+      processor.processMessages([
+        {
+          version: 'v0.9',
+          updateDataModel: {
+            surfaceId: 's1',
+            path: '/title',
+            value: 'Hello World'
+          }
+        }
+      ]);
+    });
+
+    // Now it should be rendered
+    expect(screen.getByText('Hello World')).toBeDefined();
+
+    // 4. Update data reactively
+    await act(async () => {
+      surface?.dataModel.set('/title', 'Updated Title');
+    });
+
+    expect(screen.getByText('Updated Title')).toBeDefined();
+    expect(screen.queryByText('Hello World')).toBeNull();
+  });
+});

--- a/renderers/react/package-lock.json
+++ b/renderers/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a2ui/react",
-  "version": "0.9.0-alpha.3",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a2ui/react",
-      "version": "0.9.0-alpha.3",
+      "version": "0.9.1",
       "dependencies": {
         "@a2ui/markdown-it": "file:../markdown/markdown-it",
         "@a2ui/web_core": "file:../web_core",

--- a/renderers/react/src/v0_9/A2uiSurface.tsx
+++ b/renderers/react/src/v0_9/A2uiSurface.tsx
@@ -14,119 +14,88 @@
  * limitations under the License.
  */
 
-import React, {useSyncExternalStore, memo, useMemo, useCallback} from 'react';
-import {type SurfaceModel, ComponentContext, type ComponentModel} from '@a2ui/web_core/v0_9';
+import React, {useSyncExternalStore, memo, useCallback, createContext, useContext} from 'react';
+import {type SurfaceModel, type A2uiNode} from '@a2ui/web_core/v0_9';
 import type {ReactComponentImplementation} from './adapter';
 
-const ResolvedChild = memo(
-  ({
-    surface,
-    id,
-    basePath,
-    compImpl,
-    componentModel,
-  }: {
-    surface: SurfaceModel<ReactComponentImplementation>;
-    id: string;
-    basePath: string;
-    componentModel: ComponentModel;
-    compImpl: ReactComponentImplementation;
-  }) => {
-    const ComponentToRender = compImpl.render;
+const SurfaceContext = createContext<SurfaceModel<ReactComponentImplementation> | undefined>(undefined);
 
-    // Create context. Recreate if the componentModel instance changes (e.g. type change recreation).
-    const context = useMemo(
-      () => new ComponentContext(surface, id, basePath),
-      // componentModel is used as a trigger for recreation even if not in the body
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [surface, id, basePath, componentModel]
-    );
-
-    const buildChild = useCallback(
-      (childId: string, specificPath?: string) => {
-        const path = specificPath || context.dataContext.path;
-        return (
-          <DeferredChild
-            key={`${childId}-${path}`}
-            surface={surface}
-            id={childId}
-            basePath={path}
-          />
-        );
-      },
-      [surface, context.dataContext.path]
-    );
-
-    return <ComponentToRender context={context} buildChild={buildChild} />;
+export const useSurface = () => {
+  const surface = useContext(SurfaceContext);
+  if (!surface) {
+    throw new Error('useSurface must be used within an A2uiSurface');
   }
-);
-ResolvedChild.displayName = 'ResolvedChild';
+  return surface;
+};
 
-export const DeferredChild: React.FC<{
-  surface: SurfaceModel<ReactComponentImplementation>;
-  id: string;
-  basePath: string;
-}> = memo(({surface, id, basePath}) => {
-  // 1. Subscribe specifically to this component's existence
-  const store = useMemo(() => {
-    let version = 0;
-    return {
-      subscribe: (cb: () => void) => {
-        const unsub1 = surface.componentsModel.onCreated.subscribe((comp) => {
-          if (comp.id === id) {
-            version++;
-            cb();
-          }
-        });
-        const unsub2 = surface.componentsModel.onDeleted.subscribe((delId) => {
-          if (delId === id) {
-            version++;
-            cb();
-          }
+const useNodeStore = (signal?: {subscribe: (cb: (val: any) => void) => () => void, peek: () => any}) => {
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      if (!signal) return () => {};
+      const dispose = signal.subscribe(() => {
+        callback();
+      });
+      return () => dispose();
+    },
+    [signal]
+  );
+  const getSnapshot = useCallback(() => signal?.peek(), [signal]);
+  return useSyncExternalStore(subscribe, getSnapshot);
+};
+
+export const NodeRenderer = memo(
+  ({
+    node,
+  }: {
+    node: A2uiNode;
+  }) => {
+    const surface = useSurface();
+    // 1. Subscribe specifically to this node's destruction
+    const isDestroyed = useSyncExternalStore(
+      useCallback((cb: () => void) => {
+        let active = true;
+        const sub = node.onDestroyed.subscribe(() => {
+          if (active) cb();
         });
         return () => {
-          unsub1.unsubscribe();
-          unsub2.unsubscribe();
+          active = false;
+          sub.unsubscribe();
         };
-      },
-      getSnapshot: () => {
-        const comp = surface.componentsModel.get(id);
-        // We use instance identity + version as the snapshot to ensure
-        // type replacements (e.g. Button -> Text) trigger a re-render.
-        return comp ? `${comp.type}-${version}` : `missing-${version}`;
-      },
-    };
-  }, [surface, id]);
+      }, [node]),
+      () => false // It's only true if the callback fires, causing unmount
+    );
 
-  useSyncExternalStore(store.subscribe, store.getSnapshot);
+    if (isDestroyed) {
+      return null;
+    }
 
-  const componentModel = surface.componentsModel.get(id);
+    const compImpl = surface.catalog.components.get(node.type);
 
-  if (!componentModel) {
-    return <div style={{color: 'gray', padding: '4px'}}>[Loading {id}...]</div>;
+    if (!compImpl) {
+      return <div style={{color: 'red'}}>Unknown component: {node.type}</div>;
+    }
+
+    const ComponentToRender = compImpl.render;
+
+    return <ComponentToRender node={node} />;
   }
-
-  const compImpl = surface.catalog.components.get(componentModel.type);
-
-  if (!compImpl) {
-    return <div style={{color: 'red'}}>Unknown component: {componentModel.type}</div>;
-  }
-
-  return (
-    <ResolvedChild
-      surface={surface}
-      id={id}
-      basePath={basePath}
-      componentModel={componentModel}
-      compImpl={compImpl}
-    />
-  );
-});
-DeferredChild.displayName = 'DeferredChild';
+);
+NodeRenderer.displayName = 'NodeRenderer';
 
 export const A2uiSurface: React.FC<{surface: SurfaceModel<ReactComponentImplementation>}> = ({
   surface,
 }) => {
-  // The root component always has ID 'root' and base path '/'
-  return <DeferredChild surface={surface} id="root" basePath="/" />;
+  const rootNode = useNodeStore(surface?.rootNode);
+
+  if (!surface) return null;
+
+  return (
+    <SurfaceContext.Provider value={surface}>
+      {!rootNode ? (
+        <div style={{color: 'gray', padding: '4px'}}>[Loading root...]</div>
+      ) : (
+        <NodeRenderer node={rootNode} />
+      )}
+    </SurfaceContext.Provider>
+  );
 };

--- a/renderers/react/src/v0_9/A2uiSurface.tsx
+++ b/renderers/react/src/v0_9/A2uiSurface.tsx
@@ -18,7 +18,9 @@ import React, {useSyncExternalStore, memo, useCallback, createContext, useContex
 import {type SurfaceModel, type A2uiNode} from '@a2ui/web_core/v0_9';
 import type {ReactComponentImplementation} from './adapter';
 
-const SurfaceContext = createContext<SurfaceModel<ReactComponentImplementation> | undefined>(undefined);
+export const SurfaceContext = createContext<SurfaceModel<ReactComponentImplementation> | undefined>(
+  undefined
+);
 
 export const useSurface = () => {
   const surface = useContext(SurfaceContext);
@@ -28,7 +30,10 @@ export const useSurface = () => {
   return surface;
 };
 
-const useNodeStore = (signal?: {subscribe: (cb: (val: any) => void) => () => void, peek: () => any}) => {
+const useNodeStore = (signal?: {
+  subscribe: (cb: (val: unknown) => void) => () => void;
+  peek: () => any;
+}) => {
   const subscribe = useCallback(
     (callback: () => void) => {
       if (!signal) return () => {};
@@ -43,16 +48,12 @@ const useNodeStore = (signal?: {subscribe: (cb: (val: any) => void) => () => voi
   return useSyncExternalStore(subscribe, getSnapshot);
 };
 
-export const NodeRenderer = memo(
-  ({
-    node,
-  }: {
-    node: A2uiNode;
-  }) => {
-    const surface = useSurface();
-    // 1. Subscribe specifically to this node's destruction
-    const isDestroyed = useSyncExternalStore(
-      useCallback((cb: () => void) => {
+export const NodeRenderer = memo(({node}: {node: A2uiNode}) => {
+  const surface = useSurface();
+  // 1. Subscribe specifically to this node's destruction
+  const isDestroyed = useSyncExternalStore(
+    useCallback(
+      (cb: () => void) => {
         let active = true;
         const sub = node.onDestroyed.subscribe(() => {
           if (active) cb();
@@ -61,25 +62,26 @@ export const NodeRenderer = memo(
           active = false;
           sub.unsubscribe();
         };
-      }, [node]),
-      () => false // It's only true if the callback fires, causing unmount
-    );
+      },
+      [node]
+    ),
+    () => false // It's only true if the callback fires, causing unmount
+  );
 
-    if (isDestroyed) {
-      return null;
-    }
-
-    const compImpl = surface.catalog.components.get(node.type);
-
-    if (!compImpl) {
-      return <div style={{color: 'red'}}>Unknown component: {node.type}</div>;
-    }
-
-    const ComponentToRender = compImpl.render;
-
-    return <ComponentToRender node={node} />;
+  if (isDestroyed) {
+    return null;
   }
-);
+
+  const compImpl = surface.catalog.components.get(node.type);
+
+  if (!compImpl) {
+    return <div style={{color: 'red'}}>Unknown component: {node.type}</div>;
+  }
+
+  const ComponentToRender = compImpl.render;
+
+  return <ComponentToRender node={node} />;
+});
 NodeRenderer.displayName = 'NodeRenderer';
 
 export const A2uiSurface: React.FC<{surface: SurfaceModel<ReactComponentImplementation>}> = ({

--- a/renderers/react/src/v0_9/adapter.tsx
+++ b/renderers/react/src/v0_9/adapter.tsx
@@ -21,6 +21,7 @@ import type {
   ResolveA2uiProps,
   A2uiNode,
 } from '@a2ui/web_core/v0_9';
+import {NodeRenderer} from './A2uiSurface';
 
 export interface ReactComponentImplementation extends ComponentApi {
   /** The framework-specific rendering wrapper. */
@@ -32,6 +33,7 @@ export interface ReactComponentImplementation extends ComponentApi {
 export type ReactA2uiComponentProps<T> = {
   props: T;
   node: A2uiNode;
+  buildChild: (nodeOrId: A2uiNode | string) => React.ReactNode;
 };
 
 /**
@@ -77,7 +79,17 @@ export function createComponentImplementation<Api extends ComponentApi>(
     node: A2uiNode;
   }> = ({node}) => {
     const props = useNodeProps(node as A2uiNode<Props>);
-    return <MemoizedRender props={props || ({} as Props)} node={node} />;
+    
+    // Trivial backward-compatible buildChild
+    const buildChild = useCallback((nodeOrId: A2uiNode | string) => {
+      if (typeof nodeOrId === 'object' && nodeOrId && 'instanceId' in nodeOrId) {
+        return <NodeRenderer key={nodeOrId.instanceId} node={nodeOrId as A2uiNode} />;
+      }
+      console.warn("buildChild expects an A2uiNode object, but received a string ID. The generic binder should resolve IDs into Node objects.");
+      return null;
+    }, []);
+
+    return <MemoizedRender props={props || ({} as Props)} node={node} buildChild={buildChild} />;
   };
 
   return {

--- a/renderers/react/src/v0_9/adapter.tsx
+++ b/renderers/react/src/v0_9/adapter.tsx
@@ -14,32 +14,50 @@
  * limitations under the License.
  */
 
-import React, {useRef, useSyncExternalStore, useCallback, memo, useEffect} from 'react';
-import {type ComponentContext, GenericBinder} from '@a2ui/web_core/v0_9';
+import React, {useSyncExternalStore, useCallback, memo} from 'react';
 import type {
   ComponentApi,
   InferredComponentApiSchemaType,
   ResolveA2uiProps,
+  A2uiNode,
 } from '@a2ui/web_core/v0_9';
 
 export interface ReactComponentImplementation extends ComponentApi {
   /** The framework-specific rendering wrapper. */
   render: React.FC<{
-    context: ComponentContext;
-    buildChild: (id: string, basePath?: string) => React.ReactNode;
+    node: A2uiNode;
   }>;
 }
 
 export type ReactA2uiComponentProps<T> = {
   props: T;
-  buildChild: (id: string, basePath?: string) => React.ReactNode;
-  context: ComponentContext;
+  node: A2uiNode;
 };
+
+/**
+ * Hook to subscribe to an A2uiNode's properties.
+ */
+export function useNodeProps<T>(node: A2uiNode<T>): T {
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      // Create a reactive effect that re-runs the callback when props change
+      const dispose = node.props.subscribe(() => {
+        callback();
+      });
+      return () => dispose();
+    },
+    [node]
+  );
+
+  const getSnapshot = useCallback(() => node.props.peek(), [node]);
+  
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
 
 // --- Component Factories ---
 
 /**
- * Creates a React component implementation using the deep generic binder.
+ * Creates a React component implementation using the Node Layer.
  */
 export function createComponentImplementation<Api extends ComponentApi>(
   api: Api,
@@ -51,47 +69,15 @@ export function createComponentImplementation<Api extends ComponentApi>(
 
   const MemoizedRender = memo(RenderComponent, (prev, next) => {
     if (prev.props !== next.props) return false;
-    if (prev.context.componentModel.id !== next.context.componentModel.id) return false;
-    if (prev.context.dataContext.path !== next.context.dataContext.path) return false;
+    if (prev.node.instanceId !== next.node.instanceId) return false;
     return true;
   });
 
   const ReactWrapper: React.FC<{
-    context: ComponentContext;
-    buildChild: (id: string, basePath?: string) => React.ReactNode;
-  }> = ({context, buildChild}) => {
-    const bindingRef = useRef<GenericBinder<Props> | null>(null);
-
-    // Create or recreate the binder if the context object changes.
-    // DeferredChild memoizes `context`, so reference changes strictly correspond
-    // to ComponentModel updates (like type changes) or Base Path adjustments.
-    if (!bindingRef.current) {
-      bindingRef.current = new GenericBinder<Props>(context, api.schema);
-    } else if ((bindingRef.current as unknown as {context: ComponentContext}).context !== context) {
-      bindingRef.current.dispose();
-      bindingRef.current = new GenericBinder<Props>(context, api.schema);
-    }
-    const binding = bindingRef.current;
-
-    const subscribe = useCallback(
-      (callback: () => void) => {
-        const sub = binding.subscribe(callback);
-        return () => sub.unsubscribe();
-      },
-      [binding]
-    );
-
-    const getSnapshot = useCallback(() => binding.snapshot, [binding]);
-    const props = useSyncExternalStore(subscribe, getSnapshot);
-
-    // Prevent DataModel subscription leaks on unmount
-    useEffect(() => {
-      return () => binding.dispose();
-    }, [binding]);
-
-    return (
-      <MemoizedRender props={props || ({} as Props)} buildChild={buildChild} context={context} />
-    );
+    node: A2uiNode;
+  }> = ({node}) => {
+    const props = useNodeProps(node as A2uiNode<Props>);
+    return <MemoizedRender props={props || ({} as Props)} node={node} />;
   };
 
   return {
@@ -102,13 +88,12 @@ export function createComponentImplementation<Api extends ComponentApi>(
 }
 
 /**
- * Creates a React component implementation that manages its own context bindings (no generic binder).
+ * Creates a React component implementation that manages its own bindings.
  */
 export function createBinderlessComponentImplementation(
   api: ComponentApi,
   RenderComponent: React.FC<{
-    context: ComponentContext;
-    buildChild: (id: string, basePath?: string) => React.ReactNode;
+    node: A2uiNode;
   }>
 ): ReactComponentImplementation {
   return {

--- a/renderers/react/src/v0_9/adapter.tsx
+++ b/renderers/react/src/v0_9/adapter.tsx
@@ -27,13 +27,14 @@ export interface ReactComponentImplementation extends ComponentApi {
   /** The framework-specific rendering wrapper. */
   render: React.FC<{
     node: A2uiNode;
+    buildChild?: (nodeOrId: A2uiNode | string) => React.ReactNode;
   }>;
 }
 
 export type ReactA2uiComponentProps<T> = {
   props: T;
   node: A2uiNode;
-  buildChild: (nodeOrId: A2uiNode | string) => React.ReactNode;
+  buildChild: (nodeOrId: any) => React.ReactNode;
 };
 
 /**
@@ -42,6 +43,7 @@ export type ReactA2uiComponentProps<T> = {
 export function useNodeProps<T>(node: A2uiNode<T>): T {
   const subscribe = useCallback(
     (callback: () => void) => {
+      if (!node) return () => {};
       // Create a reactive effect that re-runs the callback when props change
       const dispose = node.props.subscribe(() => {
         callback();
@@ -51,8 +53,8 @@ export function useNodeProps<T>(node: A2uiNode<T>): T {
     [node]
   );
 
-  const getSnapshot = useCallback(() => node.props.peek(), [node]);
-  
+  const getSnapshot = useCallback(() => node?.props.peek(), [node]);
+
   return useSyncExternalStore(subscribe, getSnapshot);
 }
 
@@ -77,17 +79,22 @@ export function createComponentImplementation<Api extends ComponentApi>(
 
   const ReactWrapper: React.FC<{
     node: A2uiNode;
-  }> = ({node}) => {
+    buildChild?: (nodeOrId: any) => React.ReactNode;
+  }> = ({node, buildChild: providedBuildChild}) => {
     const props = useNodeProps(node as A2uiNode<Props>);
-    
+
     // Trivial backward-compatible buildChild
-    const buildChild = useCallback((nodeOrId: A2uiNode | string) => {
+    const internalBuildChild = useCallback((nodeOrId: any) => {
       if (typeof nodeOrId === 'object' && nodeOrId && 'instanceId' in nodeOrId) {
         return <NodeRenderer key={nodeOrId.instanceId} node={nodeOrId as A2uiNode} />;
       }
-      console.warn("buildChild expects an A2uiNode object, but received a string ID. The generic binder should resolve IDs into Node objects.");
+      console.warn(
+        'buildChild expects an A2uiNode object, but received a string ID. The generic binder should resolve IDs into Node objects.'
+      );
       return null;
     }, []);
+
+    const buildChild = providedBuildChild || internalBuildChild;
 
     return <MemoizedRender props={props || ({} as Props)} node={node} buildChild={buildChild} />;
   };
@@ -106,6 +113,7 @@ export function createBinderlessComponentImplementation(
   api: ComponentApi,
   RenderComponent: React.FC<{
     node: A2uiNode;
+    buildChild?: (nodeOrId: any) => React.ReactNode;
   }>
 ): ReactComponentImplementation {
   return {

--- a/renderers/react/src/v0_9/catalog/basic/components/Button.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Button.tsx
@@ -17,7 +17,6 @@
 import {createComponentImplementation} from '../../../adapter';
 import {ButtonApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {useBasicCatalogStyles} from '../utils';
-import {NodeRenderer} from '../../../A2uiSurface';
 import styles from './Button.module.css';
 
 export const Button = createComponentImplementation(ButtonApi, ({props, buildChild}) => {

--- a/renderers/react/src/v0_9/catalog/basic/components/Button.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Button.tsx
@@ -20,7 +20,7 @@ import {useBasicCatalogStyles} from '../utils';
 import {NodeRenderer} from '../../../A2uiSurface';
 import styles from './Button.module.css';
 
-export const Button = createComponentImplementation(ButtonApi, ({props}) => {
+export const Button = createComponentImplementation(ButtonApi, ({props, buildChild}) => {
   useBasicCatalogStyles();
 
   const classes = [styles.button];
@@ -32,7 +32,7 @@ export const Button = createComponentImplementation(ButtonApi, ({props}) => {
 
   return (
     <button className={classes.join(' ')} onClick={props.action} disabled={props.isValid === false}>
-      {props.child ? <NodeRenderer node={props.child as any} /> : null}
+      {props.child ? buildChild(props.child as any) : null}
     </button>
   );
 });

--- a/renderers/react/src/v0_9/catalog/basic/components/Button.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Button.tsx
@@ -17,9 +17,10 @@
 import {createComponentImplementation} from '../../../adapter';
 import {ButtonApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {useBasicCatalogStyles} from '../utils';
+import {NodeRenderer} from '../../../A2uiSurface';
 import styles from './Button.module.css';
 
-export const Button = createComponentImplementation(ButtonApi, ({props, buildChild}) => {
+export const Button = createComponentImplementation(ButtonApi, ({props}) => {
   useBasicCatalogStyles();
 
   const classes = [styles.button];
@@ -31,7 +32,7 @@ export const Button = createComponentImplementation(ButtonApi, ({props, buildChi
 
   return (
     <button className={classes.join(' ')} onClick={props.action} disabled={props.isValid === false}>
-      {props.child ? buildChild(props.child) : null}
+      {props.child ? <NodeRenderer node={props.child as any} /> : null}
     </button>
   );
 });

--- a/renderers/react/src/v0_9/catalog/basic/components/Card.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Card.tsx
@@ -18,7 +18,6 @@ import React from 'react';
 import {createComponentImplementation} from '../../../adapter';
 import {CardApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {getBaseContainerStyle, getWeightStyle, useBasicCatalogStyles} from '../utils';
-import {NodeRenderer} from '../../../A2uiSurface';
 
 export const Card = createComponentImplementation(CardApi, ({props, buildChild}) => {
   useBasicCatalogStyles();

--- a/renderers/react/src/v0_9/catalog/basic/components/Card.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Card.tsx
@@ -20,7 +20,7 @@ import {CardApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {getBaseContainerStyle, getWeightStyle, useBasicCatalogStyles} from '../utils';
 import {NodeRenderer} from '../../../A2uiSurface';
 
-export const Card = createComponentImplementation(CardApi, ({props}) => {
+export const Card = createComponentImplementation(CardApi, ({props, buildChild}) => {
   useBasicCatalogStyles();
 
   const style: React.CSSProperties = {
@@ -36,5 +36,5 @@ export const Card = createComponentImplementation(CardApi, ({props}) => {
     margin: 'var(--a2ui-card-margin, var(--a2ui-spacing-m))',
   };
 
-  return <div style={style}>{props.child ? <NodeRenderer node={props.child as any} /> : null}</div>;
+  return <div style={style}>{props.child ? buildChild(props.child as any) : null}</div>;
 });

--- a/renderers/react/src/v0_9/catalog/basic/components/Card.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Card.tsx
@@ -18,8 +18,9 @@ import React from 'react';
 import {createComponentImplementation} from '../../../adapter';
 import {CardApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {getBaseContainerStyle, getWeightStyle, useBasicCatalogStyles} from '../utils';
+import {NodeRenderer} from '../../../A2uiSurface';
 
-export const Card = createComponentImplementation(CardApi, ({props, buildChild}) => {
+export const Card = createComponentImplementation(CardApi, ({props}) => {
   useBasicCatalogStyles();
 
   const style: React.CSSProperties = {
@@ -35,5 +36,5 @@ export const Card = createComponentImplementation(CardApi, ({props, buildChild})
     margin: 'var(--a2ui-card-margin, var(--a2ui-spacing-m))',
   };
 
-  return <div style={style}>{props.child ? buildChild(props.child) : null}</div>;
+  return <div style={style}>{props.child ? <NodeRenderer node={props.child as any} /> : null}</div>;
 });

--- a/renderers/react/src/v0_9/catalog/basic/components/ChildList.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/ChildList.tsx
@@ -27,7 +27,7 @@ export const ChildList: React.FC<{
       <>
         {childList.map((item: unknown) => {
           if (buildChild) {
-             return buildChild(item);
+            return buildChild(item);
           }
           // Fallback if buildChild isn't provided for some reason
           if (item && typeof item === 'object' && 'instanceId' in item) {

--- a/renderers/react/src/v0_9/catalog/basic/components/ChildList.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/ChildList.tsx
@@ -20,12 +20,16 @@ import {NodeRenderer} from '../../../A2uiSurface';
 
 export const ChildList: React.FC<{
   childList: unknown;
-}> = ({childList}) => {
+  buildChild?: (nodeOrId: any) => React.ReactNode;
+}> = ({childList, buildChild}) => {
   if (Array.isArray(childList)) {
     return (
       <>
         {childList.map((item: unknown) => {
-          // In the Node Layer, ChildList properties resolve to actual Node instances
+          if (buildChild) {
+             return buildChild(item);
+          }
+          // Fallback if buildChild isn't provided for some reason
           if (item && typeof item === 'object' && 'instanceId' in item) {
             const node = item as A2uiNode;
             return <NodeRenderer key={node.instanceId} node={node} />;

--- a/renderers/react/src/v0_9/catalog/basic/components/ChildList.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/ChildList.tsx
@@ -15,29 +15,20 @@
  */
 
 import React from 'react';
-import {type ComponentContext} from '@a2ui/web_core/v0_9';
+import {type A2uiNode} from '@a2ui/web_core/v0_9';
+import {NodeRenderer} from '../../../A2uiSurface';
 
 export const ChildList: React.FC<{
   childList: unknown;
-  context: ComponentContext;
-  buildChild: (id: string, basePath?: string) => React.ReactNode;
-}> = ({childList, buildChild}) => {
+}> = ({childList}) => {
   if (Array.isArray(childList)) {
     return (
       <>
-        {childList.map((item: unknown, i: number) => {
-          // The new binder outputs objects like { id: string, basePath: string } for arrays of structural nodes
-          if (item && typeof item === 'object' && 'id' in item) {
-            const node = item as {id: string; basePath?: string};
-            return (
-              <React.Fragment key={`${node.id}-${i}`}>
-                {buildChild(node.id, node.basePath)}
-              </React.Fragment>
-            );
-          }
-          // Fallback for static string lists
-          if (typeof item === 'string') {
-            return <React.Fragment key={`${item}-${i}`}>{buildChild(item)}</React.Fragment>;
+        {childList.map((item: unknown) => {
+          // In the Node Layer, ChildList properties resolve to actual Node instances
+          if (item && typeof item === 'object' && 'instanceId' in item) {
+            const node = item as A2uiNode;
+            return <NodeRenderer key={node.instanceId} node={node} />;
           }
           return null;
         })}

--- a/renderers/react/src/v0_9/catalog/basic/components/ChoicePicker.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/ChoicePicker.tsx
@@ -25,7 +25,7 @@ import styles from './ChoicePicker.module.css';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type _Option = any;
 
-export const ChoicePicker = createComponentImplementation(ChoicePickerApi, ({props, context}) => {
+export const ChoicePicker = createComponentImplementation(ChoicePickerApi, ({props, node}) => {
   useBasicCatalogStyles();
   const [filter, setFilter] = useState('');
 
@@ -85,7 +85,7 @@ export const ChoicePicker = createComponentImplementation(ChoicePickerApi, ({pro
                 type={isMutuallyExclusive ? 'radio' : 'checkbox'}
                 checked={isSelected}
                 onChange={() => onToggle(opt.value)}
-                name={isMutuallyExclusive ? `choice-${context.componentModel.id}` : undefined}
+                name={isMutuallyExclusive ? `choice-${node.componentId}` : undefined}
               />
               <span className={styles.optionText}>{opt.label}</span>
             </label>

--- a/renderers/react/src/v0_9/catalog/basic/components/Column.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Column.tsx
@@ -19,7 +19,7 @@ import {ColumnApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {ChildList} from './ChildList';
 import {mapJustify, mapAlign, getWeightStyle, useBasicCatalogStyles} from '../utils';
 
-export const Column = createComponentImplementation(ColumnApi, ({props}) => {
+export const Column = createComponentImplementation(ColumnApi, ({props, buildChild}) => {
   useBasicCatalogStyles();
   return (
     <div
@@ -32,7 +32,7 @@ export const Column = createComponentImplementation(ColumnApi, ({props}) => {
         gap: 'var(--a2ui-column-gap, var(--a2ui-spacing-m))',
       }}
     >
-      <ChildList childList={props.children} />
+      <ChildList childList={props.children} buildChild={buildChild} />
     </div>
   );
 });

--- a/renderers/react/src/v0_9/catalog/basic/components/Column.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Column.tsx
@@ -19,7 +19,7 @@ import {ColumnApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {ChildList} from './ChildList';
 import {mapJustify, mapAlign, getWeightStyle, useBasicCatalogStyles} from '../utils';
 
-export const Column = createComponentImplementation(ColumnApi, ({props, buildChild, context}) => {
+export const Column = createComponentImplementation(ColumnApi, ({props}) => {
   useBasicCatalogStyles();
   return (
     <div
@@ -27,12 +27,12 @@ export const Column = createComponentImplementation(ColumnApi, ({props, buildChi
         ...getWeightStyle(props.weight),
         display: 'flex',
         flexDirection: 'column',
-        justifyContent: mapJustify(props.justify),
-        alignItems: mapAlign(props.align),
+        justifyContent: mapJustify(props.justify as any),
+        alignItems: mapAlign(props.align as any),
         gap: 'var(--a2ui-column-gap, var(--a2ui-spacing-m))',
       }}
     >
-      <ChildList childList={props.children} buildChild={buildChild} context={context} />
+      <ChildList childList={props.children} />
     </div>
   );
 });

--- a/renderers/react/src/v0_9/catalog/basic/components/DateTimeInput.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/DateTimeInput.tsx
@@ -68,8 +68,8 @@ export const DateTimeInput = createComponentImplementation(DateTimeInputApi, ({p
         style={style}
         value={props.value || ''}
         onChange={onChange}
-        min={typeof props.min === 'string' ? props.min : undefined}
-        max={typeof props.max === 'string' ? props.max : undefined}
+        min={(props.min as any) || undefined}
+        max={(props.max as any) || undefined}
       />
     </div>
   );

--- a/renderers/react/src/v0_9/catalog/basic/components/Divider.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Divider.tsx
@@ -21,7 +21,7 @@ import {useBasicCatalogStyles} from '../utils';
 
 export const Divider = createComponentImplementation(DividerApi, ({props}) => {
   useBasicCatalogStyles();
-  const isVertical = props.axis === 'vertical';
+  const isVertical = (props.axis as any) === 'vertical';
   const style: React.CSSProperties = {
     border: 'none',
     backgroundColor: 'var(--a2ui-color-border, #ccc)',

--- a/renderers/react/src/v0_9/catalog/basic/components/Image.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Image.tsx
@@ -29,23 +29,23 @@ export const Image = createComponentImplementation(ImageApi, ({props}) => {
   const style: React.CSSProperties = {
     ...getBaseLeafStyle(),
     ...getWeightStyle(props.weight),
-    objectFit: mapFit(props.fit),
+    objectFit: mapFit(props.fit as any),
     display: 'block',
     borderRadius: 'var(--a2ui-image-border-radius, 0)',
   };
 
-  if (props.variant === 'icon') {
+  if ((props.variant as any) === 'icon') {
     style.width = 'var(--a2ui-image-icon-size, 24px)';
     style.height = 'var(--a2ui-image-icon-size, 24px)';
-  } else if (props.variant === 'avatar') {
+  } else if ((props.variant as any) === 'avatar') {
     style.width = 'var(--a2ui-image-avatar-size, 40px)';
     style.height = 'var(--a2ui-image-avatar-size, 40px)';
     style.borderRadius = '50%';
-  } else if (props.variant === 'smallFeature') {
+  } else if ((props.variant as any) === 'smallFeature') {
     style.maxWidth = 'var(--a2ui-image-small-feature-size, 100px)';
-  } else if (props.variant === 'largeFeature') {
+  } else if ((props.variant as any) === 'largeFeature') {
     style.maxHeight = 'var(--a2ui-image-large-feature-size, 400px)';
-  } else if (props.variant === 'header') {
+  } else if ((props.variant as any) === 'header') {
     style.height = 'var(--a2ui-image-header-size, 200px)';
     style.objectFit = 'cover';
   }

--- a/renderers/react/src/v0_9/catalog/basic/components/List.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/List.tsx
@@ -20,7 +20,7 @@ import {ListApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {ChildList} from './ChildList';
 import {mapAlign, useBasicCatalogStyles} from '../utils';
 
-export const List = createComponentImplementation(ListApi, ({props}) => {
+export const List = createComponentImplementation(ListApi, ({props, buildChild}) => {
   useBasicCatalogStyles();
   const isHorizontal = (props.direction as any) === 'horizontal';
   const style: React.CSSProperties = {
@@ -35,7 +35,7 @@ export const List = createComponentImplementation(ListApi, ({props}) => {
 
   return (
     <div style={style}>
-      <ChildList childList={props.children} />
+      <ChildList childList={props.children} buildChild={buildChild} />
     </div>
   );
 });

--- a/renderers/react/src/v0_9/catalog/basic/components/List.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/List.tsx
@@ -20,13 +20,13 @@ import {ListApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {ChildList} from './ChildList';
 import {mapAlign, useBasicCatalogStyles} from '../utils';
 
-export const List = createComponentImplementation(ListApi, ({props, buildChild, context}) => {
+export const List = createComponentImplementation(ListApi, ({props}) => {
   useBasicCatalogStyles();
-  const isHorizontal = props.direction === 'horizontal';
+  const isHorizontal = (props.direction as any) === 'horizontal';
   const style: React.CSSProperties = {
     display: 'flex',
     flexDirection: isHorizontal ? 'row' : 'column',
-    alignItems: mapAlign(props.align),
+    alignItems: mapAlign(props.align as any),
     overflowX: isHorizontal ? 'auto' : 'hidden',
     overflowY: isHorizontal ? 'hidden' : 'auto',
     gap: 'var(--a2ui-list-gap, var(--a2ui-spacing-s))',
@@ -35,7 +35,7 @@ export const List = createComponentImplementation(ListApi, ({props, buildChild, 
 
   return (
     <div style={style}>
-      <ChildList childList={props.children} buildChild={buildChild} context={context} />
+      <ChildList childList={props.children} />
     </div>
   );
 });

--- a/renderers/react/src/v0_9/catalog/basic/components/Modal.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Modal.tsx
@@ -20,14 +20,14 @@ import {ModalApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {useBasicCatalogStyles} from '../utils';
 import {NodeRenderer} from '../../../A2uiSurface';
 
-export const Modal = createComponentImplementation(ModalApi, ({props}) => {
+export const Modal = createComponentImplementation(ModalApi, ({props, buildChild}) => {
   useBasicCatalogStyles();
   const [isOpen, setIsOpen] = useState(false);
 
   return (
     <>
       <div onClick={() => setIsOpen(true)} style={{display: 'inline-block'}}>
-        {props.trigger ? <NodeRenderer node={props.trigger as any} /> : null}
+        {props.trigger ? buildChild(props.trigger as any) : null}
       </div>
       {isOpen && (
         <div
@@ -74,7 +74,7 @@ export const Modal = createComponentImplementation(ModalApi, ({props}) => {
                 &times;
               </button>
             </div>
-            <div style={{flex: 1}}>{props.content ? <NodeRenderer node={props.content as any} /> : null}</div>
+            <div style={{flex: 1}}>{props.content ? buildChild(props.content as any) : null}</div>
           </div>
         </div>
       )}

--- a/renderers/react/src/v0_9/catalog/basic/components/Modal.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Modal.tsx
@@ -18,15 +18,16 @@ import {useState} from 'react';
 import {createComponentImplementation} from '../../../adapter';
 import {ModalApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {useBasicCatalogStyles} from '../utils';
+import {NodeRenderer} from '../../../A2uiSurface';
 
-export const Modal = createComponentImplementation(ModalApi, ({props, buildChild}) => {
+export const Modal = createComponentImplementation(ModalApi, ({props}) => {
   useBasicCatalogStyles();
   const [isOpen, setIsOpen] = useState(false);
 
   return (
     <>
       <div onClick={() => setIsOpen(true)} style={{display: 'inline-block'}}>
-        {props.trigger ? buildChild(props.trigger) : null}
+        {props.trigger ? <NodeRenderer node={props.trigger as any} /> : null}
       </div>
       {isOpen && (
         <div
@@ -73,7 +74,7 @@ export const Modal = createComponentImplementation(ModalApi, ({props, buildChild
                 &times;
               </button>
             </div>
-            <div style={{flex: 1}}>{props.content ? buildChild(props.content) : null}</div>
+            <div style={{flex: 1}}>{props.content ? <NodeRenderer node={props.content as any} /> : null}</div>
           </div>
         </div>
       )}

--- a/renderers/react/src/v0_9/catalog/basic/components/Modal.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Modal.tsx
@@ -18,7 +18,6 @@ import {useState} from 'react';
 import {createComponentImplementation} from '../../../adapter';
 import {ModalApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {useBasicCatalogStyles} from '../utils';
-import {NodeRenderer} from '../../../A2uiSurface';
 
 export const Modal = createComponentImplementation(ModalApi, ({props, buildChild}) => {
   useBasicCatalogStyles();

--- a/renderers/react/src/v0_9/catalog/basic/components/Row.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Row.tsx
@@ -19,7 +19,7 @@ import {RowApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {ChildList} from './ChildList';
 import {mapJustify, mapAlign, getWeightStyle, useBasicCatalogStyles} from '../utils';
 
-export const Row = createComponentImplementation(RowApi, ({props, buildChild, context}) => {
+export const Row = createComponentImplementation(RowApi, ({props}) => {
   useBasicCatalogStyles();
   return (
     <div
@@ -27,12 +27,12 @@ export const Row = createComponentImplementation(RowApi, ({props, buildChild, co
         ...getWeightStyle(props.weight),
         display: 'flex',
         flexDirection: 'row',
-        justifyContent: mapJustify(props.justify),
-        alignItems: mapAlign(props.align),
+        justifyContent: mapJustify(props.justify as any),
+        alignItems: mapAlign(props.align as any),
         gap: 'var(--a2ui-row-gap, var(--a2ui-spacing-m))',
       }}
     >
-      <ChildList childList={props.children} buildChild={buildChild} context={context} />
+      <ChildList childList={props.children} />
     </div>
   );
 });

--- a/renderers/react/src/v0_9/catalog/basic/components/Row.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Row.tsx
@@ -19,7 +19,7 @@ import {RowApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {ChildList} from './ChildList';
 import {mapJustify, mapAlign, getWeightStyle, useBasicCatalogStyles} from '../utils';
 
-export const Row = createComponentImplementation(RowApi, ({props}) => {
+export const Row = createComponentImplementation(RowApi, ({props, buildChild}) => {
   useBasicCatalogStyles();
   return (
     <div
@@ -32,7 +32,7 @@ export const Row = createComponentImplementation(RowApi, ({props}) => {
         gap: 'var(--a2ui-row-gap, var(--a2ui-spacing-m))',
       }}
     >
-      <ChildList childList={props.children} />
+      <ChildList childList={props.children} buildChild={buildChild} />
     </div>
   );
 });

--- a/renderers/react/src/v0_9/catalog/basic/components/Slider.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Slider.tsx
@@ -71,8 +71,8 @@ export const Slider = createComponentImplementation(SliderApi, ({props}) => {
       <input
         id={uniqueId}
         type="range"
-        min={props.min ?? 0}
-        max={props.max}
+        min={(props.min as any) ?? 0}
+        max={props.max as any}
         value={props.value ?? 0}
         onChange={onChange}
         style={inputStyle}

--- a/renderers/react/src/v0_9/catalog/basic/components/Tabs.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Tabs.tsx
@@ -18,13 +18,14 @@ import {useState} from 'react';
 import {createComponentImplementation} from '../../../adapter';
 import {TabsApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {useBasicCatalogStyles} from '../utils';
+import {NodeRenderer} from '../../../A2uiSurface';
 
 // The type of a tab is deeply nested into the TabsApi schema, and
 // it seems z.infer is not inferring it correctly (?). We use `any` for now.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type _Tab = any;
 
-export const Tabs = createComponentImplementation(TabsApi, ({props, buildChild}) => {
+export const Tabs = createComponentImplementation(TabsApi, ({props}) => {
   useBasicCatalogStyles();
   const [selectedIndex, setSelectedIndex] = useState(0);
 
@@ -78,7 +79,7 @@ export const Tabs = createComponentImplementation(TabsApi, ({props, buildChild})
           </button>
         ))}
       </div>
-      <div style={content}>{activeTab ? buildChild(activeTab.child) : null}</div>
+      <div style={content}>{activeTab ? <NodeRenderer node={activeTab.child as any} /> : null}</div>
     </div>
   );
 });

--- a/renderers/react/src/v0_9/catalog/basic/components/Tabs.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Tabs.tsx
@@ -25,7 +25,7 @@ import {NodeRenderer} from '../../../A2uiSurface';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type _Tab = any;
 
-export const Tabs = createComponentImplementation(TabsApi, ({props}) => {
+export const Tabs = createComponentImplementation(TabsApi, ({props, buildChild}) => {
   useBasicCatalogStyles();
   const [selectedIndex, setSelectedIndex] = useState(0);
 
@@ -79,7 +79,7 @@ export const Tabs = createComponentImplementation(TabsApi, ({props}) => {
           </button>
         ))}
       </div>
-      <div style={content}>{activeTab ? <NodeRenderer node={activeTab.child as any} /> : null}</div>
+      <div style={content}>{activeTab ? buildChild(activeTab.child as any) : null}</div>
     </div>
   );
 });

--- a/renderers/react/src/v0_9/catalog/basic/components/Tabs.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Tabs.tsx
@@ -18,7 +18,6 @@ import {useState} from 'react';
 import {createComponentImplementation} from '../../../adapter';
 import {TabsApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {useBasicCatalogStyles} from '../utils';
-import {NodeRenderer} from '../../../A2uiSurface';
 
 // The type of a tab is deeply nested into the TabsApi schema, and
 // it seems z.infer is not inferring it correctly (?). We use `any` for now.

--- a/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
@@ -51,15 +51,15 @@ const handleVariant = (text: string, variant?: string): string => {
 export const Text = createComponentImplementation(TextApi, ({props}) => {
   useBasicCatalogStyles();
   const text = typeof props.text === 'string' ? props.text : String(props.text ?? '');
-  const markdownText = handleVariant(text, props.variant);
+  const markdownText = handleVariant(text, props.variant as any);
   const renderedHtml = useMarkdown(markdownText);
   const style: React.CSSProperties = {
     ...getBaseLeafStyle(),
     ...getWeightStyle(props.weight),
   };
 
-  const isCaption = props.variant === 'caption';
-  const classes = [styles.a2uiText, isCaption ? styles.a2uiCaption : props.variant || 'body'];
+  const isCaption = (props.variant as any) === 'caption';
+  const classes = [styles.a2uiText, isCaption ? styles.a2uiCaption : (props.variant as any) || 'body'];
   if (renderedHtml === null) {
     classes.push('no-markdown-renderer');
   }

--- a/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
@@ -59,7 +59,10 @@ export const Text = createComponentImplementation(TextApi, ({props}) => {
   };
 
   const isCaption = (props.variant as any) === 'caption';
-  const classes = [styles.a2uiText, isCaption ? styles.a2uiCaption : (props.variant as any) || 'body'];
+  const classes = [
+    styles.a2uiText,
+    isCaption ? styles.a2uiCaption : (props.variant as any) || 'body',
+  ];
   if (renderedHtml === null) {
     classes.push('no-markdown-renderer');
   }

--- a/renderers/react/src/v0_9/catalog/basic/components/TextField.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/TextField.tsx
@@ -28,7 +28,11 @@ export const TextField = createComponentImplementation(TextFieldApi, ({props}) =
 
   const isLong = (props.variant as any) === 'longText';
   const type =
-    (props.variant as any) === 'number' ? 'number' : (props.variant as any) === 'obscured' ? 'password' : 'text';
+    (props.variant as any) === 'number'
+      ? 'number'
+      : (props.variant as any) === 'obscured'
+        ? 'password'
+        : 'text';
 
   const uniqueId = React.useId();
   const hasError = props.validationErrors && props.validationErrors.length > 0;

--- a/renderers/react/src/v0_9/catalog/basic/components/TextField.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/TextField.tsx
@@ -26,9 +26,9 @@ export const TextField = createComponentImplementation(TextFieldApi, ({props}) =
     props.setValue(e.target.value);
   };
 
-  const isLong = props.variant === 'longText';
+  const isLong = (props.variant as any) === 'longText';
   const type =
-    props.variant === 'number' ? 'number' : props.variant === 'obscured' ? 'password' : 'text';
+    (props.variant as any) === 'number' ? 'number' : (props.variant as any) === 'obscured' ? 'password' : 'text';
 
   const uniqueId = React.useId();
   const hasError = props.validationErrors && props.validationErrors.length > 0;

--- a/renderers/react/tests/utils.tsx
+++ b/renderers/react/tests/utils.tsx
@@ -15,11 +15,12 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import { vi } from 'vitest';
-import { SurfaceModel, ComponentModel, Catalog, ComponentContext } from '@a2ui/web_core/v0_9';
+import { SurfaceModel, ComponentModel, Catalog, A2uiNode } from '@a2ui/web_core/v0_9';
 import { BASIC_FUNCTIONS } from '@a2ui/web_core/v0_9/basic_catalog';
 import type { ReactComponentImplementation } from '../src/v0_9/adapter';
+import { A2uiSurface, useSurface } from '../src/v0_9/A2uiSurface';
 
 export interface RenderA2uiOptions {
   initialData?: Record<string, any>;
@@ -65,33 +66,30 @@ export function renderA2uiComponent(
     surface.componentsModel.addComponent(childModel);
   }
 
-  const mainContext = new ComponentContext(surface, componentId, '/');
+  // Resolve the node for the component under test
+  let node: A2uiNode;
+  if (componentId === 'root') {
+     node = surface.rootNode.value!;
+  } else {
+     node = (surface as any)._nodeManager.resolveNode(componentId, '/');
+  }
 
-  // Smart buildChild mock:
-  // 1. If the component exists in the model and catalog, render it for real.
-  // 2. Otherwise, render a placeholder div that tests can query.
-  const buildChild = vi.fn((id: string, basePath?: string) => {
-    const compModel = surface.componentsModel.get(id);
+  const buildChild = vi.fn((nodeOrId: any) => {
+    if (!nodeOrId) return null;
     
-    if (!compModel) {
-      return <div key={`${id}-${basePath}`} data-testid={`child-${id}`} data-basepath={basePath} />;
+    if (typeof nodeOrId === 'object' && 'instanceId' in nodeOrId) {
+      return <NodeRenderer key={nodeOrId.instanceId} node={nodeOrId as A2uiNode} />;
     }
-
-    const compImpl = surface.catalog.components.get(compModel.type);
-    if (!compImpl) {
-       return <div key={`${id}-${basePath}`} data-testid={`error-unknown-type-${compModel.type}`} />;
-    }
-
-    const ctx = new ComponentContext(surface, id, basePath || '/');
-    const ChildComponent = (compImpl as ReactComponentImplementation).render;
-
-    return <ChildComponent key={`${id}-${basePath}`} context={ctx} buildChild={buildChild} />;
+    
+    return <div data-testid={`child-${typeof nodeOrId === 'string' ? nodeOrId : nodeOrId.componentId}`} />;
   });
 
   const ComponentToRender = impl.render;
 
   const view = render(
-    <ComponentToRender context={mainContext} buildChild={buildChild} />
+    <A2uiSurface surface={surface}>
+        {componentId !== 'root' ? <ComponentToRender node={node} buildChild={buildChild} /> : <NodeRenderer node={node} />}
+    </A2uiSurface>
   );
 
   return { 
@@ -99,12 +97,14 @@ export function renderA2uiComponent(
     surface, 
     buildChild, 
     mainModel,
-    context: mainContext,
+    node,
     // Helper to trigger data model updates and wait for re-render
     updateData: async (path: string, value: any) => {
-      surface.dataModel.set(path, value);
-      // Wait for React to process the useSyncExternalStore update
-      await new Promise(resolve => setTimeout(resolve, 0));
+      await act(async () => {
+        surface.dataModel.set(path, value);
+        // Wait for React to process the useSyncExternalStore update
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
     }
   };
 }

--- a/renderers/web_core/package-lock.json
+++ b/renderers/web_core/package-lock.json
@@ -479,7 +479,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -674,7 +673,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1185,7 +1183,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1260,7 +1257,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -2878,7 +2874,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3220,7 +3215,6 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -3491,7 +3485,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3619,7 +3612,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3866,7 +3858,6 @@
       "version": "3.25.76",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/renderers/web_core/src/v0_9/index.ts
+++ b/renderers/web_core/src/v0_9/index.ts
@@ -31,6 +31,8 @@ export * from './rendering/generic-binder.js';
 export * from './schema/index.js';
 export * from './state/component-model.js';
 export * from './state/data-model.js';
+export * from './state/node-types.js';
+export * from './state/node.js';
 export * from './state/surface-components-model.js';
 export * from './state/surface-group-model.js';
 export * from './state/surface-model.js';

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.ts
@@ -390,7 +390,10 @@ export class GenericBinder<T> {
           const initialChildren = currentArr.map((_, i) => {
             const childPath = listContext.nested(String(i)).path;
             if (this.nodeResolver) {
-              const node = this.nodeResolver.resolveNode(value.componentId, childPath);
+              const node = this.nodeResolver.resolveNode(
+                value.componentId,
+                childPath,
+              );
               this.resolvedNodes.add(node);
               return node;
             }
@@ -406,7 +409,10 @@ export class GenericBinder<T> {
           // Static ChildList
           return value.map(id => {
             if (this.nodeResolver) {
-              const node = this.nodeResolver.resolveNode(id, this.context.dataContext.path);
+              const node = this.nodeResolver.resolveNode(
+                id,
+                this.context.dataContext.path,
+              );
               this.resolvedNodes.add(node);
               return node;
             }
@@ -420,7 +426,10 @@ export class GenericBinder<T> {
         // Single ComponentId
         if (typeof value === 'string') {
           if (this.nodeResolver) {
-            const node = this.nodeResolver.resolveNode(value, this.context.dataContext.path);
+            const node = this.nodeResolver.resolveNode(
+              value,
+              this.context.dataContext.path,
+            );
             this.resolvedNodes.add(node);
             return node;
           }

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.ts
@@ -22,6 +22,7 @@ import {
   DataBinding,
   FunctionCall,
 } from '../schema/common-types.js';
+import {A2uiNode} from '../state/node-types.js';
 
 // --- Schema Scraping ---
 
@@ -75,8 +76,22 @@ function getFieldBehavior(
     current = current._def.innerType;
   }
 
+  const description = current._def.description || '';
+
   if (propertyName === 'checks') {
     return {type: 'CHECKABLE'};
+  }
+
+  // Identify A2UI-specific structural types by tag in description or property name
+  if (
+    description.includes('A2UI_TYPE:ComponentId') ||
+    description.includes('A2UI_TYPE:ChildList') ||
+    propertyName === 'child' ||
+    propertyName === 'children' ||
+    propertyName === 'trigger' ||
+    propertyName === 'content'
+  ) {
+    return {type: 'STRUCTURAL'};
   }
 
   // Structural matching for A2UI primitives using typeName to avoid dual-module instanceof issues
@@ -101,9 +116,11 @@ function getFieldBehavior(
     // ChildList is a union containing an array and an object with { componentId, path }
     const isChildList = options.some(
       o =>
-        o._def.typeName === 'ZodObject' &&
-        o._def.shape().componentId &&
-        o._def.shape().path,
+        (o._def.typeName === 'ZodObject' &&
+          o._def.shape().componentId &&
+          o._def.shape().path) ||
+        (o._def.typeName === 'ZodArray' &&
+          o._def.type._def.description?.includes('A2UI_TYPE:ComponentId')),
     );
     if (isChildList) return {type: 'STRUCTURAL'};
   } else if (current._def.typeName === 'ZodString') {
@@ -144,10 +161,14 @@ type IsDynamic<T> = DataBinding extends NonNullable<T> ? true : false;
 export type ResolveA2uiProp<T> = [NonNullable<T>] extends [Action]
   ? (() => void) | Extract<T, undefined>
   : [NonNullable<T>] extends [ChildList]
-    ? any | Extract<T, undefined>
-    : Exclude<T, DynamicTypes> extends never
-      ? any
-      : Exclude<T, DynamicTypes>;
+    ? A2uiNode[] | Extract<T, undefined>
+    : [NonNullable<T>] extends [string]
+      ? T extends string
+        ? A2uiNode | string | Extract<T, undefined>
+        : A2uiNode | Extract<T, undefined>
+      : Exclude<T, DynamicTypes> extends never
+        ? any
+        : Exclude<T, DynamicTypes>;
 
 /**
  * Automatically generates two-way binding setters for dynamic properties.
@@ -174,6 +195,14 @@ export type ResolveA2uiProps<T> = (T extends object
   };
 
 /**
+ * A resolver that transforms component IDs and paths into living Node instances.
+ */
+export interface NodeResolver {
+  resolveNode(componentId: string, dataPath: string): any;
+  releaseNode(node: any): void;
+}
+
+/**
  * The Generic Binder is a framework-agnostic engine that transforms raw A2UI JSON payload
  * configurations into a single, cohesive reactive stream of strongly-typed `ResolvedProps`.
  *
@@ -196,16 +225,31 @@ export class GenericBinder<T> {
   private compUnsub?: () => void;
   private isConnected = false;
 
+  // Track nodes resolved by this binder to manage their lifecycle
+  private resolvedNodes: Set<any> = new Set();
+
   private context: ComponentContext;
   private behaviorTree: BehaviorNode;
+  private nodeResolver?: NodeResolver;
+  private componentsUnsub?: () => void;
 
-  constructor(context: ComponentContext, schema: z.ZodTypeAny) {
+  constructor(
+    context: ComponentContext,
+    schema: z.ZodTypeAny,
+    nodeResolver?: NodeResolver,
+  ) {
     this.context = context;
     this.behaviorTree = scrapeSchemaBehavior(schema);
+    this.nodeResolver = nodeResolver;
 
     if (this.behaviorTree.type !== 'OBJECT') {
       this.behaviorTree = {type: 'OBJECT', shape: {}};
     }
+
+    const sub = this.context.surfaceComponents.onCreated.subscribe(() => {
+      this.rebuildAllBindings();
+    });
+    this.componentsUnsub = () => sub.unsubscribe();
 
     this.resolveInitialProps();
   }
@@ -229,6 +273,14 @@ export class GenericBinder<T> {
   private rebuildAllBindings() {
     this.dataListeners.forEach(l => l());
     this.dataListeners = [];
+
+    // Release all nodes resolved in previous binding session
+    if (this.nodeResolver) {
+      for (const node of this.resolvedNodes) {
+        this.nodeResolver.releaseNode(node);
+      }
+    }
+    this.resolvedNodes.clear();
 
     const props = this.context.componentModel.properties;
 
@@ -287,15 +339,41 @@ export class GenericBinder<T> {
           value.path &&
           value.componentId
         ) {
+          // Template ChildList
           const bound = this.context.dataContext.subscribeDynamicValue(
             {path: value.path},
             newVal => {
+              const propName = path[path.length - 1];
+              const oldNodes = (this.currentProps as any)[propName] || [];
+
               const arr = Array.isArray(newVal) ? newVal : [];
               const listContext = this.context.dataContext.nested(value.path);
-              const resolvedChildren = arr.map((_, i) => ({
-                id: value.componentId,
-                basePath: listContext.nested(String(i)).path,
-              }));
+              const resolvedChildren = arr.map((_, i) => {
+                const childPath = listContext.nested(String(i)).path;
+                if (this.nodeResolver) {
+                  const node = this.nodeResolver.resolveNode(
+                    value.componentId,
+                    childPath,
+                  );
+                  this.resolvedNodes.add(node);
+                  return node;
+                }
+                return {
+                  id: value.componentId,
+                  basePath: childPath,
+                };
+              });
+
+              // Cleanup old nodes from this specific prop that are no longer present
+              if (this.nodeResolver && Array.isArray(oldNodes)) {
+                for (const oldNode of oldNodes) {
+                  if (!resolvedChildren.includes(oldNode)) {
+                    this.nodeResolver.releaseNode(oldNode);
+                    this.resolvedNodes.delete(oldNode);
+                  }
+                }
+              }
+
               this.updateDeepValue(path, resolvedChildren);
               this.notify();
             },
@@ -309,11 +387,49 @@ export class GenericBinder<T> {
 
           const currentArr = Array.isArray(bound.value) ? bound.value : [];
           const listContext = this.context.dataContext.nested(value.path);
-          return currentArr.map((_, i) => ({
-            id: value.componentId,
-            basePath: listContext.nested(String(i)).path,
-          }));
+          const initialChildren = currentArr.map((_, i) => {
+            const childPath = listContext.nested(String(i)).path;
+            if (this.nodeResolver) {
+              const node = this.nodeResolver.resolveNode(value.componentId, childPath);
+              this.resolvedNodes.add(node);
+              return node;
+            }
+            return {
+              id: value.componentId,
+              basePath: childPath,
+            };
+          });
+          return initialChildren;
         }
+
+        if (Array.isArray(value)) {
+          // Static ChildList
+          return value.map(id => {
+            if (this.nodeResolver) {
+              const node = this.nodeResolver.resolveNode(id, this.context.dataContext.path);
+              this.resolvedNodes.add(node);
+              return node;
+            }
+            return {
+              id,
+              basePath: this.context.dataContext.path,
+            };
+          });
+        }
+
+        // Single ComponentId
+        if (typeof value === 'string') {
+          if (this.nodeResolver) {
+            const node = this.nodeResolver.resolveNode(value, this.context.dataContext.path);
+            this.resolvedNodes.add(node);
+            return node;
+          }
+          return {
+            id: value,
+            basePath: this.context.dataContext.path,
+          };
+        }
+
         return value;
       }
 
@@ -454,10 +570,37 @@ export class GenericBinder<T> {
   }
 
   dispose() {
-    if (!this.isConnected) return;
+    if (!this.isConnected) {
+      // Still need to release nodes if we were never connected (e.g. only initial props)
+      if (this.nodeResolver) {
+        for (const node of this.resolvedNodes) {
+          this.nodeResolver.releaseNode(node);
+        }
+      }
+      this.resolvedNodes.clear();
+      if (this.componentsUnsub) {
+        this.componentsUnsub();
+        this.componentsUnsub = undefined;
+      }
+      return;
+    }
     this.isConnected = false;
     this.dataListeners.forEach(l => l());
     this.dataListeners = [];
+
+    // Release all nodes
+    if (this.nodeResolver) {
+      for (const node of this.resolvedNodes) {
+        this.nodeResolver.releaseNode(node);
+      }
+    }
+    this.resolvedNodes.clear();
+
+    if (this.componentsUnsub) {
+      this.componentsUnsub();
+      this.componentsUnsub = undefined;
+    }
+
     if (this.compUnsub) {
       this.compUnsub();
       this.compUnsub = undefined;

--- a/renderers/web_core/src/v0_9/schema/common-types.ts
+++ b/renderers/web_core/src/v0_9/schema/common-types.ts
@@ -96,7 +96,7 @@ export type DynamicValue = z.infer<typeof DynamicValueSchema>;
 export const ComponentIdSchema = z
   .string()
   .describe(
-    'REF:common_types.json#/$defs/ComponentId|The unique identifier for a component.',
+    'A2UI_TYPE:ComponentId|REF:common_types.json#/$defs/ComponentId|The unique identifier for a component.',
   );
 /** The unique identifier for a component. */
 export type ComponentId = z.infer<typeof ComponentIdSchema>;
@@ -117,7 +117,7 @@ export const ChildListSchema = z
       })
       .describe('A template for generating a dynamic list of children.'),
   ])
-  .describe('REF:common_types.json#/$defs/ChildList');
+  .describe('A2UI_TYPE:ChildList|REF:common_types.json#/$defs/ChildList');
 /** A static list of child component IDs or a dynamic list template. */
 export type ChildList = z.infer<typeof ChildListSchema>;
 

--- a/renderers/web_core/src/v0_9/state/node-types.ts
+++ b/renderers/web_core/src/v0_9/state/node-types.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Signal} from '@preact/signals-core';
+import {EventSource} from '../common/events.js';
+
+/**
+ * An A2uiNode represents a fully resolved, living instance of a component in the view hierarchy.
+ */
+export interface A2uiNode<TProps = Record<string, any>> {
+  /**
+   * A stable, unique identifier for this instance in the rendered tree.
+   * For templated nodes, this incorporates the data path.
+   */
+  readonly instanceId: string;
+
+  /** The original component ID from the A2UI payload. */
+  readonly componentId: string;
+
+  /** The component type (e.g., 'Text', 'Button'). */
+  readonly type: string;
+
+  /** The base data path this node is scoped to. */
+  readonly dataPath: string;
+
+  /** Fully resolved, strongly-typed properties. */
+  readonly props: Signal<TProps>;
+
+  /** Signals that the node is no longer valid and should be removed from the UI. */
+  readonly onDestroyed: EventSource<void>;
+
+  /** Internal cleanup of subscriptions. */
+  dispose(): void;
+}

--- a/renderers/web_core/src/v0_9/state/node.test.ts
+++ b/renderers/web_core/src/v0_9/state/node.test.ts
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from 'node:assert';
+import {describe, it, beforeEach} from 'node:test';
+import {SurfaceModel} from './surface-model.js';
+import {Catalog, ComponentApi} from '../catalog/types.js';
+import {ComponentModel} from './component-model.js';
+import {A2uiNode} from './node-types.js';
+import {z} from 'zod';
+import {CommonSchemas} from '../schema/common-types.js';
+
+describe('Node Layer', () => {
+  let catalog: Catalog<ComponentApi>;
+  let surface: SurfaceModel<ComponentApi>;
+
+  beforeEach(() => {
+    const textApi: ComponentApi = {
+      name: 'Text',
+      schema: z.object({
+        text: CommonSchemas.DynamicString,
+      }),
+    };
+    const rowApi: ComponentApi = {
+      name: 'Row',
+      schema: z.object({
+        children: CommonSchemas.ChildList,
+      }),
+    };
+    catalog = new Catalog('test', [textApi, rowApi]);
+    surface = new SurfaceModel('s1', catalog);
+  });
+
+  it('automatically creates root node when "root" component is added', () => {
+    assert.strictEqual(surface.rootNode.value, undefined);
+
+    surface.componentsModel.addComponent(
+      new ComponentModel('root', 'Text', {text: 'Hello'})
+    );
+
+    const root = surface.rootNode.value as any;
+    assert.ok(root);
+    assert.strictEqual(root.instanceId, 'root');
+    assert.strictEqual(root.type, 'Text');
+    assert.strictEqual(root.props.value.text, 'Hello');
+  });
+
+  it('updates root node reactively when component properties change', () => {
+    const comp = new ComponentModel('root', 'Text', {text: 'Initial'});
+    surface.componentsModel.addComponent(comp);
+
+    const root = surface.rootNode.value as any;
+    assert.strictEqual(root.props.value.text, 'Initial');
+
+    comp.properties = {text: 'Updated'};
+    assert.strictEqual(root.props.value.text, 'Updated');
+  });
+
+  it('destroys root node when "root" component is deleted', () => {
+    surface.componentsModel.addComponent(
+      new ComponentModel('root', 'Text', {text: 'Hello'})
+    );
+    assert.ok(surface.rootNode.value);
+
+    let destroyed = false;
+    (surface.rootNode.value as any).onDestroyed.subscribe(() => {
+      destroyed = true;
+    });
+
+    surface.componentsModel.removeComponent('root');
+    assert.strictEqual(surface.rootNode.value, undefined);
+    assert.strictEqual(destroyed, true);
+  });
+
+  it('expands static child lists into child nodes', async () => {
+    surface.componentsModel.addComponent(
+      new ComponentModel('root', 'Row', {children: ['child1']})
+    );
+    surface.componentsModel.addComponent(
+      new ComponentModel('child1', 'Text', {text: 'I am a child'})
+    );
+
+    // Wait for async notifications to process
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const root = surface.rootNode.value as any;
+    const children = root.props.value.children;
+
+    assert.ok(Array.isArray(children));
+    assert.strictEqual(children.length, 1);
+    assert.ok(children[0], 'Child node should be defined');
+    assert.strictEqual(children[0].componentId, 'child1');
+    assert.strictEqual(children[0].instanceId, 'child1');
+    assert.strictEqual(children[0].props.value.text, 'I am a child');
+  });
+
+  it('expands template child lists into multiple child nodes based on data', async () => {
+    surface.dataModel.set('/items', ['A', 'B']);
+
+    surface.componentsModel.addComponent(
+      new ComponentModel('root', 'Row', {
+        children: {
+          componentId: 'item-template',
+          path: '/items',
+        },
+      })
+    );
+    surface.componentsModel.addComponent(
+      new ComponentModel('item-template', 'Text', {text: {path: '.'}})
+    );
+
+    // Wait for async notifications
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const root = surface.rootNode.value as any;
+    let children = root.props.value.children;
+
+    assert.strictEqual(children.length, 2);
+    assert.ok(children[0]);
+    assert.strictEqual(children[0].instanceId, 'item-template-[/items/0]');
+    assert.strictEqual(children[0].props.value.text, 'A');
+    assert.ok(children[1]);
+    assert.strictEqual(children[1].instanceId, 'item-template-[/items/1]');
+    assert.strictEqual(children[1].props.value.text, 'B');
+
+    // Update data
+    surface.dataModel.set('/items', ['A', 'B', 'C']);
+    children = root.props.value.children;
+    assert.strictEqual(children.length, 3);
+    assert.ok(children[2]);
+    assert.strictEqual(children[2].props.value.text, 'C');
+  });
+
+  it('recursively destroys child nodes when parent is destroyed', async () => {
+    surface.componentsModel.addComponent(
+      new ComponentModel('root', 'Row', {children: ['child1']})
+    );
+    surface.componentsModel.addComponent(
+      new ComponentModel('child1', 'Text', {text: 'Child'})
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const root = surface.rootNode.value as any;
+    const child = root.props.value.children[0];
+    assert.ok(child);
+
+    let childDestroyed = false;
+    child.onDestroyed.subscribe(() => {
+      childDestroyed = true;
+    });
+
+    surface.componentsModel.removeComponent('root');
+    assert.strictEqual(childDestroyed, true);
+  });
+
+  it('destroys child nodes when they are removed from the list', async () => {
+    const rootComp = new ComponentModel('root', 'Row', {children: ['c1', 'c2']});
+    surface.componentsModel.addComponent(rootComp);
+    surface.componentsModel.addComponent(new ComponentModel('c1', 'Text', {text: '1'}));
+    surface.componentsModel.addComponent(new ComponentModel('c2', 'Text', {text: '2'}));
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const root = surface.rootNode.value as any;
+    const c2 = root.props.value.children[1];
+    assert.ok(c2);
+
+    let c2Destroyed = false;
+    c2.onDestroyed.subscribe(() => {
+      c2Destroyed = true;
+    });
+
+    // Remove c2 from root's children
+    rootComp.properties = {children: ['c1']};
+
+    assert.strictEqual(root.props.value.children.length, 1);
+    assert.strictEqual(c2Destroyed, true);
+  });
+
+  it('supports shared nodes via reference counting', async () => {
+    // A2UI adjacency list allows multiple parents to refer to the same ID.
+    // In Node Layer, if they have the same dataPath, they share the Node instance.
+    
+    surface.componentsModel.addComponent(
+      new ComponentModel('root', 'Row', {children: ['parent1', 'parent2']})
+    );
+    surface.componentsModel.addComponent(
+      new ComponentModel('parent1', 'Row', {children: ['shared']})
+    );
+    surface.componentsModel.addComponent(
+      new ComponentModel('parent2', 'Row', {children: ['shared']})
+    );
+    surface.componentsModel.addComponent(
+      new ComponentModel('shared', 'Text', {text: 'Shared'})
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const root = surface.rootNode.value as any;
+    const p1 = root.props.value.children[0];
+    const p2 = root.props.value.children[1];
+    
+    assert.ok(p1);
+    assert.ok(p2);
+
+    const shared1 = p1.props.value.children[0];
+    const shared2 = p2.props.value.children[0];
+
+    assert.ok(shared1);
+    assert.ok(shared2);
+    assert.strictEqual(shared1, shared2, 'Nodes with same instanceId should be shared');
+
+    let sharedDestroyed = false;
+    shared1.onDestroyed.subscribe(() => {
+      sharedDestroyed = true;
+    });
+
+    // Remove shared from p1
+    surface.componentsModel.get('parent1')!.properties = {children: []};
+    assert.strictEqual(sharedDestroyed, false, 'Shared node should not be destroyed if still used by p2');
+
+    // Remove parent2 from root
+    surface.componentsModel.get('root')!.properties = {children: ['parent1']};
+    assert.strictEqual(sharedDestroyed, true, 'Shared node should be destroyed when no longer referenced');
+  });
+});

--- a/renderers/web_core/src/v0_9/state/node.test.ts
+++ b/renderers/web_core/src/v0_9/state/node.test.ts
@@ -19,7 +19,6 @@ import {describe, it, beforeEach} from 'node:test';
 import {SurfaceModel} from './surface-model.js';
 import {Catalog, ComponentApi} from '../catalog/types.js';
 import {ComponentModel} from './component-model.js';
-import {A2uiNode} from './node-types.js';
 import {z} from 'zod';
 import {CommonSchemas} from '../schema/common-types.js';
 
@@ -48,7 +47,7 @@ describe('Node Layer', () => {
     assert.strictEqual(surface.rootNode.value, undefined);
 
     surface.componentsModel.addComponent(
-      new ComponentModel('root', 'Text', {text: 'Hello'})
+      new ComponentModel('root', 'Text', {text: 'Hello'}),
     );
 
     const root = surface.rootNode.value as any;
@@ -71,7 +70,7 @@ describe('Node Layer', () => {
 
   it('destroys root node when "root" component is deleted', () => {
     surface.componentsModel.addComponent(
-      new ComponentModel('root', 'Text', {text: 'Hello'})
+      new ComponentModel('root', 'Text', {text: 'Hello'}),
     );
     assert.ok(surface.rootNode.value);
 
@@ -87,10 +86,10 @@ describe('Node Layer', () => {
 
   it('expands static child lists into child nodes', async () => {
     surface.componentsModel.addComponent(
-      new ComponentModel('root', 'Row', {children: ['child1']})
+      new ComponentModel('root', 'Row', {children: ['child1']}),
     );
     surface.componentsModel.addComponent(
-      new ComponentModel('child1', 'Text', {text: 'I am a child'})
+      new ComponentModel('child1', 'Text', {text: 'I am a child'}),
     );
 
     // Wait for async notifications to process
@@ -116,10 +115,10 @@ describe('Node Layer', () => {
           componentId: 'item-template',
           path: '/items',
         },
-      })
+      }),
     );
     surface.componentsModel.addComponent(
-      new ComponentModel('item-template', 'Text', {text: {path: '.'}})
+      new ComponentModel('item-template', 'Text', {text: {path: '.'}}),
     );
 
     // Wait for async notifications
@@ -146,10 +145,10 @@ describe('Node Layer', () => {
 
   it('recursively destroys child nodes when parent is destroyed', async () => {
     surface.componentsModel.addComponent(
-      new ComponentModel('root', 'Row', {children: ['child1']})
+      new ComponentModel('root', 'Row', {children: ['child1']}),
     );
     surface.componentsModel.addComponent(
-      new ComponentModel('child1', 'Text', {text: 'Child'})
+      new ComponentModel('child1', 'Text', {text: 'Child'}),
     );
 
     await new Promise(resolve => setTimeout(resolve, 0));
@@ -168,10 +167,16 @@ describe('Node Layer', () => {
   });
 
   it('destroys child nodes when they are removed from the list', async () => {
-    const rootComp = new ComponentModel('root', 'Row', {children: ['c1', 'c2']});
+    const rootComp = new ComponentModel('root', 'Row', {
+      children: ['c1', 'c2'],
+    });
     surface.componentsModel.addComponent(rootComp);
-    surface.componentsModel.addComponent(new ComponentModel('c1', 'Text', {text: '1'}));
-    surface.componentsModel.addComponent(new ComponentModel('c2', 'Text', {text: '2'}));
+    surface.componentsModel.addComponent(
+      new ComponentModel('c1', 'Text', {text: '1'}),
+    );
+    surface.componentsModel.addComponent(
+      new ComponentModel('c2', 'Text', {text: '2'}),
+    );
 
     await new Promise(resolve => setTimeout(resolve, 0));
 
@@ -194,18 +199,18 @@ describe('Node Layer', () => {
   it('supports shared nodes via reference counting', async () => {
     // A2UI adjacency list allows multiple parents to refer to the same ID.
     // In Node Layer, if they have the same dataPath, they share the Node instance.
-    
+
     surface.componentsModel.addComponent(
-      new ComponentModel('root', 'Row', {children: ['parent1', 'parent2']})
+      new ComponentModel('root', 'Row', {children: ['parent1', 'parent2']}),
     );
     surface.componentsModel.addComponent(
-      new ComponentModel('parent1', 'Row', {children: ['shared']})
+      new ComponentModel('parent1', 'Row', {children: ['shared']}),
     );
     surface.componentsModel.addComponent(
-      new ComponentModel('parent2', 'Row', {children: ['shared']})
+      new ComponentModel('parent2', 'Row', {children: ['shared']}),
     );
     surface.componentsModel.addComponent(
-      new ComponentModel('shared', 'Text', {text: 'Shared'})
+      new ComponentModel('shared', 'Text', {text: 'Shared'}),
     );
 
     await new Promise(resolve => setTimeout(resolve, 0));
@@ -213,7 +218,7 @@ describe('Node Layer', () => {
     const root = surface.rootNode.value as any;
     const p1 = root.props.value.children[0];
     const p2 = root.props.value.children[1];
-    
+
     assert.ok(p1);
     assert.ok(p2);
 
@@ -222,7 +227,11 @@ describe('Node Layer', () => {
 
     assert.ok(shared1);
     assert.ok(shared2);
-    assert.strictEqual(shared1, shared2, 'Nodes with same instanceId should be shared');
+    assert.strictEqual(
+      shared1,
+      shared2,
+      'Nodes with same instanceId should be shared',
+    );
 
     let sharedDestroyed = false;
     shared1.onDestroyed.subscribe(() => {
@@ -231,10 +240,18 @@ describe('Node Layer', () => {
 
     // Remove shared from p1
     surface.componentsModel.get('parent1')!.properties = {children: []};
-    assert.strictEqual(sharedDestroyed, false, 'Shared node should not be destroyed if still used by p2');
+    assert.strictEqual(
+      sharedDestroyed,
+      false,
+      'Shared node should not be destroyed if still used by p2',
+    );
 
     // Remove parent2 from root
     surface.componentsModel.get('root')!.properties = {children: ['parent1']};
-    assert.strictEqual(sharedDestroyed, true, 'Shared node should be destroyed when no longer referenced');
+    assert.strictEqual(
+      sharedDestroyed,
+      true,
+      'Shared node should be destroyed when no longer referenced',
+    );
   });
 });

--- a/renderers/web_core/src/v0_9/state/node.ts
+++ b/renderers/web_core/src/v0_9/state/node.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Signal, signal} from '@preact/signals-core';
+import {z} from 'zod';
+import {EventEmitter, EventSource} from '../common/events.js';
+import {ComponentContext} from '../rendering/component-context.js';
+import {GenericBinder, NodeResolver} from '../rendering/generic-binder.js';
+import {SurfaceModel} from './surface-model.js';
+import {A2uiNode} from './node-types.js';
+
+/**
+ * Internal implementation of the A2uiNode interface.
+ */
+export class NodeImpl<TProps = Record<string, any>> implements A2uiNode<TProps> {
+  private readonly _onDestroyed = new EventEmitter<void>();
+  private readonly _props = signal<TProps>({} as TProps);
+  private binder: GenericBinder<TProps>;
+  private binderUnsub: {unsubscribe: () => void};
+
+  readonly onDestroyed: EventSource<void> = this._onDestroyed;
+
+  constructor(
+    readonly instanceId: string,
+    readonly componentId: string,
+    readonly type: string,
+    readonly dataPath: string,
+    surface: SurfaceModel<any>,
+    nodeResolver: NodeResolver,
+  ) {
+    const context = new ComponentContext(surface, componentId, dataPath);
+    const catalogEntry = surface.catalog.components.get(type);
+    const schema = catalogEntry?.schema || z.object({});
+
+    this.binder = new GenericBinder<TProps>(context, schema, nodeResolver);
+    this.binderUnsub = this.binder.subscribe(props => {
+      this._props.value = props;
+    });
+    // Initial props
+    this._props.value = this.binder.snapshot;
+  }
+
+  get props(): Signal<TProps> {
+    return this._props;
+  }
+
+  dispose(): void {
+    this.binderUnsub.unsubscribe();
+    this.binder.dispose();
+    this._onDestroyed.emit();
+    this._onDestroyed.dispose();
+  }
+}
+
+/**
+ * Manages the mapping between ComponentModels and A2uiNode instances.
+ */
+export class NodeManager implements NodeResolver {
+  private nodes = new Map<string, A2uiNode>();
+  private refCounts = new Map<string, number>();
+
+  constructor(private surface: SurfaceModel<any>) {}
+
+  /**
+   * Resolves a node for the given component ID and data path.
+   * If a node already exists for this instance ID, its reference count is incremented.
+   * Returns undefined if the component ID does not exist in the components model.
+   */
+  resolveNode(componentId: string, dataPath: string): A2uiNode | undefined {
+    const instanceId = this.createInstanceId(componentId, dataPath);
+    let node = this.nodes.get(instanceId);
+
+    if (!node) {
+      const component = this.surface.componentsModel.get(componentId);
+      if (!component) {
+        return undefined;
+      }
+      node = new NodeImpl(
+        instanceId,
+        componentId,
+        component.type,
+        dataPath,
+        this.surface,
+        this,
+      );
+      this.nodes.set(instanceId, node);
+      this.refCounts.set(instanceId, 1);
+    } else {
+      this.refCounts.set(instanceId, (this.refCounts.get(instanceId) || 0) + 1);
+    }
+
+    return node;
+  }
+
+  /**
+   * Decrements the reference count for a node and disposes of it if it reaches zero.
+   * This is intended to be used by the GenericBinder or parent nodes when a child is removed.
+   */
+  releaseNode(node: A2uiNode | undefined): void {
+    if (!node) return;
+    const count = this.refCounts.get(node.instanceId) || 0;
+    if (count <= 1) {
+      this.nodes.delete(node.instanceId);
+      this.refCounts.delete(node.instanceId);
+      node.dispose();
+    } else {
+      this.refCounts.set(node.instanceId, count - 1);
+    }
+  }
+
+  private createInstanceId(componentId: string, dataPath: string): string {
+    return dataPath === '/' || dataPath === ''
+      ? componentId
+      : `${componentId}-[${dataPath}]`;
+  }
+
+  dispose(): void {
+    for (const node of this.nodes.values()) {
+      node.dispose();
+    }
+    this.nodes.clear();
+    this.refCounts.clear();
+  }
+}

--- a/renderers/web_core/src/v0_9/state/node.ts
+++ b/renderers/web_core/src/v0_9/state/node.ts
@@ -25,7 +25,9 @@ import {A2uiNode} from './node-types.js';
 /**
  * Internal implementation of the A2uiNode interface.
  */
-export class NodeImpl<TProps = Record<string, any>> implements A2uiNode<TProps> {
+export class NodeImpl<
+  TProps = Record<string, any>,
+> implements A2uiNode<TProps> {
   private readonly _onDestroyed = new EventEmitter<void>();
   private readonly _props = signal<TProps>({} as TProps);
   private binder: GenericBinder<TProps>;

--- a/renderers/web_core/src/v0_9/state/surface-model.ts
+++ b/renderers/web_core/src/v0_9/state/surface-model.ts
@@ -22,6 +22,9 @@ import {
   A2uiClientAction,
   A2uiClientActionSchema,
 } from '../schema/client-to-server.js';
+import {A2uiNode} from './node-types.js';
+import {NodeManager} from './node.js';
+import {Signal, signal} from '@preact/signals-core';
 
 /** A function that listens for actions emitted from a surface. */
 export type ActionListener = (action: A2uiClientAction) => void | Promise<void>;
@@ -39,9 +42,12 @@ export class SurfaceModel<T extends ComponentApi> {
   readonly dataModel: DataModel;
   /** The collection of component models for this surface. */
   readonly componentsModel: SurfaceComponentsModel;
+  /** The root node of the reactive view hierarchy. */
+  readonly rootNode: Signal<A2uiNode | undefined>;
 
   private readonly _onAction = new EventEmitter<A2uiClientAction>();
   private readonly _onError = new EventEmitter<any>();
+  private readonly _nodeManager: NodeManager;
 
   /** Fires whenever an action is dispatched from this surface. */
   readonly onAction: EventSource<A2uiClientAction> = this._onAction;
@@ -65,6 +71,40 @@ export class SurfaceModel<T extends ComponentApi> {
   ) {
     this.dataModel = new DataModel({});
     this.componentsModel = new SurfaceComponentsModel();
+    this._nodeManager = new NodeManager(this);
+    this.rootNode = signal<A2uiNode | undefined>(undefined);
+
+    // Automatically manage rootNode lifecycle based on 'root' component availability
+    this.componentsModel.onCreated.subscribe(comp => {
+      if (comp.id === 'root') {
+        this.updateRootNode();
+      }
+    });
+    this.componentsModel.onDeleted.subscribe(id => {
+      if (id === 'root') {
+        this.updateRootNode();
+      }
+    });
+  }
+
+  private updateRootNode() {
+    const rootComp = this.componentsModel.get('root');
+    const currentRoot = this.rootNode.peek();
+    if (rootComp) {
+      if (!currentRoot || currentRoot.type !== rootComp.type) {
+        // If type changed or no root node, recreate it
+        if (currentRoot) {
+          this._nodeManager.releaseNode(currentRoot);
+        }
+        const newNode = this._nodeManager.resolveNode('root', '/');
+        this.rootNode.value = newNode;
+      }
+    } else {
+      if (currentRoot) {
+        this._nodeManager.releaseNode(currentRoot);
+        this.rootNode.value = undefined;
+      }
+    }
   }
 
   /**
@@ -100,7 +140,7 @@ export class SurfaceModel<T extends ComponentApi> {
       }
     }
     // Note: local functionCall actions are currently handled by the renderer or binder
-    // and do not necessarily need to be emitted here if they are not intended for the server.
+    // and do not necessarily need to be here if they are not intended for the server.
   }
 
   /**
@@ -123,6 +163,11 @@ export class SurfaceModel<T extends ComponentApi> {
    * Disposes of the surface and its resources.
    */
   dispose(): void {
+    const currentRoot = this.rootNode.peek();
+    if (currentRoot) {
+      this._nodeManager.releaseNode(currentRoot);
+    }
+    this._nodeManager.dispose();
     this.dataModel.dispose();
     this.componentsModel.dispose();
     this._onAction.dispose();


### PR DESCRIPTION
## Description of Changes

This PR implements the **Node Layer** architecture as defined in the A2UI v0.9 specification (`node_layer_design.md`). It fundamentally shifts the A2UI client architecture from a flat adjacency list with manual binders to a centrally-managed, reactive view hierarchy.

**Key features include:**

1. **`web_core` Enhancements:**
   * Introduced `A2uiNode` and `NodeManager` to encapsulate the mapping between raw `ComponentModel`s and fully resolved, reactive node instances.
   * Enhanced `GenericBinder` to identify and resolve structural properties (like `children`, `child`, `trigger`) automatically, supporting both static arrays and template-based expansion from the data model.
   * Centralized lifecycle management in `NodeManager`, ensuring reactive data model subscriptions are robustly managed and recursively disposed of when components unmount, fixing potential memory leaks.
   * `SurfaceModel` now exports a reactive `rootNode` signal, acting as the entry point for UI frameworks.

2. **`react` Renderer Migration:**
   * Refactored `A2uiSurface` and the React adapter to natively consume and observe `A2uiNode` instances.
   * Introduced `<NodeRenderer />` for seamless, recursive rendering of child nodes.
   * Re-introduced a trivial, backward-compatible `buildChild` function to the adapter props. This ensures existing components (and the Basic Catalog) continue to work while mapping seamlessly to the new Node Layer under the hood.

3. **Validation & Testing:**
   * Added comprehensive unit and integration tests to `web_core` verifying 1-to-N node expansion, reference counting for shared nodes, and recursive destruction.
   * Added a new integration test suite to the `a2ui_explorer` application demonstrating progressive rendering and dynamic reactivity across the entire stack.

## Rationale
The previous architecture forced every framework adapter to manually manage tree recursion, templated list expansions, and the complex lifecycle of reactive binders. This led to high complexity, inconsistencies, and risks of memory leaks.

By pushing the `Node` logic into the framework-agnostic `web_core`, we drastically simplify the requirements for native view adapters (React, Flutter, etc.). They now receive a strictly-typed, fully resolved `A2uiNode` and merely need to map its properties to native UI components.

## Testing/Running Instructions
1. Run `npm install && npm run build` from the root or inside `renderers/web_core` and `renderers/react`.
2. Navigate to `renderers/react/a2ui_explorer`.
3. Run `npm test` to execute the integration test suite.
4. Run `npm run dev` to launch the Gallery Application and manually verify the interactive samples and stepper functionality.