### PR TITLE
feat(catalogs): allow binding to openUrl url

### DIFF
--- a/samples/agent/adk/custom-components-example/inline_catalog_0.9.json
+++ b/samples/agent/adk/custom-components-example/inline_catalog_0.9.json
@@ -1319,10 +1319,24 @@
           "type": "object",
           "properties": {
             "url": {
-              "type": "string"
+              "allOf": [
+                {
+                  "$ref": "common_types.json#/$defs/DynamicString"
+                },
+                {
+                  "if": {
+                    "type": "string"
+                  },
+                  "then": {
+                    "format": "uri"
+                  }
+                }
+              ],
+              "description": "The URL to open."
             }
           },
-          "required": ["url"]
+          "required": ["url"],
+          "unevaluatedProperties": false
         },
         "returnType": {
           "const": "void"

--- a/specification/v0_10/json/basic_catalog.json
+++ b/specification/v0_10/json/basic_catalog.json
@@ -998,13 +998,24 @@
           "type": "object",
           "properties": {
             "url": {
-              "type": "string",
-              "format": "uri",
+              "allOf": [
+                {
+                  "$ref": "common_types.json#/$defs/DynamicString"
+                },
+                {
+                  "if": {
+                    "type": "string"
+                  },
+                  "then": {
+                    "format": "uri"
+                  }
+                }
+              ],
               "description": "The URL to open."
             }
           },
           "required": ["url"],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         "returnType": {
           "const": "void"

--- a/specification/v0_10/test/cases/function_catalog_validation.json
+++ b/specification/v0_10/test/cases/function_catalog_validation.json
@@ -471,6 +471,31 @@
       }
     },
     {
+      "description": "openUrl: Valid call with dynamic binding URL",
+      "valid": true,
+      "data": {
+        "version": "v0.10",
+        "updateComponents": {
+          "surfaceId": "test",
+          "components": [
+            {
+              "id": "btn1",
+              "component": "Button",
+              "child": "txt1",
+              "action": {
+                "functionCall": {
+                  "call": "openUrl",
+                  "args": {"url": {"path": "/targetUrl"}},
+                  "returnType": "void"
+                }
+              }
+            },
+            {"id": "txt1", "component": "Text", "text": "Go"}
+          ]
+        }
+      }
+    },
+    {
       "description": "openUrl: Invalid args (string instead of object)",
       "valid": false,
       "data": {

--- a/specification/v0_10/test/testing_catalog.json
+++ b/specification/v0_10/test/testing_catalog.json
@@ -37,13 +37,24 @@
           "type": "object",
           "properties": {
             "url": {
-              "type": "string",
-              "format": "uri",
+              "allOf": [
+                {
+                  "$ref": "common_types.json#/$defs/DynamicString"
+                },
+                {
+                  "if": {
+                    "type": "string"
+                  },
+                  "then": {
+                    "format": "uri"
+                  }
+                }
+              ],
               "description": "The URL to open."
             }
           },
           "required": ["url"],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         "returnType": {
           "const": "void"

--- a/specification/v0_9/json/basic_catalog.json
+++ b/specification/v0_9/json/basic_catalog.json
@@ -1143,13 +1143,24 @@
           "type": "object",
           "properties": {
             "url": {
-              "type": "string",
-              "format": "uri",
+              "allOf": [
+                {
+                  "$ref": "common_types.json#/$defs/DynamicString"
+                },
+                {
+                  "if": {
+                    "type": "string"
+                  },
+                  "then": {
+                    "format": "uri"
+                  }
+                }
+              ],
               "description": "The URL to open."
             }
           },
           "required": ["url"],
-          "additionalProperties": false
+          "unevaluatedProperties": false
         },
         "returnType": {
           "const": "void"

--- a/specification/v0_9/test/cases/function_catalog_validation.json
+++ b/specification/v0_9/test/cases/function_catalog_validation.json
@@ -471,6 +471,31 @@
       }
     },
     {
+      "description": "openUrl: Valid call with dynamic binding URL",
+      "valid": true,
+      "data": {
+        "version": "v0.9",
+        "updateComponents": {
+          "surfaceId": "test",
+          "components": [
+            {
+              "id": "btn1",
+              "component": "Button",
+              "child": "txt1",
+              "action": {
+                "functionCall": {
+                  "call": "openUrl",
+                  "args": {"url": {"path": "/targetUrl"}},
+                  "returnType": "void"
+                }
+              }
+            },
+            {"id": "txt1", "component": "Text", "text": "Go"}
+          ]
+        }
+      }
+    },
+    {
       "description": "openUrl: Invalid args (string instead of object)",
       "valid": false,
       "data": {


### PR DESCRIPTION
# Description

Allow the `url` of the `openUrl` function to bind to a path in the data model.

This allows to have buttons in a list of cards that are bound to a url in a datamodel.

Fixes https://github.com/google/a2ui/issues/1390.

## Pre-launch Checklist

- [X] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [X] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
