### PR TITLE
[lit] Wire A2UI primaryColor on basic catalog elements.

### DIFF
--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- (v0_9) Wire up agent-provided primary color to basic catalog components.
 - (v0_9) Re-style the v0_9 catalog components using the default theme from
   `web_core`. [#1079](https://github.com/google/A2UI/pull/1079)
 - (v0_9) Add missing features to ChoicePicker and CheckBox. [#1145](https://github.com/google/A2UI/pull/1145)

--- a/renderers/lit/a2ui_explorer/package-lock.json
+++ b/renderers/lit/a2ui_explorer/package-lock.json
@@ -54,7 +54,7 @@
       "version": "0.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "dompurify": "^3.3.1",
+        "dompurify": "3.3.1",
         "markdown-it": "^14.1.0"
       },
       "devDependencies": {

--- a/renderers/lit/a2ui_explorer/src/local-gallery.css.ts
+++ b/renderers/lit/a2ui_explorer/src/local-gallery.css.ts
@@ -111,8 +111,9 @@ export const appStyles = css`
     background: #1e293b;
     border-bottom: 1px solid rgba(148, 163, 184, 0.1);
     display: flex;
-    justify-content: space-between;
-    align-items: center;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
   }
 
   .stepper-controls {

--- a/renderers/lit/a2ui_explorer/src/local-gallery.css.ts
+++ b/renderers/lit/a2ui_explorer/src/local-gallery.css.ts
@@ -112,14 +112,56 @@ export const appStyles = css`
     border-bottom: 1px solid rgba(148, 163, 184, 0.1);
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: stretch;
     gap: 12px;
+
+    h2 {
+      margin: 0;
+    }
   }
 
-  .stepper-controls {
+  .agent-controls {
     display: flex;
     gap: 8px;
-    align-items: center;
+    justify-content: space-between;
+
+    fieldset {
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      border-radius: 8px;
+    }
+
+    .theme-controls {
+      font-size: 0.9rem;
+      margin-right: 8px;
+      color: #94a3b8;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 4px;
+    }
+
+    .color-input-group {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+    }
+
+    .color-input {
+      border: none;
+      padding: 0;
+      width: 24px;
+      height: 24px;
+      cursor: pointer;
+      background: none;
+    }
+
+    .message-controls {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      font-size: 0.9rem;
+      color: #94a3b8;
+    }
   }
 
   button {

--- a/renderers/lit/a2ui_explorer/src/local-gallery.ts
+++ b/renderers/lit/a2ui_explorer/src/local-gallery.ts
@@ -68,8 +68,7 @@ export class LocalGallery extends LitElement {
 
   selectItem(index: number) {
     this.activeItemIndex = index;
-    this.resetSurface();
-    this.advanceMessages(true);
+    this.reloadExample();
   }
 
   resetSurface() {
@@ -116,6 +115,15 @@ export class LocalGallery extends LitElement {
   }
 
   /**
+   * Reloads the current example by resetting the surface and reprocessing all messages.
+   * This is used when switching examples or when theme properties change.
+   */
+  private reloadExample() {
+    this.resetSurface();
+    this.advanceMessages(true);
+  }
+
+  /**
    * Applies the user-selected primary color to `createSurface` messages.
    *
    * This is necessary for the explorer application to allow users to live-preview
@@ -128,7 +136,7 @@ export class LocalGallery extends LitElement {
    * @returns A new list of messages with the primary color applied to `createSurface` messages.
    */
   private applyPrimaryColorToMessages(messages: A2uiMessage[]): A2uiMessage[] {
-    return messages.map((msg) => {
+    return messages.map(msg => {
       if ('createSurface' in msg && this.primaryColor) {
         return {
           ...msg,
@@ -145,17 +153,17 @@ export class LocalGallery extends LitElement {
     });
   }
 
-  onColorInput(e: Event) {
+  /** Handles color input events to update the primary color. */
+  private onColorInput(e: Event) {
     const input = e.target as HTMLInputElement;
     this.primaryColor = input.value;
-    this.resetSurface();
-    this.advanceMessages(true);
+    this.reloadExample();
   }
 
-  clearColor() {
+  /** Clears the custom primary color and reloads the example. */
+  private clearColor() {
     this.primaryColor = '';
-    this.resetSurface();
-    this.advanceMessages(true);
+    this.reloadExample();
   }
 
   log(msg: string, detail?: any) {

--- a/renderers/lit/a2ui_explorer/src/local-gallery.ts
+++ b/renderers/lit/a2ui_explorer/src/local-gallery.ts
@@ -30,6 +30,7 @@ export class LocalGallery extends LitElement {
   @state() accessor activeItemIndex = 0;
   @state() accessor processedMessageCount = 0;
   @state() accessor currentDataModelText = '{}';
+  @state() accessor primaryColor = '#002f6c';
 
   @provide({context: Context.markdown})
   private accessor markdownRenderer = renderMarkdown;
@@ -98,7 +99,23 @@ export class LocalGallery extends LitElement {
 
     if (toProcess.length === 0) return;
 
-    this.processor.processMessages(toProcess);
+    const modifiedToProcess = toProcess.map((msg: any) => {
+      if ('createSurface' in msg && this.primaryColor) {
+        return {
+          ...msg,
+          createSurface: {
+            ...msg.createSurface,
+            theme: {
+              ...msg.createSurface.theme,
+              primaryColor: this.primaryColor,
+            },
+          },
+        };
+      }
+      return msg;
+    });
+
+    this.processor.processMessages(modifiedToProcess);
     this.processedMessageCount += toProcess.length;
 
     // Subscribe to data model on first advance if not already subscribed
@@ -110,6 +127,19 @@ export class LocalGallery extends LitElement {
         });
       }
     }
+  }
+
+  onColorInput(e: Event) {
+    const input = e.target as HTMLInputElement;
+    this.primaryColor = input.value;
+    this.resetSurface();
+    this.advanceMessages(true);
+  }
+
+  clearColor() {
+    this.primaryColor = '';
+    this.resetSurface();
+    this.advanceMessages(true);
   }
 
   log(msg: string, detail?: any) {
@@ -154,6 +184,23 @@ export class LocalGallery extends LitElement {
               </p>
             </div>
             <div class="stepper-controls">
+              <span
+                style="font-size:0.9rem; margin-right:8px; color:#94a3b8; display: inline-flex; align-items: center; gap: 4px;"
+              >
+                Primary Color:
+                <input
+                  type="color"
+                  .value=${this.primaryColor || '#002f6c'}
+                  @input=${this.onColorInput}
+                  style="border: none; padding: 0; width: 24px; height: 24px; cursor: pointer; background: none;"
+                />
+                <button
+                  @click=${this.clearColor}
+                  style="padding: 2px 4px; font-size: 0.8rem; cursor: pointer;"
+                >
+                  Clear
+                </button>
+              </span>
               <span style="font-size:0.9rem; margin-right:8px; color:#94a3b8">
                 Messages: ${this.processedMessageCount} / ${activeItem?.messages.length || 0}
               </span>

--- a/renderers/lit/a2ui_explorer/src/local-gallery.ts
+++ b/renderers/lit/a2ui_explorer/src/local-gallery.ts
@@ -30,7 +30,7 @@ export class LocalGallery extends LitElement {
   @state() accessor activeItemIndex = 0;
   @state() accessor processedMessageCount = 0;
   @state() accessor currentDataModelText = '{}';
-  @state() accessor primaryColor = '#002f6c';
+  @state() accessor primaryColor = '#1177ee';
 
   @provide({context: Context.markdown})
   private accessor markdownRenderer = renderMarkdown;
@@ -178,39 +178,34 @@ export class LocalGallery extends LitElement {
         <section class="gallery-pane">
           <div class="preview-header">
             <div>
-              <h2 style="margin:0">${activeItem?.title || 'No selection'}</h2>
-              <p style="margin:4px 0 0 0; font-size:0.9rem; color:#94a3b8">
-                ${activeItem?.description}
-              </p>
+              <h2>${activeItem?.title || 'No selection'}</h2>
+              <p class="subtitle">${activeItem?.description}</p>
             </div>
-            <div class="stepper-controls">
-              <span
-                style="font-size:0.9rem; margin-right:8px; color:#94a3b8; display: inline-flex; align-items: center; gap: 4px;"
-              >
-                Primary Color:
-                <input
-                  type="color"
-                  .value=${this.primaryColor || '#002f6c'}
-                  @input=${this.onColorInput}
-                  style="border: none; padding: 0; width: 24px; height: 24px; cursor: pointer; background: none;"
-                />
-                <button
-                  @click=${this.clearColor}
-                  style="padding: 2px 4px; font-size: 0.8rem; cursor: pointer;"
-                >
-                  Clear
+            <div class="agent-controls">
+              <fieldset class="message-controls">
+                <legend>
+                  Messages: ${this.processedMessageCount} / ${activeItem?.messages.length || 0}
+                </legend>
+                <button @click=${() => this.resetSurface()}>Reset</button>
+                <button @click=${() => this.advanceMessages(false)} ?disabled=${!canAdvance}>
+                  +1 Message
                 </button>
-              </span>
-              <span style="font-size:0.9rem; margin-right:8px; color:#94a3b8">
-                Messages: ${this.processedMessageCount} / ${activeItem?.messages.length || 0}
-              </span>
-              <button @click=${() => this.resetSurface()}>Reset</button>
-              <button @click=${() => this.advanceMessages(false)} ?disabled=${!canAdvance}>
-                +1 Message
-              </button>
-              <button @click=${() => this.advanceMessages(true)} ?disabled=${!canAdvance}>
-                All Messages
-              </button>
+                <button @click=${() => this.advanceMessages(true)} ?disabled=${!canAdvance}>
+                  All Messages
+                </button>
+              </fieldset>
+              <fieldset class="theme-controls">
+                <legend>Primary color</legend>
+                <div class="color-input-group">
+                  <input
+                    type="color"
+                    .value=${this.primaryColor || '#1177ee'}
+                    @input=${this.onColorInput}
+                    class="color-input"
+                  />
+                  <button @click=${this.clearColor} class="clear-btn">Clear</button>
+                </div>
+              </fieldset>
             </div>
           </div>
 

--- a/renderers/lit/a2ui_explorer/src/local-gallery.ts
+++ b/renderers/lit/a2ui_explorer/src/local-gallery.ts
@@ -17,7 +17,7 @@
 import {LitElement, html, css, nothing} from 'lit';
 import {provide} from '@lit/context';
 import {customElement, state} from 'lit/decorators.js';
-import {MessageProcessor} from '@a2ui/web_core/v0_9';
+import {MessageProcessor, A2uiMessage} from '@a2ui/web_core/v0_9';
 import {basicCatalog, Context} from '@a2ui/lit/v0_9';
 import {renderMarkdown} from '@a2ui/markdown-it';
 import {getDemoItems, DemoItem} from './examples';
@@ -99,7 +99,36 @@ export class LocalGallery extends LitElement {
 
     if (toProcess.length === 0) return;
 
-    const modifiedToProcess = toProcess.map((msg: any) => {
+    const modifiedToProcess = this.applyPrimaryColorToMessages(toProcess);
+
+    this.processor.processMessages(modifiedToProcess);
+    this.processedMessageCount += toProcess.length;
+
+    // Subscribe to data model on first advance if not already subscribed
+    if (!this.dataModelSubscription) {
+      const surface = this.processor.model.getSurface(item.id);
+      if (surface) {
+        this.dataModelSubscription = surface.dataModel.subscribe('/', val => {
+          this.currentDataModelText = JSON.stringify(val || {}, null, 2);
+        });
+      }
+    }
+  }
+
+  /**
+   * Applies the user-selected primary color to `createSurface` messages.
+   *
+   * This is necessary for the explorer application to allow users to live-preview
+   * theme changes by injecting the selected color into the message stream.
+   * In a standard A2UI renderer deployment, this is not needed as the renderer
+   * simply processes messages as received from the agent, which is responsible
+   * for providing the correct theme.
+   *
+   * @param messages The list of messages to process.
+   * @returns A new list of messages with the primary color applied to `createSurface` messages.
+   */
+  private applyPrimaryColorToMessages(messages: A2uiMessage[]): A2uiMessage[] {
+    return messages.map((msg) => {
       if ('createSurface' in msg && this.primaryColor) {
         return {
           ...msg,
@@ -114,19 +143,6 @@ export class LocalGallery extends LitElement {
       }
       return msg;
     });
-
-    this.processor.processMessages(modifiedToProcess);
-    this.processedMessageCount += toProcess.length;
-
-    // Subscribe to data model on first advance if not already subscribed
-    if (!this.dataModelSubscription) {
-      const surface = this.processor.model.getSurface(item.id);
-      if (surface) {
-        this.dataModelSubscription = surface.dataModel.subscribe('/', val => {
-          this.currentDataModelText = JSON.stringify(val || {}, null, 2);
-        });
-      }
-    }
   }
 
   onColorInput(e: Event) {

--- a/renderers/lit/a2ui_explorer/src/local-gallery.ts
+++ b/renderers/lit/a2ui_explorer/src/local-gallery.ts
@@ -88,7 +88,12 @@ export class LocalGallery extends LitElement {
     }
   }
 
-  advanceMessages(all = false) {
+  /**
+   * Advances the message processing.
+   *
+   * @param all Whether to process all remaining messages or just the next one.
+   */
+  advanceMessages(all: boolean = false) {
     const item = this.demoItems[this.activeItemIndex];
     if (!item) return;
 

--- a/renderers/lit/src/v0_9/catalogs/basic/basic-catalog-a2ui-lit-element.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/basic-catalog-a2ui-lit-element.ts
@@ -16,7 +16,7 @@
 
 import {ComponentApi} from '@a2ui/web_core/v0_9';
 import {A2uiLitElement} from '../../a2ui-lit-element.js';
-import {injectBasicCatalogStyles} from '@a2ui/web_core/v0_9/basic_catalog';
+import {injectBasicCatalogStyles, computeColor} from '@a2ui/web_core/v0_9/basic_catalog';
 
 /**
  * A base class for A2UI basic catalog components.
@@ -40,6 +40,32 @@ export abstract class BasicCatalogA2uiLitElement<
       this.style.flex = String(props.weight);
     } else {
       this.style.removeProperty('flex');
+    }
+
+    const surface = this.context?.dataContext?.surface;
+    const primaryColor = surface?.theme?.primaryColor;
+    if (primaryColor) {
+      this.style.setProperty('--a2ui-color-primary', primaryColor);
+      this.style.setProperty(
+        '--a2ui-color-primary-light',
+        computeColor('light', {colorVar: '--a2ui-color-primary'}),
+      );
+      this.style.setProperty(
+        '--a2ui-color-primary-dark',
+        computeColor('dark', {colorVar: '--a2ui-color-primary'}),
+      );
+      this.style.setProperty(
+        '--a2ui-color-primary-hover',
+        computeColor('hover', {
+          darkVar: '--a2ui-color-primary-dark',
+          lightVar: '--a2ui-color-primary-light',
+        }),
+      );
+    } else {
+      this.style.removeProperty('--a2ui-color-primary');
+      this.style.removeProperty('--a2ui-color-primary-light');
+      this.style.removeProperty('--a2ui-color-primary-dark');
+      this.style.removeProperty('--a2ui-color-primary-hover');
     }
   }
 }

--- a/renderers/lit/src/v0_9/catalogs/basic/basic-catalog-a2ui-lit-element.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/basic-catalog-a2ui-lit-element.ts
@@ -16,7 +16,7 @@
 
 import {ComponentApi} from '@a2ui/web_core/v0_9';
 import {A2uiLitElement} from '../../a2ui-lit-element.js';
-import {injectBasicCatalogStyles, computeColor} from '@a2ui/web_core/v0_9/basic_catalog';
+import {injectBasicCatalogStyles, computeColorVariant} from '@a2ui/web_core/v0_9/basic_catalog';
 
 /**
  * A base class for A2UI basic catalog components.
@@ -48,15 +48,15 @@ export abstract class BasicCatalogA2uiLitElement<
       this.style.setProperty('--a2ui-color-primary', primaryColor);
       this.style.setProperty(
         '--a2ui-color-primary-light',
-        computeColor('light', {colorVar: '--a2ui-color-primary'}),
+        computeColorVariant('light', {colorVar: '--a2ui-color-primary'}),
       );
       this.style.setProperty(
         '--a2ui-color-primary-dark',
-        computeColor('dark', {colorVar: '--a2ui-color-primary'}),
+        computeColorVariant('dark', {colorVar: '--a2ui-color-primary'}),
       );
       this.style.setProperty(
         '--a2ui-color-primary-hover',
-        computeColor('hover', {
+        computeColorVariant('hover', {
           darkVar: '--a2ui-color-primary-dark',
           lightVar: '--a2ui-color-primary-light',
         }),

--- a/renderers/lit/src/v0_9/catalogs/basic/basic-catalog-a2ui-lit-element.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/basic-catalog-a2ui-lit-element.ts
@@ -33,8 +33,9 @@ export abstract class BasicCatalogA2uiLitElement<
     injectBasicCatalogStyles();
   }
 
-  updated(changedProperties: Map<PropertyKey, unknown>) {
-    super.updated(changedProperties);
+  willUpdate(changedProperties: Map<string, any>) {
+    super.willUpdate(changedProperties);
+
     const props = this.controller?.props as any;
     if (props && props.weight !== undefined) {
       this.style.flex = String(props.weight);
@@ -42,8 +43,7 @@ export abstract class BasicCatalogA2uiLitElement<
       this.style.removeProperty('flex');
     }
 
-    const surface = this.context?.dataContext?.surface;
-    const primaryColor = surface?.theme?.primaryColor;
+    const primaryColor = this.context?.theme?.primaryColor;
     if (primaryColor) {
       this.style.setProperty('--a2ui-color-primary', primaryColor);
       this.style.setProperty(

--- a/renderers/lit/src/v0_9/tests/basic-catalog-a2ui-lit-element.test.ts
+++ b/renderers/lit/src/v0_9/tests/basic-catalog-a2ui-lit-element.test.ts
@@ -18,8 +18,15 @@ import {setupTestDom, teardownTestDom, asyncUpdate} from './dom-setup.js';
 import assert from 'node:assert';
 import {describe, it, beforeEach, after, before} from 'node:test';
 
-import {ComponentContext, MessageProcessor, Catalog} from '@a2ui/web_core/v0_9';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+} from '@a2ui/web_core/v0_9';
 import {LitComponentApi} from '../types.js';
+import {A2uiController} from '../a2ui-controller.js';
 
 describe('BasicCatalogA2uiLitElement', () => {
   let basicCatalog: Catalog<LitComponentApi>;
@@ -30,13 +37,15 @@ describe('BasicCatalogA2uiLitElement', () => {
     const module = await import('../catalogs/basic/basic-catalog-a2ui-lit-element.js');
     basicCatalog = (await import('../catalogs/basic/index.js')).basicCatalog;
 
-    // Create a mock subclass
-    class TestBasicElement extends module.BasicCatalogA2uiLitElement<any> {
+    // Create a mock A2uiLitElement for tests
+    class TestBasicElement extends module.BasicCatalogA2uiLitElement<ComponentApi> {
       createController() {
-        return {
+        const controllerMock = {
           props: {},
           dispose: () => {},
-        } as any;
+        } as A2uiController<ComponentApi>;
+
+        return controllerMock;
       }
 
       render() {
@@ -49,8 +58,8 @@ describe('BasicCatalogA2uiLitElement', () => {
 
   after(teardownTestDom);
 
-  let processor: MessageProcessor<any>;
-  let surface: any;
+  let processor: MessageProcessor<LitComponentApi>;
+  let surface: SurfaceModel<LitComponentApi>;
 
   beforeEach(() => {
     processor = new MessageProcessor([basicCatalog]);
@@ -123,12 +132,12 @@ describe('BasicCatalogA2uiLitElement', () => {
     assert.strictEqual(el.style.getPropertyValue('--a2ui-color-primary'), '#ff0000');
 
     // Create a new context with a surface that has no theme.
-    const surfaceNoTheme = {
+    const surfaceNoThemeMock = {
       ...surface,
       theme: {},
-    };
+    } as SurfaceModel<LitComponentApi>;
 
-    const contextNoTheme = new ComponentContext(surfaceNoTheme, 'root');
+    const contextNoTheme = new ComponentContext(surfaceNoThemeMock, 'root');
     await asyncUpdate(el, (e: any) => {
       e.context = contextNoTheme;
     });

--- a/renderers/lit/src/v0_9/tests/basic-catalog-a2ui-lit-element.test.ts
+++ b/renderers/lit/src/v0_9/tests/basic-catalog-a2ui-lit-element.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from './dom-setup.js';
+import assert from 'node:assert';
+import {describe, it, beforeEach, after, before} from 'node:test';
+
+import {ComponentContext, MessageProcessor, Catalog} from '@a2ui/web_core/v0_9';
+import {LitComponentApi} from '../types.js';
+
+describe('BasicCatalogA2uiLitElement', () => {
+  let basicCatalog: Catalog<LitComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+
+    const module = await import('../catalogs/basic/basic-catalog-a2ui-lit-element.js');
+    basicCatalog = (await import('../catalogs/basic/index.js')).basicCatalog;
+
+    // Create a mock subclass
+    class TestBasicElement extends module.BasicCatalogA2uiLitElement<any> {
+      createController() {
+        return {
+          props: {},
+          dispose: () => {},
+        } as any;
+      }
+
+      render() {
+        return null;
+      }
+    }
+
+    customElements.define('test-basic-element', TestBasicElement);
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<any>;
+  let surface: any;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+          theme: {
+            primaryColor: '#ff0000',
+          },
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'root',
+              component: 'Text',
+              text: 'Root',
+            },
+          ],
+        },
+      },
+    ]);
+
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  it('should apply primary color from theme', async () => {
+    const el = document.createElement('test-basic-element');
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'root');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    assert.strictEqual(el.style.getPropertyValue('--a2ui-color-primary'), '#ff0000');
+    assert.strictEqual(
+      el.style.getPropertyValue('--a2ui-color-primary-light'),
+      'color-mix(in oklab, var(--a2ui-color-primary) 85%, white)',
+    );
+    assert.strictEqual(
+      el.style.getPropertyValue('--a2ui-color-primary-dark'),
+      'color-mix(in oklab, var(--a2ui-color-primary) 85%, black)',
+    );
+    assert.strictEqual(
+      el.style.getPropertyValue('--a2ui-color-primary-hover'),
+      'light-dark(var(--a2ui-color-primary-dark), var(--a2ui-color-primary-light))',
+    );
+    document.body.removeChild(el);
+  });
+
+  // This test ensures that if the element's context changes to a surface without a
+  // theme, the CSS variable is removed. While surface themes are currently immutable
+  // after creation, this ensures robust cleanup behavior if elements are reused.
+  it('should remove primary color when theme changes or is missing', async () => {
+    const el = document.createElement('test-basic-element');
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'root');
+    await asyncUpdate(el, (e: any) => {
+      e.context = context;
+    });
+
+    assert.strictEqual(el.style.getPropertyValue('--a2ui-color-primary'), '#ff0000');
+
+    // Create a new context with a surface that has no theme.
+    const surfaceNoTheme = {
+      ...surface,
+      theme: {},
+    };
+
+    const contextNoTheme = new ComponentContext(surfaceNoTheme, 'root');
+    await asyncUpdate(el, (e: any) => {
+      e.context = contextNoTheme;
+    });
+
+    assert.strictEqual(el.style.getPropertyValue('--a2ui-color-primary'), '');
+    assert.strictEqual(el.style.getPropertyValue('--a2ui-color-primary-light'), '');
+    assert.strictEqual(el.style.getPropertyValue('--a2ui-color-primary-dark'), '');
+    assert.strictEqual(el.style.getPropertyValue('--a2ui-color-primary-hover'), '');
+    document.body.removeChild(el);
+  });
+});

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- (v0_9) Add `computeColor` helper function for basic catalog components to generate CSS formulas for color variants (light, dark, hover), allowing reuse across renderers.
+- (v0_9) Add `computeColorVariant` helper function for basic catalog components to generate CSS formulas for color variants (light, dark, hover), allowing reuse across renderers.
 
 ## 0.9.1
 

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- (v0_9) Add `computeColor` helper function for basic catalog components to generate CSS formulas for color variants (light, dark, hover), allowing reuse across renderers.
+
 ## 0.9.1
 
 - Add new `FrameworkSignal` concept, which represents a generic signal from a

--- a/renderers/web_core/src/v0_9/basic_catalog/index.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/index.ts
@@ -18,4 +18,5 @@ export * from './expressions/expression_parser.js';
 export * from './functions/basic_functions.js';
 export * from './functions/basic_functions_api.js';
 export * from './components/basic_components.js';
-export {injectBasicCatalogStyles} from './styles/default.js';
+export {injectBasicCatalogStyles, computeColor} from './styles/default.js';
+export type {ComputeColorLightDarkOptions, ComputeColorHoverOptions} from './styles/default.js';

--- a/renderers/web_core/src/v0_9/basic_catalog/index.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/index.ts
@@ -18,5 +18,5 @@ export * from './expressions/expression_parser.js';
 export * from './functions/basic_functions.js';
 export * from './functions/basic_functions_api.js';
 export * from './components/basic_components.js';
-export {injectBasicCatalogStyles, computeColor} from './styles/default.js';
-export type {ComputeColorLightDarkOptions, ComputeColorHoverOptions} from './styles/default.js';
+export {injectBasicCatalogStyles, computeColorVariant} from './styles/default.js';
+export type {ColorVariantLightDarkOptions, ColorVariantHoverOptions} from './styles/default.js';

--- a/renderers/web_core/src/v0_9/basic_catalog/styles/default.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/styles/default.ts
@@ -51,15 +51,15 @@ const DEFAULT_CSS = `
     --a2ui-color-on-surface: light-dark(#333, #eee);
 
     --a2ui-color-primary: #17e;
-    --a2ui-color-primary-light: ${computeColor('light', {colorVar: '--a2ui-color-primary'})};
-    --a2ui-color-primary-dark: ${computeColor('dark', {colorVar: '--a2ui-color-primary'})};
-    --a2ui-color-primary-hover: ${computeColor('hover', {darkVar: '--a2ui-color-primary-dark', lightVar: '--a2ui-color-primary-light'})};
+    --a2ui-color-primary-light: ${computeColorVariant('light', {colorVar: '--a2ui-color-primary'})};
+    --a2ui-color-primary-dark: ${computeColorVariant('dark', {colorVar: '--a2ui-color-primary'})};
+    --a2ui-color-primary-hover: ${computeColorVariant('hover', {darkVar: '--a2ui-color-primary-dark', lightVar: '--a2ui-color-primary-light'})};
     --a2ui-color-on-primary: #fff;
 
     --a2ui-color-secondary: light-dark(#ddd, #333);
-    --a2ui-color-secondary-light: ${computeColor('light', {colorVar: '--a2ui-color-secondary'})};
-    --a2ui-color-secondary-dark: ${computeColor('dark', {colorVar: '--a2ui-color-secondary', percentage: 95})};
-    --a2ui-color-secondary-hover: ${computeColor('hover', {darkVar: '--a2ui-color-secondary-dark', lightVar: '--a2ui-color-secondary-light'})};
+    --a2ui-color-secondary-light: ${computeColorVariant('light', {colorVar: '--a2ui-color-secondary'})};
+    --a2ui-color-secondary-dark: ${computeColorVariant('dark', {colorVar: '--a2ui-color-secondary', percentage: 95})};
+    --a2ui-color-secondary-hover: ${computeColorVariant('hover', {darkVar: '--a2ui-color-secondary-dark', lightVar: '--a2ui-color-secondary-light'})};
     --a2ui-color-on-secondary: light-dark(#333, #eee);
 
     --a2ui-border-radius: 0.25rem;
@@ -140,7 +140,7 @@ export function injectBasicCatalogStyles() {
 /**
  * Options for computing light and dark color variants.
  */
-export interface ComputeColorLightDarkOptions {
+export interface ColorVariantLightDarkOptions {
   /** The CSS variable name of the base color (e.g., '--a2ui-color-primary'). */
   colorVar: string;
   /** The percentage of the base color to retain in the mix (default 85). */
@@ -152,7 +152,7 @@ export interface ComputeColorLightDarkOptions {
 /**
  * Options for computing hover color variants using light-dark().
  */
-export interface ComputeColorHoverOptions {
+export interface ColorVariantHoverOptions {
   /** The CSS variable name of the dark variant. */
   darkVar: string;
   /** The CSS variable name of the light variant. */
@@ -165,7 +165,10 @@ export interface ComputeColorHoverOptions {
  * @param options Options containing the base color variable and optional percentage.
  * @returns The CSS formula string.
  */
-export function computeColor(type: 'light' | 'dark', options: ComputeColorLightDarkOptions): string;
+export function computeColorVariant(
+  type: 'light' | 'dark',
+  options: ColorVariantLightDarkOptions,
+): string;
 
 /**
  * Computes the formula for hover variants of a color.
@@ -173,7 +176,7 @@ export function computeColor(type: 'light' | 'dark', options: ComputeColorLightD
  * @param options Options containing the dark and light variant variable names.
  * @returns The CSS formula string.
  */
-export function computeColor(type: 'hover', options: ComputeColorHoverOptions): string;
+export function computeColorVariant(type: 'hover', options: ColorVariantHoverOptions): string;
 
 /**
  * Computes the formula for light, dark, or hover variants of a color.
@@ -182,21 +185,21 @@ export function computeColor(type: 'hover', options: ComputeColorHoverOptions): 
  * @param options Options containing variable names, percentages, and optional mix color.
  * @returns The CSS formula string.
  */
-export function computeColor(
+export function computeColorVariant(
   type: 'light' | 'dark' | 'hover',
-  options: ComputeColorLightDarkOptions | ComputeColorHoverOptions,
+  options: ColorVariantLightDarkOptions | ColorVariantHoverOptions,
 ): string {
   switch (type) {
     case 'light': {
-      const opt = options as ComputeColorLightDarkOptions;
+      const opt = options as ColorVariantLightDarkOptions;
       return `color-mix(in oklab, var(${opt.colorVar}) ${opt.percentage ?? 85}%, ${opt.mixColor ?? 'white'})`;
     }
     case 'dark': {
-      const opt = options as ComputeColorLightDarkOptions;
+      const opt = options as ColorVariantLightDarkOptions;
       return `color-mix(in oklab, var(${opt.colorVar}) ${opt.percentage ?? 85}%, ${opt.mixColor ?? 'black'})`;
     }
     case 'hover': {
-      const opt = options as ComputeColorHoverOptions;
+      const opt = options as ColorVariantHoverOptions;
       return `light-dark(var(${opt.darkVar}), var(${opt.lightVar}))`;
     }
   }

--- a/renderers/web_core/src/v0_9/basic_catalog/styles/default.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/styles/default.ts
@@ -51,15 +51,15 @@ const DEFAULT_CSS = `
     --a2ui-color-on-surface: light-dark(#333, #eee);
 
     --a2ui-color-primary: #17e;
-    --a2ui-color-primary-light: color-mix(in oklab, var(--a2ui-color-primary) 85%, white);
-    --a2ui-color-primary-dark: color-mix(in oklab, var(--a2ui-color-primary) 85%, black);
-    --a2ui-color-primary-hover: light-dark(var(--a2ui-color-primary-dark), var(--a2ui-color-primary-light));
+    --a2ui-color-primary-light: ${computeColor('light', {colorVar: '--a2ui-color-primary'})};
+    --a2ui-color-primary-dark: ${computeColor('dark', {colorVar: '--a2ui-color-primary'})};
+    --a2ui-color-primary-hover: ${computeColor('hover', {darkVar: '--a2ui-color-primary-dark', lightVar: '--a2ui-color-primary-light'})};
     --a2ui-color-on-primary: #fff;
 
     --a2ui-color-secondary: light-dark(#ddd, #333);
-    --a2ui-color-secondary-light: color-mix(in oklab, var(--a2ui-color-secondary) 85%, white);
-    --a2ui-color-secondary-dark: color-mix(in oklab, var(--a2ui-color-secondary) 95%, black);
-    --a2ui-color-secondary-hover: light-dark(var(--a2ui-color-secondary-dark), var(--a2ui-color-secondary-light));
+    --a2ui-color-secondary-light: ${computeColor('light', {colorVar: '--a2ui-color-secondary'})};
+    --a2ui-color-secondary-dark: ${computeColor('dark', {colorVar: '--a2ui-color-secondary', percentage: 95})};
+    --a2ui-color-secondary-hover: ${computeColor('hover', {darkVar: '--a2ui-color-secondary-dark', lightVar: '--a2ui-color-secondary-light'})};
     --a2ui-color-on-secondary: light-dark(#333, #eee);
 
     --a2ui-border-radius: 0.25rem;
@@ -134,5 +134,70 @@ export function injectBasicCatalogStyles() {
   const sheet = getDefaultStyleSheet();
   if (!document.adoptedStyleSheets.includes(sheet)) {
     document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+  }
+}
+
+/**
+ * Options for computing light and dark color variants.
+ */
+export interface ComputeColorLightDarkOptions {
+  /** The CSS variable name of the base color (e.g., '--a2ui-color-primary'). */
+  colorVar: string;
+  /** The percentage of the base color to retain in the mix (default 85). */
+  percentage?: number;
+  /** The color to mix with (default 'white' for light, 'black' for dark). */
+  mixColor?: string;
+}
+
+/**
+ * Options for computing hover color variants using light-dark().
+ */
+export interface ComputeColorHoverOptions {
+  /** The CSS variable name of the dark variant. */
+  darkVar: string;
+  /** The CSS variable name of the light variant. */
+  lightVar: string;
+}
+
+/**
+ * Computes the formula for light or dark variants of a color.
+ * @param type The type of variant to compute ('light' or 'dark').
+ * @param options Options containing the base color variable and optional percentage.
+ * @returns The CSS formula string.
+ */
+export function computeColor(type: 'light' | 'dark', options: ComputeColorLightDarkOptions): string;
+
+/**
+ * Computes the formula for hover variants of a color.
+ * @param type The type of variant to compute ('hover').
+ * @param options Options containing the dark and light variant variable names.
+ * @returns The CSS formula string.
+ */
+export function computeColor(type: 'hover', options: ComputeColorHoverOptions): string;
+
+/**
+ * Computes the formula for light, dark, or hover variants of a color.
+ * By default, light variants are mixed with white and dark variants with black.
+ * @param type The type of variant to compute ('light', 'dark', 'hover').
+ * @param options Options containing variable names, percentages, and optional mix color.
+ * @returns The CSS formula string.
+ */
+export function computeColor(
+  type: 'light' | 'dark' | 'hover',
+  options: ComputeColorLightDarkOptions | ComputeColorHoverOptions,
+): string {
+  switch (type) {
+    case 'light': {
+      const opt = options as ComputeColorLightDarkOptions;
+      return `color-mix(in oklab, var(${opt.colorVar}) ${opt.percentage ?? 85}%, ${opt.mixColor ?? 'white'})`;
+    }
+    case 'dark': {
+      const opt = options as ComputeColorLightDarkOptions;
+      return `color-mix(in oklab, var(${opt.colorVar}) ${opt.percentage ?? 85}%, ${opt.mixColor ?? 'black'})`;
+    }
+    case 'hover': {
+      const opt = options as ComputeColorHoverOptions;
+      return `light-dark(var(${opt.darkVar}), var(${opt.lightVar}))`;
+    }
   }
 }

--- a/specification/v0_9/json/catalogs/basic/examples/05_product-card.json
+++ b/specification/v0_9/json/catalogs/basic/examples/05_product-card.json
@@ -122,6 +122,7 @@
             "id": "add-cart-btn",
             "component": "Button",
             "child": "add-cart-btn-text",
+            "variant": "primary",
             "action": {
               "event": {
                 "name": "addToCart",


### PR DESCRIPTION
# Description

This PR modifies the Lit renderer to wire the [`theme.primaryColor` property](https://github.com/google/A2UI/blob/33faad298f0dca457a70424ef6784c6c1c3ede89/specification/v0_9/json/basic_catalog.json#L1255-L1259) coming from the A2UI responses that use the basic catalog.

There's some minor changes to other packages to make this easier to test:

* `specification`: adds a "primary" button to the basic catalog example 5
* `web_core`: adds a mechanism to recompute the "light"/"dark"/"hover" colors using the same formula across the default stylesheet and Lit components later.
* `lit/a2ui_explorer`: (optional) adds a way to override the `theme.primaryColor` of the sample apps that gets updated in real time as the user changes it.

## Issues

* Fixes: https://github.com/google/A2UI/issues/979

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes. - n/a, not flutter changes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
