### PR TITLE
fix(build): chain @a2ui/lit tsc to web_core, drop redundant --watch

### DIFF
--- a/renderers/lit/package.json
+++ b/renderers/lit/package.json
@@ -71,6 +71,9 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "../web_core:build:tsc"
+      ],
       "files": [
         "src/**/*.ts",
         "src/**/*.json",

--- a/tools/editor/package.json
+++ b/tools/editor/package.json
@@ -10,7 +10,7 @@
     "prepack": "npm run build",
     "build": "wireit",
     "build:tsc": "wireit",
-    "dev": "npm run serve --watch",
+    "dev": "npm run serve",
     "serve": "wireit"
   },
   "wireit": {

--- a/tools/inspector/package.json
+++ b/tools/inspector/package.json
@@ -10,7 +10,7 @@
     "prepack": "npm run build",
     "build": "wireit",
     "build:tsc": "wireit",
-    "dev": "npm run serve --watch",
+    "dev": "npm run serve",
     "test": "wireit",
     "serve": "wireit"
   },


### PR DESCRIPTION
## Summary

- Adds a missing cross-package wireit dependency so `@a2ui/lit:build:tsc` builds `@a2ui/web_core:build:tsc` first. Without it, a clean clone fails `npm run dev` in `tools/inspector` with 345 TypeScript errors on unresolved `@a2ui/web_core/*` imports.
- Drops `--watch` from the `dev` script in `tools/inspector` and `tools/editor` to silence `npm warn Unknown cli config "--watch"`. The flag is consumed by npm (not forwarded to the script) and is redundant since the `serve` wireit entry is already `service: true`.

## Why the build was broken

`@a2ui/lit` declares `"@a2ui/web_core": "file:../web_core"` as a dependency, and `@a2ui/web_core`'s `package.json` exports point at `./dist/...`:

```json
"./v0_9": {
  "types": "./dist/src/v0_9/index.d.ts",
  "default": "./dist/src/v0_9/index.js"
}
```

On a fresh checkout, `web_core/dist/` doesn't exist. tsc resolution against the package exports fails, producing errors like:

```
src/0.8/core.ts:20:23 - error TS2307: Cannot find module '@a2ui/web_core' or its corresponding type declarations.
```

`tools/inspector/package.json` already chains via `../../renderers/lit:build:tsc`, but lit itself had no edge to web_core, so the dep graph terminated before reaching the package that actually needs to be built first.

## What changed

```diff
   "build:tsc": {
     "command": "tsc -b --pretty",
     "env": { "FORCE_COLOR": "1" },
+    "dependencies": [
+      "../web_core:build:tsc"
+    ],
     "files": [...],
     ...
   }
```

```diff
-    "dev": "npm run serve --watch",
+    "dev": "npm run serve",
```

## Verification

```
rm -rf renderers/web_core/dist renderers/lit/dist tools/inspector/dist
cd tools/inspector && npm install && npm run dev
```

Before: tsc fails with 345 errors. After: all three `dist/` trees rebuild in dependency order, vite serves on :5173, no npm warning.

## CLA

I'll sign the Google CLA before merge. Flagging here in case CI gates on it.

## Test plan

- [ ] CI passes on the PR branch
- [ ] Reviewer can run the verification command above and reproduce
- [ ] CLA signed