### PR TITLE
fix: add null check for node properties before iterating to prevent r…

### DIFF
--- a/renderers/angular/src/v0_8/rendering/renderer.spec.ts
+++ b/renderers/angular/src/v0_8/rendering/renderer.spec.ts
@@ -231,4 +231,17 @@ describe('v0.8 Renderer Regression Tests', () => {
     expect(setCapture.children).toEqual([{ id: 'child-1' }]);
     expect(setCapture.child).toEqual({ id: 'child-2' });
   });
+
+  it('should gracefully handle components with missing properties', async () => {
+    // This covers the fix where node.properties might be undefined.
+    fixture.componentInstance.surfaceId = 'surf-1';
+    fixture.componentInstance.component = {
+      type: 'CompWithInputs',
+      // Notice: No 'properties' key here.
+    };
+
+    expect(() => {
+      fixture.detectChanges();
+    }).not.toThrow();
+  });
 });

--- a/renderers/angular/src/v0_8/rendering/renderer.ts
+++ b/renderers/angular/src/v0_8/rendering/renderer.ts
@@ -165,14 +165,16 @@ export class Renderer {
     componentRef.setInput('component', node);
     componentRef.setInput('weight', node.weight ?? 0);
 
-    const props = node.properties as Record<string, unknown>;
-    for (const [key, value] of Object.entries(props)) {
-      try {
-        componentRef.setInput(key, value);
-      } catch (e) {
-        console.warn(
-          `[Renderer] Property "${key}" could not be set on component ${node.type}. If this property is required by the specification, ensure the component declares it as an input.`,
-        );
+    if (node.properties) {
+      const props = node.properties as Record<string, unknown>;
+      for (const [key, value] of Object.entries(props)) {
+        try {
+          componentRef.setInput(key, value);
+        } catch (e) {
+          console.warn(
+            `[Renderer] Property "${key}" could not be set on component ${node.type}. If this property is required by the specification, ensure the component declares it as an input.`,
+          );
+        }
       }
     }
     componentRef.changeDetectorRef.markForCheck();


### PR DESCRIPTION
…untime errors

# Description

The absence of null/undefined check will result in run time error if node.property is null/undefined.

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
