### PR TITLE
Change 'type' to 'textFieldType' in booking_form.json

### DIFF
--- a/samples/agent/adk/restaurant_finder/examples/0.8/booking_form.json
+++ b/samples/agent/adk/restaurant_finder/examples/0.8/booking_form.json
@@ -72,7 +72,7 @@
               "text": {
                 "path": "/partySize"
               },
-              "type": "number"
+              "textFieldType": "number"
             }
           }
         },


### PR DESCRIPTION
The A2UI v0.8 spec uses `textFieldType` as the property name in the `TextField` component. The unknown `type` property will cause a validation failure.

# Description

_Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots._

_List which issues are fixed by this PR. For larger changes, raising an issue first helps reduce redundant work._

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
