### PR TITLE
fix(angular): expose checks type in ExtendedProps

### DIFF
--- a/renderers/angular/CHANGELOG.md
+++ b/renderers/angular/CHANGELOG.md
@@ -4,6 +4,7 @@
 - (v0_8) Fix Icon component to handle camelCase and TitleCase names by converting them to snake_case for `g-icon`.
 - (v0_8) Fix Modal component styling and position fixed for overlay.
 - (v0_9) Remove `placeholder` prop support from the `TextField` component, since it was not part of the v0_9 basic catalog schema. [#1372](https://github.com/google/A2UI/pull/1372)
+- (v0_9) Preserve `checks` property in `ExtendedProps` type. [#1523](https://github.com/google/A2UI/pull/1523)
 
 ## 0.10.0
 

--- a/renderers/angular/src/v0_9/core/types.ts
+++ b/renderers/angular/src/v0_9/core/types.ts
@@ -82,9 +82,7 @@ interface CheckProps {
 
 /** The binder can add some properties to the Props object. This util adds them to the type. */
 export type ExtendedProps<ComponentProps extends {[key: string]: unknown}> =
-  'checks' extends keyof ComponentProps
-    ? Omit<ComponentProps, 'checks'> & CheckProps
-    : ComponentProps;
+  'checks' extends keyof ComponentProps ? ComponentProps & CheckProps : ComponentProps;
 
 /**
  * Utility to convert a component Api Type to the props Type, where the


### PR DESCRIPTION
This exposes the checks type that is currently present in the resulting object from the binder. This is needed because I found a 1P component relying on this type.