### PR TITLE
refactor(angular): use declarative HTML for known Text variants

### DIFF
--- a/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
@@ -60,8 +60,8 @@ describe('TextComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    const span = fixture.debugElement.query(By.css('span'));
-    expect(span.nativeElement.innerHTML.trim()).toBe('<p>Hello World</p>');
+    const element = fixture.debugElement.query(By.css('.a2ui-text'));
+    expect(element.nativeElement.innerHTML.trim()).toBe('<p>Hello World</p>');
     expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('Hello World');
   });
 
@@ -75,9 +75,9 @@ describe('TextComponent', () => {
     fixture.detectChanges();
 
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
-    const span = fixture.debugElement.query(By.css('span.a2ui-text.h1'));
-    expect(span).toBeTruthy();
-    const h1 = span.query(By.css('h1'));
+    const element = fixture.debugElement.query(By.css('.a2ui-text.h1'));
+    expect(element).toBeTruthy();
+    const h1 = element.query(By.css('h1'));
     expect(h1).toBeTruthy();
     expect(h1.nativeElement.textContent.trim()).toBe('Heading');
   });
@@ -92,9 +92,9 @@ describe('TextComponent', () => {
     fixture.detectChanges();
 
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
-    const span = fixture.debugElement.query(By.css('span.a2ui-text.caption'));
-    expect(span).toBeTruthy();
-    const em = span.query(By.css('em'));
+    const element = fixture.debugElement.query(By.css('.a2ui-text.caption'));
+    expect(element).toBeTruthy();
+    const em = element.query(By.css('em'));
     expect(em).toBeTruthy();
     expect(em.nativeElement.textContent.trim()).toBe('Caption');
   });
@@ -109,9 +109,9 @@ describe('TextComponent', () => {
     fixture.detectChanges();
 
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
-    const span = fixture.debugElement.query(By.css('span.a2ui-text.h2'));
-    expect(span).toBeTruthy();
-    const h2 = span.query(By.css('h2'));
+    const element = fixture.debugElement.query(By.css('.a2ui-text.h2'));
+    expect(element).toBeTruthy();
+    const h2 = element.query(By.css('h2'));
     expect(h2).toBeTruthy();
     expect(h2.nativeElement.textContent.trim()).toBe('Heading');
   });
@@ -126,9 +126,9 @@ describe('TextComponent', () => {
     fixture.detectChanges();
 
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
-    const span = fixture.debugElement.query(By.css('span.a2ui-text.h3'));
-    expect(span).toBeTruthy();
-    const h3 = span.query(By.css('h3'));
+    const element = fixture.debugElement.query(By.css('.a2ui-text.h3'));
+    expect(element).toBeTruthy();
+    const h3 = element.query(By.css('h3'));
     expect(h3).toBeTruthy();
     expect(h3.nativeElement.textContent.trim()).toBe('Heading');
   });
@@ -143,9 +143,9 @@ describe('TextComponent', () => {
     fixture.detectChanges();
 
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
-    const span = fixture.debugElement.query(By.css('span.a2ui-text.h4'));
-    expect(span).toBeTruthy();
-    const h4 = span.query(By.css('h4'));
+    const element = fixture.debugElement.query(By.css('.a2ui-text.h4'));
+    expect(element).toBeTruthy();
+    const h4 = element.query(By.css('h4'));
     expect(h4).toBeTruthy();
     expect(h4.nativeElement.textContent.trim()).toBe('Heading');
   });
@@ -160,9 +160,9 @@ describe('TextComponent', () => {
     fixture.detectChanges();
 
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
-    const span = fixture.debugElement.query(By.css('span.a2ui-text.h5'));
-    expect(span).toBeTruthy();
-    const h5 = span.query(By.css('h5'));
+    const element = fixture.debugElement.query(By.css('.a2ui-text.h5'));
+    expect(element).toBeTruthy();
+    const h5 = element.query(By.css('h5'));
     expect(h5).toBeTruthy();
     expect(h5.nativeElement.textContent.trim()).toBe('Heading');
   });

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
@@ -77,8 +77,9 @@ describe('TextComponent', () => {
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
     const element = fixture.debugElement.query(By.css('.a2ui-text.h1'));
     expect(element).toBeTruthy();
-    expect(element.nativeElement.tagName.toLowerCase()).toBe('h1');
-    expect(element.nativeElement.textContent.trim()).toBe('Heading');
+    const h1 = element.query(By.css('h1'));
+    expect(h1).toBeTruthy();
+    expect(h1.nativeElement.textContent.trim()).toBe('Heading');
   });
 
   it('should handle variant caption', async () => {
@@ -93,8 +94,9 @@ describe('TextComponent', () => {
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
     const element = fixture.debugElement.query(By.css('.a2ui-text.caption'));
     expect(element).toBeTruthy();
-    expect(element.nativeElement.tagName.toLowerCase()).toBe('em');
-    expect(element.nativeElement.textContent.trim()).toBe('Caption');
+    const em = element.query(By.css('em'));
+    expect(em).toBeTruthy();
+    expect(em.nativeElement.textContent.trim()).toBe('Caption');
   });
 
   it('should handle variant h2', async () => {
@@ -109,8 +111,9 @@ describe('TextComponent', () => {
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
     const element = fixture.debugElement.query(By.css('.a2ui-text.h2'));
     expect(element).toBeTruthy();
-    expect(element.nativeElement.tagName.toLowerCase()).toBe('h2');
-    expect(element.nativeElement.textContent.trim()).toBe('Heading');
+    const h2 = element.query(By.css('h2'));
+    expect(h2).toBeTruthy();
+    expect(h2.nativeElement.textContent.trim()).toBe('Heading');
   });
 
   it('should handle variant h3', async () => {
@@ -125,8 +128,9 @@ describe('TextComponent', () => {
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
     const element = fixture.debugElement.query(By.css('.a2ui-text.h3'));
     expect(element).toBeTruthy();
-    expect(element.nativeElement.tagName.toLowerCase()).toBe('h3');
-    expect(element.nativeElement.textContent.trim()).toBe('Heading');
+    const h3 = element.query(By.css('h3'));
+    expect(h3).toBeTruthy();
+    expect(h3.nativeElement.textContent.trim()).toBe('Heading');
   });
 
   it('should handle variant h4', async () => {
@@ -141,8 +145,9 @@ describe('TextComponent', () => {
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
     const element = fixture.debugElement.query(By.css('.a2ui-text.h4'));
     expect(element).toBeTruthy();
-    expect(element.nativeElement.tagName.toLowerCase()).toBe('h4');
-    expect(element.nativeElement.textContent.trim()).toBe('Heading');
+    const h4 = element.query(By.css('h4'));
+    expect(h4).toBeTruthy();
+    expect(h4.nativeElement.textContent.trim()).toBe('Heading');
   });
 
   it('should handle variant h5', async () => {
@@ -157,8 +162,9 @@ describe('TextComponent', () => {
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
     const element = fixture.debugElement.query(By.css('.a2ui-text.h5'));
     expect(element).toBeTruthy();
-    expect(element.nativeElement.tagName.toLowerCase()).toBe('h5');
-    expect(element.nativeElement.textContent.trim()).toBe('Heading');
+    const h5 = element.query(By.css('h5'));
+    expect(h5).toBeTruthy();
+    expect(h5.nativeElement.textContent.trim()).toBe('Heading');
   });
 
   it('should handle missing text property', async () => {

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
@@ -74,7 +74,12 @@ describe('TextComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('# Heading');
+    expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
+    const span = fixture.debugElement.query(By.css('span.a2ui-text.h1'));
+    expect(span).toBeTruthy();
+    const h1 = span.query(By.css('h1'));
+    expect(h1).toBeTruthy();
+    expect(h1.nativeElement.textContent.trim()).toBe('Heading');
   });
 
   it('should handle variant caption', async () => {
@@ -86,7 +91,12 @@ describe('TextComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('*Caption*');
+    expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
+    const span = fixture.debugElement.query(By.css('span.a2ui-text.caption'));
+    expect(span).toBeTruthy();
+    const em = span.query(By.css('em'));
+    expect(em).toBeTruthy();
+    expect(em.nativeElement.textContent.trim()).toBe('Caption');
   });
 
   it('should handle variant h2', async () => {
@@ -98,7 +108,12 @@ describe('TextComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('## Heading');
+    expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
+    const span = fixture.debugElement.query(By.css('span.a2ui-text.h2'));
+    expect(span).toBeTruthy();
+    const h2 = span.query(By.css('h2'));
+    expect(h2).toBeTruthy();
+    expect(h2.nativeElement.textContent.trim()).toBe('Heading');
   });
 
   it('should handle variant h3', async () => {
@@ -110,7 +125,12 @@ describe('TextComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('### Heading');
+    expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
+    const span = fixture.debugElement.query(By.css('span.a2ui-text.h3'));
+    expect(span).toBeTruthy();
+    const h3 = span.query(By.css('h3'));
+    expect(h3).toBeTruthy();
+    expect(h3.nativeElement.textContent.trim()).toBe('Heading');
   });
 
   it('should handle variant h4', async () => {
@@ -122,7 +142,12 @@ describe('TextComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('#### Heading');
+    expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
+    const span = fixture.debugElement.query(By.css('span.a2ui-text.h4'));
+    expect(span).toBeTruthy();
+    const h4 = span.query(By.css('h4'));
+    expect(h4).toBeTruthy();
+    expect(h4.nativeElement.textContent.trim()).toBe('Heading');
   });
 
   it('should handle variant h5', async () => {
@@ -134,7 +159,12 @@ describe('TextComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('##### Heading');
+    expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
+    const span = fixture.debugElement.query(By.css('span.a2ui-text.h5'));
+    expect(span).toBeTruthy();
+    const h5 = span.query(By.css('h5'));
+    expect(h5).toBeTruthy();
+    expect(h5.nativeElement.textContent.trim()).toBe('Heading');
   });
 
   it('should handle missing text property', async () => {

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
@@ -61,7 +61,10 @@ describe('TextComponent', () => {
     fixture.detectChanges();
 
     const element = fixture.debugElement.query(By.css('.a2ui-text'));
-    expect(element.nativeElement.innerHTML.trim()).toBe('<p>Hello World</p>');
+    expect(element).toBeTruthy();
+    const p = element.query(By.css('p'));
+    expect(p).toBeTruthy();
+    expect(p.nativeElement.textContent.trim()).toBe('Hello World');
     expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('Hello World');
   });
 

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
@@ -77,9 +77,8 @@ describe('TextComponent', () => {
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
     const element = fixture.debugElement.query(By.css('.a2ui-text.h1'));
     expect(element).toBeTruthy();
-    const h1 = element.query(By.css('h1'));
-    expect(h1).toBeTruthy();
-    expect(h1.nativeElement.textContent.trim()).toBe('Heading');
+    expect(element.nativeElement.tagName.toLowerCase()).toBe('h1');
+    expect(element.nativeElement.textContent.trim()).toBe('Heading');
   });
 
   it('should handle variant caption', async () => {
@@ -94,9 +93,8 @@ describe('TextComponent', () => {
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
     const element = fixture.debugElement.query(By.css('.a2ui-text.caption'));
     expect(element).toBeTruthy();
-    const em = element.query(By.css('em'));
-    expect(em).toBeTruthy();
-    expect(em.nativeElement.textContent.trim()).toBe('Caption');
+    expect(element.nativeElement.tagName.toLowerCase()).toBe('em');
+    expect(element.nativeElement.textContent.trim()).toBe('Caption');
   });
 
   it('should handle variant h2', async () => {
@@ -111,9 +109,8 @@ describe('TextComponent', () => {
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
     const element = fixture.debugElement.query(By.css('.a2ui-text.h2'));
     expect(element).toBeTruthy();
-    const h2 = element.query(By.css('h2'));
-    expect(h2).toBeTruthy();
-    expect(h2.nativeElement.textContent.trim()).toBe('Heading');
+    expect(element.nativeElement.tagName.toLowerCase()).toBe('h2');
+    expect(element.nativeElement.textContent.trim()).toBe('Heading');
   });
 
   it('should handle variant h3', async () => {
@@ -128,9 +125,8 @@ describe('TextComponent', () => {
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
     const element = fixture.debugElement.query(By.css('.a2ui-text.h3'));
     expect(element).toBeTruthy();
-    const h3 = element.query(By.css('h3'));
-    expect(h3).toBeTruthy();
-    expect(h3.nativeElement.textContent.trim()).toBe('Heading');
+    expect(element.nativeElement.tagName.toLowerCase()).toBe('h3');
+    expect(element.nativeElement.textContent.trim()).toBe('Heading');
   });
 
   it('should handle variant h4', async () => {
@@ -145,9 +141,8 @@ describe('TextComponent', () => {
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
     const element = fixture.debugElement.query(By.css('.a2ui-text.h4'));
     expect(element).toBeTruthy();
-    const h4 = element.query(By.css('h4'));
-    expect(h4).toBeTruthy();
-    expect(h4.nativeElement.textContent.trim()).toBe('Heading');
+    expect(element.nativeElement.tagName.toLowerCase()).toBe('h4');
+    expect(element.nativeElement.textContent.trim()).toBe('Heading');
   });
 
   it('should handle variant h5', async () => {
@@ -162,9 +157,8 @@ describe('TextComponent', () => {
     expect(mockMarkdownRenderer.render).not.toHaveBeenCalled();
     const element = fixture.debugElement.query(By.css('.a2ui-text.h5'));
     expect(element).toBeTruthy();
-    const h5 = element.query(By.css('h5'));
-    expect(h5).toBeTruthy();
-    expect(h5.nativeElement.textContent.trim()).toBe('Heading');
+    expect(element.nativeElement.tagName.toLowerCase()).toBe('h5');
+    expect(element.nativeElement.textContent.trim()).toBe('Heading');
   });
 
   it('should handle missing text property', async () => {

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.ts
@@ -40,16 +40,14 @@ import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
   standalone: true,
   template: `
     @if (isKnownVariant()) {
-      <span [class]="'a2ui-text ' + variant()">
-        @switch (variant()) {
-          @case ('h1') { <h1>{{ text() }}</h1> }
-          @case ('h2') { <h2>{{ text() }}</h2> }
-          @case ('h3') { <h3>{{ text() }}</h3> }
-          @case ('h4') { <h4>{{ text() }}</h4> }
-          @case ('h5') { <h5>{{ text() }}</h5> }
-          @case ('caption') { <em>{{ text() }}</em> }
-        }
-      </span>
+      @switch (variant()) {
+        @case ('h1') { <h1 class="a2ui-text h1">{{ text() }}</h1> }
+        @case ('h2') { <h2 class="a2ui-text h2">{{ text() }}</h2> }
+        @case ('h3') { <h3 class="a2ui-text h3">{{ text() }}</h3> }
+        @case ('h4') { <h4 class="a2ui-text h4">{{ text() }}</h4> }
+        @case ('h5') { <h5 class="a2ui-text h5">{{ text() }}</h5> }
+        @case ('caption') { <em class="a2ui-text caption">{{ text() }}</em> }
+      }
     } @else {
       <span [class]="'a2ui-text ' + variant()" [innerHTML]="resolvedText()"></span>
     }
@@ -60,11 +58,11 @@ import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
   styles: [
     `
       :host ::ng-deep .a2ui-text p,
-      :host ::ng-deep .a2ui-text h1,
-      :host ::ng-deep .a2ui-text h2,
-      :host ::ng-deep .a2ui-text h3,
-      :host ::ng-deep .a2ui-text h4,
-      :host ::ng-deep .a2ui-text h5,
+      :host ::ng-deep .a2ui-text h1, :host ::ng-deep h1.a2ui-text,
+      :host ::ng-deep .a2ui-text h2, :host ::ng-deep h2.a2ui-text,
+      :host ::ng-deep .a2ui-text h3, :host ::ng-deep h3.a2ui-text,
+      :host ::ng-deep .a2ui-text h4, :host ::ng-deep h4.a2ui-text,
+      :host ::ng-deep .a2ui-text h5, :host ::ng-deep h5.a2ui-text,
       :host ::ng-deep .a2ui-text h6,
       :host ::ng-deep .a2ui-text ol,
       :host ::ng-deep .a2ui-text ul,
@@ -79,29 +77,29 @@ import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
           var(--a2ui-text-color-text, var(--a2ui-color-on-background))
         );
       }
-      :host ::ng-deep .a2ui-text h1,
-      :host ::ng-deep .a2ui-text h2,
-      :host ::ng-deep .a2ui-text h3,
-      :host ::ng-deep .a2ui-text h4,
-      :host ::ng-deep .a2ui-text h5,
+      :host ::ng-deep .a2ui-text h1, :host ::ng-deep h1.a2ui-text,
+      :host ::ng-deep .a2ui-text h2, :host ::ng-deep h2.a2ui-text,
+      :host ::ng-deep .a2ui-text h3, :host ::ng-deep h3.a2ui-text,
+      :host ::ng-deep .a2ui-text h4, :host ::ng-deep h4.a2ui-text,
+      :host ::ng-deep .a2ui-text h5, :host ::ng-deep h5.a2ui-text,
       :host ::ng-deep .a2ui-text h6 {
         font-family: var(--a2ui-font-family-title, inherit);
         line-height: var(--a2ui-line-height-headings, 1.2);
       }
-      :host ::ng-deep .a2ui-text h1 {
+      :host ::ng-deep .a2ui-text h1, :host ::ng-deep h1.a2ui-text {
         font-size: var(--a2ui-font-size-2xl);
       }
-      :host ::ng-deep .a2ui-text h2 {
+      :host ::ng-deep .a2ui-text h2, :host ::ng-deep h2.a2ui-text {
         font-size: var(--a2ui-font-size-xl);
       }
-      :host ::ng-deep .a2ui-text h3 {
+      :host ::ng-deep .a2ui-text h3, :host ::ng-deep h3.a2ui-text {
         font-size: var(--a2ui-font-size-l);
       }
       :host ::ng-deep .a2ui-text p,
-      :host ::ng-deep .a2ui-text h4 {
+      :host ::ng-deep .a2ui-text h4, :host ::ng-deep h4.a2ui-text {
         font-size: var(--a2ui-font-size-m);
       }
-      :host ::ng-deep .a2ui-text h5 {
+      :host ::ng-deep .a2ui-text h5, :host ::ng-deep h5.a2ui-text {
         font-size: var(--a2ui-font-size-s);
       }
       :host ::ng-deep .a2ui-text p {

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.ts
@@ -38,7 +38,22 @@ import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
 @Component({
   selector: 'a2ui-v09-text',
   standalone: true,
-  template: ` <span [class]="'a2ui-text ' + variant()" [innerHTML]="resolvedText()"> </span> `,
+  template: `
+    @if (isKnownVariant()) {
+      <span [class]="'a2ui-text ' + variant()">
+        @switch (variant()) {
+          @case ('h1') { <h1>{{ text() }}</h1> }
+          @case ('h2') { <h2>{{ text() }}</h2> }
+          @case ('h3') { <h3>{{ text() }}</h3> }
+          @case ('h4') { <h4>{{ text() }}</h4> }
+          @case ('h5') { <h5>{{ text() }}</h5> }
+          @case ('caption') { <em>{{ text() }}</em> }
+        }
+      </span>
+    } @else {
+      <span [class]="'a2ui-text ' + variant()" [innerHTML]="resolvedText()"></span>
+    }
+  `,
   // We use :host ::ng-deep because the template content is injected via innerHTML (Markdown).
   // Angular's default view encapsulation cannot target elements injected via innerHTML because they lack the scoping attributes generated at compile time.
   // ::ng-deep allows styles to reach into the injected HTML, while :host keeps them scoped to this component.
@@ -110,39 +125,23 @@ export class TextComponent extends BasicCatalogComponent<typeof TextApi> {
   readonly variant = computed(() => this.props()['variant']?.value() || 'body');
   readonly text = computed(() => this.props()['text']?.value() || '');
 
+  readonly isKnownVariant = computed(() => {
+    const v = this.variant();
+    return ['h1', 'h2', 'h3', 'h4', 'h5', 'caption'].includes(v);
+  });
+
   resolvedText = signal<string>('');
   private renderRequestId = 0;
 
   constructor() {
     super();
     effect(() => {
-      const text = this.text();
-      const variant = this.variant();
-      let value = text;
-
-      switch (variant) {
-        case 'h1':
-          value = `# ${text}`;
-          break;
-        case 'h2':
-          value = `## ${text}`;
-          break;
-        case 'h3':
-          value = `### ${text}`;
-          break;
-        case 'h4':
-          value = `#### ${text}`;
-          break;
-        case 'h5':
-          value = `##### ${text}`;
-          break;
-        case 'caption':
-          value = `*${text}*`;
-          break;
+      if (this.isKnownVariant()) {
+        return;
       }
-
+      const text = this.text();
       const requestId = ++this.renderRequestId;
-      this.markdownRenderer.render(value).then(rendered => {
+      this.markdownRenderer.render(text).then(rendered => {
         if (requestId === this.renderRequestId) {
           this.resolvedText.set(rendered);
         }

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.ts
@@ -42,12 +42,24 @@ import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
     @if (isKnownVariant()) {
       <span [class]="'a2ui-text ' + variant()">
         @switch (variant()) {
-          @case ('h1') { <h1>{{ text() }}</h1> }
-          @case ('h2') { <h2>{{ text() }}</h2> }
-          @case ('h3') { <h3>{{ text() }}</h3> }
-          @case ('h4') { <h4>{{ text() }}</h4> }
-          @case ('h5') { <h5>{{ text() }}</h5> }
-          @case ('caption') { <em>{{ text() }}</em> }
+          @case ('h1') {
+            <h1>{{ text() }}</h1>
+          }
+          @case ('h2') {
+            <h2>{{ text() }}</h2>
+          }
+          @case ('h3') {
+            <h3>{{ text() }}</h3>
+          }
+          @case ('h4') {
+            <h4>{{ text() }}</h4>
+          }
+          @case ('h5') {
+            <h5>{{ text() }}</h5>
+          }
+          @case ('caption') {
+            <em>{{ text() }}</em>
+          }
         }
       </span>
     } @else {

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.ts
@@ -40,14 +40,16 @@ import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
   standalone: true,
   template: `
     @if (isKnownVariant()) {
-      @switch (variant()) {
-        @case ('h1') { <h1 class="a2ui-text h1">{{ text() }}</h1> }
-        @case ('h2') { <h2 class="a2ui-text h2">{{ text() }}</h2> }
-        @case ('h3') { <h3 class="a2ui-text h3">{{ text() }}</h3> }
-        @case ('h4') { <h4 class="a2ui-text h4">{{ text() }}</h4> }
-        @case ('h5') { <h5 class="a2ui-text h5">{{ text() }}</h5> }
-        @case ('caption') { <em class="a2ui-text caption">{{ text() }}</em> }
-      }
+      <span [class]="'a2ui-text ' + variant()">
+        @switch (variant()) {
+          @case ('h1') { <h1>{{ text() }}</h1> }
+          @case ('h2') { <h2>{{ text() }}</h2> }
+          @case ('h3') { <h3>{{ text() }}</h3> }
+          @case ('h4') { <h4>{{ text() }}</h4> }
+          @case ('h5') { <h5>{{ text() }}</h5> }
+          @case ('caption') { <em>{{ text() }}</em> }
+        }
+      </span>
     } @else {
       <span [class]="'a2ui-text ' + variant()" [innerHTML]="resolvedText()"></span>
     }
@@ -58,11 +60,11 @@ import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
   styles: [
     `
       :host ::ng-deep .a2ui-text p,
-      :host ::ng-deep .a2ui-text h1, :host ::ng-deep h1.a2ui-text,
-      :host ::ng-deep .a2ui-text h2, :host ::ng-deep h2.a2ui-text,
-      :host ::ng-deep .a2ui-text h3, :host ::ng-deep h3.a2ui-text,
-      :host ::ng-deep .a2ui-text h4, :host ::ng-deep h4.a2ui-text,
-      :host ::ng-deep .a2ui-text h5, :host ::ng-deep h5.a2ui-text,
+      :host ::ng-deep .a2ui-text h1,
+      :host ::ng-deep .a2ui-text h2,
+      :host ::ng-deep .a2ui-text h3,
+      :host ::ng-deep .a2ui-text h4,
+      :host ::ng-deep .a2ui-text h5,
       :host ::ng-deep .a2ui-text h6,
       :host ::ng-deep .a2ui-text ol,
       :host ::ng-deep .a2ui-text ul,
@@ -77,29 +79,29 @@ import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
           var(--a2ui-text-color-text, var(--a2ui-color-on-background))
         );
       }
-      :host ::ng-deep .a2ui-text h1, :host ::ng-deep h1.a2ui-text,
-      :host ::ng-deep .a2ui-text h2, :host ::ng-deep h2.a2ui-text,
-      :host ::ng-deep .a2ui-text h3, :host ::ng-deep h3.a2ui-text,
-      :host ::ng-deep .a2ui-text h4, :host ::ng-deep h4.a2ui-text,
-      :host ::ng-deep .a2ui-text h5, :host ::ng-deep h5.a2ui-text,
+      :host ::ng-deep .a2ui-text h1,
+      :host ::ng-deep .a2ui-text h2,
+      :host ::ng-deep .a2ui-text h3,
+      :host ::ng-deep .a2ui-text h4,
+      :host ::ng-deep .a2ui-text h5,
       :host ::ng-deep .a2ui-text h6 {
         font-family: var(--a2ui-font-family-title, inherit);
         line-height: var(--a2ui-line-height-headings, 1.2);
       }
-      :host ::ng-deep .a2ui-text h1, :host ::ng-deep h1.a2ui-text {
+      :host ::ng-deep .a2ui-text h1 {
         font-size: var(--a2ui-font-size-2xl);
       }
-      :host ::ng-deep .a2ui-text h2, :host ::ng-deep h2.a2ui-text {
+      :host ::ng-deep .a2ui-text h2 {
         font-size: var(--a2ui-font-size-xl);
       }
-      :host ::ng-deep .a2ui-text h3, :host ::ng-deep h3.a2ui-text {
+      :host ::ng-deep .a2ui-text h3 {
         font-size: var(--a2ui-font-size-l);
       }
       :host ::ng-deep .a2ui-text p,
-      :host ::ng-deep .a2ui-text h4, :host ::ng-deep h4.a2ui-text {
+      :host ::ng-deep .a2ui-text h4 {
         font-size: var(--a2ui-font-size-m);
       }
-      :host ::ng-deep .a2ui-text h5, :host ::ng-deep h5.a2ui-text {
+      :host ::ng-deep .a2ui-text h5 {
         font-size: var(--a2ui-font-size-s);
       }
       :host ::ng-deep .a2ui-text p {

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.ts
@@ -120,12 +120,20 @@ import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
 export class TextComponent extends BasicCatalogComponent<typeof TextApi> {
   private markdownRenderer = inject(MarkdownRenderer);
 
+  private static readonly KNOWN_VARIANTS = new Set<string>([
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'caption',
+  ]);
+
   readonly variant = computed(() => this.props()['variant']?.value() || 'body');
   readonly text = computed(() => this.props()['text']?.value() || '');
 
   readonly isKnownVariant = computed(() => {
-    const v = this.variant();
-    return ['h1', 'h2', 'h3', 'h4', 'h5', 'caption'].includes(v);
+    return TextComponent.KNOWN_VARIANTS.has(this.variant());
   });
 
   resolvedText = signal<string>('');

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.ts
@@ -39,8 +39,9 @@ import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
   selector: 'a2ui-v09-text',
   standalone: true,
   template: `
-    @if (isKnownVariant()) {
+    @if (isNonMarkdownVariant()) {
       <span [class]="'a2ui-text ' + variant()">
+        <!-- Nesting block elements like h1 inside a span is not correct HTML5. We should refactor this-->
         @switch (variant()) {
           @case ('h1') {
             <h1>{{ text() }}</h1>
@@ -134,7 +135,7 @@ import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
 export class TextComponent extends BasicCatalogComponent<typeof TextApi> {
   private markdownRenderer = inject(MarkdownRenderer);
 
-  private static readonly KNOWN_VARIANTS = new Set<string>([
+  private static readonly NON_MARKDOWN_VARIANTS = new Set<string>([
     'h1',
     'h2',
     'h3',
@@ -146,8 +147,8 @@ export class TextComponent extends BasicCatalogComponent<typeof TextApi> {
   readonly variant = computed(() => this.props()['variant']?.value() || 'body');
   readonly text = computed(() => this.props()['text']?.value() || '');
 
-  readonly isKnownVariant = computed(() => {
-    return TextComponent.KNOWN_VARIANTS.has(this.variant());
+  readonly isNonMarkdownVariant = computed(() => {
+    return TextComponent.NON_MARKDOWN_VARIANTS.has(this.variant());
   });
 
   resolvedText = signal<string>('');
@@ -156,7 +157,7 @@ export class TextComponent extends BasicCatalogComponent<typeof TextApi> {
   constructor() {
     super();
     effect(() => {
-      if (this.isKnownVariant()) {
+      if (this.isNonMarkdownVariant()) {
         return;
       }
       const text = this.text();


### PR DESCRIPTION
## What

Refactors Angular 0.9 Text component to render headings (h1-h5) and caption variants using declarative HTML elements in the template with {{ text }} notation instead of using the markdown renderer.

Markdown rendering is still used for unknown/default variants (like 'body').

## Why?

In 1P code, there are some builds that don't allow the g3mark implementation of the markdown renderer, due to a strict CSP (blocking 'unsafe-eval'). The only reason to provide a markdown renderer is because the Text component requires some kind of markdown renderer, even to display simple variants like headings. With the changes in this PR, apps can use `provideMarkdownRenderer(async text => text)` and still get all simple variants working correctly.

Tests have been updated to assert this new behavior.

TAG=agy
CONV=3f5af79d-d201-4229-8c8a-40e91c4eb343