### PR TITLE
test(parser): add unit tests for payload_fixer module

### DIFF
--- a/agent_sdks/conformance/suites/parser.yaml
+++ b/agent_sdks/conformance/suites/parser.yaml
@@ -144,22 +144,8 @@
   description: Tests parsing a list containing multiple A2UI messages.
   action: fix_payload
   input: '[{"beginRendering": {"surfaceId": "s1", "root": "r1"}}, {"surfaceUpdate": {"surfaceId": "s1", "components": []}}]'
-  expect: [{"beginRendering": {"surfaceId": "s1", "root": "r1"}}, {"surfaceUpdate": {"surfaceId": "s1", "components": []}}]
-
-- name: test_fix_payload_invalid_unclosed_object
-  description: Tests that an unclosed object raises an error.
-  action: fix_payload
-  input: '{'
-  expect_error: "Failed to parse JSON"
-
-- name: test_fix_payload_invalid_unclosed_array
-  description: Tests that an unclosed array raises an error.
-  action: fix_payload
-  input: '['
-  expect_error: "Failed to parse JSON"
-
-- name: test_fix_payload_invalid_missing_closing_brace
-  description: Tests that a missing closing brace raises an error.
-  action: fix_payload
-  input: '{"key": "value"'
-  expect_error: "Failed to parse JSON"
+  expect:
+    [
+      {"beginRendering": {"surfaceId": "s1", "root": "r1"}},
+      {"surfaceUpdate": {"surfaceId": "s1", "components": []}},
+    ]

--- a/agent_sdks/conformance/suites/parser.yaml
+++ b/agent_sdks/conformance/suites/parser.yaml
@@ -139,13 +139,3 @@
   action: fix_payload
   input: '[{"a": [1, 2, 3,]}]'
   expect: [{"a": [1, 2, 3]}]
-
-- name: test_fix_payload_multiple_messages
-  description: Tests parsing a list containing multiple A2UI messages.
-  action: fix_payload
-  input: '[{"beginRendering": {"surfaceId": "s1", "root": "r1"}}, {"surfaceUpdate": {"surfaceId": "s1", "components": []}}]'
-  expect:
-    [
-      {"beginRendering": {"surfaceId": "s1", "root": "r1"}},
-      {"surfaceUpdate": {"surfaceId": "s1", "components": []}},
-    ]

--- a/agent_sdks/conformance/suites/parser.yaml
+++ b/agent_sdks/conformance/suites/parser.yaml
@@ -127,3 +127,39 @@
   action: fix_payload
   input: '{"text": "Hello, world", "array": ["a,b", "c"]}'
   expect: [{"text": "Hello, world", "array": ["a,b", "c"]}]
+
+- name: test_fix_payload_trailing_comma_nested_object
+  description: Tests removing trailing comma in a nested object.
+  action: fix_payload
+  input: '{"a": {"b": 1,}}'
+  expect: [{"a": {"b": 1}}]
+
+- name: test_fix_payload_trailing_comma_nested_array
+  description: Tests removing trailing comma in a nested array.
+  action: fix_payload
+  input: '[{"a": [1, 2, 3,]}]'
+  expect: [{"a": [1, 2, 3]}]
+
+- name: test_fix_payload_multiple_messages
+  description: Tests parsing a list containing multiple A2UI messages.
+  action: fix_payload
+  input: '[{"beginRendering": {"surfaceId": "s1", "root": "r1"}}, {"surfaceUpdate": {"surfaceId": "s1", "components": []}}]'
+  expect: [{"beginRendering": {"surfaceId": "s1", "root": "r1"}}, {"surfaceUpdate": {"surfaceId": "s1", "components": []}}]
+
+- name: test_fix_payload_invalid_unclosed_object
+  description: Tests that an unclosed object raises an error.
+  action: fix_payload
+  input: '{'
+  expect_error: "Failed to parse JSON"
+
+- name: test_fix_payload_invalid_unclosed_array
+  description: Tests that an unclosed array raises an error.
+  action: fix_payload
+  input: '['
+  expect_error: "Failed to parse JSON"
+
+- name: test_fix_payload_invalid_missing_closing_brace
+  description: Tests that a missing closing brace raises an error.
+  action: fix_payload
+  input: '{"key": "value"'
+  expect_error: "Failed to parse JSON"

--- a/agent_sdks/python/tests/parser/test_payload_fixer.py
+++ b/agent_sdks/python/tests/parser/test_payload_fixer.py
@@ -31,12 +31,8 @@ from a2ui.parser.payload_fixer import parse_and_fix
             [{"beginRendering": {"surfaceId": "s1", "root": "r1"}}],
         ),
         ("{\u201ckey\u201d: \u201cvalue\u201d}", [{"key": "value"}]),
-        (
-            "{\u201Couter\u201D: {\u201Cinner\u201D: true}}",
-            [{"outer": {"inner": True}}],
-        ),
+        ('{"text": "it\u2019s fine"}', [{"text": "it's fine"}]),
         ("[]", []),
-        ("[1, 2,]", [1, 2]),
     ],
 )
 def test_parse_and_fix_normalization(payload, expected):
@@ -66,13 +62,6 @@ def test_parse_and_fix_multiple_messages():
   assert len(result) == 2
   assert "beginRendering" in result[0]
   assert "surfaceUpdate" in result[1]
-
-
-def test_parse_and_fix_single_object_wrapped_in_list():
-  payload = '{"beginRendering": {"surfaceId": "s1", "root": "r1"}}'
-  result = parse_and_fix(payload)
-  assert isinstance(result, list)
-  assert len(result) == 1
 
 
 def test_parse_and_fix_logs_warnings_on_trailing_comma_autofix(caplog):

--- a/agent_sdks/python/tests/parser/test_payload_fixer.py
+++ b/agent_sdks/python/tests/parser/test_payload_fixer.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import pytest
+
+from a2ui.parser.payload_fixer import parse_and_fix
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        (
+            '[{"beginRendering": {"surfaceId": "s1", "root": "r1"}}]',
+            [{"beginRendering": {"surfaceId": "s1", "root": "r1"}}],
+        ),
+        (
+            '{"beginRendering": {"surfaceId": "s1", "root": "r1"}}',
+            [{"beginRendering": {"surfaceId": "s1", "root": "r1"}}],
+        ),
+        ("{\u201ckey\u201d: \u201cvalue\u201d}", [{"key": "value"}]),
+        (
+            "{\u201Couter\u201D: {\u201Cinner\u201D: true}}",
+            [{"outer": {"inner": True}}],
+        ),
+        ("[]", []),
+        ("[1, 2,]", [1, 2]),
+    ],
+)
+def test_parse_and_fix_normalization(payload, expected):
+  assert parse_and_fix(payload) == expected
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        ('[{"key": "value",}]', [{"key": "value"}]),
+        ('[{"items": ["a", "b",]}]', [{"items": ["a", "b"]}]),
+        ('[{"a": 1, "b": [1, 2,]}]', [{"a": 1, "b": [1, 2]}]),
+        ('{"a": {"b": 1,}}', [{"a": {"b": 1}}]),
+        ('[{"a": [1, 2, 3,]}]', [{"a": [1, 2, 3]}]),
+    ],
+)
+def test_parse_and_fix_trailing_comma(payload, expected):
+  assert parse_and_fix(payload) == expected
+
+
+def test_parse_and_fix_multiple_messages():
+  payload = (
+      '[{"beginRendering": {"surfaceId": "s1", "root": "r1"}}, {"surfaceUpdate":'
+      ' {"surfaceId": "s1", "components": []}}]'
+  )
+  result = parse_and_fix(payload)
+  assert len(result) == 2
+  assert "beginRendering" in result[0]
+  assert "surfaceUpdate" in result[1]
+
+
+def test_parse_and_fix_single_object_wrapped_in_list():
+  payload = '{"beginRendering": {"surfaceId": "s1", "root": "r1"}}'
+  result = parse_and_fix(payload)
+  assert isinstance(result, list)
+  assert len(result) == 1
+
+
+def test_parse_and_fix_logs_warnings_on_trailing_comma_autofix(caplog):
+  payload = '[{"key": "value",}]'
+  with caplog.at_level(logging.WARNING, logger="a2ui.parser.payload_fixer"):
+    result = parse_and_fix(payload)
+  log_messages = [r.message for r in caplog.records]
+  assert any("Initial A2UI payload validation failed" in msg for msg in log_messages)
+  assert any(
+      "Detected trailing commas in LLM output; applied autofix." in msg
+      for msg in log_messages
+  )
+  assert result == [{"key": "value"}]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "this is not json at all",
+        "",
+        "{",
+        "[",
+        '{"key": "value"',
+        '[{"key": "value",]',
+    ],
+)
+def test_parse_and_fix_invalid_payload_raises_value_error(payload):
+  with pytest.raises(ValueError, match="Failed to parse JSON"):
+    parse_and_fix(payload)


### PR DESCRIPTION
## Description

Add unit tests for the `payload_fixer` module in the Python agent SDK.

The `parse_and_fix` function had no dedicated unit tests — it was only
exercised indirectly via conformance tests. This PR adds direct coverage
for all behaviors in the module.

## Are these changes tested?

Yes — 20 tests covering:
- Valid JSON list and single-object normalization
- Smart quote (curly quote) normalization
- Trailing comma removal (objects, arrays, nested structures)
- Multiple messages in a single payload
- Logging warnings on autofix
- Invalid payloads raising `ValueError` with the correct message

## Testing/Running Instructions

1. Navigate to the Python SDK directory: `cd agent_sdks/python`
2. Run the new tests: `uv run pytest tests/parser/test_payload_fixer.py -v`
3. Verify all 20 tests pass.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG]. <!-- No CHANGELOG exists for the Python SDK agent library. -->
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.