### PR TITLE
fix: escape ${expression} in formatString description to prevent ADK KeyError

### DIFF
--- a/specification/v0_10/json/basic_catalog.json
+++ b/specification/v0_10/json/basic_catalog.json
@@ -811,7 +811,7 @@
     },
     "formatString": {
       "type": "object",
-      "description": "Performs string interpolation of data model values and other functions in the catalog functions list and returns the resulting string. The value string can contain interpolated expressions in the `${expression}` format. Supported expression types include: JSON Pointer paths to the data model (e.g., `${/absolute/path}` or `${relative/path}`), and client-side function calls (e.g., `${now()}`). Function arguments must be named (e.g., `${formatDate(value:${/currentDate}, format:'MM-dd')}`). To include a literal `${` sequence, escape it as `\\${`.",
+      "description": "Performs string interpolation of data model values and other functions in the catalog functions list and returns the resulting string. The value string can contain interpolated expressions in the `${<expression>}` format. Supported expression types include: JSON Pointer paths to the data model (e.g., `${/absolute/path}` or `${relative/path}`), and client-side function calls (e.g., `${now()}`). Function arguments must be named (e.g., `${formatDate(value:${/currentDate}, format:'MM-dd')}`). To include a literal `${` sequence, escape it as `\\${`.",
       "properties": {
         "call": {
           "const": "formatString"

--- a/specification/v0_9/json/basic_catalog.json
+++ b/specification/v0_9/json/basic_catalog.json
@@ -962,7 +962,7 @@
     },
     "formatString": {
       "type": "object",
-      "description": "Performs string interpolation of data model values and other functions in the catalog functions list and returns the resulting string. The value string can contain interpolated expressions in the `${expression}` format. Supported expression types include: JSON Pointer paths to the data model (e.g., `${/absolute/path}` or `${relative/path}`), and client-side function calls (e.g., `${now()}`). Function arguments must be named (e.g., `${formatDate(value:${/currentDate}, format:'MM-dd')}`). To include a literal `${` sequence, escape it as `\\${`.",
+      "description": "Performs string interpolation of data model values and other functions in the catalog functions list and returns the resulting string. The value string can contain interpolated expressions in the `${<expression>}` format. Supported expression types include: JSON Pointer paths to the data model (e.g., `${/absolute/path}` or `${relative/path}`), and client-side function calls (e.g., `${now()}`). Function arguments must be named (e.g., `${formatDate(value:${/currentDate}, format:'MM-dd')}`). To include a literal `${` sequence, escape it as `\\${`.",
       "properties": {
         "call": {
           "const": "formatString"


### PR DESCRIPTION
## Summary

Fixes #1388

The `formatString` function description in `basic_catalog.json` contained the literal text `${expression}`, which the ADK's `inject_session_state()` matched as a template variable. Since `expression` passes Python's `str.isidentifier()` check, the ADK raised a `KeyError` when it couldn't find it in the session state.

## Changes

Changed `${expression}` → `${<expression>}` in the `formatString` description for both `v0_9` and `v0_10` catalog schemas.

The angle brackets cause `<expression>` to fail the `isidentifier()` check, so the ADK's `_is_valid_state_name()` returns `False` and the match is returned as-is (line 108 of `instructions_utils.py`).

## Why only `${expression}` was affected

The other interpolation examples in the same description were already safe:
- `${/absolute/path}` → `/absolute/path` is not a valid identifier (contains `/`)
- `${now()}` → `now()` is not a valid identifier (contains `()`)
- `${relative/path}` → `relative/path` is not a valid identifier (contains `/`)

Only `expression` was a bare, valid Python identifier.

## Files changed

- `specification/v0_9/json/basic_catalog.json`
- `specification/v0_10/json/basic_catalog.json`