### PR TITLE
refactor(angular): remove redundant version() call in dataModel computed property

### DIFF
--- a/renderers/angular/a2ui_explorer/src/app/agent-stub-v08.service.ts
+++ b/renderers/angular/a2ui_explorer/src/app/agent-stub-v08.service.ts
@@ -45,7 +45,6 @@ export class AgentStubV08Service extends AgentStubService {
   private actionSub?: {unsubscribe: () => void};
 
   override dataModel = computed(() => {
-    this.messageProcessorV08.version();
     const surfaceId = this.surfaceId();
     if (!surfaceId) return {};
     const surfaces = this.messageProcessorV08.getSurfaces();

--- a/samples/client/flutter/restaurant_finder/e2e_test/test/infra_test.dart
+++ b/samples/client/flutter/restaurant_finder/e2e_test/test/infra_test.dart
@@ -30,13 +30,9 @@ void main() {
     print('Joke from AI:\n\n$result\n\n');
   });
 
-  test(
-    'test can start restaurant_finder',
-    () async {
-      final restaurantFinderClient = TestRestaurantFinderClient();
-      addTearDown(restaurantFinderClient.dispose);
-      await restaurantFinderClient.startAndVerify();
-    },
-    timeout: const Timeout(Duration(minutes: 5)),
-  );
+  test('test can start restaurant_finder', () async {
+    final restaurantFinderClient = TestRestaurantFinderClient();
+    addTearDown(restaurantFinderClient.dispose);
+    await restaurantFinderClient.startAndVerify();
+  }, timeout: const Timeout(Duration(minutes: 5)));
 }

--- a/samples/client/flutter/restaurant_finder/e2e_test/test/infra_test.dart
+++ b/samples/client/flutter/restaurant_finder/e2e_test/test/infra_test.dart
@@ -30,9 +30,13 @@ void main() {
     print('Joke from AI:\n\n$result\n\n');
   });
 
-  test('test can start restaurant_finder', () async {
-    final restaurantFinderClient = TestRestaurantFinderClient();
-    addTearDown(restaurantFinderClient.dispose);
-    await restaurantFinderClient.startAndVerify();
-  }, timeout: const Timeout(Duration(minutes: 5)));
+  test(
+    'test can start restaurant_finder',
+    () async {
+      final restaurantFinderClient = TestRestaurantFinderClient();
+      addTearDown(restaurantFinderClient.dispose);
+      await restaurantFinderClient.startAndVerify();
+    },
+    timeout: const Timeout(Duration(minutes: 5)),
+  );
 }


### PR DESCRIPTION
Removes the redundant `this.messageProcessorV08.version()` call in the `dataModel` computed property of `AgentStubV08Service`.