### PR TITLE
fix: update stale catalogId references broken by #1452 spec restructure

### DIFF
--- a/agent_sdks/python/tests/integration/verify_load_real.py
+++ b/agent_sdks/python/tests/integration/verify_load_real.py
@@ -403,9 +403,7 @@ def verify():
             'version': 'v0.9',
             'createSurface': {
                 'surfaceId': 'contact_form_1',
-                'catalogId': (
-                    'https://a2ui.dev/specification/v0_9/catalogs/basic/catalog.json'
-                ),
+                'catalogId': 'https://a2ui.dev/specification/v0_9/catalogs/basic/catalog.json',
                 'fakeProperty': 'should be allowed',
             },
         },

--- a/agent_sdks/python/tests/schema/test_validator.py
+++ b/agent_sdks/python/tests/schema/test_validator.py
@@ -449,9 +449,7 @@ class TestValidator:
             "version": "v0.9",
             "createSurface": {
                 "surfaceId": "recipe-card",
-                "catalogId": (
-                    "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
-                ),
+                "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
             },
         },
         {

--- a/samples/agent/adk/migrate_v08_to_v09.py
+++ b/samples/agent/adk/migrate_v08_to_v09.py
@@ -16,9 +16,7 @@ import json
 import argparse
 from pathlib import Path
 
-VERSION_0_9_CATALOG_ID = (
-    "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
-)
+VERSION_0_9_CATALOG_ID = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
 
 
 def _convert_map(v_map):


### PR DESCRIPTION
## Summary

PR #1452 moved the basic catalog schema from:
- `specification/v{ver}/json/basic_catalog.json`

to:
- `specification/v{ver}/catalogs/basic/catalog.json`

The lit renderer's `basicCatalog` was correctly updated to the new canonical `$id` (`https://a2ui.org/specification/v{ver}/catalogs/basic/catalog.json`), but all downstream consumers were missed, causing a runtime crash:

```
A2uiStateError: Catalog not found: https://a2ui.org/specification/v0_9/basic_catalog.json
```

This happens because the agent samples include examples with the old `catalogId` in the LLM system prompt, so the model generates `createSurface` messages with the outdated ID — which no longer matches the registered catalog on the client.

## Files updated

- `samples/agent/adk/restaurant_finder/examples/0.9/*.json` — LLM prompt examples
- `samples/agent/adk/custom-components-example/examples/0.9/*.json`
- `samples/agent/adk/rizzcharts/examples/standard_catalog/0.9/*.json` + `prompt_builder.py`
- `samples/client/lit/shell/public/samples/*.json` — local file loading samples
- `samples/client/react/shell/src/mock/restaurantMessages.ts`
- `samples/mcp/a2ui-over-mcp-recipe/recipe_a2ui.json`
- `samples/agent/adk/migrate_v08_to_v09.py`
- `specification/v0_9/eval/src/generation_flow.ts` + `validator.ts`
- `specification/v0_10/eval/src/generation_flow.ts` + `validator.ts`
- `specification/v0_9/test/cases/*.json` + `run_tests.py` (fixed path to removed `basic_catalog.json`)
- `specification/v0_10/test/cases/*.json` + `run_tests.py`
- `agent_sdks/python/tests/schema/test_validator.py`
- `agent_sdks/python/tests/integration/verify_load_real.py`

## Test plan

- [x] Run the restaurant finder sample server and verify no `Catalog not found` error on first message
- [x] Load `contact_card.json` / `workspace_settings.json` via the local file upload in the lit shell — should render without error
- [x] Run `specification/v0_9/test/run_tests.py` — all tests pass
- [x] Run `specification/v0_10/test/run_tests.py` — all tests pass