### PR TITLE
Fix non-determinisitc test failure and add format check for Kotlin

### DIFF
--- a/.github/workflows/kotlin_agent_sdk_build_and_test.yml
+++ b/.github/workflows/kotlin_agent_sdk_build_and_test.yml
@@ -47,6 +47,10 @@ jobs:
         working-directory: agent_sdks/kotlin
         run: chmod +x gradlew
 
+      - name: Check formatting
+        working-directory: agent_sdks/kotlin
+        run: ./gradlew ktfmtCheck
+
       - name: Run tests
         working-directory: agent_sdks/kotlin
         run: ./gradlew test --info

--- a/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/core/schema/Catalog.kt
+++ b/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/core/schema/Catalog.kt
@@ -147,7 +147,9 @@ data class A2uiCatalog(
       return ""
     }
 
-    val files = dir.listFiles { _, name -> name.endsWith(".json") } ?: emptyArray()
+    // Sort files by name to ensure deterministic output order for tests.
+    val files =
+      dir.listFiles { _, name -> name.endsWith(".json") }?.sortedBy { it.name } ?: emptyList<File>()
 
     return files
       .mapNotNull { file ->

--- a/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/core/schema/Validator.kt
+++ b/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/core/schema/Validator.kt
@@ -232,9 +232,10 @@ constructor(
 
       if (MSG_BEGIN_RENDERING in message) {
         val beginRendering = message[MSG_BEGIN_RENDERING] as? JsonObject
-        val msgSurfaceId = requireNotNull(beginRendering?.get("surfaceId")?.jsonPrimitive?.content) {
-          "surfaceId is required in beginRendering"
-        }
+        val msgSurfaceId =
+          requireNotNull(beginRendering?.get("surfaceId")?.jsonPrimitive?.content) {
+            "surfaceId is required in beginRendering"
+          }
         if (!surfaceRootIds.containsKey(msgSurfaceId)) {
           val rootElem = beginRendering?.get(ROOT)
           val rootId =
@@ -249,9 +250,10 @@ constructor(
 
       if (MSG_CREATE_SURFACE in message) {
         val createSurface = message[MSG_CREATE_SURFACE] as? JsonObject
-        val msgSurfaceId = requireNotNull(createSurface?.get("surfaceId")?.jsonPrimitive?.content) {
-          "surfaceId is required in createSurface"
-        }
+        val msgSurfaceId =
+          requireNotNull(createSurface?.get("surfaceId")?.jsonPrimitive?.content) {
+            "surfaceId is required in createSurface"
+          }
         surfaceRootIds.putIfAbsent(msgSurfaceId, ROOT)
       }
     }

--- a/agent_sdks/kotlin/src/test/kotlin/com/google/a2ui/conformance/A2aConformanceTest.kt
+++ b/agent_sdks/kotlin/src/test/kotlin/com/google/a2ui/conformance/A2aConformanceTest.kt
@@ -16,13 +16,13 @@
 
 package com.google.a2ui.conformance
 
-// TODO: Migrate to extensions.yaml conformance tests when Kotlin SDK matches Python version's RequestContext and Card usage.
-
-import com.google.a2ui.a2a.A2uiA2a
-import com.google.a2ui.a2a.A2aHandler
+// TODO: Migrate to extensions.yaml conformance tests when Kotlin SDK matches Python version's
+// RequestContext and Card usage.
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.google.a2ui.a2a.A2aHandler
+import com.google.a2ui.a2a.A2uiA2a
 import com.google.adk.agents.RunConfig
 import com.google.adk.events.Event
 import com.google.adk.runner.Runner
@@ -36,17 +36,14 @@ import io.mockk.every
 import io.mockk.mockk
 import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.core.Maybe
-import java.io.File
 import java.util.Optional
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlin.test.assertFalse
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
 
@@ -59,9 +56,8 @@ class A2aConformanceTest {
     when (any) {
       null -> JsonNull
       is Map<*, *> -> {
-        val map: Map<String, JsonElement> = any.entries.associate { (key, value) ->
-          key.toString() to anyToJsonElement(value)
-        }
+        val map: Map<String, JsonElement> =
+          any.entries.associate { (key, value) -> key.toString() to anyToJsonElement(value) }
         JsonObject(map)
       }
       is List<*> -> JsonArray(any.map { anyToJsonElement(it) })
@@ -87,17 +83,20 @@ class A2aConformanceTest {
           "create_a2ui_part" -> {
             val data = args["data"] as Map<*, *>
             val jsonElement = anyToJsonElement(data) as JsonObject
-            
+
             val part = A2uiA2a.createA2uiPart(jsonElement)
             assertTrue(part is DataPart)
             val expect = case[ConformanceTestHelper.KEY_EXPECT] as Map<*, *>
-            assertEquals(expect["mime_type"] as String, (part as DataPart).metadata?.get(A2uiA2a.MIME_TYPE_KEY))
+            assertEquals(
+              expect["mime_type"] as String,
+              (part as DataPart).metadata?.get(A2uiA2a.MIME_TYPE_KEY),
+            )
           }
           "is_a2ui_part" -> {
             val mimeType = args["mime_type"] as String
             val part = mockk<DataPart>()
             every { part.metadata } returns mapOf(A2uiA2a.MIME_TYPE_KEY to mimeType)
-            
+
             val result = A2uiA2a.isA2uiPart(part)
             val expect = case[ConformanceTestHelper.KEY_EXPECT] as Boolean
             assertEquals(expect, result)
@@ -106,7 +105,7 @@ class A2aConformanceTest {
             val uris = args["uris"] as List<String>
             val activated = mutableListOf<String>()
             val result = A2uiA2a.tryActivateA2uiExtension(uris) { activated.add(it) }
-            
+
             val expect = case[ConformanceTestHelper.KEY_EXPECT] as Boolean
             assertEquals(expect, result)
             if (expect) {
@@ -143,9 +142,8 @@ class A2aConformanceTest {
             every { mockEvent.id() } returns "test-event-id"
             every { mockEvent.content() } returns Optional.of(mockContent)
 
-            every {
-              mockRunner.runAsync(any<Session>(), any<Content>(), any<RunConfig>())
-            } returns Flowable.just(mockEvent)
+            every { mockRunner.runAsync(any<Session>(), any<Content>(), any<RunConfig>()) } returns
+              Flowable.just(mockEvent)
 
             val handler = A2aHandler(mockRunner)
 
@@ -162,12 +160,15 @@ class A2aConformanceTest {
               val expPart = expectParts[i] as Map<*, *>
               val part = parts[i]
               assertEquals(expPart["kind"] as String, part["kind"])
-              
+
               if (expPart.containsKey("text")) {
                 assertEquals(expPart["text"] as String, part["text"])
               }
               if (expPart.containsKey("mimeType")) {
-                assertEquals(expPart["mimeType"] as String, (part["metadata"] as Map<*, *>)["mimeType"])
+                assertEquals(
+                  expPart["mimeType"] as String,
+                  (part["metadata"] as Map<*, *>)["mimeType"],
+                )
               }
               if (expPart.containsKey("data")) {
                 val expData = expPart["data"] as Map<*, *>

--- a/agent_sdks/kotlin/src/test/kotlin/com/google/a2ui/conformance/AdkExtensionsConformanceTest.kt
+++ b/agent_sdks/kotlin/src/test/kotlin/com/google/a2ui/conformance/AdkExtensionsConformanceTest.kt
@@ -16,36 +16,33 @@
 
 package com.google.a2ui.conformance
 
-import com.google.a2ui.adk.a2a_extension.A2uiEventConverter
-import com.google.a2ui.adk.a2a_extension.SendA2uiToClientToolset
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.google.a2ui.adk.a2a_extension.A2uiEventConverter
+import com.google.a2ui.adk.a2a_extension.SendA2uiToClientToolset
 import com.google.a2ui.core.schema.A2uiCatalog
 import com.google.a2ui.core.schema.A2uiVersion
 import com.google.adk.a2a.converters.EventConverter
 import com.google.adk.agents.InvocationContext
 import com.google.adk.agents.ReadonlyContext
-import com.google.adk.tools.ToolContext
 import com.google.adk.events.Event
 import com.google.adk.sessions.Session
+import com.google.adk.tools.ToolContext
 import com.google.common.collect.ImmutableList
 import com.google.genai.types.Content
-import com.google.genai.types.Part
 import com.google.genai.types.FinishReason
+import com.google.genai.types.Part
 import io.a2a.spec.TaskState
 import io.a2a.spec.TaskStatusUpdateEvent
 import io.a2a.spec.TextPart
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import java.io.File
 import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
-import kotlin.test.assertNull
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
@@ -136,12 +133,13 @@ class AdkExtensionsConformanceTest {
 
               assertEquals("task-1", result.taskId())
               assertEquals("context-1", result.contextId())
-              
-              val expectedTaskState = when (expectState) {
-                "FAILED" -> TaskState.TASK_STATE_FAILED
-                "WORKING" -> TaskState.TASK_STATE_WORKING
-                else -> throw IllegalArgumentException("Unknown state $expectState")
-              }
+
+              val expectedTaskState =
+                when (expectState) {
+                  "FAILED" -> TaskState.TASK_STATE_FAILED
+                  "WORKING" -> TaskState.TASK_STATE_WORKING
+                  else -> throw IllegalArgumentException("Unknown state $expectState")
+                }
               assertEquals(expectedTaskState, result.status().state())
 
               val msg = result.status().message()!!
@@ -151,17 +149,28 @@ class AdkExtensionsConformanceTest {
           }
           "execute_tool" -> {
             val a2uiJsonStr = args["a2ui_json"] as? String
-            val toolArgs = if (a2uiJsonStr != null) mapOf("a2ui_json" to a2uiJsonStr) else args as Map<String, Any>
+            val toolArgs =
+              if (a2uiJsonStr != null) mapOf("a2ui_json" to a2uiJsonStr)
+              else args as Map<String, Any>
 
-            val serverToClientSchema = Json.parseToJsonElement("""{"type": "object", "properties": {"beginRendering": {"type": "object"}}}""").jsonObject
-            val catalogSchema = Json.parseToJsonElement("""{"catalogId": "dummy", "components": {"TestComp": {"type": "object"}}}""").jsonObject
-            val dummyCatalog = A2uiCatalog(
-              version = A2uiVersion.VERSION_0_9,
-              name = "dummy",
-              serverToClientSchema = serverToClientSchema,
-              commonTypesSchema = JsonObject(emptyMap()),
-              catalogSchema = catalogSchema
-            )
+            val serverToClientSchema =
+              Json.parseToJsonElement(
+                  """{"type": "object", "properties": {"beginRendering": {"type": "object"}}}"""
+                )
+                .jsonObject
+            val catalogSchema =
+              Json.parseToJsonElement(
+                  """{"catalogId": "dummy", "components": {"TestComp": {"type": "object"}}}"""
+                )
+                .jsonObject
+            val dummyCatalog =
+              A2uiCatalog(
+                version = A2uiVersion.VERSION_0_9,
+                name = "dummy",
+                serverToClientSchema = serverToClientSchema,
+                commonTypesSchema = JsonObject(emptyMap()),
+                catalogSchema = catalogSchema,
+              )
 
             val mockContext = mockk<ReadonlyContext>(relaxed = true)
             val mockToolContext = mockk<ToolContext>(relaxed = true)
@@ -178,7 +187,8 @@ class AdkExtensionsConformanceTest {
               assertTrue(result.containsKey(SendA2uiToClientToolset.VALIDATED_A2UI_JSON_KEY))
               val containsValidatedJson = expect["contains_validated_json"] as? Boolean ?: false
               if (containsValidatedJson) {
-                val validatedPayload = result[SendA2uiToClientToolset.VALIDATED_A2UI_JSON_KEY].toString()
+                val validatedPayload =
+                  result[SendA2uiToClientToolset.VALIDATED_A2UI_JSON_KEY].toString()
                 assertTrue(validatedPayload.contains("beginRendering"))
               }
             } else {

--- a/agent_sdks/kotlin/src/test/kotlin/com/google/a2ui/conformance/ConformanceTest.kt
+++ b/agent_sdks/kotlin/src/test/kotlin/com/google/a2ui/conformance/ConformanceTest.kt
@@ -16,42 +16,35 @@
 
 package com.google.a2ui.conformance
 
-import com.google.a2ui.core.schema.A2uiCatalog
-import com.google.a2ui.core.schema.A2uiVersion
-import com.google.a2ui.core.schema.A2uiValidator
-import com.google.a2ui.core.schema.A2uiCatalogProvider
-import com.google.a2ui.core.schema.CatalogConfig
-import com.google.a2ui.core.schema.SchemaModifiers
-import com.google.a2ui.core.schema.A2uiConstants
-import com.google.a2ui.core.schema.A2uiSchemaManager
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.google.a2ui.core.parser.PayloadFixer
+import com.google.a2ui.core.parser.hasA2uiParts
+import com.google.a2ui.core.parser.parseResponseToParts
+import com.google.a2ui.core.schema.A2uiCatalog
+import com.google.a2ui.core.schema.A2uiCatalogProvider
+import com.google.a2ui.core.schema.A2uiSchemaManager
+import com.google.a2ui.core.schema.A2uiValidator
+import com.google.a2ui.core.schema.A2uiVersion
+import com.google.a2ui.core.schema.CatalogConfig
+import com.google.a2ui.core.schema.SchemaModifiers
 import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.booleanOrNull
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
-import com.google.a2ui.core.parser.hasA2uiParts
-import com.google.a2ui.core.parser.parseResponseToParts
-import com.google.a2ui.core.parser.PayloadFixer
 
 class ConformanceTest {
 
   private val yamlMapper = ObjectMapper(YAMLFactory())
   private val jsonMapper = ObjectMapper()
-
-
 
   private fun loadJsonFile(file: File): JsonObject {
     val jsonStr = file.readText()
@@ -63,15 +56,17 @@ class ConformanceTest {
 
     val baseSchemaMappings = mutableMapOf<String, String>()
     val repoRoot = ConformanceTestHelper.repoRoot
-    val jsonDirs = listOf(
-      conformanceDir to listOf(URL_PREFIX_V09, URL_PREFIX_V08),
-      File(conformanceDir, "test_data") to listOf(URL_PREFIX_V09, URL_PREFIX_V08),
-      File(repoRoot, "specification/v0_9/json") to listOf(URL_PREFIX_V09),
-      File(repoRoot, "specification/v0_8/json") to listOf(URL_PREFIX_V08)
-    )
+    val jsonDirs =
+      listOf(
+        conformanceDir to listOf(URL_PREFIX_V09, URL_PREFIX_V08),
+        File(conformanceDir, "test_data") to listOf(URL_PREFIX_V09, URL_PREFIX_V08),
+        File(repoRoot, "specification/v0_9/json") to listOf(URL_PREFIX_V09),
+        File(repoRoot, "specification/v0_8/json") to listOf(URL_PREFIX_V08),
+      )
 
     jsonDirs.forEach { (dir, prefixes) ->
-      dir.listFiles { _, name -> name.endsWith(".json") }
+      dir
+        .listFiles { _, name -> name.endsWith(".json") }
         ?.forEach { f ->
           prefixes.forEach { prefix ->
             baseSchemaMappings["$prefix${f.name}"] = f.toURI().toString()
@@ -83,26 +78,33 @@ class ConformanceTest {
     return rawList.map { caseObj ->
       val case = caseObj as Map<*, *>
       val name = case[ConformanceTestHelper.KEY_NAME] as String
- 
+
       val catalogMap = case[ConformanceTestHelper.KEY_CATALOG] as Map<*, *>
       val (catalog, schemaMappings) = buildCatalog(catalogMap, conformanceDir, baseSchemaMappings)
 
-      val stepsList = case[ConformanceTestHelper.KEY_STEPS] as? List<*> 
-        ?: case[ConformanceTestHelper.KEY_VALIDATE] as? List<*>
-        ?: if (case.containsKey(ConformanceTestHelper.KEY_PAYLOAD)) listOf(case) else null
-        
+      val stepsList =
+        case[ConformanceTestHelper.KEY_STEPS] as? List<*>
+          ?: case[ConformanceTestHelper.KEY_VALIDATE] as? List<*>
+          ?: if (case.containsKey(ConformanceTestHelper.KEY_PAYLOAD)) listOf(case) else null
+
       if (stepsList == null) {
         throw IllegalArgumentException("No steps or payload found in test case: $name")
       }
 
-      val validate = stepsList.map { stepObj ->
-        val step = stepObj as Map<*, *>
-        val payloadObj = step[ConformanceTestHelper.KEY_PAYLOAD]
-        val jsonStr = jsonMapper.writeValueAsString(payloadObj)
-        val payload = Json.parseToJsonElement(jsonStr)
+      val validate =
+        stepsList.map { stepObj ->
+          val step = stepObj as Map<*, *>
+          val payloadObj = step[ConformanceTestHelper.KEY_PAYLOAD]
+          val jsonStr = jsonMapper.writeValueAsString(payloadObj)
+          val payload = Json.parseToJsonElement(jsonStr)
 
-        ValidateStep(payload = payload, expectError = step[ConformanceTestHelper.KEY_EXPECT_ERROR] as? String ?: case[ConformanceTestHelper.KEY_EXPECT_ERROR] as? String)
-      }
+          ValidateStep(
+            payload = payload,
+            expectError =
+              step[ConformanceTestHelper.KEY_EXPECT_ERROR] as? String
+                ?: case[ConformanceTestHelper.KEY_EXPECT_ERROR] as? String,
+          )
+        }
 
       ConformanceTestCase(name, catalog, validate, schemaMappings)
     }
@@ -138,15 +140,16 @@ class ConformanceTest {
         val tempFile = java.io.File.createTempFile("custom_catalog", ".json")
         tempFile.deleteOnExit()
         tempFile.writeText(jsonStr)
-        schemaMappings["$URL_PREFIX_V09$SIMPLIFIED_CATALOG_V09"] =
-          tempFile.toURI().toString()
+        schemaMappings["$URL_PREFIX_V09$SIMPLIFIED_CATALOG_V09"] = tempFile.toURI().toString()
         schemaMappings[SIMPLIFIED_CATALOG_V09] = tempFile.toURI().toString()
         schemaMappings["catalog.json"] = tempFile.toURI().toString()
         schemaMappings["${urlPrefix}catalog.json"] = tempFile.toURI().toString()
 
         Json.parseToJsonElement(jsonStr) as JsonObject
       } else {
-        throw IllegalArgumentException("catalog_schema is required in conformance test catalog config")
+        throw IllegalArgumentException(
+          "catalog_schema is required in conformance test catalog config"
+        )
       }
 
     val commonTypesFile = catalogMap["common_types_schema"] as? String
@@ -224,24 +227,33 @@ class ConformanceTest {
       val args = case[ConformanceTestHelper.KEY_ARGS] as? Map<*, *> ?: emptyMap<Any, Any>()
 
       // Filter out non-conformant tests for Kotlin
-      if (action == "prune" && (args.containsKey("allowed_messages") || name.contains("common_types"))) {
+      if (
+        action == "prune" && (args.containsKey("allowed_messages") || name.contains("common_types"))
+      ) {
         println("Skipping non-conformant test (prune messages/common_types): $name")
         return@mapNotNull null
       }
-      if (action == "load" && (args[KEY_PATH] as? String)?.let { it.contains("*") || it.contains("[") || it.contains("?") } == true) {
+      if (
+        action == "load" &&
+          (args[KEY_PATH] as? String)?.let {
+            it.contains("*") || it.contains("[") || it.contains("?")
+          } == true
+      ) {
         println("Skipping non-conformant test (load with glob): $name")
         return@mapNotNull null
       }
       if (action == "load" && case.containsKey(ConformanceTestHelper.KEY_EXPECT_ERROR)) {
-        // Kotlin loadExamples skips invalid files instead of throwing, so it's not conformant with error expectation
+        // Kotlin loadExamples skips invalid files instead of throwing, so it's not conformant with
+        // error expectation
         println("Skipping non-conformant test (load expecting error): $name")
         return@mapNotNull null
       }
       DynamicTest.dynamicTest(name) {
-        val catalog = (case[ConformanceTestHelper.KEY_CATALOG] as? Map<*, *>)?.let {
+        val catalog =
+          (case[ConformanceTestHelper.KEY_CATALOG] as? Map<*, *>)?.let {
             val (cat, _) = buildCatalog(it, conformanceDir, emptyMap())
             cat
-        }
+          }
 
         when (action) {
           "prune" -> {
@@ -257,17 +269,21 @@ class ConformanceTest {
             val path = args[KEY_PATH] as? String
             val fullPath = path?.let { File(conformanceDir, it).absolutePath }
             val validate = args[ConformanceTestHelper.KEY_VALIDATE] as? Boolean ?: false
-            
+
             if (case.containsKey(ConformanceTestHelper.KEY_EXPECT_ERROR)) {
-               val expectError = case[ConformanceTestHelper.KEY_EXPECT_ERROR] as String
-               val exception = assertFailsWith<IllegalArgumentException> {
-                   catalog!!.loadExamples(fullPath, validate = validate)
-               }
-               assertTrue(exception.message!!.contains(expectError) || exception.message!!.contains("Failed to validate example"))
+              val expectError = case[ConformanceTestHelper.KEY_EXPECT_ERROR] as String
+              val exception =
+                assertFailsWith<IllegalArgumentException> {
+                  catalog!!.loadExamples(fullPath, validate = validate)
+                }
+              assertTrue(
+                exception.message!!.contains(expectError) ||
+                  exception.message!!.contains("Failed to validate example")
+              )
             } else {
-               val output = catalog!!.loadExamples(fullPath, validate = validate)
-               val expectOutput = case["expect_output"] as String
-               assertEquals(expectOutput.trim(), output.trim())
+              val output = catalog!!.loadExamples(fullPath, validate = validate)
+              val expectOutput = case["expect_output"] as String
+              assertEquals(expectOutput.trim(), output.trim())
             }
           }
           "remove_strict_validation" -> {
@@ -275,7 +291,7 @@ class ConformanceTest {
             val jsonStr = jsonMapper.writeValueAsString(schema)
             val jsonElement = Json.parseToJsonElement(jsonStr) as JsonObject
             val modified = SchemaModifiers.removeStrictValidation(jsonElement)
-            
+
             val expect = case[ConformanceTestHelper.KEY_EXPECT] as Map<*, *>
             val expectSchemaStr = jsonMapper.writeValueAsString(expect["schema"])
             val expectSchema = Json.parseToJsonElement(expectSchemaStr) as JsonObject
@@ -305,29 +321,33 @@ class ConformanceTest {
             val clientCapabilities = args["client_capabilities"] as? Map<*, *>
             val acceptsInlineCatalogs = args["accepts_inline_catalogs"] as? Boolean ?: false
 
-            val configs = supportedCatalogs.map { catDefObj ->
-              val catDef = catDefObj as Map<*, *>
-              val catalogId = catDef["catalogId"] as String
-              val jsonStr = jsonMapper.writeValueAsString(catDef)
-              val schema = Json.parseToJsonElement(jsonStr) as JsonObject
-              CatalogConfig(name = catalogId, provider = MemoryCatalogProvider(schema))
-            }
+            val configs =
+              supportedCatalogs.map { catDefObj ->
+                val catDef = catDefObj as Map<*, *>
+                val catalogId = catDef["catalogId"] as String
+                val jsonStr = jsonMapper.writeValueAsString(catDef)
+                val schema = Json.parseToJsonElement(jsonStr) as JsonObject
+                CatalogConfig(name = catalogId, provider = MemoryCatalogProvider(schema))
+              }
 
-            val manager = A2uiSchemaManager(
-              version = A2uiVersion.VERSION_0_9,
-              catalogs = configs,
-              acceptsInlineCatalogs = acceptsInlineCatalogs
-            )
+            val manager =
+              A2uiSchemaManager(
+                version = A2uiVersion.VERSION_0_9,
+                catalogs = configs,
+                acceptsInlineCatalogs = acceptsInlineCatalogs,
+              )
 
             val capsJsonStr = jsonMapper.writeValueAsString(clientCapabilities)
             val capsJson = Json.parseToJsonElement(capsJsonStr) as JsonObject
 
             if (case.containsKey(ConformanceTestHelper.KEY_EXPECT_ERROR)) {
               val expectError = case[ConformanceTestHelper.KEY_EXPECT_ERROR] as String
-              val exception = assertFailsWith<IllegalArgumentException> {
-                manager.getSelectedCatalog(capsJson)
-              }
-              assertTrue(exception.message!!.contains(expectError) || exception.message!!.contains("No client-supported catalog found"))
+              val exception =
+                assertFailsWith<IllegalArgumentException> { manager.getSelectedCatalog(capsJson) }
+              assertTrue(
+                exception.message!!.contains(expectError) ||
+                  exception.message!!.contains("No client-supported catalog found")
+              )
             } else {
               val selected = manager.getSelectedCatalog(capsJson)
               if (case.containsKey("expect_selected")) {
@@ -343,34 +363,36 @@ class ConformanceTest {
           "load_catalog" -> {
             val catalogConfigs = case["catalog_configs"] as? List<*> ?: emptyList<Any>()
             val modifiers = case["modifiers"] as? List<String> ?: emptyList()
-            
+
             val schemaModifiers = mutableListOf<(JsonObject) -> JsonObject>()
             if (modifiers.contains("remove_strict_validation")) {
               schemaModifiers.add { SchemaModifiers.removeStrictValidation(it) }
             }
 
-            val configs = catalogConfigs.map { cfgObj ->
-              val cfg = cfgObj as Map<*, *>
-              val path = cfg["path"] as String
-              val fullPath = File(conformanceDir, path).absolutePath
-              CatalogConfig.fromPath(name = cfg["name"] as String, catalogPath = fullPath)
-            }
+            val configs =
+              catalogConfigs.map { cfgObj ->
+                val cfg = cfgObj as Map<*, *>
+                val path = cfg["path"] as String
+                val fullPath = File(conformanceDir, path).absolutePath
+                CatalogConfig.fromPath(name = cfg["name"] as String, catalogPath = fullPath)
+              }
 
-            val manager = A2uiSchemaManager(
-              version = A2uiVersion.VERSION_0_8,
-              catalogs = configs,
-              schemaModifiers = schemaModifiers
-            )
+            val manager =
+              A2uiSchemaManager(
+                version = A2uiVersion.VERSION_0_8,
+                catalogs = configs,
+                schemaModifiers = schemaModifiers,
+              )
 
             val selected = manager.getSelectedCatalog()
             val expect = case[ConformanceTestHelper.KEY_EXPECT] as Map<*, *>
-            
+
             if (expect.containsKey("catalog_schema")) {
               val expectSchemaStr = jsonMapper.writeValueAsString(expect["catalog_schema"])
               val expectSchema = Json.parseToJsonElement(expectSchemaStr)
               assertEquals(expectSchema, selected.catalogSchema)
             }
-            
+
             if (expect.containsKey("supported_catalog_ids")) {
               val expectIds = expect["supported_catalog_ids"] as List<String>
               assertEquals(expectIds, manager.supportedCatalogIds)
@@ -378,14 +400,15 @@ class ConformanceTest {
           }
           "generate_prompt" -> {
             val versionStr = args["version"] as? String ?: "0.8"
-            val version = if (versionStr == "0.8") A2uiVersion.VERSION_0_8 else A2uiVersion.VERSION_0_9
+            val version =
+              if (versionStr == "0.8") A2uiVersion.VERSION_0_8 else A2uiVersion.VERSION_0_9
             val role = args["role_description"] as? String ?: ""
             val workflow = args["workflow_description"] as? String ?: ""
             val uiDesc = args["ui_description"] as? String ?: ""
             val includeSchema = args["include_schema"] as? Boolean ?: false
             val includeExamples = args["include_examples"] as? Boolean ?: false
             val validateExamples = args["validate_examples"] as? Boolean ?: false
-            
+
             val clientCapabilities = args["client_ui_capabilities"] as? Map<*, *>
             val capsJsonStr = jsonMapper.writeValueAsString(clientCapabilities)
             val capsJson = Json.parseToJsonElement(capsJsonStr) as? JsonObject
@@ -395,25 +418,36 @@ class ConformanceTest {
             val examplesPath = args["examples_path"] as? String
             val fullExamplesPath = examplesPath?.let { File(conformanceDir, it).absolutePath }
 
-            val dummyCatalog = Json.parseToJsonElement("""{"catalogId": "https://a2ui.org/specification/v0_8/standard_catalog_definition.json", "components": {"Text": {}}}""").jsonObject
-            val dummyConfig = CatalogConfig(name = "basic", provider = MemoryCatalogProvider(dummyCatalog), examplesPath = fullExamplesPath)
+            val dummyCatalog =
+              Json.parseToJsonElement(
+                  """{"catalogId": "https://a2ui.org/specification/v0_8/standard_catalog_definition.json", "components": {"Text": {}}}"""
+                )
+                .jsonObject
+            val dummyConfig =
+              CatalogConfig(
+                name = "basic",
+                provider = MemoryCatalogProvider(dummyCatalog),
+                examplesPath = fullExamplesPath,
+              )
 
-            val manager = A2uiSchemaManager(
-              version = version,
-              catalogs = listOf(dummyConfig),
-              acceptsInlineCatalogs = args["accepts_inline_catalogs"] as? Boolean ?: false
-            )
+            val manager =
+              A2uiSchemaManager(
+                version = version,
+                catalogs = listOf(dummyConfig),
+                acceptsInlineCatalogs = args["accepts_inline_catalogs"] as? Boolean ?: false,
+              )
 
-            val output = manager.generateSystemPrompt(
-              roleDescription = role,
-              workflowDescription = workflow,
-              uiDescription = uiDesc,
-              clientUiCapabilities = capsJson,
-              allowedComponents = allowedComponents,
-              includeSchema = includeSchema,
-              includeExamples = includeExamples,
-              validateExamples = validateExamples
-            )
+            val output =
+              manager.generateSystemPrompt(
+                roleDescription = role,
+                workflowDescription = workflow,
+                uiDescription = uiDesc,
+                clientUiCapabilities = capsJson,
+                allowedComponents = allowedComponents,
+                includeSchema = includeSchema,
+                includeExamples = includeExamples,
+                validateExamples = validateExamples,
+              )
 
             val outputNormalized = output.replace(Regex("\\s+"), "").trim()
 
@@ -423,7 +457,7 @@ class ConformanceTest {
                 val expectedNormalized = expected.replace(Regex("\\s+"), "").trim()
                 assertTrue(
                   outputNormalized.contains(expectedNormalized),
-                  "Expected output to contain '$expectedNormalized', but got: $outputNormalized"
+                  "Expected output to contain '$expectedNormalized', but got: $outputNormalized",
                 )
               }
             }
@@ -449,12 +483,14 @@ class ConformanceTest {
           "parse_full" -> {
             if (case.containsKey(ConformanceTestHelper.KEY_EXPECT_ERROR)) {
               val expectError = case[ConformanceTestHelper.KEY_EXPECT_ERROR] as String
-              val exception = assertFailsWith<IllegalArgumentException> {
-                parseResponseToParts(input)
-              }
+              val exception =
+                assertFailsWith<IllegalArgumentException> { parseResponseToParts(input) }
               assertTrue(
-                exception.message!!.contains(expectError) || exception.message!!.contains("not found in response") || exception.message!!.contains("A2UI JSON part is empty") || exception.message!!.contains("Failed to parse"),
-                "Expected error containing '$expectError', but got: ${exception.message}"
+                exception.message!!.contains(expectError) ||
+                  exception.message!!.contains("not found in response") ||
+                  exception.message!!.contains("A2UI JSON part is empty") ||
+                  exception.message!!.contains("Failed to parse"),
+                "Expected error containing '$expectError', but got: ${exception.message}",
               )
             } else {
               val parts = parseResponseToParts(input)
@@ -476,16 +512,16 @@ class ConformanceTest {
             }
           }
           "fix_payload" -> {
-             val result = PayloadFixer.parseAndFix(input)
-             val expect = case[ConformanceTestHelper.KEY_EXPECT] as List<*>
-             val expectJsonStr = jsonMapper.writeValueAsString(expect)
-             val expectJson = Json.parseToJsonElement(expectJsonStr) as JsonArray
-             assertEquals(expectJson, result)
+            val result = PayloadFixer.parseAndFix(input)
+            val expect = case[ConformanceTestHelper.KEY_EXPECT] as List<*>
+            val expectJsonStr = jsonMapper.writeValueAsString(expect)
+            val expectJson = Json.parseToJsonElement(expectJsonStr) as JsonArray
+            assertEquals(expectJson, result)
           }
           "has_parts" -> {
-             val result = hasA2uiParts(input)
-             val expect = case[ConformanceTestHelper.KEY_EXPECT] as Boolean
-             assertEquals(expect, result)
+            val result = hasA2uiParts(input)
+            val expect = case[ConformanceTestHelper.KEY_EXPECT] as Boolean
+            assertEquals(expect, result)
           }
         }
       }


### PR DESCRIPTION
# Description

- The `test_load_examples` test was failing randomly because `dir.listFiles()` returns files in a non-deterministic order depending on the filesystem. This caused the concatenated output string to differ from the expected output in `catalog.yaml`. This PR updates `Catalog.kt` to sort the loaded JSON files by name before processing them, ensuring a deterministic output order.
- Applied `ktfmt` formatting to the Kotlin code and added a `Check formatting` step in CI.