### PR TITLE
Create AnyDuringSchemaAlignment alias to track Angular any fix

### DIFF
--- a/renderers/angular/src/v0_9/catalog/basic/icon.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/icon.component.ts
@@ -17,6 +17,7 @@
 import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
 import { BasicCatalogComponent } from './basic-catalog-component';
 import { IconApi } from '@a2ui/web_core/v0_9/basic_catalog';
+import { AnyDuringSchemaAlignment } from '../types';
 
 const ICON_NAME_OVERRIDES: Record<string, string> = {
   play: 'play_arrow',
@@ -84,7 +85,7 @@ const ICON_NAME_OVERRIDES: Record<string, string> = {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IconComponent extends BasicCatalogComponent<typeof IconApi> {
-  readonly color = computed(() => (this.props() as any)['color']?.value());
+  readonly color = computed(() => (this.props() as AnyDuringSchemaAlignment)['color']?.value());
   readonly iconNameRaw = computed(() => this.props()['name']?.value());
 
   readonly isPath = computed(() => {

--- a/renderers/angular/src/v0_9/catalog/basic/text-field.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text-field.component.ts
@@ -17,6 +17,8 @@
 import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
 import { BasicCatalogComponent } from './basic-catalog-component';
 import { TextFieldApi } from '@a2ui/web_core/v0_9/basic_catalog';
+import { AnyDuringSchemaAlignment } from '../types';
+
 
 /**
  * Angular implementation of the A2UI TextField component (v0.9).
@@ -97,7 +99,7 @@ import { TextFieldApi } from '@a2ui/web_core/v0_9/basic_catalog';
 export class TextFieldComponent extends BasicCatalogComponent<typeof TextFieldApi> {
   readonly label = computed(() => this.props()['label']?.value());
   readonly value = computed(() => this.props()['value']?.value() || '');
-  readonly placeholder = computed(() => (this.props() as any)['placeholder']?.value() || '');
+  readonly placeholder = computed(() => (this.props() as AnyDuringSchemaAlignment)['placeholder']?.value() || '');
   readonly variant = computed(() => this.props()['variant']?.value());
 
   readonly inputType = computed(() => {

--- a/renderers/angular/src/v0_9/catalog/basic/video.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/video.component.ts
@@ -17,6 +17,8 @@
 import { Component, computed, ChangeDetectionStrategy } from '@angular/core';
 import { BasicCatalogComponent } from './basic-catalog-component';
 import { VideoApi } from '@a2ui/web_core/v0_9/basic_catalog';
+import { AnyDuringSchemaAlignment } from '../types';
+
 
 /**
  * Angular implementation of the A2UI Video component (v0.9).
@@ -60,5 +62,5 @@ import { VideoApi } from '@a2ui/web_core/v0_9/basic_catalog';
 })
 export class VideoComponent extends BasicCatalogComponent<typeof VideoApi> {
   readonly url = computed(() => this.props()['url']?.value());
-  readonly posterUrl = computed(() => (this.props() as any)['posterUrl']?.value());
+  readonly posterUrl = computed(() => (this.props() as AnyDuringSchemaAlignment)['posterUrl']?.value());
 }

--- a/renderers/angular/src/v0_9/catalog/types.ts
+++ b/renderers/angular/src/v0_9/catalog/types.ts
@@ -18,6 +18,15 @@ import { Type } from '@angular/core';
 import { Catalog, ComponentApi } from '@a2ui/web_core/v0_9';
 
 /**
+ * Temporary type used during v0.9 schema alignment to bypass strict type checking.
+ * 
+ * To be removed once all fields conform to the A2UI v0.9 specifications.
+ * @see https://github.com/google/A2UI/issues/1303
+ */
+export type AnyDuringSchemaAlignment = any;
+
+
+/**
  * Extends the generic {@link ComponentApi} to include Angular-specific component metadata.
  */
 export interface AngularComponentImplementation extends ComponentApi {

--- a/renderers/angular/src/v0_9/catalog/types.ts
+++ b/renderers/angular/src/v0_9/catalog/types.ts
@@ -18,9 +18,10 @@ import { Type } from '@angular/core';
 import { Catalog, ComponentApi } from '@a2ui/web_core/v0_9';
 
 /**
- * Temporary type used during v0.9 schema alignment to bypass strict type checking.
+ * Temporary type used during basic catalog schema alignment to bypass strict type checking.
  * 
- * To be removed once all fields conform to the A2UI v0.9 specifications.
+ * To be removed once all properties implemented in Angular basic catalog components conform
+ * to the basic catalog schema.
  * @see https://github.com/google/A2UI/issues/1303
  */
 export type AnyDuringSchemaAlignment = any;


### PR DESCRIPTION
Introduces the `AnyDuringSchemaAlignment` type alias in the v0.9 catalog to temporarily track instances of `any` during this improvement.
Part of #1303, to help identify the offending sites, and also to show readers of the code that these usages of any are temporary and will be fixed soon.