### PR TITLE
Align runtime validation behavior with v0.8 schema expectations for bindable fields

### DIFF
--- a/renderers/web_core/src/v0_8/schema/common-types.ts
+++ b/renderers/web_core/src/v0_8/schema/common-types.ts
@@ -59,11 +59,51 @@ const DataValueMapItemSchema: z.ZodType<any> = z.lazy(() =>
       if (count !== 1) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: `Value map item must have at least one value property (valueString, valueNumber, valueBoolean, valueMap), found ${count}.`,
+          message: `Value map item must have exactly one value property (valueString, valueNumber, valueBoolean, valueMap), found ${count}.`,
         });
       }
     }),
 );
+
+export const DataValueSchema = z
+  .object({
+    key: z.string(),
+    valueString: z.string().optional(),
+    valueNumber: z.number().optional(),
+    valueBoolean: z.boolean().optional(),
+    valueMap: z.array(DataValueMapItemSchema).optional(),
+  })
+  .strict()
+  .superRefine((val: any, ctx: z.RefinementCtx) => {
+    let count = 0;
+    if (val.valueString !== undefined) count++;
+    if (val.valueNumber !== undefined) count++;
+    if (val.valueBoolean !== undefined) count++;
+    if (val.valueMap !== undefined) count++;
+    if (count !== 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Value must have exactly one value property (valueString, valueNumber, valueBoolean, valueMap), found ${count}.`,
+      });
+    }
+  })
+  .superRefine((val: any, ctx: z.RefinementCtx) => {
+    const checkDepth = (v: any, currentDepth: number) => {
+      if (currentDepth > 5) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'valueMap recursion exceeded maximum depth of 5.',
+        });
+        return;
+      }
+      if (v.valueMap && Array.isArray(v.valueMap)) {
+        for (const item of v.valueMap) {
+          checkDepth(item, currentDepth + 1);
+        }
+      }
+    };
+    checkDepth(val, 1);
+  });
 
 export function createDataValueSchema(options: {maxDepth?: number} = {}) {
   const maxDepth = options.maxDepth ?? 5;
@@ -85,8 +125,6 @@ export function createDataValueSchema(options: {maxDepth?: number} = {}) {
     checkDepth(val, 1);
   });
 }
-
-export const DataValueSchema = createDataValueSchema();
 
 export const NumberValueSchema = z
   .object({
@@ -129,7 +167,7 @@ export const ActionSchema = z.object({
             literalNumber: z.number().optional(),
             literalBoolean: z.boolean().optional(),
           })
-          .describe('The dynamic value. Define EXACTLY ONE of the nested properties.')
+          .describe('The dynamic value. Define at least one of the nested properties.')
           .strict()
           .superRefine(atLeastOneKey),
       }),

--- a/renderers/web_core/src/v0_8/schema/common-types.ts
+++ b/renderers/web_core/src/v0_8/schema/common-types.ts
@@ -20,12 +20,12 @@ import {z} from 'zod';
  * Base primitives
  */
 
-const exactlyOneKey = (val: any, ctx: z.RefinementCtx) => {
+const atLeastOneKey = (val: any, ctx: z.RefinementCtx) => {
   const keys = Object.keys(val).filter(k => val[k] !== undefined);
-  if (keys.length !== 1) {
+  if (keys.length < 1) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: `Must define exactly one property, found ${keys.length} (${keys.join(', ')}).`,
+      message: `Must define at least one property, found ${keys.length} (${keys.join(', ')}).`,
     });
   }
 };
@@ -37,7 +37,7 @@ export const StringValueSchema = z
     literal: z.string().optional(),
   })
   .strict()
-  .superRefine(exactlyOneKey);
+  .superRefine(atLeastOneKey);
 export type StringValue = z.infer<typeof StringValueSchema>;
 
 const DataValueMapItemSchema: z.ZodType<any> = z.lazy(() =>
@@ -59,7 +59,7 @@ const DataValueMapItemSchema: z.ZodType<any> = z.lazy(() =>
       if (count !== 1) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: `Value map item must have exactly one value property (valueString, valueNumber, valueBoolean, valueMap), found ${count}.`,
+          message: `Value map item must have at least one value property (valueString, valueNumber, valueBoolean, valueMap), found ${count}.`,
         });
       }
     }),
@@ -95,7 +95,7 @@ export const NumberValueSchema = z
     literal: z.number().optional(),
   })
   .strict()
-  .superRefine(exactlyOneKey);
+  .superRefine(atLeastOneKey);
 export type NumberValue = z.infer<typeof NumberValueSchema>;
 
 export const BooleanValueSchema = z
@@ -105,7 +105,7 @@ export const BooleanValueSchema = z
     literal: z.boolean().optional(),
   })
   .strict()
-  .superRefine(exactlyOneKey);
+  .superRefine(atLeastOneKey);
 export type BooleanValue = z.infer<typeof BooleanValueSchema>;
 
 /**
@@ -131,7 +131,7 @@ export const ActionSchema = z.object({
           })
           .describe('The dynamic value. Define EXACTLY ONE of the nested properties.')
           .strict()
-          .superRefine(exactlyOneKey),
+          .superRefine(atLeastOneKey),
       }),
     )
     .describe('A key-value map of data bindings to be resolved when the action is triggered.')
@@ -200,7 +200,7 @@ export const TabsSchema = z.object({
             });
           }
           if (val.title) {
-            exactlyOneKey(val.title, ctx);
+            atLeastOneKey(val.title, ctx);
           }
         }),
     )
@@ -243,7 +243,7 @@ export const CheckboxSchema = z.object({
       literalBoolean: z.boolean().optional(),
     })
     .strict()
-    .superRefine(exactlyOneKey),
+    .superRefine(atLeastOneKey),
 });
 
 export const TextFieldSchema = z.object({
@@ -273,7 +273,7 @@ export const MultipleChoiceSchema = z.object({
       literalArray: z.array(z.string()).optional(),
     })
     .strict()
-    .superRefine(exactlyOneKey),
+    .superRefine(atLeastOneKey),
   options: z
     .array(
       z.object({
@@ -288,7 +288,7 @@ export const MultipleChoiceSchema = z.object({
             literalString: z.string().describe('A fixed, hardcoded string value.').optional(),
           })
           .strict()
-          .superRefine(exactlyOneKey),
+          .superRefine(atLeastOneKey),
         value: z.string(),
       }),
     )
@@ -308,7 +308,7 @@ export const SliderSchema = z.object({
       literalNumber: z.number().optional(),
     })
     .strict()
-    .superRefine(exactlyOneKey),
+    .superRefine(atLeastOneKey),
   minValue: z.number().optional(),
   maxValue: z.number().optional(),
   label: StringValueSchema.optional(),
@@ -327,7 +327,7 @@ export const ComponentArrayReferenceSchema = z
     ).optional(),
   })
   .strict()
-  .superRefine(exactlyOneKey);
+  .superRefine(atLeastOneKey);
 
 export const RowSchema = z.object({
   children: ComponentArrayReferenceSchema,

--- a/renderers/web_core/src/v0_8/schema/common-types.ts
+++ b/renderers/web_core/src/v0_8/schema/common-types.ts
@@ -25,7 +25,7 @@ const atLeastOneKey = (val: any, ctx: z.RefinementCtx) => {
   if (keys.length < 1) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: `Must define at least one property, found ${keys.length} (${keys.join(', ')}).`,
+      message: `Must define at least one property, found ${keys.length}.`,
     });
   }
 };
@@ -65,46 +65,6 @@ const DataValueMapItemSchema: z.ZodType<any> = z.lazy(() =>
     }),
 );
 
-export const DataValueSchema = z
-  .object({
-    key: z.string(),
-    valueString: z.string().optional(),
-    valueNumber: z.number().optional(),
-    valueBoolean: z.boolean().optional(),
-    valueMap: z.array(DataValueMapItemSchema).optional(),
-  })
-  .strict()
-  .superRefine((val: any, ctx: z.RefinementCtx) => {
-    let count = 0;
-    if (val.valueString !== undefined) count++;
-    if (val.valueNumber !== undefined) count++;
-    if (val.valueBoolean !== undefined) count++;
-    if (val.valueMap !== undefined) count++;
-    if (count !== 1) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `Value must have exactly one value property (valueString, valueNumber, valueBoolean, valueMap), found ${count}.`,
-      });
-    }
-  })
-  .superRefine((val: any, ctx: z.RefinementCtx) => {
-    const checkDepth = (v: any, currentDepth: number) => {
-      if (currentDepth > 5) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: 'valueMap recursion exceeded maximum depth of 5.',
-        });
-        return;
-      }
-      if (v.valueMap && Array.isArray(v.valueMap)) {
-        for (const item of v.valueMap) {
-          checkDepth(item, currentDepth + 1);
-        }
-      }
-    };
-    checkDepth(val, 1);
-  });
-
 export function createDataValueSchema(options: {maxDepth?: number} = {}) {
   const maxDepth = options.maxDepth ?? 5;
   return DataValueMapItemSchema.superRefine((val: any, ctx: z.RefinementCtx) => {
@@ -125,6 +85,8 @@ export function createDataValueSchema(options: {maxDepth?: number} = {}) {
     checkDepth(val, 1);
   });
 }
+
+export const DataValueSchema = createDataValueSchema();
 
 export const NumberValueSchema = z
   .object({


### PR DESCRIPTION
### Description
Addresses a runtime validation regression introduced in newer `@a2ui/react` versions when validating spec-compliant A2UI v0.8 payloads.

In `@a2ui/react@0.8.0`, bindable fields (such as `MultipleChoice.selections`) containing both `path` and a literal fallback (e.g., `literalArray`) were correctly validated, matching the official A2UI v0.8 catalog specification. Later releases introduced a strict refinement (`exactlyOneKey`) that failed at runtime with `Must define exactly one property`.

This PR replaces `exactlyOneKey` with `atLeastOneKey` for v0.8 bindable properties in `@a2ui/web_core`. This aligns runtime validation behavior with official v0.8 schema expectations while preserving backwards compatibility for producers emitting both data bindings and literal initial values.

Fixes: [#1469](https://github.com/google/A2UI/issues/1469)



## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [x] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
