### PR TITLE
Fix e2e tests by switching to native Gemini integration

### DIFF
--- a/samples/agent/adk/restaurant_finder/agent.py
+++ b/samples/agent/adk/restaurant_finder/agent.py
@@ -32,7 +32,7 @@ from google.adk.agents import run_config
 from google.adk.agents.llm_agent import LlmAgent
 from google.adk.artifacts import InMemoryArtifactService
 from google.adk.memory.in_memory_memory_service import InMemoryMemoryService
-from google.adk.models.lite_llm import LiteLlm
+from google.adk.models import Gemini
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
@@ -149,7 +149,8 @@ class RestaurantAgent:
       self, schema_manager: Optional[A2uiSchemaManager] = None
   ) -> LlmAgent:
     """Builds the LLM agent for the restaurant agent."""
-    LITELLM_MODEL = os.getenv("LITELLM_MODEL", "gemini/gemini-2.5-flash")
+    model_env = os.getenv("MODEL_NAME") or os.getenv("LITELLM_MODEL") or "gemini-2.5-flash"
+    model_name = model_env.removeprefix("gemini/")
 
     instruction = (
         schema_manager.generate_system_prompt(
@@ -164,7 +165,7 @@ class RestaurantAgent:
     )
 
     return LlmAgent(
-        model=LiteLlm(model=LITELLM_MODEL),
+        model=Gemini(model=model_name),
         name="restaurant_agent",
         description="An agent that finds restaurants and helps book tables.",
         instruction=instruction,

--- a/samples/agent/adk/restaurant_finder/agent.py
+++ b/samples/agent/adk/restaurant_finder/agent.py
@@ -149,8 +149,12 @@ class RestaurantAgent:
       self, schema_manager: Optional[A2uiSchemaManager] = None
   ) -> LlmAgent:
     """Builds the LLM agent for the restaurant agent."""
-    model_env = os.getenv("MODEL_NAME") or os.getenv("LITELLM_MODEL") or "gemini-2.5-flash"
-    model_name = model_env.removeprefix("gemini/")
+    model_env = (
+        os.getenv("MODEL_NAME")
+        or os.getenv("LITELLM_MODEL")
+        or "gemini-3-flash-preview"
+    )
+    model_name = model_env.split("/")[-1]
 
     instruction = (
         schema_manager.generate_system_prompt(


### PR DESCRIPTION
# Description
This PR fixes the failed e2e tests for `restaurant_finder` in CI.

## Error
The tests failed with the following error from LiteLLM:
```
litellm.NotFoundError: Vertex_ai_betaException - b'{\\n  "error": {\\n    "code": 404,\\n    "message": "models/gemini-2.5-flash is not found for API version v1beta, or is not supported for generateContent. Call ListModels to see the list of available models and their supported methods.",\\n    "status": "NOT_FOUND"\\n  }\\n}\\n'
```

## Fix
As suggested by the warning in the logs, I switched from using `LiteLlm` to native `Gemini` integration in `RestaurantAgent` (`samples/agent/adk/restaurant_finder/agent.py`).
This avoids the issue with LiteLLM trying to use an unavailable API version.

## Verification
I verified that the tests pass locally after:
1. Switching Flutter to the `beta` channel (version `3.44.0-0.3.pre`) to match CI.
2. Using `gemini-3-flash-preview` as the model (by setting `MODEL_NAME` environment variable), as `gemini-2.5-flash` continued to return 404 errors even with the native SDK.

All 4 tests passed locally.
