### PR TITLE
refactor(lit): tighten `A2uiChildRef` type

### DIFF
--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- (v0_9) Narrow `A2uiChildRef` to the supported child reference shapes used by
+  `renderNode`.
+
 ## 0.10.0
 
 - **BREAKING CHANGE**: (v0_9) Rename Icon `path` property to `svgPath` and update component to correctly render SVG elements.

--- a/renderers/lit/src/v0_9/a2ui-lit-element.ts
+++ b/renderers/lit/src/v0_9/a2ui-lit-element.ts
@@ -16,24 +16,15 @@
 
 import {LitElement, nothing} from 'lit';
 import {property} from 'lit/decorators.js';
-import {ComponentContext, ComponentApi} from '@a2ui/web_core/v0_9';
+import {ComponentContext, ComponentApi, type ComponentId} from '@a2ui/web_core/v0_9';
 import {renderA2uiNode} from './surface/render-a2ui-node.js';
 import {A2uiController} from '@a2ui/lit/v0_9';
 
 /**
- * Represents a reference to a child component that should be rendered.
- * In A2UI, a child can be provided in one of three ways:
- *
- * 1. A string ID (e.g., "submit_button"). Tells the renderer to look up the component
- *    from the Surface's registry. The child will inherit the parent's data context path.
- * 2. A reference object (e.g., { id: 'foo', basePath: '/bar' }). Tells the renderer where
- *    to find the component AND binds it to a specific slice of the data model.
- * 3. An inline component object (e.g., { type: 'Button', props: { ... } }). Provides the
- *    full component definition directly instead of looking it up by ID.
- *
- * (This probably should come from the binder in web_core!)
+ * A reference to a child component to render. Either a string ID, or an object
+ * pairing an ID with an explicit data context path.
  */
-type A2uiChildRef = string | {id?: string; basePath?: string; type?: string};
+type A2uiChildRef = ComponentId | {id: ComponentId; basePath: string};
 
 /**
  * A base class for A2UI Lit elements that manages the A2uiController lifecycle.
@@ -63,35 +54,30 @@ export abstract class A2uiLitElement<Api extends ComponentApi> extends LitElemen
    * Helper method to render a child A2UI node.
    * Abstracts away the need to manually create a ComponentContext.
    *
-   * @param childRef The reference to the child component to render. Can be a string ID,
-   *                 a reference object containing `{ id, basePath }`, or a full inline component definition.
+   * @param childRef The reference to the child component to render. Either a string ID
+   *                 or a reference object containing `{id, basePath}`.
    * @param customPath An explicit data model path to bind the child to. If provided,
-   *                   this completely overrides any path defined in the `childRef` object.
-   *                   If omitted, it falls back to the `childRef`'s `basePath`, or the current component's path.
+   *                   this overrides any path defined in the `childRef` object. If omitted,
+   *                   falls back to the `childRef`'s `basePath`, or the current component's path.
    *
    * @returns A Lit template result containing the rendered child component, or `nothing` if the reference is empty.
    */
   protected renderNode(childRef?: A2uiChildRef, customPath?: string) {
     if (!childRef) return nothing;
-    let model: any = childRef;
     const {surface, path: parentPath} = this.context.dataContext;
 
-    // Path is resolved in the following order:
-    //   customPath > childRef.basePath > parentPath
+    // Path resolution order: customPath > childRef.basePath > parentPath
+    let componentId: ComponentId;
     let path = customPath;
-
-    // We check !childRef.type because an inline component definition (e.g. { type: 'Button' })
-    // should be passed directly to the ComponentContext. If it doesn't have a .type,
-    // we treat it as a child reference object (e.g. { id: 'foo', basePath: '/bar' }).
-    if (typeof childRef === 'object' && childRef !== null && childRef.id && !childRef.type) {
-      model = childRef.id;
+    if (typeof childRef === 'object') {
+      componentId = childRef.id;
       path = path ?? childRef.basePath;
+    } else {
+      componentId = childRef;
     }
-
-    // Fallback to the current component's context.
     path = path ?? parentPath;
 
-    return renderA2uiNode(new ComponentContext(surface, model, path), surface.catalog);
+    return renderA2uiNode(new ComponentContext(surface, componentId, path), surface.catalog);
   }
 
   /**

--- a/renderers/lit/src/v0_9/a2ui-lit-element.ts
+++ b/renderers/lit/src/v0_9/a2ui-lit-element.ts
@@ -75,6 +75,9 @@ export abstract class A2uiLitElement<Api extends ComponentApi> extends LitElemen
     } else {
       componentId = childRef;
     }
+
+    // Keep this fallback because the previous A2uiChildRef type allowed object
+    // refs without a basePath.
     path = path ?? parentPath;
 
     return renderA2uiNode(new ComponentContext(surface, componentId, path), surface.catalog);


### PR DESCRIPTION
See #1513.

`A2uiChildRef` is the type that describes a "child to render," used by the helper method `renderNode` on `A2uiLitElement`. `A2uiLitElement` is the base class for Lit A2UI components.

This PR narrows the type from

```ts
string | {id?: string; basePath?: string; type?: string}
```

to the two shapes the protocol actually uses:

```ts
ComponentId | {id: ComponentId; basePath: string}
```

`ComponentId` is just an alias for `string` that exists presumably to make the code a little more intuitive to read.

**It is technically possible for customer code to get broken (typecheck error) by this change if they took a dependency on specific cases of the previous type definition.** Typechecking will fail if a custom component calls `this.renderNode` with an object literal of the shape `{id: 'foo'}` (`renderNode` has fallback behavior to just take the component ID out and pretend it was called as `renderNode('foo')`). Other object literals (e.g. `{basePath: '/path'}`) would result in a runtime error, so those cases are not broken by this PR. For whatever's worth, I didn't find any internal override of `renderNode` or reference to `A2uiChildRef` that would be broken by this change.
