### PR TITLE
Fix: Pin dompurify to 3.3.1 in markdown-it package

### DIFF
--- a/renderers/angular/package-lock.json
+++ b/renderers/angular/package-lock.json
@@ -61,7 +61,7 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "dompurify": "^3.3.1",
+        "dompurify": "3.3.1",
         "markdown-it": "^14.1.0"
       },
       "devDependencies": {

--- a/renderers/markdown/markdown-it/package-lock.json
+++ b/renderers/markdown/markdown-it/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@a2ui/markdown-it",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a2ui/markdown-it",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "dompurify": "^3.3.1",
+        "dompurify": "3.3.1",
         "markdown-it": "^14.1.0"
       },
       "devDependencies": {
@@ -531,8 +531,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/renderers/markdown/markdown-it/package.json
+++ b/renderers/markdown/markdown-it/package.json
@@ -41,7 +41,7 @@
     "test": "wireit"
   },
   "dependencies": {
-    "dompurify": "^3.3.1",
+    "dompurify": "3.3.1",
     "markdown-it": "^14.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Pin the dompurify dependency in the markdown-it package to a stable 3.3.1 to avoid installation errors caused by caret matching versions not yet mirrored in internal registries.

Literal error encountered:
```
npm error code ETARGET
npm error notarget No matching version found for dompurify@3.4.0.
```
