### PR TITLE
Updates version descriptions in docs for 0.9 release

### DIFF
--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -28,24 +28,13 @@ How components connect to application state using JSON Pointer paths. Covers rea
 
 ## Message Types
 
-=== "v0.8 (Stable)"
+Version 0.9 uses the following message types:
 
-    Version 0.8 uses the following message types:
+- **`createSurface`**: Create a new surface and specify its catalog
+- **`updateComponents`**: Add or update UI components in a surface
+- **`updateDataModel`**: Update application state
+- **`deleteSurface`**: Remove a UI surface
 
-    - **`surfaceUpdate`**: Define or update UI components
-    - **`dataModelUpdate`**: Update application state
-    - **`beginRendering`**: Signal the client to render
-    - **`deleteSurface`**: Remove a UI surface
-
-=== "v0.9 (Draft)"
-
-    Version 0.9 uses the following message types:
-
-    - **`createSurface`**: Create a new surface and specify its catalog
-    - **`updateComponents`**: Add or update UI components in a surface
-    - **`updateDataModel`**: Update application state
-    - **`deleteSurface`**: Remove a UI surface
-
-    v0.9 separates surface creation from rendering — `createSurface` replaces both `beginRendering` and the implicit surface creation in `surfaceUpdate`. All messages include a `version` field.
+Note: v0.9 separates surface creation from rendering — `createSurface` replaces both `beginRendering` and the implicit surface creation in `surfaceUpdate`. All messages include a `version` field.
 
 For complete technical details, see [Message Reference](../reference/messages.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,8 +24,8 @@ A2UI enables AI agents to generate rich, interactive user interfaces that render
 
 | Version                                | Status     | Description                                                                                                                                               |
 | -------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **[v0.8](specification/v0.8-a2ui.md)** | **Stable** | Current production release. Surfaces, components, data binding, adjacency list model.                                                                     |
-| **[v0.9](specification/v0.9-a2ui.md)** | **Draft**  | Adds `createSurface`, client-side functions, custom catalogs, and the extension specification. [Evolution guide →](specification/v0.9-evolution-guide.md) |
+| **[v0.9](specification/v0.9-a2ui.md)** | **Stable** | Current production release. Adds `createSurface`, client-side functions, custom catalogs, and the extension specification. |
+| **[v0.10](specification/v0.10-a2ui.md)** | **Draft**  | Next version under development.                                                                                                                           |
 
 A2UI is Apache 2.0 licensed,
 created by Google with contributions from CopilotKit and the open source community,
@@ -37,7 +37,7 @@ Instead of text-only responses or risky code execution, A2UI lets agents send **
 
 This repository contains:
 
-- **[A2UI specifications](specification/v0.8-a2ui.md)** (v0.8 stable, v0.9 draft).
+- **[A2UI specifications](specification/v0.9-a2ui.md)** (v0.9 stable, v0.10 draft).
 - **Implementations for [renderers](reference/renderers.md)** (Angular, Flutter, Lit, Markdown, etc.) on the client side.
 - **Transports like [A2A](concepts/transports.md)** which communicate A2UI messages between agents and clients.
 
@@ -125,9 +125,9 @@ This repository contains:
 
   ***
 
-  Dive into the complete technical specs: [v0.8 (stable)](specification/v0.8-a2ui.md) · [v0.9 (draft)](specification/v0.9-a2ui.md)
+  Dive into the complete technical specs: [v0.9 (stable)](specification/v0.9-a2ui.md) · [v0.10 (draft)](specification/v0.10-a2ui.md)
 
-  [:octicons-arrow-right-24: Read the v0.8 spec](specification/v0.8-a2ui.md)
+  [:octicons-arrow-right-24: Read the v0.9 spec](specification/v0.9-a2ui.md)
 
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,10 +22,10 @@ A2UI enables AI agents to generate rich, interactive user interfaces that render
 
 ## Specification Versions
 
-| Version                                | Status     | Description                                                                                                                                               |
-| -------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **[v0.9](specification/v0.9-a2ui.md)** | **Stable** | Current production release. Adds `createSurface`, client-side functions, custom catalogs, and the extension specification. |
-| **[v0.10](specification/v0.10-a2ui.md)** | **Draft**  | Next version under development.                                                                                                                           |
+| Version                                  | Status     | Description                                                                                                                |
+| ---------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **[v0.9](specification/v0.9-a2ui.md)**   | **Stable** | Current production release. Adds `createSurface`, client-side functions, custom catalogs, and the extension specification. |
+| **[v0.10](specification/v0.10-a2ui.md)** | **Draft**  | Next version under development.                                                                                            |
 
 A2UI is Apache 2.0 licensed,
 created by Google with contributions from CopilotKit and the open source community,

--- a/docs/introduction/what-is-a2ui.md
+++ b/docs/introduction/what-is-a2ui.md
@@ -40,129 +40,59 @@ A2UI: JSON messages describing UI that:
 
 ### Example
 
-=== "v0.8 (Stable)"
-
-    ```jsonl
-    {
-      "surfaceUpdate": {
-        "surfaceId": "booking",
-        "components": [
-          {
-            "id": "title",
-            "component": {
-              "Text": {
-                "text": { "literalString": "Book Your Table" },
-                "usageHint": "h1"
-              }
-            }
-          },
-          {
-            "id": "datetime",
-            "component": {
-              "DateTimeInput": {
-                "value": { "path": "/booking/date" },
-                "enableDate": true
-              }
-            }
-          },
-          {
-            "id": "submit-text",
-            "component": {
-              "Text": {
-                "text": { "literalString": "Confirm" }
-              }
-            }
-          },
-          {
-            "id": "submit-btn",
-            "component": {
-              "Button": {
-                "child": "submit-text",
-                "action": { "name": "confirm_booking" }
-              }
-            }
-          }
-        ]
-      }
-    }
-    {
-      "dataModelUpdate": {
-        "surfaceId": "booking",
-        "contents": [
-          {
-            "key": "booking",
-            "valueMap": [
-              { "key": "date", "valueString": "2025-12-16T19:00:00Z" }
-            ]
-          }
-        ]
-      }
-    }
-    {
-      "beginRendering": {
-        "surfaceId": "booking",
-        "root": "title"
-      }
-    }
-    ```
-
-=== "v0.9 (Draft)"
-
-    ```jsonl
-    {
-      "version": "v0.9",
-      "createSurface": {
-        "surfaceId": "booking",
-        "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
-      }
-    }
-    {
-      "version": "v0.9",
-      "updateComponents": {
-        "surfaceId": "booking",
-        "components": [
-          {
-            "id": "title",
-            "component": "Text",
-            "text": "Book Your Table",
-            "variant": "h1"
-          },
-          {
-            "id": "datetime",
-            "component": "DateTimeInput",
-            "value": { "path": "/booking/date" },
-            "enableDate": true
-          },
-          {
-            "id": "submit-text",
-            "component": "Text",
-            "text": "Confirm"
-          },
-          {
-            "id": "submit-btn",
-            "component": "Button",
-            "child": "submit-text",
-            "variant": "primary",
-            "action": {
-              "event": { "name": "confirm_booking" }
-            }
-          }
-        ]
-      }
-    }
-    {
-      "version": "v0.9",
-      "updateDataModel": {
-        "surfaceId": "booking",
-        "path": "/booking",
-        "value": {
-          "date": "2025-12-16T19:00:00Z"
+```jsonl
+{
+  "version": "v0.9",
+  "createSurface": {
+    "surfaceId": "booking",
+    "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
+  }
+}
+{
+  "version": "v0.9",
+  "updateComponents": {
+    "surfaceId": "booking",
+    "components": [
+      {
+        "id": "title",
+        "component": "Text",
+        "text": "Book Your Table",
+        "variant": "h1"
+      },
+      {
+        "id": "datetime",
+        "component": "DateTimeInput",
+        "value": { "path": "/booking/date" },
+        "enableDate": true
+      },
+      {
+        "id": "submit-text",
+        "component": "Text",
+        "text": "Confirm"
+      },
+      {
+        "id": "submit-btn",
+        "component": "Button",
+        "child": "submit-text",
+        "variant": "primary",
+        "action": {
+          "event": { "name": "confirm_booking" }
         }
       }
+    ]
+  }
+}
+{
+  "version": "v0.9",
+  "updateDataModel": {
+    "surfaceId": "booking",
+    "path": "/booking",
+    "value": {
+      "date": "2025-12-16T19:00:00Z"
     }
-    ```
-
-    Key differences in v0.9: `createSurface` replaces `beginRendering`, components use a flatter structure with `"component": "Text"` instead of nested objects, and all messages include a `version` field.
+  }
+}
+```
 
 Client renders these messages as native components (Angular, Flutter, React, etc.).
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -134,24 +134,55 @@ Let's peek at what the agent is sending. Here's a simplified example of the JSON
 **Creating the surface:**
 
 ```json
-{"version": "v0.9", "createSurface": {"surfaceId": "main", "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"}}
+{
+  "version": "v0.9",
+  "createSurface": {
+    "surfaceId": "main",
+    "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
+  }
+}
 ```
 
 **Defining the UI:**
 
 ```json
-{"version": "v0.9", "updateComponents": {"surfaceId": "main", "components": [
-  {"id": "header", "component": "Text", "text": "# Book Your Table", "variant": "h1"},
-  {"id": "date-picker", "component": "DateTimeInput", "label": "Select Date", "value": {"path": "/reservation/date"}, "enableDate": true},
-  {"id": "submit-text", "component": "Text", "text": "Confirm Reservation"},
-  {"id": "submit-btn", "component": "Button", "child": "submit-text", "variant": "primary", "action": {"event": {"name": "confirm_booking"}}}
-]}}
+{
+  "version": "v0.9",
+  "updateComponents": {
+    "surfaceId": "main",
+    "components": [
+      {"id": "header", "component": "Text", "text": "# Book Your Table", "variant": "h1"},
+      {
+        "id": "date-picker",
+        "component": "DateTimeInput",
+        "label": "Select Date",
+        "value": {"path": "/reservation/date"},
+        "enableDate": true
+      },
+      {"id": "submit-text", "component": "Text", "text": "Confirm Reservation"},
+      {
+        "id": "submit-btn",
+        "component": "Button",
+        "child": "submit-text",
+        "variant": "primary",
+        "action": {"event": {"name": "confirm_booking"}}
+      }
+    ]
+  }
+}
 ```
 
 **Populating data:**
 
 ```json
-{"version": "v0.9", "updateDataModel": {"surfaceId": "main", "path": "/reservation", "value": {"date": "2025-12-15", "time": "19:00", "guests": 2}}}
+{
+  "version": "v0.9",
+  "updateDataModel": {
+    "surfaceId": "main",
+    "path": "/reservation",
+    "value": {"date": "2025-12-15", "time": "19:00", "guests": 2}
+  }
+}
 ```
 
 TIP: It's Just JSON

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -131,63 +131,28 @@ In the web app, try these prompts:
 
 Let's peek at what the agent is sending. Here's a simplified example of the JSON messages:
 
-=== "v0.8 (Stable)"
+**Creating the surface:**
 
-    **Defining the UI:**
+```json
+{"version": "v0.9", "createSurface": {"surfaceId": "main", "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"}}
+```
 
-    ```json
-    {"surfaceUpdate": {"surfaceId": "main", "components": [
-      {"id": "header", "component": {"Text": {"text": {"literalString": "Book Your Table"}, "usageHint": "h1"}}},
-      {"id": "date-picker", "component": {"DateTimeInput": {"label": {"literalString": "Select Date"}, "value": {"path": "/reservation/date"}, "enableDate": true}}},
-      {"id": "submit-text", "component": {"Text": {"text": {"literalString": "Confirm Reservation"}}}},
-      {"id": "submit-btn", "component": {"Button": {"child": "submit-text", "action": {"name": "confirm_booking"}}}}
-    ]}}
-    ```
+**Defining the UI:**
 
-    **Populating data:**
+```json
+{"version": "v0.9", "updateComponents": {"surfaceId": "main", "components": [
+  {"id": "header", "component": "Text", "text": "# Book Your Table", "variant": "h1"},
+  {"id": "date-picker", "component": "DateTimeInput", "label": "Select Date", "value": {"path": "/reservation/date"}, "enableDate": true},
+  {"id": "submit-text", "component": "Text", "text": "Confirm Reservation"},
+  {"id": "submit-btn", "component": "Button", "child": "submit-text", "variant": "primary", "action": {"event": {"name": "confirm_booking"}}}
+]}}
+```
 
-    ```json
-    {"dataModelUpdate": {"surfaceId": "main", "contents": [
-      {"key": "reservation", "valueMap": [
-        {"key": "date", "valueString": "2025-12-15"},
-        {"key": "time", "valueString": "19:00"},
-        {"key": "guests", "valueInt": 2}
-      ]}
-    ]}}
-    ```
+**Populating data:**
 
-    **Signaling render:**
-
-    ```json
-    {"beginRendering": {"surfaceId": "main", "root": "header"}}
-    ```
-
-=== "v0.9 (Draft)"
-
-    **Creating the surface:**
-
-    ```json
-    {"version": "v0.9", "createSurface": {"surfaceId": "main", "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"}}
-    ```
-
-    **Defining the UI:**
-
-    ```json
-    {"version": "v0.9", "updateComponents": {"surfaceId": "main", "components": [
-      {"id": "header", "component": "Text", "text": "# Book Your Table", "variant": "h1"},
-      {"id": "date-picker", "component": "DateTimeInput", "label": "Select Date", "value": {"path": "/reservation/date"}, "enableDate": true},
-      {"id": "submit-text", "component": "Text", "text": "Confirm Reservation"},
-      {"id": "submit-btn", "component": "Button", "child": "submit-text", "variant": "primary", "action": {"event": {"name": "confirm_booking"}}}
-    ]}}
-    ```
-
-    **Populating data:**
-
-    ```json
-    {"version": "v0.9", "updateDataModel": {"surfaceId": "main", "path": "/reservation", "value": {"date": "2025-12-15", "time": "19:00", "guests": 2}}}
-    ```
-
-    Note: In v0.9, `createSurface` replaces `beginRendering`, components use a flatter format, and the data model uses plain JSON values instead of typed adjacency lists.
+```json
+{"version": "v0.9", "updateDataModel": {"surfaceId": "main", "path": "/reservation", "value": {"date": "2025-12-15", "time": "19:00", "guests": 2}}}
+```
 
 TIP: It's Just JSON
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,10 +6,10 @@ This roadmap outlines the current state and future plans for the A2UI project. T
 
 ### Protocol
 
-| Version  | Status    | Notes                                   |
-| -------- | --------- | --------------------------------------- |
-| **v0.9** | ✅ Stable | Prompt-First specification improvements |
-| **v0.10** | 🚧 Draft | Draft of the next release |
+| Version   | Status    | Notes                                   |
+| --------- | --------- | --------------------------------------- |
+| **v0.9**  | ✅ Stable | Prompt-First specification improvements |
+| **v0.10** | 🚧 Draft  | Draft of the next release               |
 
 Key features:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,8 +8,8 @@ This roadmap outlines the current state and future plans for the A2UI project. T
 
 | Version  | Status    | Notes                                   |
 | -------- | --------- | --------------------------------------- |
-| **v0.8** | ✅ Stable | Initial public release                  |
-| **v0.9** | 🚧 Draft  | Prompt-First specification improvements |
+| **v0.9** | ✅ Stable | Prompt-First specification improvements |
+| **v0.10** | 🚧 Draft | Draft of the next release |
 
 Key features:
 

--- a/docs/specification/v0.8-a2a-extension.md
+++ b/docs/specification/v0.8-a2a-extension.md
@@ -1,4 +1,4 @@
-# A2UI Extension for A2A Protocol <span class="version-badge stable">v0.8 — Stable</span>
+# A2UI Extension for A2A Protocol <span class="version-badge legacy">v0.8 — Legacy</span>
 
 > NOTE: Living Document
 >
@@ -10,7 +10,7 @@
 
 For more information, see the following related documentation:
 
-- [A2UI Protocol v0.8](v0.8-a2ui.md) (Stable).
+- [A2UI Protocol v0.8](v0.8-a2ui.md) (Legacy).
 - [A2A Protocol Documentation](https://a2a-protocol.org).
 
 ---

--- a/docs/specification/v0.8-a2ui.md
+++ b/docs/specification/v0.8-a2ui.md
@@ -1,6 +1,6 @@
-# A2UI Protocol <span class="version-badge stable">v0.8 — Stable</span>
+# A2UI Protocol <span class="version-badge legacy">v0.8 — Legacy</span>
 
-> Version 0.8 is the current stable release, recommended for production use.
+> Version 0.8 is a legacy release. For production use, consider [v0.9 (Stable)](v0.9-a2ui.md).
 
 > NOTE: Living Document
 >
@@ -8,7 +8,8 @@
 
 For more information, see the following related documentation:
 
-- [v0.9 Protocol Specification](v0.9-a2ui.md) (Draft).
+- [v0.9 Protocol Specification](v0.9-a2ui.md) (Stable).
+- [v0.10 Protocol Specification](v0.10-a2ui.md) (Draft).
 - [Evolution Guide: v0.8 → v0.9](v0.9-evolution-guide.md).
 - [A2A Extension Specification](v0.8-a2a-extension.md) (for v0.8).
 

--- a/docs/specification/v0.9-a2ui.md
+++ b/docs/specification/v0.9-a2ui.md
@@ -1,6 +1,6 @@
-# A2UI Protocol <span class="version-badge draft">v0.9 — Draft</span>
+# A2UI Protocol <span class="version-badge stable">v0.9 — Stable</span>
 
-> Version 0.9 is currently in draft status. For production use, consider [v0.8 (Stable)](v0.8-a2ui.md).
+> Version 0.9 is the current stable release, recommended for production use.
 
 > NOTE: Living Document
 >
@@ -8,7 +8,8 @@
 
 For more information, see the following related documentation:
 
-- [v0.8 Protocol Specification](v0.8-a2ui.md) (Stable).
+- [v0.10 Protocol Specification](v0.10-a2ui.md) (Draft).
+- [v0.8 Protocol Specification](v0.8-a2ui.md) (Legacy).
 - [Evolution Guide: v0.8 → v0.9](v0.9-evolution-guide.md).
 
 ---

--- a/docs/specification/v0.9-evolution-guide.md
+++ b/docs/specification/v0.9-evolution-guide.md
@@ -4,8 +4,8 @@
 
 For more information, see the following related documentation:
 
-- [A2UI Protocol v0.8](v0.8-a2ui.md) (Stable - what you're migrating from).
-- [A2UI Protocol v0.9](v0.9-a2ui.md) (Draft - what you're migrating to).
+- [A2UI Protocol v0.8](v0.8-a2ui.md) (Legacy - what you're migrating from).
+- [A2UI Protocol v0.9](v0.9-a2ui.md) (Stable - what you're migrating to).
 
 ---
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -65,12 +65,15 @@ nav:
       - Renderers (Clients): reference/renderers.md
       - Agents (Server-side): reference/agents.md
   - Specifications:
-      - v0.8 (Stable):
+      - v0.8 (Legacy):
           - A2UI Protocol: specification/v0.8-a2ui.md
           - A2A Extension: specification/v0.8-a2a-extension.md
-      - v0.9 (Draft):
+      - v0.9 (Stable):
           - A2UI Protocol: specification/v0.9-a2ui.md
           - Evolution Guide: specification/v0.9-evolution-guide.md
+      - v0.10 (Draft):
+          - A2UI Protocol: specification/v0.10-a2ui.md
+          - Evolution Guide: specification/v0.10-evolution-guide.md
   - Ecosystem:
       - A2UI in the World: ecosystem/a2ui-in-the-world.md
       - Community Renderers: ecosystem/renderers.md


### PR DESCRIPTION
This PR updates the docs to better reflect the status of current versions:

* 0.8 becomes "legacy"
* 0.9 becomes "stable"
* 0.10 becomes "draft"