### PR TITLE
refactor: rename checked input property to value in Checkbox component

### DIFF
--- a/renderers/angular/src/v0_8/components/checkbox.spec.ts
+++ b/renderers/angular/src/v0_8/components/checkbox.spec.ts
@@ -58,7 +58,7 @@ describe('Checkbox Component', () => {
     fixture.componentRef.setInput('component', mockNode);
     fixture.componentRef.setInput('weight', 1);
     fixture.componentRef.setInput('label', { literalString: 'Accept Terms' });
-    fixture.componentRef.setInput('checked', { literalBoolean: false });
+    fixture.componentRef.setInput('value', { literalBoolean: false });
 
     fixture.detectChanges();
   });
@@ -76,7 +76,7 @@ describe('Checkbox Component', () => {
     const inputEl = fixture.nativeElement.querySelector('input');
     expect(inputEl.checked).toBeFalse();
 
-    fixture.componentRef.setInput('checked', { literalBoolean: true });
+    fixture.componentRef.setInput('value', { literalBoolean: true });
     fixture.detectChanges();
     expect(inputEl.checked).toBeTrue();
   });
@@ -89,6 +89,6 @@ describe('Checkbox Component', () => {
     expect(mockProcessor.dispatch).toHaveBeenCalled();
     const message = mockProcessor.dispatch.calls.mostRecent().args[0] as A2UIClientEventMessage;
     expect(message.userAction!.name).toBe('toggle');
-    expect(message.userAction!.context!['checked']).toBeTrue();
+    expect(message.userAction!.context!['value']).toBeTrue();
   });
 });

--- a/renderers/angular/src/v0_8/components/checkbox.spec.ts
+++ b/renderers/angular/src/v0_8/components/checkbox.spec.ts
@@ -89,6 +89,6 @@ describe('Checkbox Component', () => {
     expect(mockProcessor.dispatch).toHaveBeenCalled();
     const message = mockProcessor.dispatch.calls.mostRecent().args[0] as A2UIClientEventMessage;
     expect(message.userAction!.name).toBe('toggle');
-    expect(message.userAction!.context!['value']).toBeTrue();
+    expect(message.userAction!.context!['checked']).toBeTrue();
   });
 });

--- a/renderers/angular/src/v0_8/components/checkbox.ts
+++ b/renderers/angular/src/v0_8/components/checkbox.ts
@@ -42,9 +42,9 @@ import type { BooleanValue, CheckboxNode, StringValue } from '../types';
 })
 export class Checkbox extends DynamicComponent<CheckboxNode> {
   readonly label = input.required<StringValue | null>();
-  readonly checked = input.required<BooleanValue | null>();
+  readonly value = input.required<BooleanValue | null>();
 
-  protected inputChecked = computed(() => super.resolvePrimitive(this.checked()) ?? false);
+  protected inputChecked = computed(() => super.resolvePrimitive(this.value()) ?? false);
   protected resolvedLabel = computed(() => super.resolvePrimitive(this.label()));
   protected readonly inputId = super.getUniqueId('a2ui-checkbox');
 

--- a/renderers/angular/src/v0_8/components/checkbox.ts
+++ b/renderers/angular/src/v0_8/components/checkbox.ts
@@ -50,7 +50,7 @@ export class Checkbox extends DynamicComponent<CheckboxNode> {
 
   onToggle(event: Event) {
     const checked = (event.target as HTMLInputElement).checked;
-    const checkedNode = this.checked();
+    const checkedNode = this.value();
     if (
       checkedNode &&
       typeof checkedNode === 'object' &&


### PR DESCRIPTION
# Description

This change updates the Angular CheckBox component's primary status input from checked to value.

The renderer dynamically dynamically binds property keys from the parsed A2UI node to angular component @inputs. Because the v0.8 protocol specification strictly defines this input property as value, the previous misalignment prevented data bindings from being pushed into the component successfully.

This PR establishes full alignment between the renderer data ingestion logic and the component definition to correctly deliver backend model mutations to the UI state.


- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [x] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
