### PR TITLE
Stop formatting from asking to install prettier

### DIFF
--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -26,9 +26,9 @@ cd "$REPO_ROOT"
 
 echo "Running Prettier..."
 if [ "$CHECK_ONLY" = true ]; then
-  npx prettier --config .prettierrc --check .
+  npx -y prettier --config .prettierrc --check .
 else
-  npx prettier --config .prettierrc --write .
+  npx -y prettier --config .prettierrc --write .
 fi
 
 echo "Running Pyink for Python..."


### PR DESCRIPTION
# Description

`fix_format.sh` was asking every time it ran to approve installing prettier when running npx.  This just bypasses the prompt to install.