### PR TITLE
attempt to fix authoring-components.md

### DIFF
--- a/docs/guides/authoring-components.md
+++ b/docs/guides/authoring-components.md
@@ -110,6 +110,8 @@ Implement your component using your client-side framework. For Angular, your com
 
 In the [`rizzcharts`](../../samples/client/angular/projects/rizzcharts/README.md) example, the `Chart` component is defined in [`chart.ts`](../../samples/client/angular/projects/rizzcharts/src/a2ui-catalog/chart.ts).
 
+{% raw %}
+
 ```typescript
 import {DynamicComponent} from '@a2ui/angular';
 import * as Primitives from '@a2ui/web_core/types/primitives';
@@ -136,6 +138,8 @@ export class Chart extends DynamicComponent<Types.CustomNode> {
   // ... data resolution logic using super.resolvePrimitive for data paths
 }
 ```
+
+{% endraw %}
 
 Keep these key points in mind when implementing components:
 

--- a/docs/guides/authoring-components.md
+++ b/docs/guides/authoring-components.md
@@ -111,6 +111,7 @@ Implement your component using your client-side framework. For Angular, your com
 In the [`rizzcharts`](../../samples/client/angular/projects/rizzcharts/README.md) example, the `Chart` component is defined in [`chart.ts`](../../samples/client/angular/projects/rizzcharts/src/a2ui-catalog/chart.ts).
 
 {% raw %}
+
 ```typescript
 import {DynamicComponent} from '@a2ui/angular';
 import * as Primitives from '@a2ui/web_core/types/primitives';
@@ -137,6 +138,7 @@ export class Chart extends DynamicComponent<Types.CustomNode> {
   // ... data resolution logic using super.resolvePrimitive for data paths
 }
 ```
+
 {% endraw %}
 
 Keep these key points in mind when implementing components:

--- a/docs/guides/authoring-components.md
+++ b/docs/guides/authoring-components.md
@@ -111,7 +111,6 @@ Implement your component using your client-side framework. For Angular, your com
 In the [`rizzcharts`](../../samples/client/angular/projects/rizzcharts/README.md) example, the `Chart` component is defined in [`chart.ts`](../../samples/client/angular/projects/rizzcharts/src/a2ui-catalog/chart.ts).
 
 {% raw %}
-
 ```typescript
 import {DynamicComponent} from '@a2ui/angular';
 import * as Primitives from '@a2ui/web_core/types/primitives';
@@ -138,7 +137,6 @@ export class Chart extends DynamicComponent<Types.CustomNode> {
   // ... data resolution logic using super.resolvePrimitive for data paths
 }
 ```
-
 {% endraw %}
 
 Keep these key points in mind when implementing components:


### PR DESCRIPTION
https://a2ui.org/guides/authoring-components/ throws the following:

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.13.13/x64/lib/python3.13/site-packages/mkdocs_macros/plugin.py", line 703, in render
    return md_template.render(**page_variables)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.13/x64/lib/python3.13/site-packages/jinja2/environment.py", line 1295, in render
    self.environment.handle_exception()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/opt/hostedtoolcache/Python/3.13.13/x64/lib/python3.13/site-packages/jinja2/environment.py", line 942, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "<template>", line 123, in top-level template code
  File "/opt/hostedtoolcache/Python/3.13.13/x64/lib/python3.13/site-packages/jinja2/utils.py", line 92, in from_obj
    if hasattr(obj, "jinja_pass_arg"):
       ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
jinja2.exceptions.UndefinedError: 'resolvedTitle' is undefined
```

It seems mkdocs is attempting to evaluate the `{{ resolvedTitle() }}` in the Angular template. This PR escape that piece of Angular in a `{% raw %}` block, which should fix it 🤞 