### PR TITLE
Ignore generated file in Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -21,3 +21,4 @@ build
 *.min.js
 agent_sdks/conformance/test_data/**
 **/pnpm-lock.yaml
+renderers/angular/a2ui_explorer/src/app/generated/examples-bundle.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -21,4 +21,4 @@ build
 *.min.js
 agent_sdks/conformance/test_data/**
 **/pnpm-lock.yaml
-renderers/angular/a2ui_explorer/src/app/generated/examples-bundle.ts
+renderers/angular/a2ui_explorer/src/app/generated/**


### PR DESCRIPTION
Ignore `renderers/angular/a2ui_explorer/src/app/generated/examples-bundle.ts` in Prettier to fix format script failures.

This file is ignored in renderers/angular/.gitignore, but when running the app locally, this file gets generated and after running the formatting script, it fails because this generated file does not conform with the format. Since this is a generated file, we can exclude it from the formatter.