### PR TITLE
Move EventConverter and PartConverter to modular a2a subpackage and support extracting A2UI tags from generic tool responses

### DIFF
--- a/agent_sdks/python/src/a2ui/adk/a2a/event_converter.py
+++ b/agent_sdks/python/src/a2ui/adk/a2a/event_converter.py
@@ -1,0 +1,91 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the A2UI Event Converter.
+
+This module provides the `A2uiEventConverter` which intercepts ADK events and automatically
+translates GenAI model outputs (both tool-based A2UI function calls and text-based delimited A2UI blocks)
+into A2A (Agent-to-Agent) event structures with A2UI payloads, using the session catalog if available.
+
+Key Components:
+  * `A2uiEventConverter`: An event converter that automatically injects the A2UI catalog into part conversion.
+
+Usage Example:
+
+  Configure the ADK executor to use the A2UI event converter:
+
+  ```python
+  config = A2aAgentExecutorConfig(
+      event_converter=A2uiEventConverter()
+  )
+  executor = A2aAgentExecutor(config)
+  ```
+"""
+
+from typing import TYPE_CHECKING, Optional
+
+from a2ui.adk.a2a.part_converter import A2uiPartConverter
+from google.adk.a2a.converters import part_converter
+from google.adk.utils.feature_decorator import experimental
+
+if TYPE_CHECKING:
+  from a2a.server.events import Event as A2AEvent
+  from google.adk.a2a.converters.part_converter import GenAIPartToA2APartConverter
+  from google.adk.agents.invocation_context import InvocationContext
+  from google.adk.events.event import Event
+
+
+@experimental
+class A2uiEventConverter:
+  """An event converter that automatically injects the A2UI catalog into part conversion.
+
+  This allows text-based A2UI extraction and validation to work even when the
+  catalog is session-specific.
+  """
+
+  def __init__(
+      self, catalog_key: str = "system:a2ui_catalog", bypass_tool_check: bool = False
+  ):
+    self._catalog_key = catalog_key
+    self._bypass_tool_check = bypass_tool_check
+
+  def __call__(
+      self,
+      event: "Event",
+      invocation_context: "InvocationContext",
+      task_id: Optional[str] = None,
+      context_id: Optional[str] = None,
+      part_converter_func: "GenAIPartToA2APartConverter" = part_converter.convert_genai_part_to_a2a_part,
+  ) -> list["A2AEvent"]:
+    """Converts an ADK event to A2A events, using the session catalog if available."""
+    from google.adk.a2a.converters.event_converter import (
+        convert_event_to_a2a_events,
+    )
+
+    catalog = invocation_context.session.state.get(self._catalog_key)
+    if catalog:
+      # Use the catalog-aware part converter
+      effective_converter = A2uiPartConverter(
+          catalog, bypass_tool_check=self._bypass_tool_check
+      ).convert
+    else:
+      effective_converter = part_converter_func
+
+    return convert_event_to_a2a_events(
+        event,
+        invocation_context,
+        task_id,
+        context_id,
+        effective_converter,
+    )

--- a/agent_sdks/python/src/a2ui/adk/a2a/event_converter.py
+++ b/agent_sdks/python/src/a2ui/adk/a2a/event_converter.py
@@ -55,10 +55,14 @@ class A2uiEventConverter:
   """
 
   def __init__(
-      self, catalog_key: str = "system:a2ui_catalog", bypass_tool_check: bool = False
+      self,
+      catalog_key: str = "system:a2ui_catalog",
+      bypass_tool_check: bool = False,
+      fallback_text: Optional[str] = None,
   ):
     self._catalog_key = catalog_key
     self._bypass_tool_check = bypass_tool_check
+    self._fallback_text = fallback_text
 
   def __call__(
       self,
@@ -77,7 +81,9 @@ class A2uiEventConverter:
     if catalog:
       # Use the catalog-aware part converter
       effective_converter = A2uiPartConverter(
-          catalog, bypass_tool_check=self._bypass_tool_check
+          catalog,
+          bypass_tool_check=self._bypass_tool_check,
+          fallback_text=self._fallback_text,
       ).convert
     else:
       effective_converter = part_converter_func

--- a/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
+++ b/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
@@ -104,9 +104,7 @@ class A2uiPartConverter:
           return []
 
       # Handle generic/other tool responses that returned a string containing A2UI tags.
-      if function_response.response and function_response.response.get(
-          "result"
-      ):
+      if function_response.response and function_response.response.get("result"):
         result = function_response.response.get("result")
         if has_a2ui_parts(result):
           return parse_response_to_parts(

--- a/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
+++ b/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
@@ -37,12 +37,8 @@ import logging
 from a2a import types as a2a_types
 from a2ui.a2a.parts import create_a2ui_part, parse_response_to_parts
 from a2ui.parser.parser import has_a2ui_parts
+from a2ui.schema import constants
 from a2ui.schema.catalog import A2uiCatalog
-from a2ui.schema.constants import (
-    A2UI_TOOL_ERROR_KEY,
-    A2UI_TOOL_NAME,
-    A2UI_VALIDATED_JSON_KEY,
-)
 from google.adk.a2a.converters import part_converter
 from google.adk.utils.feature_decorator import experimental
 from google.genai import types as genai_types
@@ -76,17 +72,17 @@ class A2uiPartConverter:
     """
     # 1. Handle Tool Responses (FunctionResponse)
     if function_response := part.function_response:
-      is_send_a2ui_json_to_client_response = function_response.name == A2UI_TOOL_NAME
+      is_send_a2ui_json_to_client_response = function_response.name == constants.A2UI_TOOL_NAME
 
       if is_send_a2ui_json_to_client_response or self._bypass_tool_check:
         response_dict = function_response.response or {}
 
-        if A2UI_TOOL_ERROR_KEY in response_dict:
-          logger.warning(f"A2UI tool call failed: {response_dict[A2UI_TOOL_ERROR_KEY]}")
+        if constants.A2UI_TOOL_ERROR_KEY in response_dict:
+          logger.warning(f"A2UI tool call failed: {response_dict[constantsA2UI_TOOL_ERROR_KEY]}")
           return []
 
-        if isinstance(response_dict, dict) and A2UI_VALIDATED_JSON_KEY in response_dict:
-          json_data = response_dict.get(A2UI_VALIDATED_JSON_KEY)
+        if isinstance(response_dict, dict) and constants.A2UI_VALIDATED_JSON_KEY in response_dict:
+          json_data = response_dict.get(constants.A2UI_VALIDATED_JSON_KEY)
           if json_data:
             return [create_a2ui_part(message) for message in json_data]
 
@@ -95,7 +91,7 @@ class A2uiPartConverter:
           return []
 
     # 2. Handle Tool Calls (FunctionCall) - Skip sending to client
-    if (function_call := part.function_call) and function_call.name == A2UI_TOOL_NAME:
+    if (function_call := part.function_call) and function_call.name == constants.A2UI_TOOL_NAME:
       return []
 
     # 3. Handle Text-based A2UI (TextPart)

--- a/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
+++ b/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
@@ -1,0 +1,108 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the A2UI Part Converter.
+
+This module provides the `A2uiPartConverter` which acts as a catalog-aware GenAI to A2A
+part converter. It handles both tool-based A2UI (via the `send_a2ui_json_to_client` tool response)
+and text-based A2UI (extracted and healed via A2UI custom tags), validating the structures
+against the active A2UI catalog schema.
+
+Key Components:
+  * `A2uiPartConverter`: A catalog-aware GenAI to A2A part converter.
+
+Usage Example:
+
+  Typically used internally by the A2uiEventConverter or manually configured for custom part conversions:
+
+  ```python
+  converter = A2uiPartConverter(a2ui_catalog=my_catalog)
+  a2a_parts = converter.convert(genai_part)
+  ```
+"""
+
+import logging
+
+from a2a import types as a2a_types
+from a2ui.a2a.parts import create_a2ui_part, parse_response_to_parts
+from a2ui.parser.parser import has_a2ui_parts
+from a2ui.schema.catalog import A2uiCatalog
+from a2ui.schema.constants import (
+    A2UI_TOOL_ERROR_KEY,
+    A2UI_TOOL_NAME,
+    A2UI_VALIDATED_JSON_KEY,
+)
+from google.adk.a2a.converters import part_converter
+from google.adk.utils.feature_decorator import experimental
+from google.genai import types as genai_types
+
+logger = logging.getLogger(__name__)
+
+
+@experimental
+class A2uiPartConverter:
+  """A catalog-aware GenAI to A2A part converter.
+
+  This converter handles both tool-based A2UI (via `send_a2ui_json_to_client`)
+  and text-based A2UI (via A2UI delimiter tags). It uses the provided
+  catalog to validate and fix JSON payloads.
+  """
+
+  def __init__(
+      self, a2ui_catalog: A2uiCatalog, bypass_tool_check: bool = False
+  ):
+    self._catalog = a2ui_catalog
+    self._bypass_tool_check = bypass_tool_check
+
+  def convert(self, part: genai_types.Part) -> list[a2a_types.Part]:
+    """Converts a GenAI part to A2A parts, with A2UI validation.
+
+    Args:
+        part: The GenAI part to convert.
+
+    Returns:
+        A list of A2A parts.
+    """
+    # 1. Handle Tool Responses (FunctionResponse)
+    if function_response := part.function_response:
+      is_send_a2ui_json_to_client_response = function_response.name == A2UI_TOOL_NAME
+
+      if is_send_a2ui_json_to_client_response or self._bypass_tool_check:
+        response_dict = function_response.response or {}
+
+        if A2UI_TOOL_ERROR_KEY in response_dict:
+          logger.warning(f"A2UI tool call failed: {response_dict[A2UI_TOOL_ERROR_KEY]}")
+          return []
+
+        if isinstance(response_dict, dict) and A2UI_VALIDATED_JSON_KEY in response_dict:
+          json_data = response_dict.get(A2UI_VALIDATED_JSON_KEY)
+          if json_data:
+            return [create_a2ui_part(message) for message in json_data]
+
+        if is_send_a2ui_json_to_client_response:
+          logger.info("No result in A2UI tool response")
+          return []
+
+    # 2. Handle Tool Calls (FunctionCall) - Skip sending to client
+    if (function_call := part.function_call) and function_call.name == A2UI_TOOL_NAME:
+      return []
+
+    # 3. Handle Text-based A2UI (TextPart)
+    if text := part.text:
+      if has_a2ui_parts(text):
+        return parse_response_to_parts(text, validator=self._catalog.validator)
+
+    # 4. Default conversion for other parts
+    converted_part = part_converter.convert_genai_part_to_a2a_part(part)
+    return [converted_part] if converted_part else []

--- a/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
+++ b/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
@@ -95,6 +95,18 @@ class A2uiPartConverter:
           logger.info("No result in A2UI tool response")
           return []
 
+      # Handle generic/other tool responses that returned a string containing A2UI tags.
+      if function_response.response and function_response.response.get(
+          "result"
+      ):
+        result = function_response.response.get("result")
+        if has_a2ui_parts(result):
+          return parse_response_to_parts(
+              result,
+              validator=self._catalog.validator,
+              fallback_text="Failed to parse A2UI response.",
+          )
+
     # 2. Handle Tool Calls (FunctionCall) - Skip sending to client
     if (
         function_call := part.function_call

--- a/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
+++ b/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
@@ -55,9 +55,7 @@ class A2uiPartConverter:
   catalog to validate and fix JSON payloads.
   """
 
-  def __init__(
-      self, a2ui_catalog: A2uiCatalog, bypass_tool_check: bool = False
-  ):
+  def __init__(self, a2ui_catalog: A2uiCatalog, bypass_tool_check: bool = False):
     self._catalog = a2ui_catalog
     self._bypass_tool_check = bypass_tool_check
 
@@ -72,16 +70,23 @@ class A2uiPartConverter:
     """
     # 1. Handle Tool Responses (FunctionResponse)
     if function_response := part.function_response:
-      is_send_a2ui_json_to_client_response = function_response.name == constants.A2UI_TOOL_NAME
+      is_send_a2ui_json_to_client_response = (
+          function_response.name == constants.A2UI_TOOL_NAME
+      )
 
       if is_send_a2ui_json_to_client_response or self._bypass_tool_check:
         response_dict = function_response.response or {}
 
         if constants.A2UI_TOOL_ERROR_KEY in response_dict:
-          logger.warning(f"A2UI tool call failed: {response_dict[constants.A2UI_TOOL_ERROR_KEY]}")
+          logger.warning(
+              f"A2UI tool call failed: {response_dict[constants.A2UI_TOOL_ERROR_KEY]}"
+          )
           return []
 
-        if isinstance(response_dict, dict) and constants.A2UI_VALIDATED_JSON_KEY in response_dict:
+        if (
+            isinstance(response_dict, dict)
+            and constants.A2UI_VALIDATED_JSON_KEY in response_dict
+        ):
           json_data = response_dict.get(constants.A2UI_VALIDATED_JSON_KEY)
           if json_data:
             return [create_a2ui_part(message) for message in json_data]
@@ -91,7 +96,9 @@ class A2uiPartConverter:
           return []
 
     # 2. Handle Tool Calls (FunctionCall) - Skip sending to client
-    if (function_call := part.function_call) and function_call.name == constants.A2UI_TOOL_NAME:
+    if (
+        function_call := part.function_call
+    ) and function_call.name == constants.A2UI_TOOL_NAME:
       return []
 
     # 3. Handle Text-based A2UI (TextPart)

--- a/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
+++ b/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
@@ -33,6 +33,8 @@ Usage Example:
 """
 
 import logging
+from typing import Optional
+
 
 from a2a import types as a2a_types
 from a2ui.a2a.parts import create_a2ui_part, parse_response_to_parts
@@ -55,9 +57,15 @@ class A2uiPartConverter:
   catalog to validate and fix JSON payloads.
   """
 
-  def __init__(self, a2ui_catalog: A2uiCatalog, bypass_tool_check: bool = False):
+  def __init__(
+      self,
+      a2ui_catalog: A2uiCatalog,
+      bypass_tool_check: bool = False,
+      fallback_text: Optional[str] = None,
+  ):
     self._catalog = a2ui_catalog
     self._bypass_tool_check = bypass_tool_check
+    self._fallback_text = fallback_text
 
   def convert(self, part: genai_types.Part) -> list[a2a_types.Part]:
     """Converts a GenAI part to A2A parts, with A2UI validation.
@@ -104,7 +112,7 @@ class A2uiPartConverter:
           return parse_response_to_parts(
               result,
               validator=self._catalog.validator,
-              fallback_text="Failed to parse A2UI response.",
+              fallback_text=self._fallback_text,
           )
 
     # 2. Handle Tool Calls (FunctionCall) - Skip sending to client
@@ -116,7 +124,11 @@ class A2uiPartConverter:
     # 3. Handle Text-based A2UI (TextPart)
     if text := part.text:
       if has_a2ui_parts(text):
-        return parse_response_to_parts(text, validator=self._catalog.validator)
+        return parse_response_to_parts(
+            text,
+            validator=self._catalog.validator,
+            fallback_text=self._fallback_text,
+        )
 
     # 4. Default conversion for other parts
     converted_part = part_converter.convert_genai_part_to_a2a_part(part)

--- a/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
+++ b/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
@@ -78,7 +78,7 @@ class A2uiPartConverter:
         response_dict = function_response.response or {}
 
         if constants.A2UI_TOOL_ERROR_KEY in response_dict:
-          logger.warning(f"A2UI tool call failed: {response_dict[constantsA2UI_TOOL_ERROR_KEY]}")
+          logger.warning(f"A2UI tool call failed: {response_dict[constants.A2UI_TOOL_ERROR_KEY]}")
           return []
 
         if isinstance(response_dict, dict) and constants.A2UI_VALIDATED_JSON_KEY in response_dict:

--- a/agent_sdks/python/src/a2ui/adk/send_a2ui_to_client_toolset.py
+++ b/agent_sdks/python/src/a2ui/adk/send_a2ui_to_client_toolset.py
@@ -94,6 +94,8 @@ from a2ui.parser.payload_fixer import parse_and_fix
 from a2ui.schema import catalog
 from a2ui.schema import constants
 from a2ui.schema.catalog import A2uiCatalog
+from a2ui.schema import catalog
+from a2ui.schema.catalog import A2uiCatalog
 from a2ui.schema.constants import (
     A2UI_SCHEMA_BLOCK_END,
     A2UI_SCHEMA_BLOCK_START,

--- a/agent_sdks/python/src/a2ui/adk/send_a2ui_to_client_toolset.py
+++ b/agent_sdks/python/src/a2ui/adk/send_a2ui_to_client_toolset.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module for the SendA2uiToClientToolset and Part Converter.
+"""Module for the SendA2uiToClientToolset.
 
 This module provides the necessary components to enable an agent to send A2UI (Agent-to-User Interface)
-JSON payloads to a client. It includes the `SendA2uiToClientToolset` for managing A2UI tools, a specific tool for the LLM
-to send JSON, and a part converter to translate the LLM's tool calls into A2A (Agent-to-Agent) parts.
+JSON payloads to a client. It includes the `SendA2uiToClientToolset` for managing A2UI tools, and a specific tool for the LLM
+to send JSON.
 
 This is just one approach for capturing A2UI JSON payloads from an LLM.
 
@@ -28,7 +28,6 @@ Key Components:
     that effectively sends a JSON payload to the client. This tool validates the JSON against
     the provided schema. It automatically wraps the provided schema in an array structure,
     instructing the LLM that it can send a list of UI items.
-  * `A2uiEventConverter`: An event converter that automatically injects the A2UI catalog into part conversion.
 
 Usage Examples:
 
@@ -75,22 +74,10 @@ Usage Examples:
         ],
     )
     ```
-
-  3. Integration with Executor:
-    Configure the executor to use the A2UI part converter.
-
-    ```python
-    config = A2aAgentExecutorConfig(
-        event_converter=A2uiEventConverter()
-    )
-    executor = A2aAgentExecutor(config)
-    ```
 """
 
 import inspect
-import json
 import logging
-import re
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -101,17 +88,19 @@ from typing import (
     Union,
 )
 
-import jsonschema
-
-from a2a import types as a2a_types
-from a2ui.a2a import parts
-from a2ui.parser.parser import has_a2ui_parts
+from a2ui.adk.a2a.event_converter import A2uiEventConverter
+from a2ui.adk.a2a.part_converter import A2uiPartConverter
 from a2ui.parser.payload_fixer import parse_and_fix
-from a2ui.schema import catalog
-from a2ui.schema import constants
-from google.adk import models
-from google.adk.a2a.converters import part_converter
-from google.adk.agents import readonly_context
+from a2ui.schema.catalog import A2uiCatalog
+from a2ui.schema.constants import (
+    A2UI_SCHEMA_BLOCK_END,
+    A2UI_SCHEMA_BLOCK_START,
+    A2UI_TOOL_ERROR_KEY,
+    A2UI_TOOL_NAME,
+    A2UI_VALIDATED_JSON_KEY,
+)
+from google.adk.agents.readonly_context import ReadonlyContext
+from google.adk.models import LlmRequest
 from google.adk.tools import base_toolset
 from google.adk.tools import base_tool
 from google.adk.tools import tool_context
@@ -119,8 +108,6 @@ from google.adk.utils.feature_decorator import experimental
 from google.genai import types as genai_types
 
 if TYPE_CHECKING:
-  from a2a.server.events import Event as A2AEvent
-  from google.adk.a2a.converters.part_converter import GenAIPartToA2APartConverter
   from google.adk.agents.invocation_context import InvocationContext
   from google.adk.events.event import Event
 
@@ -206,10 +193,10 @@ class SendA2uiToClientToolset(base_toolset.BaseToolset):
     return A2uiPartConverter(catalog)
 
   class _SendA2uiJsonToClientTool(base_tool.BaseTool):
-    TOOL_NAME = "send_a2ui_json_to_client"
-    VALIDATED_A2UI_JSON_KEY = "validated_a2ui_json"
+    TOOL_NAME = A2UI_TOOL_NAME
+    VALIDATED_A2UI_JSON_KEY = A2UI_VALIDATED_JSON_KEY
     A2UI_JSON_ARG_NAME = "a2ui_json"
-    TOOL_ERROR_KEY = "error"
+    TOOL_ERROR_KEY = A2UI_TOOL_ERROR_KEY
 
     def __init__(
         self,
@@ -334,125 +321,3 @@ class SendA2uiToClientToolset(base_toolset.BaseToolset):
         logger.error(err)
 
         return {self.TOOL_ERROR_KEY: err}
-
-
-@experimental
-class A2uiPartConverter:
-  """A catalog-aware GenAI to A2A part converter.
-
-  This converter handles both tool-based A2UI (via `send_a2ui_json_to_client`)
-  and text-based A2UI (via A2UI delimiter tags). It uses the provided
-  catalog to validate and fix JSON payloads.
-  """
-
-  def __init__(
-      self, a2ui_catalog: catalog.A2uiCatalog, bypass_tool_check: bool = False
-  ):
-    self._catalog = a2ui_catalog
-    self._bypass_tool_check = bypass_tool_check
-
-  def convert(self, part: genai_types.Part) -> list[a2a_types.Part]:
-    """Converts a GenAI part to A2A parts, with A2UI validation.
-
-    Args:
-        part: The GenAI part to convert.
-
-    Returns:
-        A list of A2A parts.
-    """
-    # 1. Handle Tool Responses (FunctionResponse)
-    if function_response := part.function_response:
-      is_send_a2ui_json_to_client_response = (
-          function_response.name
-          == SendA2uiToClientToolset._SendA2uiJsonToClientTool.TOOL_NAME
-      )
-
-      if is_send_a2ui_json_to_client_response or self._bypass_tool_check:
-        response_dict = function_response.response or {}
-
-        if (
-            SendA2uiToClientToolset._SendA2uiJsonToClientTool.TOOL_ERROR_KEY
-            in response_dict
-        ):
-          logger.warning(
-              "A2UI tool call failed:"
-              f" {response_dict[SendA2uiToClientToolset._SendA2uiJsonToClientTool.TOOL_ERROR_KEY]}"
-          )
-          return []
-
-        if (
-            isinstance(response_dict, dict)
-            and SendA2uiToClientToolset._SendA2uiJsonToClientTool.VALIDATED_A2UI_JSON_KEY
-            in response_dict
-        ):
-          json_data = response_dict.get(
-              SendA2uiToClientToolset._SendA2uiJsonToClientTool.VALIDATED_A2UI_JSON_KEY
-          )
-          if json_data:
-            return [parts.create_a2ui_part(message) for message in json_data]
-
-        if is_send_a2ui_json_to_client_response:
-          logger.info("No result in A2UI tool response")
-          return []
-
-    # 2. Handle Tool Calls (FunctionCall) - Skip sending to client
-    if (
-        (function_call := part.function_call)
-        and function_call.name
-        == SendA2uiToClientToolset._SendA2uiJsonToClientTool.TOOL_NAME
-    ):
-      return []
-
-    # 3. Handle Text-based A2UI (TextPart)
-    if text := part.text:
-      if has_a2ui_parts(text):
-        return parts.parse_response_to_parts(text, validator=self._catalog.validator)
-
-    # 4. Default conversion for other parts
-    converted_part = part_converter.convert_genai_part_to_a2a_part(part)
-    return [converted_part] if converted_part else []
-
-
-@experimental
-class A2uiEventConverter:
-  """An event converter that automatically injects the A2UI catalog into part conversion.
-
-  This allows text-based A2UI extraction and validation to work even when the
-  catalog is session-specific.
-  """
-
-  def __init__(
-      self, catalog_key: str = "system:a2ui_catalog", bypass_tool_check: bool = False
-  ):
-    self._catalog_key = catalog_key
-    self._bypass_tool_check = bypass_tool_check
-
-  def __call__(
-      self,
-      event: "Event",
-      invocation_context: "InvocationContext",
-      task_id: Optional[str] = None,
-      context_id: Optional[str] = None,
-      part_converter_func: "GenAIPartToA2APartConverter" = part_converter.convert_genai_part_to_a2a_part,
-  ) -> list["A2AEvent"]:
-    """Converts an ADK event to A2A events, using the session catalog if available."""
-    from google.adk.a2a.converters.event_converter import (
-        convert_event_to_a2a_events,
-    )
-
-    catalog = invocation_context.session.state.get(self._catalog_key)
-    if catalog:
-      # Use the catalog-aware part converter
-      effective_converter = A2uiPartConverter(
-          catalog, bypass_tool_check=self._bypass_tool_check
-      ).convert
-    else:
-      effective_converter = part_converter_func
-
-    return convert_event_to_a2a_events(
-        event,
-        invocation_context,
-        task_id,
-        context_id,
-        effective_converter,
-    )

--- a/agent_sdks/python/src/a2ui/adk/send_a2ui_to_client_toolset.py
+++ b/agent_sdks/python/src/a2ui/adk/send_a2ui_to_client_toolset.py
@@ -94,8 +94,6 @@ from a2ui.parser.payload_fixer import parse_and_fix
 from a2ui.schema import catalog
 from a2ui.schema import constants
 from a2ui.schema.catalog import A2uiCatalog
-from a2ui.schema import catalog
-from a2ui.schema.catalog import A2uiCatalog
 from a2ui.schema.constants import (
     A2UI_SCHEMA_BLOCK_END,
     A2UI_SCHEMA_BLOCK_START,

--- a/agent_sdks/python/src/a2ui/adk/send_a2ui_to_client_toolset.py
+++ b/agent_sdks/python/src/a2ui/adk/send_a2ui_to_client_toolset.py
@@ -91,6 +91,8 @@ from typing import (
 from a2ui.adk.a2a.event_converter import A2uiEventConverter
 from a2ui.adk.a2a.part_converter import A2uiPartConverter
 from a2ui.parser.payload_fixer import parse_and_fix
+from a2ui.schema import catalog
+from a2ui.schema import constants
 from a2ui.schema.catalog import A2uiCatalog
 from a2ui.schema.constants import (
     A2UI_SCHEMA_BLOCK_END,
@@ -99,6 +101,7 @@ from a2ui.schema.constants import (
     A2UI_TOOL_NAME,
     A2UI_VALIDATED_JSON_KEY,
 )
+from google.adk.agents import readonly_context
 from google.adk.agents.readonly_context import ReadonlyContext
 from google.adk.models import LlmRequest
 from google.adk.tools import base_toolset

--- a/agent_sdks/python/src/a2ui/schema/constants.py
+++ b/agent_sdks/python/src/a2ui/schema/constants.py
@@ -64,3 +64,9 @@ The generated response MUST follow these rules:
     - Parent components MUST appear before their child components.
     This specific ordering allows the streaming parser to yield and render the UI incrementally as it arrives.
 """
+
+
+# A2UI Tool constants
+A2UI_TOOL_NAME = "send_a2ui_json_to_client"
+A2UI_VALIDATED_JSON_KEY = "validated_a2ui_json"
+A2UI_TOOL_ERROR_KEY = "error"

--- a/agent_sdks/python/tests/adk/a2a/test_event_converter.py
+++ b/agent_sdks/python/tests/adk/a2a/test_event_converter.py
@@ -93,4 +93,3 @@ def test_event_converter_propagates_fallback_text():
 
     assert isinstance(effective_part_converter.__self__, A2uiPartConverter)
     assert effective_part_converter.__self__._fallback_text == custom_fallback
-

--- a/agent_sdks/python/tests/adk/a2a/test_event_converter.py
+++ b/agent_sdks/python/tests/adk/a2a/test_event_converter.py
@@ -23,8 +23,7 @@ from a2ui.adk.a2a.part_converter import A2uiPartConverter
 from a2ui.schema.catalog import A2uiCatalog
 
 
-@pytest.mark.asyncio
-async def test_event_converter_injects_catalog():
+def test_event_converter_injects_catalog():
   catalog_mock = MagicMock(spec=A2uiCatalog)
   event_mock = MagicMock()
   invocation_context_mock = MagicMock()
@@ -50,8 +49,7 @@ async def test_event_converter_injects_catalog():
     assert effective_part_converter.__self__._catalog == catalog_mock
 
 
-@pytest.mark.asyncio
-async def test_event_converter_falls_back_without_catalog():
+def test_event_converter_falls_back_without_catalog():
   event_mock = MagicMock()
   invocation_context_mock = MagicMock()
   invocation_context_mock.session.state = {}  # No catalog

--- a/agent_sdks/python/tests/adk/a2a/test_event_converter.py
+++ b/agent_sdks/python/tests/adk/a2a/test_event_converter.py
@@ -70,3 +70,27 @@ def test_event_converter_falls_back_without_catalog():
     from google.adk.a2a.converters.part_converter import convert_genai_part_to_a2a_part
 
     assert effective_part_converter == convert_genai_part_to_a2a_part
+
+
+def test_event_converter_propagates_fallback_text():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  event_mock = MagicMock()
+  invocation_context_mock = MagicMock()
+  invocation_context_mock.session.state = {"system:a2ui_catalog": catalog_mock}
+
+  custom_fallback = "Custom event fallback text"
+  converter = A2uiEventConverter(fallback_text=custom_fallback)
+
+  with patch(
+      "google.adk.a2a.converters.event_converter.convert_event_to_a2a_events"
+  ) as mock_base_converter:
+    mock_base_converter.return_value = []
+
+    converter(event_mock, invocation_context_mock)
+
+    args, kwargs = mock_base_converter.call_args
+    effective_part_converter = args[4]
+
+    assert isinstance(effective_part_converter.__self__, A2uiPartConverter)
+    assert effective_part_converter.__self__._fallback_text == custom_fallback
+

--- a/agent_sdks/python/tests/adk/a2a/test_event_converter.py
+++ b/agent_sdks/python/tests/adk/a2a/test_event_converter.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the A2uiEventConverter class."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from a2ui.adk.a2a.event_converter import A2uiEventConverter
+from a2ui.adk.a2a.part_converter import A2uiPartConverter
+from a2ui.schema.catalog import A2uiCatalog
+
+
+@pytest.mark.asyncio
+async def test_event_converter_injects_catalog():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  event_mock = MagicMock()
+  invocation_context_mock = MagicMock()
+  # Correctly access session via mock
+  invocation_context_mock.session.state = {"system:a2ui_catalog": catalog_mock}
+
+  converter = A2uiEventConverter()
+
+  with patch(
+      "google.adk.a2a.converters.event_converter.convert_event_to_a2a_events"
+  ) as mock_base_converter:
+    mock_base_converter.return_value = []
+
+    # Converter is not async
+    converter(event_mock, invocation_context_mock)
+
+    # Verify that mock_base_converter was called with a part_converter that uses the catalog
+    args, kwargs = mock_base_converter.call_args
+    effective_part_converter = args[4]
+
+    assert effective_part_converter.__name__ == "convert"
+    assert isinstance(effective_part_converter.__self__, A2uiPartConverter)
+    assert effective_part_converter.__self__._catalog == catalog_mock
+
+
+@pytest.mark.asyncio
+async def test_event_converter_falls_back_without_catalog():
+  event_mock = MagicMock()
+  invocation_context_mock = MagicMock()
+  invocation_context_mock.session.state = {}  # No catalog
+
+  converter = A2uiEventConverter()
+
+  with patch(
+      "google.adk.a2a.converters.event_converter.convert_event_to_a2a_events"
+  ) as mock_base_converter:
+    mock_base_converter.return_value = []
+
+    # Converter is not async
+    converter(event_mock, invocation_context_mock)
+
+    args, kwargs = mock_base_converter.call_args
+    effective_part_converter = args[4]
+
+    from google.adk.a2a.converters.part_converter import convert_genai_part_to_a2a_part
+
+    assert effective_part_converter == convert_genai_part_to_a2a_part

--- a/agent_sdks/python/tests/adk/a2a/test_part_converter.py
+++ b/agent_sdks/python/tests/adk/a2a/test_part_converter.py
@@ -182,7 +182,10 @@ def test_converter_class_convert_tool_response_with_result_containing_a2ui():
   valid_a2ui = [{"type": "Text", "text": "Result UI"}]
   catalog_mock.validator.validate.return_value = None
 
-  result_text = f"Here is the result:\n{A2UI_OPEN_TAG}\n{json.dumps(valid_a2ui)}\n{A2UI_CLOSE_TAG}"
+  result_text = (
+      "Here is the"
+      f" result:\n{A2UI_OPEN_TAG}\n{json.dumps(valid_a2ui)}\n{A2UI_CLOSE_TAG}"
+  )
   function_response = genai_types.FunctionResponse(
       name="some_generic_tool",
       response={"result": result_text},
@@ -226,7 +229,6 @@ def test_converter_class_convert_tool_response_with_result_containing_invalid_a2
   assert len(a2a_parts) == 0
 
 
-
 def test_converter_class_convert_tool_response_with_result_containing_invalid_a2ui_and_custom_fallback():
   catalog_mock = MagicMock(spec=A2uiCatalog)
   custom_fallback = "Could not load the custom tool UI."
@@ -242,5 +244,3 @@ def test_converter_class_convert_tool_response_with_result_containing_invalid_a2
   a2a_parts = converter.convert(part)
   assert len(a2a_parts) == 1
   assert a2a_parts[0].root.text == custom_fallback
-
-

--- a/agent_sdks/python/tests/adk/a2a/test_part_converter.py
+++ b/agent_sdks/python/tests/adk/a2a/test_part_converter.py
@@ -1,0 +1,175 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the A2uiPartConverter class."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from a2a import types as a2a_types
+from a2ui.a2a.parts import create_a2ui_part
+from a2ui.adk.a2a.part_converter import A2uiPartConverter
+from a2ui.adk.send_a2ui_to_client_toolset import SendA2uiToClientToolset
+from a2ui.schema.catalog import A2uiCatalog
+from a2ui.schema.constants import A2UI_CLOSE_TAG, A2UI_OPEN_TAG
+from google.genai import types as genai_types
+
+
+def test_converter_class_convert_valid_tool_response():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  converter = A2uiPartConverter(catalog_mock)
+
+  valid_a2ui = {"type": "Text", "text": "Hello"}
+  function_response = genai_types.FunctionResponse(
+      name=SendA2uiToClientToolset._SendA2uiJsonToClientTool.TOOL_NAME,
+      response={
+          SendA2uiToClientToolset._SendA2uiJsonToClientTool.VALIDATED_A2UI_JSON_KEY: [
+              valid_a2ui
+          ]
+      },
+  )
+  part = genai_types.Part(function_response=function_response)
+
+  a2a_parts = converter.convert(part)
+  assert len(a2a_parts) == 1
+  assert a2a_parts[0] == create_a2ui_part(valid_a2ui)
+
+
+def test_converter_class_convert_tool_error_response():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  converter = A2uiPartConverter(catalog_mock)
+
+  function_response = genai_types.FunctionResponse(
+      name=SendA2uiToClientToolset._SendA2uiJsonToClientTool.TOOL_NAME,
+      response={
+          SendA2uiToClientToolset._SendA2uiJsonToClientTool.TOOL_ERROR_KEY: "Some error"
+      },
+  )
+  part = genai_types.Part(function_response=function_response)
+
+  a2a_parts = converter.convert(part)
+  assert len(a2a_parts) == 0
+
+
+def test_converter_class_convert_tool_response_no_result():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  converter = A2uiPartConverter(catalog_mock)
+
+  function_response = genai_types.FunctionResponse(
+      name=SendA2uiToClientToolset._SendA2uiJsonToClientTool.TOOL_NAME,
+      response={},
+  )
+  part = genai_types.Part(function_response=function_response)
+
+  a2a_parts = converter.convert(part)
+  assert len(a2a_parts) == 0
+
+
+def test_converter_class_convert_function_call_ignores():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  converter = A2uiPartConverter(catalog_mock)
+
+  function_call = genai_types.FunctionCall(
+      name=SendA2uiToClientToolset._SendA2uiJsonToClientTool.TOOL_NAME,
+      args={SendA2uiToClientToolset._SendA2uiJsonToClientTool.A2UI_JSON_ARG_NAME: "{}"},
+  )
+  part = genai_types.Part(function_call=function_call)
+
+  a2a_parts = converter.convert(part)
+  assert len(a2a_parts) == 0
+
+
+def test_converter_class_convert_text_with_a2ui():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  converter = A2uiPartConverter(catalog_mock)
+
+  valid_a2ui = [{"type": "Text", "text": "Hello"}]
+  catalog_mock.validator.validate.return_value = None
+
+  text = f"Here is the UI:\n{A2UI_OPEN_TAG}\n{json.dumps(valid_a2ui)}\n{A2UI_CLOSE_TAG}"
+  part = genai_types.Part(text=text)
+
+  a2a_parts = converter.convert(part)
+
+  # Expect 2 parts: TextPart and A2UI DataPart
+  assert len(a2a_parts) == 2
+  assert a2a_parts[0].root.text == "Here is the UI:"
+  assert a2a_parts[1] == create_a2ui_part(valid_a2ui[0])
+  catalog_mock.validator.validate.assert_called_once_with(valid_a2ui)
+
+
+def test_converter_class_convert_text_empty_leading():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  converter = A2uiPartConverter(catalog_mock)
+
+  ui = [{"type": "Text", "text": "Top"}]
+  catalog_mock.validator.validate.return_value = None
+
+  text = f"\n{A2UI_OPEN_TAG}\n{json.dumps(ui)}\n{A2UI_CLOSE_TAG}"
+  part = genai_types.Part(text=text)
+  a2a_parts = converter.convert(part)
+
+  assert len(a2a_parts) == 1
+  assert a2a_parts[0] == create_a2ui_part(ui[0])
+
+
+def test_converter_class_convert_text_markdown_wrapped():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  converter = A2uiPartConverter(catalog_mock)
+
+  ui = [{"type": "Text", "text": "Inside Markdown"}]
+  catalog_mock.validator.validate.return_value = None
+
+  # Text containing JSON wrapped in markdown tags
+  text = f"Behold:\n{A2UI_OPEN_TAG}\n```json\n{json.dumps(ui)}\n```\n{A2UI_CLOSE_TAG}"
+  part = genai_types.Part(text=text)
+  a2a_parts = converter.convert(part)
+
+  assert len(a2a_parts) == 2
+  assert a2a_parts[0].root.text == "Behold:"
+  assert a2a_parts[1] == create_a2ui_part(ui[0])
+  catalog_mock.validator.validate.assert_called_once_with(ui)
+
+
+def test_converter_class_convert_text_with_invalid_a2ui():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  converter = A2uiPartConverter(catalog_mock)
+
+  text = f"Here is the UI:\n{A2UI_OPEN_TAG}\ninvalid_json\n{A2UI_CLOSE_TAG}"
+  part = genai_types.Part(text=text)
+
+  a2a_parts = converter.convert(part)
+  assert len(a2a_parts) == 0
+
+
+def test_converter_class_convert_other_part():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  converter = A2uiPartConverter(catalog_mock)
+
+  part = genai_types.Part(
+      inline_data=genai_types.Blob(mime_type="image/png", data=b"abc")
+  )
+
+  with patch(
+      "google.adk.a2a.converters.part_converter.convert_genai_part_to_a2a_part"
+  ) as mock_convert:
+    mock_a2a_part = a2a_types.Part(root=a2a_types.DataPart(kind="data", data={}))
+    mock_convert.return_value = mock_a2a_part
+
+    a2a_parts = converter.convert(part)
+    assert len(a2a_parts) == 1
+    assert a2a_parts[0] is mock_a2a_part
+    mock_convert.assert_called_once_with(part)

--- a/agent_sdks/python/tests/adk/a2a/test_part_converter.py
+++ b/agent_sdks/python/tests/adk/a2a/test_part_converter.py
@@ -197,3 +197,50 @@ def test_converter_class_convert_tool_response_with_result_containing_a2ui():
   assert a2a_parts[1] == create_a2ui_part(valid_a2ui[0])
   catalog_mock.validator.validate.assert_called_once_with(valid_a2ui)
 
+
+def test_converter_class_convert_text_with_invalid_a2ui_and_custom_fallback():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  custom_fallback = "Could not build interface."
+  converter = A2uiPartConverter(catalog_mock, fallback_text=custom_fallback)
+
+  text = f"Here is the UI:\n{A2UI_OPEN_TAG}\ninvalid_json\n{A2UI_CLOSE_TAG}"
+  part = genai_types.Part(text=text)
+
+  a2a_parts = converter.convert(part)
+  assert len(a2a_parts) == 1
+  assert a2a_parts[0].root.text == custom_fallback
+
+
+def test_converter_class_convert_tool_response_with_result_containing_invalid_a2ui_and_default_fallback():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  converter = A2uiPartConverter(catalog_mock)
+
+  result_text = f"Here is the result:\n{A2UI_OPEN_TAG}\ninvalid_json\n{A2UI_CLOSE_TAG}"
+  function_response = genai_types.FunctionResponse(
+      name="some_generic_tool",
+      response={"result": result_text},
+  )
+  part = genai_types.Part(function_response=function_response)
+
+  a2a_parts = converter.convert(part)
+  assert len(a2a_parts) == 0
+
+
+
+def test_converter_class_convert_tool_response_with_result_containing_invalid_a2ui_and_custom_fallback():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  custom_fallback = "Could not load the custom tool UI."
+  converter = A2uiPartConverter(catalog_mock, fallback_text=custom_fallback)
+
+  result_text = f"Here is the result:\n{A2UI_OPEN_TAG}\ninvalid_json\n{A2UI_CLOSE_TAG}"
+  function_response = genai_types.FunctionResponse(
+      name="some_generic_tool",
+      response={"result": result_text},
+  )
+  part = genai_types.Part(function_response=function_response)
+
+  a2a_parts = converter.convert(part)
+  assert len(a2a_parts) == 1
+  assert a2a_parts[0].root.text == custom_fallback
+
+

--- a/agent_sdks/python/tests/adk/a2a/test_part_converter.py
+++ b/agent_sdks/python/tests/adk/a2a/test_part_converter.py
@@ -173,3 +173,27 @@ def test_converter_class_convert_other_part():
     assert len(a2a_parts) == 1
     assert a2a_parts[0] is mock_a2a_part
     mock_convert.assert_called_once_with(part)
+
+
+def test_converter_class_convert_tool_response_with_result_containing_a2ui():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  converter = A2uiPartConverter(catalog_mock)
+
+  valid_a2ui = [{"type": "Text", "text": "Result UI"}]
+  catalog_mock.validator.validate.return_value = None
+
+  result_text = f"Here is the result:\n{A2UI_OPEN_TAG}\n{json.dumps(valid_a2ui)}\n{A2UI_CLOSE_TAG}"
+  function_response = genai_types.FunctionResponse(
+      name="some_generic_tool",
+      response={"result": result_text},
+  )
+  part = genai_types.Part(function_response=function_response)
+
+  a2a_parts = converter.convert(part)
+
+  # Expect 2 parts: TextPart and A2UI DataPart
+  assert len(a2a_parts) == 2
+  assert a2a_parts[0].root.text == "Here is the result:"
+  assert a2a_parts[1] == create_a2ui_part(valid_a2ui[0])
+  catalog_mock.validator.validate.assert_called_once_with(valid_a2ui)
+

--- a/agent_sdks/python/tests/adk/test_send_a2ui_to_client_toolset.py
+++ b/agent_sdks/python/tests/adk/test_send_a2ui_to_client_toolset.py
@@ -13,22 +13,12 @@
 # limitations under the License.
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
-from a2a import types as a2a_types
-from a2ui.a2a.parts import create_a2ui_part
-from google.adk.agents.invocation_context import InvocationContext
-from google.adk.events.event import Event
-
-from a2ui.adk.send_a2ui_to_client_toolset import (
-    A2uiEventConverter,
-    A2uiPartConverter,
-    SendA2uiToClientToolset,
-)
+from a2ui.adk.send_a2ui_to_client_toolset import SendA2uiToClientToolset
 from a2ui.schema.catalog import A2uiCatalog
-from a2ui.schema.constants import A2UI_OPEN_TAG, A2UI_CLOSE_TAG
 from google.adk.agents.readonly_context import ReadonlyContext
 from google.adk.tools.tool_context import ToolContext
 from google.genai import types as genai_types
@@ -285,147 +275,6 @@ async def test_send_tool_run_async_schema_validation_fail():
   assert "error" in result
   assert "Failed to call A2UI tool" in result["error"]
   assert "'text' is a required property" in result["error"]
-
-
-# endregion
-
-# region A2uiPartConverter Tests
-"""Tests for the A2uiPartConverter class."""
-
-
-def test_converter_class_convert_valid_tool_response():
-  catalog_mock = MagicMock(spec=A2uiCatalog)
-  converter = A2uiPartConverter(catalog_mock)
-
-  valid_a2ui = {"type": "Text", "text": "Hello"}
-  function_response = genai_types.FunctionResponse(
-      name=SendA2uiToClientToolset._SendA2uiJsonToClientTool.TOOL_NAME,
-      response={
-          SendA2uiToClientToolset._SendA2uiJsonToClientTool.VALIDATED_A2UI_JSON_KEY: [
-              valid_a2ui
-          ]
-      },
-  )
-  part = genai_types.Part(function_response=function_response)
-
-  a2a_parts = converter.convert(part)
-  assert len(a2a_parts) == 1
-  assert a2a_parts[0] == create_a2ui_part(valid_a2ui)
-
-
-def test_converter_class_convert_tool_error_response():
-  catalog_mock = MagicMock(spec=A2uiCatalog)
-  converter = A2uiPartConverter(catalog_mock)
-
-  function_response = genai_types.FunctionResponse(
-      name=SendA2uiToClientToolset._SendA2uiJsonToClientTool.TOOL_NAME,
-      response={
-          SendA2uiToClientToolset._SendA2uiJsonToClientTool.TOOL_ERROR_KEY: "Some error"
-      },
-  )
-  part = genai_types.Part(function_response=function_response)
-
-  a2a_parts = converter.convert(part)
-  assert len(a2a_parts) == 0
-
-
-def test_converter_class_convert_tool_response_no_result():
-  catalog_mock = MagicMock(spec=A2uiCatalog)
-  converter = A2uiPartConverter(catalog_mock)
-
-  function_response = genai_types.FunctionResponse(
-      name=SendA2uiToClientToolset._SendA2uiJsonToClientTool.TOOL_NAME,
-      response={},
-  )
-  part = genai_types.Part(function_response=function_response)
-
-  a2a_parts = converter.convert(part)
-  assert len(a2a_parts) == 0
-
-
-def test_converter_class_convert_function_call_ignores():
-  catalog_mock = MagicMock(spec=A2uiCatalog)
-  converter = A2uiPartConverter(catalog_mock)
-
-  function_call = genai_types.FunctionCall(
-      name=SendA2uiToClientToolset._SendA2uiJsonToClientTool.TOOL_NAME,
-      args={SendA2uiToClientToolset._SendA2uiJsonToClientTool.A2UI_JSON_ARG_NAME: "{}"},
-  )
-  part = genai_types.Part(function_call=function_call)
-
-  a2a_parts = converter.convert(part)
-  assert len(a2a_parts) == 0
-
-
-def test_converter_class_convert_other_part():
-  catalog_mock = MagicMock(spec=A2uiCatalog)
-  converter = A2uiPartConverter(catalog_mock)
-
-  part = genai_types.Part(
-      inline_data=genai_types.Blob(mime_type="image/png", data=b"abc")
-  )
-
-  with patch(
-      "google.adk.a2a.converters.part_converter.convert_genai_part_to_a2a_part"
-  ) as mock_convert:
-    mock_a2a_part = a2a_types.Part(root=a2a_types.DataPart(kind="data", data={}))
-    mock_convert.return_value = mock_a2a_part
-
-    a2a_parts = converter.convert(part)
-    assert len(a2a_parts) == 1
-    assert a2a_parts[0] is mock_a2a_part
-    mock_convert.assert_called_once_with(part)
-
-
-@pytest.mark.asyncio
-async def test_event_converter_injects_catalog():
-  catalog_mock = MagicMock(spec=A2uiCatalog)
-  event_mock = MagicMock()
-  invocation_context_mock = MagicMock()
-  # Correctly access session via mock
-  invocation_context_mock.session.state = {"system:a2ui_catalog": catalog_mock}
-
-  converter = A2uiEventConverter()
-
-  with patch(
-      "google.adk.a2a.converters.event_converter.convert_event_to_a2a_events"
-  ) as mock_base_converter:
-    mock_base_converter.return_value = []
-
-    # Converter is not async
-    converter(event_mock, invocation_context_mock)
-
-    # Verify that mock_base_converter was called with a part_converter that uses the catalog
-    args, kwargs = mock_base_converter.call_args
-    effective_part_converter = args[4]
-
-    assert effective_part_converter.__name__ == "convert"
-    assert isinstance(effective_part_converter.__self__, A2uiPartConverter)
-    assert effective_part_converter.__self__._catalog == catalog_mock
-
-
-@pytest.mark.asyncio
-async def test_event_converter_falls_back_without_catalog():
-  event_mock = MagicMock()
-  invocation_context_mock = MagicMock()
-  invocation_context_mock.session.state = {}  # No catalog
-
-  converter = A2uiEventConverter()
-
-  with patch(
-      "google.adk.a2a.converters.event_converter.convert_event_to_a2a_events"
-  ) as mock_base_converter:
-    mock_base_converter.return_value = []
-
-    # Converter is not async
-    converter(event_mock, invocation_context_mock)
-
-    args, kwargs = mock_base_converter.call_args
-    effective_part_converter = args[4]
-
-    from google.adk.a2a.converters.part_converter import convert_genai_part_to_a2a_part
-
-    assert effective_part_converter == convert_genai_part_to_a2a_part
 
 
 # endregion

--- a/docs/guides/authoring-components.md
+++ b/docs/guides/authoring-components.md
@@ -237,10 +237,10 @@ agent.tools = [
 
 ### 4.3 Tool Execution
 
-Invocations of the tool in [SendA2uiToClientToolset](../../agent_sdks/python/src/a2ui/adk/send_a2ui_to_client_toolset.py) by the LLM are intercepted in the A2A Agent Executor using the [A2uiEventConverter](../../agent_sdks/python/src/a2ui/adk/send_a2ui_to_client_toolset.py). This automatically translates tool calls into A2A Dataparts with the A2UI payload.
+Invocations of the tool in [SendA2uiToClientToolset](../../agent_sdks/python/src/a2ui/adk/send_a2ui_to_client_toolset.py) by the LLM are intercepted in the A2A Agent Executor using the [A2uiEventConverter](../../agent_sdks/python/src/a2ui/adk/a2a/event_converter.py). This automatically translates tool calls into A2A Dataparts with the A2UI payload.
 
 ```python
-from a2ui.adk.send_a2ui_to_client_toolset import (
+from a2ui.adk.a2a.event_converter import (
     A2uiEventConverter,
 )
 

--- a/samples/agent/adk/mcp_app_proxy/agent_executor.py
+++ b/samples/agent/adk/mcp_app_proxy/agent_executor.py
@@ -18,7 +18,7 @@ from typing import override
 from a2a.server.agent_execution import RequestContext
 from a2a.types import AgentCapabilities, AgentCard, AgentExtension, AgentSkill
 from a2ui.a2a.extension import try_activate_a2ui_extension
-from a2ui.adk.send_a2ui_to_client_toolset import A2uiEventConverter
+from a2ui.adk.a2a.event_converter import A2uiEventConverter
 from a2ui.schema.constants import A2UI_CLIENT_CAPABILITIES_KEY
 from a2ui.schema.manager import A2uiSchemaManager
 from google.adk.a2a.converters.request_converter import AgentRunRequest

--- a/samples/agent/adk/rizzcharts/python/agent_executor.py
+++ b/samples/agent/adk/rizzcharts/python/agent_executor.py
@@ -19,11 +19,9 @@ from typing import override
 from a2a.server.agent_execution import RequestContext
 from a2a.types import AgentCapabilities, AgentCard, AgentExtension, AgentSkill
 from a2ui.a2a.extension import get_a2ui_agent_extension, try_activate_a2ui_extension
-from a2ui.adk.send_a2ui_to_client_toolset import (
-    A2uiEventConverter,
-    A2uiPartConverter,
-    SendA2uiToClientToolset,
-)
+from a2ui.adk.a2a.event_converter import A2uiEventConverter
+from a2ui.adk.a2a.part_converter import A2uiPartConverter
+from a2ui.adk.send_a2ui_to_client_toolset import SendA2uiToClientToolset
 from a2ui.schema.constants import A2UI_CLIENT_CAPABILITIES_KEY
 from a2ui.schema.manager import A2uiSchemaManager
 

--- a/samples/agent/adk/rizzcharts/python/agent_executor.py
+++ b/samples/agent/adk/rizzcharts/python/agent_executor.py
@@ -20,7 +20,6 @@ from a2a.server.agent_execution import RequestContext
 from a2a.types import AgentCapabilities, AgentCard, AgentExtension, AgentSkill
 from a2ui.a2a.extension import get_a2ui_agent_extension, try_activate_a2ui_extension
 from a2ui.adk.a2a.event_converter import A2uiEventConverter
-from a2ui.adk.a2a.part_converter import A2uiPartConverter
 from a2ui.adk.send_a2ui_to_client_toolset import SendA2uiToClientToolset
 from a2ui.schema.constants import A2UI_CLIENT_CAPABILITIES_KEY
 from a2ui.schema.manager import A2uiSchemaManager


### PR DESCRIPTION
Extracts A2uiEventConverter and A2uiPartConverter from the bloated send_a2ui_to_client_toolset.py module and moves them to separate source and test modules under the adk/a2a package.