### PR TITLE
bug: parameters were reversed when creating the AgentExtension.

### DIFF
--- a/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/a2a/A2uiA2a.kt
+++ b/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/a2a/A2uiA2a.kt
@@ -55,10 +55,10 @@ object A2uiA2a {
 
     val isSupportRequired = false
     return AgentExtension(
-      A2UI_EXTENSION_URI,
+      "Provides agent driven UI using the A2UI JSON format.",
       params,
       isSupportRequired,
-      "Provides agent driven UI using the A2UI JSON format.",
+      A2UI_EXTENSION_URI,
     )
   }
 

--- a/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/adk/a2a_extension/Converters.kt
+++ b/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/adk/a2a_extension/Converters.kt
@@ -28,6 +28,7 @@ import com.google.genai.types.Part
 import io.a2a.spec.Event as A2aEvent
 import io.a2a.spec.Message
 import io.a2a.spec.Message.Role.ROLE_AGENT
+import io.a2a.spec.Part as A2aPart
 import io.a2a.spec.TaskState
 import io.a2a.spec.TaskStatus
 import io.a2a.spec.TaskStatusUpdateEvent
@@ -49,7 +50,7 @@ class A2uiPartConverter(
   // to returning DataParts for A2UI, and omitting standard conversions here.
   // Client applications should adapt this integration logic based on actual available converters.
 
-  fun convert(part: Part): List<io.a2a.spec.Part<*>> {
+  fun convert(part: Part): List<A2aPart<*>> {
     val functionResponse = part.functionResponse().orElse(null)
     val isSendA2uiJsonToClientResponse =
       functionResponse != null &&
@@ -129,7 +130,7 @@ class A2uiEventConverter(
     // 2. Process Content
     val content = event.content().orElse(null)
     if (content != null) {
-      val outputParts = mutableListOf<io.a2a.spec.Part<*>>()
+      val outputParts = mutableListOf<A2aPart<*>>()
 
       val genaiParts = content.parts().orElse(emptyList()) ?: emptyList()
       for (part in genaiParts) {

--- a/agent_sdks/kotlin/src/test/kotlin/com/google/a2ui/a2a/A2uiA2aTest.kt
+++ b/agent_sdks/kotlin/src/test/kotlin/com/google/a2ui/a2a/A2uiA2aTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.a2ui.a2a
+
+import com.google.a2ui.core.schema.A2uiConstants
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class A2uiA2aTest {
+
+  @Test
+  fun createsAgentExtensionWithDefaultParams() {
+    val extension = A2uiA2a.getA2uiAgentExtension()
+
+    assertEquals("Provides agent driven UI using the A2UI JSON format.", extension.description)
+    assertNotNull(extension.params)
+    assertTrue(extension.params!!.isEmpty())
+    assertFalse(extension.required)
+    assertEquals(A2uiA2a.A2UI_EXTENSION_URI, extension.uri)
+  }
+
+  @Test
+  fun createsAgentExtensionWithCustomParams() {
+    val extension =
+      A2uiA2a.getA2uiAgentExtension(
+        acceptsInlineCatalogs = true,
+        supportedCatalogIds = listOf("c1", "c2"),
+      )
+
+    assertNotNull(extension.params)
+    assertEquals(true, extension.params!![A2uiConstants.INLINE_CATALOGS_KEY])
+    assertEquals(listOf("c1", "c2"), extension.params!![A2uiConstants.SUPPORTED_CATALOG_IDS_KEY])
+  }
+}


### PR DESCRIPTION
# Description

parameters were reversed when creating the AgentExtension.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [x] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
