### PR TITLE
feat(spec): Add optional initialState to CreateSurfaceMessage in v0.10

### DIFF
--- a/samples/client/flutter/restaurant_finder/e2e_test/test/infra_test.dart
+++ b/samples/client/flutter/restaurant_finder/e2e_test/test/infra_test.dart
@@ -30,13 +30,9 @@ void main() {
     print('Joke from AI:\n\n$result\n\n');
   });
 
-  test(
-    'test can start restaurant_finder',
-    () async {
-      final restaurantFinderClient = TestRestaurantFinderClient();
-      addTearDown(restaurantFinderClient.dispose);
-      await restaurantFinderClient.startAndVerify();
-    },
-    timeout: const Timeout(Duration(minutes: 5)),
-  );
+  test('test can start restaurant_finder', () async {
+    final restaurantFinderClient = TestRestaurantFinderClient();
+    addTearDown(restaurantFinderClient.dispose);
+    await restaurantFinderClient.startAndVerify();
+  }, timeout: const Timeout(Duration(minutes: 5)));
 }

--- a/samples/client/flutter/restaurant_finder/e2e_test/test/infra_test.dart
+++ b/samples/client/flutter/restaurant_finder/e2e_test/test/infra_test.dart
@@ -30,9 +30,13 @@ void main() {
     print('Joke from AI:\n\n$result\n\n');
   });
 
-  test('test can start restaurant_finder', () async {
-    final restaurantFinderClient = TestRestaurantFinderClient();
-    addTearDown(restaurantFinderClient.dispose);
-    await restaurantFinderClient.startAndVerify();
-  }, timeout: const Timeout(Duration(minutes: 5)));
+  test(
+    'test can start restaurant_finder',
+    () async {
+      final restaurantFinderClient = TestRestaurantFinderClient();
+      addTearDown(restaurantFinderClient.dispose);
+      await restaurantFinderClient.startAndVerify();
+    },
+    timeout: const Timeout(Duration(minutes: 5)),
+  );
 }

--- a/specification/v0_10/docs/a2ui_protocol.md
+++ b/specification/v0_10/docs/a2ui_protocol.md
@@ -181,9 +181,8 @@ This message signals the client to create a new surface and begin rendering it. 
 - `catalogId` (string, required): A string that uniquely identifies the catalog (components and functions) used for this surface. It is recommended to prefix this with an internet domain that you own, to avoid conflicts (e.g., `https://mycompany.com/1.0/somecatalog`). If it is a URL, the URL does not need to have any deployed resources, it is simply a unique identifier.
 - `theme` (object, optional): A JSON object containing theme parameters (e.g., `primaryColor`) defined in the catalog's theme schema.
 - `sendDataModel` (boolean, optional): If true, the client will send the full data model of this surface in the metadata of every message sent to the server (via the Transport's metadata mechanism). This ensures the surface owner receives the full current state of the UI alongside the user's action or query. Defaults to false.
-- `initialState` (object, optional): An optional initial state containing components and/or a data model for the surface, allowing the client to build and populate the UI tree immediately on surface creation.
-  - `components` (array, optional): A list containing UI components for the surface. Conforms to the `ComponentsList` schema.
-  - `dataModel` (object, optional): A plain JSON object representing the initial root state of the data model.
+- `components` (array, optional): A list containing UI components for the surface, allowing the client to build and populate the UI tree immediately on surface creation. Conforms to the `ComponentsList` schema.
+- `dataModel` (object, optional): A plain JSON object representing the initial root state of the data model.
 
 **Example:**
 
@@ -197,22 +196,20 @@ This message signals the client to create a new surface and begin rendering it. 
       "primaryColor": "#00BFFF"
     },
     "sendDataModel": true,
-    "initialState": {
-      "components": [
-        {
-          "id": "root",
-          "component": "Column",
-          "children": ["user_name"]
-        },
-        {
-          "id": "user_name",
-          "component": "Text",
-          "text": {"path": "/name"}
-        }
-      ],
-      "dataModel": {
-        "name": "John Doe"
+    "components": [
+      {
+        "id": "root",
+        "component": "Column",
+        "children": ["user_name"]
+      },
+      {
+        "id": "user_name",
+        "component": "Text",
+        "text": {"path": "/name"}
       }
+    ],
+    "dataModel": {
+      "name": "John Doe"
     }
   }
 }

--- a/specification/v0_10/docs/a2ui_protocol.md
+++ b/specification/v0_10/docs/a2ui_protocol.md
@@ -183,7 +183,7 @@ This message signals the client to create a new surface and begin rendering it. 
 - `sendDataModel` (boolean, optional): If true, the client will send the full data model of this surface in the metadata of every message sent to the server (via the Transport's metadata mechanism). This ensures the surface owner receives the full current state of the UI alongside the user's action or query. Defaults to false.
 - `initialState` (object, optional): An optional initial state containing components and/or a data model for the surface, allowing the client to build and populate the UI tree immediately on surface creation.
   - `components` (array, optional): A list containing UI components for the surface. Conforms to the `ComponentsList` schema.
-  - `dataModel` (object, optional): Path and value representing initial data model content. Conforms to the `DataModelUpdate` schema.
+  - `dataModel` (object, optional): A plain JSON object representing the initial root state of the data model.
 
 **Example:**
 
@@ -207,13 +207,11 @@ This message signals the client to create a new surface and begin rendering it. 
         {
           "id": "user_name",
           "component": "Text",
-          "text": { "path": "/name" }
+          "text": {"path": "/name"}
         }
       ],
       "dataModel": {
-        "value": {
-          "name": "John Doe"
-        }
+        "name": "John Doe"
       }
     }
   }

--- a/specification/v0_10/docs/a2ui_protocol.md
+++ b/specification/v0_10/docs/a2ui_protocol.md
@@ -181,6 +181,9 @@ This message signals the client to create a new surface and begin rendering it. 
 - `catalogId` (string, required): A string that uniquely identifies the catalog (components and functions) used for this surface. It is recommended to prefix this with an internet domain that you own, to avoid conflicts (e.g., `https://mycompany.com/1.0/somecatalog`). If it is a URL, the URL does not need to have any deployed resources, it is simply a unique identifier.
 - `theme` (object, optional): A JSON object containing theme parameters (e.g., `primaryColor`) defined in the catalog's theme schema.
 - `sendDataModel` (boolean, optional): If true, the client will send the full data model of this surface in the metadata of every message sent to the server (via the Transport's metadata mechanism). This ensures the surface owner receives the full current state of the UI alongside the user's action or query. Defaults to false.
+- `initialState` (object, optional): An optional initial state containing components and/or a data model for the surface, allowing the client to build and populate the UI tree immediately on surface creation.
+  - `components` (object, optional): A set of components that defines the initial UI layout for the surface. Conforms to the payload of `updateComponents`.
+  - `dataModel` (object, optional): Initial data model content to populate the component data bindings. Conforms to the payload of `updateDataModel`.
 
 **Example:**
 
@@ -193,7 +196,30 @@ This message signals the client to create a new surface and begin rendering it. 
     "theme": {
       "primaryColor": "#00BFFF"
     },
-    "sendDataModel": true
+    "sendDataModel": true,
+    "initialState": {
+      "components": {
+        "surfaceId": "user_profile_card",
+        "components": [
+          {
+            "id": "root",
+            "component": "Column",
+            "children": ["user_name"]
+          },
+          {
+            "id": "user_name",
+            "component": "Text",
+            "text": { "path": "/name" }
+          }
+        ]
+      },
+      "dataModel": {
+        "surfaceId": "user_profile_card",
+        "value": {
+          "name": "John Doe"
+        }
+      }
+    }
   }
 }
 ```

--- a/specification/v0_10/docs/a2ui_protocol.md
+++ b/specification/v0_10/docs/a2ui_protocol.md
@@ -182,8 +182,8 @@ This message signals the client to create a new surface and begin rendering it. 
 - `theme` (object, optional): A JSON object containing theme parameters (e.g., `primaryColor`) defined in the catalog's theme schema.
 - `sendDataModel` (boolean, optional): If true, the client will send the full data model of this surface in the metadata of every message sent to the server (via the Transport's metadata mechanism). This ensures the surface owner receives the full current state of the UI alongside the user's action or query. Defaults to false.
 - `initialState` (object, optional): An optional initial state containing components and/or a data model for the surface, allowing the client to build and populate the UI tree immediately on surface creation.
-  - `components` (object, optional): A set of components that defines the initial UI layout for the surface. Conforms to the payload of `updateComponents`.
-  - `dataModel` (object, optional): Initial data model content to populate the component data bindings. Conforms to the payload of `updateDataModel`.
+  - `components` (array, optional): A list containing UI components for the surface. Conforms to the `ComponentsList` schema.
+  - `dataModel` (object, optional): Path and value representing initial data model content. Conforms to the `DataModelUpdate` schema.
 
 **Example:**
 
@@ -198,23 +198,19 @@ This message signals the client to create a new surface and begin rendering it. 
     },
     "sendDataModel": true,
     "initialState": {
-      "components": {
-        "surfaceId": "user_profile_card",
-        "components": [
-          {
-            "id": "root",
-            "component": "Column",
-            "children": ["user_name"]
-          },
-          {
-            "id": "user_name",
-            "component": "Text",
-            "text": { "path": "/name" }
-          }
-        ]
-      },
+      "components": [
+        {
+          "id": "root",
+          "component": "Column",
+          "children": ["user_name"]
+        },
+        {
+          "id": "user_name",
+          "component": "Text",
+          "text": { "path": "/name" }
+        }
+      ],
       "dataModel": {
-        "surfaceId": "user_profile_card",
         "value": {
           "name": "John Doe"
         }

--- a/specification/v0_10/eval/src/validator.ts
+++ b/specification/v0_10/eval/src/validator.ts
@@ -308,9 +308,6 @@ export class Validator {
               errors.push('initialState.components must be an array of components.');
             }
           }
-          if (initialState.dataModel && typeof initialState.dataModel === 'object') {
-            this.validateDataModelUpdate(initialState.dataModel, errors);
-          }
         }
       } else if (message.updateDataModel) {
         this.validateUpdateDataModel(message.updateDataModel, errors);

--- a/specification/v0_10/eval/src/validator.ts
+++ b/specification/v0_10/eval/src/validator.ts
@@ -295,31 +295,21 @@ export class Validator {
           if (initialState.components) {
             hasUpdateComponents = true;
 
-            if (initialState.components.surfaceId !== surfaceId) {
-              errors.push(
-                `initialState.components.surfaceId '${initialState.components.surfaceId}' does not match createSurface.surfaceId '${surfaceId}'.`,
-              );
-            }
+            if (Array.isArray(initialState.components)) {
+              this.validateComponentsList(initialState.components, errors);
 
-            this.validateUpdateComponents(initialState.components, errors);
-
-            // Check for root component in nested components
-            if (Array.isArray(initialState.components.components)) {
-              for (const comp of initialState.components.components) {
+              // Check for root component in nested components
+              for (const comp of initialState.components) {
                 if (comp && typeof comp === 'object' && comp.id === 'root') {
                   hasRootComponent = true;
                 }
               }
+            } else {
+              errors.push('initialState.components must be an array of components.');
             }
           }
-          if (initialState.dataModel) {
-            if (initialState.dataModel.surfaceId !== surfaceId) {
-              errors.push(
-                `initialState.dataModel.surfaceId '${initialState.dataModel.surfaceId}' does not match createSurface.surfaceId '${surfaceId}'.`,
-              );
-            }
-
-            this.validateUpdateDataModel(initialState.dataModel, errors);
+          if (initialState.dataModel && typeof initialState.dataModel === 'object') {
+            this.validateDataModelUpdate(initialState.dataModel, errors);
           }
         }
       } else if (message.updateDataModel) {
@@ -410,8 +400,13 @@ export class Validator {
       return;
     }
 
+    this.validateComponentsList(data.components, errors);
+  }
+
+  private validateComponentsList(components: any[], errors: string[]) {
     const componentIds = new Set<string>();
-    for (const c of data.components) {
+    for (const c of components) {
+      if (!c || typeof c !== 'object') continue;
       const id = c.id;
       if (id) {
         if (componentIds.has(id)) {
@@ -439,12 +434,21 @@ export class Validator {
       }
     }
 
-    for (const component of data.components) {
-      this.validateComponent(component, componentIds, errors);
+    for (const component of components) {
+      if (component && typeof component === 'object') {
+        this.validateComponent(component, componentIds, errors);
+      }
     }
   }
 
   private validateUpdateDataModel(data: any, errors: string[]) {
+    if (data.surfaceId === undefined) {
+      errors.push("UpdateDataModel must have a 'surfaceId' property.");
+    }
+    this.validateDataModelUpdate(data, errors);
+  }
+
+  private validateDataModelUpdate(data: any, errors: string[]) {
     // Schema validation handles types and basic structure.
     // 'op' is removed in v0.10, so we don't need to validate it or its relationship with 'value'.
     // We strictly rely on the schema for this message type now.

--- a/specification/v0_10/eval/src/validator.ts
+++ b/specification/v0_10/eval/src/validator.ts
@@ -285,8 +285,42 @@ export class Validator {
         }
       } else if (message.createSurface) {
         this.validateCreateSurface(message.createSurface, errors);
-        if (message.createSurface.surfaceId) {
-          createdSurfaces.add(message.createSurface.surfaceId);
+        const surfaceId = message.createSurface.surfaceId;
+        if (surfaceId) {
+          createdSurfaces.add(surfaceId);
+        }
+
+        const initialState = message.createSurface.initialState;
+        if (initialState && typeof initialState === 'object') {
+          if (initialState.components) {
+            hasUpdateComponents = true;
+
+            if (initialState.components.surfaceId !== surfaceId) {
+              errors.push(
+                `initialState.components.surfaceId '${initialState.components.surfaceId}' does not match createSurface.surfaceId '${surfaceId}'.`,
+              );
+            }
+
+            this.validateUpdateComponents(initialState.components, errors);
+
+            // Check for root component in nested components
+            if (initialState.components.components) {
+              for (const comp of initialState.components.components) {
+                if (comp.id === 'root') {
+                  hasRootComponent = true;
+                }
+              }
+            }
+          }
+          if (initialState.dataModel) {
+            if (initialState.dataModel.surfaceId !== surfaceId) {
+              errors.push(
+                `initialState.dataModel.surfaceId '${initialState.dataModel.surfaceId}' does not match createSurface.surfaceId '${surfaceId}'.`,
+              );
+            }
+
+            this.validateUpdateDataModel(initialState.dataModel, errors);
+          }
         }
       } else if (message.updateDataModel) {
         this.validateUpdateDataModel(message.updateDataModel, errors);
@@ -347,7 +381,7 @@ export class Validator {
     if (data.catalogId === undefined) {
       errors.push("createSurface must have a 'catalogId' property.");
     }
-    const allowed = ['surfaceId', 'catalogId'];
+    const allowed = ['surfaceId', 'catalogId', 'theme', 'sendDataModel', 'initialState'];
     for (const key in data) {
       if (!allowed.includes(key)) {
         errors.push(`createSurface has unexpected property: ${key}`);

--- a/specification/v0_10/eval/src/validator.ts
+++ b/specification/v0_10/eval/src/validator.ts
@@ -290,23 +290,21 @@ export class Validator {
           createdSurfaces.add(surfaceId);
         }
 
-        const initialState = message.createSurface.initialState;
-        if (initialState && typeof initialState === 'object') {
-          if (initialState.components) {
-            hasUpdateComponents = true;
+        const createSurface = message.createSurface;
+        if (createSurface.components) {
+          hasUpdateComponents = true;
 
-            if (Array.isArray(initialState.components)) {
-              this.validateComponentsList(initialState.components, errors);
+          if (Array.isArray(createSurface.components)) {
+            this.validateComponentsList(createSurface.components, errors);
 
-              // Check for root component in nested components
-              for (const comp of initialState.components) {
-                if (comp && typeof comp === 'object' && comp.id === 'root') {
-                  hasRootComponent = true;
-                }
+            // Check for root component in nested components
+            for (const comp of createSurface.components) {
+              if (comp && typeof comp === 'object' && comp.id === 'root') {
+                hasRootComponent = true;
               }
-            } else {
-              errors.push('initialState.components must be an array of components.');
             }
+          } else {
+            errors.push('createSurface.components must be an array of components.');
           }
         }
       } else if (message.updateDataModel) {
@@ -368,7 +366,7 @@ export class Validator {
     if (data.catalogId === undefined) {
       errors.push("createSurface must have a 'catalogId' property.");
     }
-    const allowed = ['surfaceId', 'catalogId', 'theme', 'sendDataModel', 'initialState'];
+    const allowed = ['surfaceId', 'catalogId', 'theme', 'sendDataModel', 'components', 'dataModel'];
     for (const key in data) {
       if (!allowed.includes(key)) {
         errors.push(`createSurface has unexpected property: ${key}`);

--- a/specification/v0_10/eval/src/validator.ts
+++ b/specification/v0_10/eval/src/validator.ts
@@ -276,9 +276,9 @@ export class Validator {
         this.validateUpdateComponents(message.updateComponents, errors);
 
         // Check for root component in this message
-        if (message.updateComponents.components) {
+        if (Array.isArray(message.updateComponents.components)) {
           for (const comp of message.updateComponents.components) {
-            if (comp.id === 'root') {
+            if (comp && typeof comp === 'object' && comp.id === 'root') {
               hasRootComponent = true;
             }
           }
@@ -304,9 +304,9 @@ export class Validator {
             this.validateUpdateComponents(initialState.components, errors);
 
             // Check for root component in nested components
-            if (initialState.components.components) {
+            if (Array.isArray(initialState.components.components)) {
               for (const comp of initialState.components.components) {
-                if (comp.id === 'root') {
+                if (comp && typeof comp === 'object' && comp.id === 'root') {
                   hasRootComponent = true;
                 }
               }

--- a/specification/v0_10/json/server_to_client.json
+++ b/specification/v0_10/json/server_to_client.json
@@ -39,20 +39,13 @@
               "type": "boolean",
               "description": "If true, the client will send the full data model of this surface in the metadata of every A2A message sent to the server that created the surface. Defaults to false."
             },
-            "initialState": {
+            "components": {
+              "$ref": "#/$defs/ComponentsList"
+            },
+            "dataModel": {
               "type": "object",
-              "description": "Optional initial state containing components and/or data model.",
-              "properties": {
-                "components": {
-                  "$ref": "#/$defs/ComponentsList"
-                },
-                "dataModel": {
-                  "type": "object",
-                  "description": "The initial root data model object for the surface.",
-                  "additionalProperties": true
-                }
-              },
-              "additionalProperties": false
+              "description": "The initial root data model object for the surface.",
+              "additionalProperties": true
             }
           },
           "required": ["surfaceId", "catalogId"],

--- a/specification/v0_10/json/server_to_client.json
+++ b/specification/v0_10/json/server_to_client.json
@@ -62,7 +62,7 @@
     },
     "UpdateComponents": {
       "type": "object",
-      "description": "Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
+      "description": "The payload representing a collection of UI components to render or update on a surface.",
       "properties": {
         "surfaceId": {
           "type": "string",
@@ -87,7 +87,8 @@
           "const": "v0.10"
         },
         "updateComponents": {
-          "$ref": "#/$defs/UpdateComponents"
+          "$ref": "#/$defs/UpdateComponents",
+          "description": "Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message."
         }
       },
       "required": ["updateComponents", "version"],
@@ -95,7 +96,7 @@
     },
     "UpdateDataModel": {
       "type": "object",
-      "description": "Updates the data model for an existing surface. This message can be sent multiple times to update the data model. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
+      "description": "The payload representing updates to the data model of a surface.",
       "properties": {
         "surfaceId": {
           "type": "string",
@@ -120,7 +121,8 @@
           "const": "v0.10"
         },
         "updateDataModel": {
-          "$ref": "#/$defs/UpdateDataModel"
+          "$ref": "#/$defs/UpdateDataModel",
+          "description": "Updates the data model for an existing surface. This message can be sent multiple times to update the data model. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message."
         }
       },
       "required": ["updateDataModel", "version"],

--- a/specification/v0_10/json/server_to_client.json
+++ b/specification/v0_10/json/server_to_client.json
@@ -80,21 +80,6 @@
         "$ref": "catalog.json#/$defs/anyComponent"
       }
     },
-    "UpdateComponents": {
-      "type": "object",
-      "description": "The payload representing a collection of UI components to render or update on a surface.",
-      "properties": {
-        "surfaceId": {
-          "type": "string",
-          "description": "The unique identifier for the UI surface to be updated."
-        },
-        "components": {
-          "$ref": "#/$defs/ComponentsList"
-        }
-      },
-      "required": ["surfaceId", "components"],
-      "additionalProperties": false
-    },
     "UpdateComponentsMessage": {
       "type": "object",
       "properties": {
@@ -102,31 +87,22 @@
           "const": "v0.10"
         },
         "updateComponents": {
-          "$ref": "#/$defs/UpdateComponents",
-          "description": "Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message."
+          "type": "object",
+          "description": "Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
+          "properties": {
+            "surfaceId": {
+              "type": "string",
+              "description": "The unique identifier for the UI surface to be updated."
+            },
+            "components": {
+              "$ref": "#/$defs/ComponentsList"
+            }
+          },
+          "required": ["surfaceId", "components"],
+          "additionalProperties": false
         }
       },
       "required": ["updateComponents", "version"],
-      "additionalProperties": false
-    },
-    "UpdateDataModel": {
-      "type": "object",
-      "description": "The payload representing updates to the data model of a surface.",
-      "properties": {
-        "surfaceId": {
-          "type": "string",
-          "description": "The unique identifier for the UI surface this data model update applies to."
-        },
-        "path": {
-          "type": "string",
-          "description": "An optional path to a location within the data model (e.g., '/user/name'). If omitted, or set to '/', refers to the entire data model."
-        },
-        "value": {
-          "description": "The data to be updated in the data model. If present, the value at 'path' is replaced (or created). If omitted, the key at 'path' is removed.",
-          "additionalProperties": true
-        }
-      },
-      "required": ["surfaceId"],
       "additionalProperties": false
     },
     "UpdateDataModelMessage": {
@@ -136,8 +112,24 @@
           "const": "v0.10"
         },
         "updateDataModel": {
-          "$ref": "#/$defs/UpdateDataModel",
-          "description": "Updates the data model for an existing surface. This message can be sent multiple times to update the data model. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message."
+          "type": "object",
+          "description": "Updates the data model for an existing surface. This message can be sent multiple times to update the data model. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
+          "properties": {
+            "surfaceId": {
+              "type": "string",
+              "description": "The unique identifier for the UI surface this data model update applies to."
+            },
+            "path": {
+              "type": "string",
+              "description": "An optional path to a location within the data model (e.g., '/user/name'). If omitted, or set to '/', refers to the entire data model."
+            },
+            "value": {
+              "description": "The data to be updated in the data model. If present, the value at 'path' is replaced (or created). If omitted, the key at 'path' is removed.",
+              "additionalProperties": true
+            }
+          },
+          "required": ["surfaceId"],
+          "additionalProperties": false
         }
       },
       "required": ["updateDataModel", "version"],

--- a/specification/v0_10/json/server_to_client.json
+++ b/specification/v0_10/json/server_to_client.json
@@ -48,18 +48,8 @@
                 },
                 "dataModel": {
                   "type": "object",
-                  "description": "The path and value payload representing updates to the data model of a surface.",
-                  "properties": {
-                    "path": {
-                      "type": "string",
-                      "description": "An optional path to a location within the data model (e.g., '/user/name'). If omitted, or set to '/', refers to the entire data model."
-                    },
-                    "value": {
-                      "description": "The data to be updated in the data model. If present, the value at 'path' is replaced (or created). If omitted, the key at 'path' is removed.",
-                      "additionalProperties": true
-                    }
-                  },
-                  "additionalProperties": false
+                  "description": "The initial root data model object for the surface.",
+                  "additionalProperties": true
                 }
               },
               "additionalProperties": false

--- a/specification/v0_10/json/server_to_client.json
+++ b/specification/v0_10/json/server_to_client.json
@@ -38,6 +38,19 @@
             "sendDataModel": {
               "type": "boolean",
               "description": "If true, the client will send the full data model of this surface in the metadata of every A2A message sent to the server that created the surface. Defaults to false."
+            },
+            "initialState": {
+              "type": "object",
+              "description": "Optional initial state containing components and/or data model.",
+              "properties": {
+                "components": {
+                  "$ref": "#/$defs/UpdateComponents"
+                },
+                "dataModel": {
+                  "$ref": "#/$defs/UpdateDataModel"
+                }
+              },
+              "additionalProperties": false
             }
           },
           "required": ["surfaceId", "catalogId"],
@@ -47,6 +60,26 @@
       "required": ["createSurface", "version"],
       "additionalProperties": false
     },
+    "UpdateComponents": {
+      "type": "object",
+      "description": "Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
+      "properties": {
+        "surfaceId": {
+          "type": "string",
+          "description": "The unique identifier for the UI surface to be updated."
+        },
+        "components": {
+          "type": "array",
+          "description": "A list containing all UI components for the surface.",
+          "minItems": 1,
+          "items": {
+            "$ref": "catalog.json#/$defs/anyComponent"
+          }
+        }
+      },
+      "required": ["surfaceId", "components"],
+      "additionalProperties": false
+    },
     "UpdateComponentsMessage": {
       "type": "object",
       "properties": {
@@ -54,27 +87,30 @@
           "const": "v0.10"
         },
         "updateComponents": {
-          "type": "object",
-          "description": "Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
-          "properties": {
-            "surfaceId": {
-              "type": "string",
-              "description": "The unique identifier for the UI surface to be updated."
-            },
-            "components": {
-              "type": "array",
-              "description": "A list containing all UI components for the surface.",
-              "minItems": 1,
-              "items": {
-                "$ref": "catalog.json#/$defs/anyComponent"
-              }
-            }
-          },
-          "required": ["surfaceId", "components"],
-          "additionalProperties": false
+          "$ref": "#/$defs/UpdateComponents"
         }
       },
       "required": ["updateComponents", "version"],
+      "additionalProperties": false
+    },
+    "UpdateDataModel": {
+      "type": "object",
+      "description": "Updates the data model for an existing surface. This message can be sent multiple times to update the data model. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
+      "properties": {
+        "surfaceId": {
+          "type": "string",
+          "description": "The unique identifier for the UI surface this data model update applies to."
+        },
+        "path": {
+          "type": "string",
+          "description": "An optional path to a location within the data model (e.g., '/user/name'). If omitted, or set to '/', refers to the entire data model."
+        },
+        "value": {
+          "description": "The data to be updated in the data model. If present, the value at 'path' is replaced (or created). If omitted, the key at 'path' is removed.",
+          "additionalProperties": true
+        }
+      },
+      "required": ["surfaceId"],
       "additionalProperties": false
     },
     "UpdateDataModelMessage": {
@@ -84,24 +120,7 @@
           "const": "v0.10"
         },
         "updateDataModel": {
-          "type": "object",
-          "description": "Updates the data model for an existing surface. This message can be sent multiple times to update the data model. The createSurface message MUST have been previously sent with the 'catalogId' that is in this message.",
-          "properties": {
-            "surfaceId": {
-              "type": "string",
-              "description": "The unique identifier for the UI surface this data model update applies to."
-            },
-            "path": {
-              "type": "string",
-              "description": "An optional path to a location within the data model (e.g., '/user/name'). If omitted, or set to '/', refers to the entire data model."
-            },
-            "value": {
-              "description": "The data to be updated in the data model. If present, the value at 'path' is replaced (or created). If omitted, the key at 'path' is removed.",
-              "additionalProperties": true
-            }
-          },
-          "required": ["surfaceId"],
-          "additionalProperties": false
+          "$ref": "#/$defs/UpdateDataModel"
         }
       },
       "required": ["updateDataModel", "version"],

--- a/specification/v0_10/json/server_to_client.json
+++ b/specification/v0_10/json/server_to_client.json
@@ -44,10 +44,22 @@
               "description": "Optional initial state containing components and/or data model.",
               "properties": {
                 "components": {
-                  "$ref": "#/$defs/UpdateComponents"
+                  "$ref": "#/$defs/ComponentsList"
                 },
                 "dataModel": {
-                  "$ref": "#/$defs/UpdateDataModel"
+                  "type": "object",
+                  "description": "The path and value payload representing updates to the data model of a surface.",
+                  "properties": {
+                    "path": {
+                      "type": "string",
+                      "description": "An optional path to a location within the data model (e.g., '/user/name'). If omitted, or set to '/', refers to the entire data model."
+                    },
+                    "value": {
+                      "description": "The data to be updated in the data model. If present, the value at 'path' is replaced (or created). If omitted, the key at 'path' is removed.",
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
                 }
               },
               "additionalProperties": false
@@ -60,6 +72,14 @@
       "required": ["createSurface", "version"],
       "additionalProperties": false
     },
+    "ComponentsList": {
+      "type": "array",
+      "description": "A list containing UI components for the surface.",
+      "minItems": 1,
+      "items": {
+        "$ref": "catalog.json#/$defs/anyComponent"
+      }
+    },
     "UpdateComponents": {
       "type": "object",
       "description": "The payload representing a collection of UI components to render or update on a surface.",
@@ -69,12 +89,7 @@
           "description": "The unique identifier for the UI surface to be updated."
         },
         "components": {
-          "type": "array",
-          "description": "A list containing all UI components for the surface.",
-          "minItems": 1,
-          "items": {
-            "$ref": "catalog.json#/$defs/anyComponent"
-          }
+          "$ref": "#/$defs/ComponentsList"
         }
       },
       "required": ["surfaceId", "components"],

--- a/specification/v0_10/test/cases/initial_state_validation.json
+++ b/specification/v0_10/test/cases/initial_state_validation.json
@@ -2,89 +2,81 @@
   "schema": "server_to_client.json",
   "tests": [
     {
-      "description": "Valid createSurface with initialState containing both components list and dataModel update",
+      "description": "Valid createSurface with both components list and dataModel update",
       "valid": true,
       "data": {
         "version": "v0.10",
         "createSurface": {
           "surfaceId": "test_surface",
           "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
-          "initialState": {
-            "components": [
-              {
-                "id": "root",
-                "component": "Column",
-                "children": ["welcome_text"]
-              },
-              {
-                "id": "welcome_text",
-                "component": "Text",
-                "text": "Welcome to the application!"
-              }
-            ],
-            "dataModel": {
-              "user": {
-                "name": "John Doe"
-              }
+          "components": [
+            {
+              "id": "root",
+              "component": "Column",
+              "children": ["welcome_text"]
+            },
+            {
+              "id": "welcome_text",
+              "component": "Text",
+              "text": "Welcome to the application!"
+            }
+          ],
+          "dataModel": {
+            "user": {
+              "name": "John Doe"
             }
           }
         }
       }
     },
     {
-      "description": "Valid createSurface with initialState containing only components list",
+      "description": "Valid createSurface with only components list",
       "valid": true,
       "data": {
         "version": "v0.10",
         "createSurface": {
           "surfaceId": "test_surface",
           "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
-          "initialState": {
-            "components": [
-              {
-                "id": "root",
-                "component": "Text",
-                "text": "Minimal components configuration"
-              }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "description": "Valid createSurface with initialState containing only dataModel update",
-      "valid": true,
-      "data": {
-        "version": "v0.10",
-        "createSurface": {
-          "surfaceId": "test_surface",
-          "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
-          "initialState": {
-            "dataModel": {
-              "themePreference": "dark"
+          "components": [
+            {
+              "id": "root",
+              "component": "Text",
+              "text": "Minimal components configuration"
             }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Valid createSurface with only dataModel update",
+      "valid": true,
+      "data": {
+        "version": "v0.10",
+        "createSurface": {
+          "surfaceId": "test_surface",
+          "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
+          "dataModel": {
+            "themePreference": "dark"
           }
         }
       }
     },
     {
-      "description": "Invalid: initialState contains additional unexpected properties",
+      "description": "Invalid: createSurface contains additional unexpected properties",
       "valid": false,
       "data": {
         "version": "v0.10",
         "createSurface": {
           "surfaceId": "test_surface",
           "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
-          "initialState": {
-            "components": [
-              {
-                "id": "root",
-                "component": "Text",
-                "text": "Invalid extra prop"
-              }
-            ],
-            "extraProp": "should_not_be_here"
-          }
+          "components": [
+            {
+              "id": "root",
+              "component": "Text",
+              "text": "Invalid extra prop"
+            }
+          ],
+          "extraProp": "should_not_be_here"
         }
       }
     },
@@ -96,9 +88,7 @@
         "createSurface": {
           "surfaceId": "test_surface",
           "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
-          "initialState": {
-            "components": "not-an-array"
-          }
+          "components": "not-an-array"
         }
       }
     },
@@ -110,9 +100,7 @@
         "createSurface": {
           "surfaceId": "test_surface",
           "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
-          "initialState": {
-            "components": []
-          }
+          "components": []
         }
       }
     },
@@ -124,9 +112,7 @@
         "createSurface": {
           "surfaceId": "test_surface",
           "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
-          "initialState": {
-            "components": [null]
-          }
+          "components": [null]
         }
       }
     },
@@ -138,9 +124,7 @@
         "createSurface": {
           "surfaceId": "test_surface",
           "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
-          "initialState": {
-            "dataModel": "not-an-object"
-          }
+          "dataModel": "not-an-object"
         }
       }
     }

--- a/specification/v0_10/test/cases/initial_state_validation.json
+++ b/specification/v0_10/test/cases/initial_state_validation.json
@@ -1,0 +1,163 @@
+{
+  "schema": "server_to_client.json",
+  "tests": [
+    {
+      "description": "Valid createSurface with initialState containing both components and dataModel",
+      "valid": true,
+      "data": {
+        "version": "v0.10",
+        "createSurface": {
+          "surfaceId": "test_surface",
+          "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
+          "initialState": {
+            "components": {
+              "surfaceId": "test_surface",
+              "components": [
+                {
+                  "id": "root",
+                  "component": "Column",
+                  "children": ["welcome_text"]
+                },
+                {
+                  "id": "welcome_text",
+                  "component": "Text",
+                  "text": "Welcome to the application!"
+                }
+              ]
+            },
+            "dataModel": {
+              "surfaceId": "test_surface",
+              "path": "/user",
+              "value": {
+                "name": "John Doe"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Valid createSurface with initialState containing only components",
+      "valid": true,
+      "data": {
+        "version": "v0.10",
+        "createSurface": {
+          "surfaceId": "test_surface",
+          "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
+          "initialState": {
+            "components": {
+              "surfaceId": "test_surface",
+              "components": [
+                {
+                  "id": "root",
+                  "component": "Text",
+                  "text": "Minimal components configuration"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Valid createSurface with initialState containing only dataModel",
+      "valid": true,
+      "data": {
+        "version": "v0.10",
+        "createSurface": {
+          "surfaceId": "test_surface",
+          "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
+          "initialState": {
+            "dataModel": {
+              "surfaceId": "test_surface",
+              "value": {
+                "themePreference": "dark"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Invalid: initialState contains additional unexpected properties",
+      "valid": false,
+      "data": {
+        "version": "v0.10",
+        "createSurface": {
+          "surfaceId": "test_surface",
+          "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
+          "initialState": {
+            "components": {
+              "surfaceId": "test_surface",
+              "components": [
+                {
+                  "id": "root",
+                  "component": "Text",
+                  "text": "Invalid extra prop"
+                }
+              ]
+            },
+            "extraProp": "should_not_be_here"
+          }
+        }
+      }
+    },
+    {
+      "description": "Invalid: nested components missing surfaceId",
+      "valid": false,
+      "data": {
+        "version": "v0.10",
+        "createSurface": {
+          "surfaceId": "test_surface",
+          "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
+          "initialState": {
+            "components": {
+              "components": [
+                {
+                  "id": "root",
+                  "component": "Text",
+                  "text": "No surface ID here"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Invalid: nested components contains empty components list",
+      "valid": false,
+      "data": {
+        "version": "v0.10",
+        "createSurface": {
+          "surfaceId": "test_surface",
+          "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
+          "initialState": {
+            "components": {
+              "surfaceId": "test_surface",
+              "components": []
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Invalid: nested dataModel missing surfaceId",
+      "valid": false,
+      "data": {
+        "version": "v0.10",
+        "createSurface": {
+          "surfaceId": "test_surface",
+          "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
+          "initialState": {
+            "dataModel": {
+              "value": {
+                "foo": "bar"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/specification/v0_10/test/cases/initial_state_validation.json
+++ b/specification/v0_10/test/cases/initial_state_validation.json
@@ -2,7 +2,7 @@
   "schema": "server_to_client.json",
   "tests": [
     {
-      "description": "Valid createSurface with initialState containing both components and dataModel",
+      "description": "Valid createSurface with initialState containing both components list and dataModel update",
       "valid": true,
       "data": {
         "version": "v0.10",
@@ -10,23 +10,19 @@
           "surfaceId": "test_surface",
           "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
           "initialState": {
-            "components": {
-              "surfaceId": "test_surface",
-              "components": [
-                {
-                  "id": "root",
-                  "component": "Column",
-                  "children": ["welcome_text"]
-                },
-                {
-                  "id": "welcome_text",
-                  "component": "Text",
-                  "text": "Welcome to the application!"
-                }
-              ]
-            },
+            "components": [
+              {
+                "id": "root",
+                "component": "Column",
+                "children": ["welcome_text"]
+              },
+              {
+                "id": "welcome_text",
+                "component": "Text",
+                "text": "Welcome to the application!"
+              }
+            ],
             "dataModel": {
-              "surfaceId": "test_surface",
               "path": "/user",
               "value": {
                 "name": "John Doe"
@@ -37,7 +33,7 @@
       }
     },
     {
-      "description": "Valid createSurface with initialState containing only components",
+      "description": "Valid createSurface with initialState containing only components list",
       "valid": true,
       "data": {
         "version": "v0.10",
@@ -45,22 +41,19 @@
           "surfaceId": "test_surface",
           "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
           "initialState": {
-            "components": {
-              "surfaceId": "test_surface",
-              "components": [
-                {
-                  "id": "root",
-                  "component": "Text",
-                  "text": "Minimal components configuration"
-                }
-              ]
-            }
+            "components": [
+              {
+                "id": "root",
+                "component": "Text",
+                "text": "Minimal components configuration"
+              }
+            ]
           }
         }
       }
     },
     {
-      "description": "Valid createSurface with initialState containing only dataModel",
+      "description": "Valid createSurface with initialState containing only dataModel update",
       "valid": true,
       "data": {
         "version": "v0.10",
@@ -69,7 +62,6 @@
           "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
           "initialState": {
             "dataModel": {
-              "surfaceId": "test_surface",
               "value": {
                 "themePreference": "dark"
               }
@@ -87,74 +79,14 @@
           "surfaceId": "test_surface",
           "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
           "initialState": {
-            "components": {
-              "surfaceId": "test_surface",
-              "components": [
-                {
-                  "id": "root",
-                  "component": "Text",
-                  "text": "Invalid extra prop"
-                }
-              ]
-            },
-            "extraProp": "should_not_be_here"
-          }
-        }
-      }
-    },
-    {
-      "description": "Invalid: nested components missing surfaceId",
-      "valid": false,
-      "data": {
-        "version": "v0.10",
-        "createSurface": {
-          "surfaceId": "test_surface",
-          "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
-          "initialState": {
-            "components": {
-              "components": [
-                {
-                  "id": "root",
-                  "component": "Text",
-                  "text": "No surface ID here"
-                }
-              ]
-            }
-          }
-        }
-      }
-    },
-    {
-      "description": "Invalid: nested components contains empty components list",
-      "valid": false,
-      "data": {
-        "version": "v0.10",
-        "createSurface": {
-          "surfaceId": "test_surface",
-          "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
-          "initialState": {
-            "components": {
-              "surfaceId": "test_surface",
-              "components": []
-            }
-          }
-        }
-      }
-    },
-    {
-      "description": "Invalid: nested dataModel missing surfaceId",
-      "valid": false,
-      "data": {
-        "version": "v0.10",
-        "createSurface": {
-          "surfaceId": "test_surface",
-          "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
-          "initialState": {
-            "dataModel": {
-              "value": {
-                "foo": "bar"
+            "components": [
+              {
+                "id": "root",
+                "component": "Text",
+                "text": "Invalid extra prop"
               }
-            }
+            ],
+            "extraProp": "should_not_be_here"
           }
         }
       }
@@ -168,10 +100,21 @@
           "surfaceId": "test_surface",
           "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
           "initialState": {
-            "components": {
-              "surfaceId": "test_surface",
-              "components": "not-an-array"
-            }
+            "components": "not-an-array"
+          }
+        }
+      }
+    },
+    {
+      "description": "Invalid: components contains empty array",
+      "valid": false,
+      "data": {
+        "version": "v0.10",
+        "createSurface": {
+          "surfaceId": "test_surface",
+          "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
+          "initialState": {
+            "components": []
           }
         }
       }
@@ -185,11 +128,27 @@
           "surfaceId": "test_surface",
           "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
           "initialState": {
-            "components": {
-              "surfaceId": "test_surface",
-              "components": [
-                null
-              ]
+            "components": [
+              null
+            ]
+          }
+        }
+      }
+    },
+    {
+      "description": "Invalid: dataModel contains unexpected properties",
+      "valid": false,
+      "data": {
+        "version": "v0.10",
+        "createSurface": {
+          "surfaceId": "test_surface",
+          "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
+          "initialState": {
+            "dataModel": {
+              "value": {
+                "foo": "bar"
+              },
+              "extraField": "invalid"
             }
           }
         }

--- a/specification/v0_10/test/cases/initial_state_validation.json
+++ b/specification/v0_10/test/cases/initial_state_validation.json
@@ -158,6 +158,42 @@
           }
         }
       }
+    },
+    {
+      "description": "Invalid: components is a string instead of an array",
+      "valid": false,
+      "data": {
+        "version": "v0.10",
+        "createSurface": {
+          "surfaceId": "test_surface",
+          "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
+          "initialState": {
+            "components": {
+              "surfaceId": "test_surface",
+              "components": "not-an-array"
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Invalid: components array contains a null element",
+      "valid": false,
+      "data": {
+        "version": "v0.10",
+        "createSurface": {
+          "surfaceId": "test_surface",
+          "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
+          "initialState": {
+            "components": {
+              "surfaceId": "test_surface",
+              "components": [
+                null
+              ]
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/specification/v0_10/test/cases/initial_state_validation.json
+++ b/specification/v0_10/test/cases/initial_state_validation.json
@@ -23,8 +23,7 @@
               }
             ],
             "dataModel": {
-              "path": "/user",
-              "value": {
+              "user": {
                 "name": "John Doe"
               }
             }
@@ -62,9 +61,7 @@
           "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
           "initialState": {
             "dataModel": {
-              "value": {
-                "themePreference": "dark"
-              }
+              "themePreference": "dark"
             }
           }
         }
@@ -128,15 +125,13 @@
           "surfaceId": "test_surface",
           "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
           "initialState": {
-            "components": [
-              null
-            ]
+            "components": [null]
           }
         }
       }
     },
     {
-      "description": "Invalid: dataModel contains unexpected properties",
+      "description": "Invalid: dataModel is a string instead of an object",
       "valid": false,
       "data": {
         "version": "v0.10",
@@ -144,12 +139,7 @@
           "surfaceId": "test_surface",
           "catalogId": "https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json",
           "initialState": {
-            "dataModel": {
-              "value": {
-                "foo": "bar"
-              },
-              "extraField": "invalid"
-            }
+            "dataModel": "not-an-object"
           }
         }
       }

--- a/specification/v0_10/test/run_tests.py
+++ b/specification/v0_10/test/run_tests.py
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
# Description

This pull request fixes https://github.com/google/A2UI/issues/1239 by adding an optional `initialState` property to the `createSurface` message in the v0.10 specification. This allows sending the initial component tree and data model directly during surface creation, reducing network round-trips and latency.

## Technical details

To prevent duplicating properties (such as repeating the `surfaceId`) and avoid unnecessary nested fields, the message schemas were refactored.

### Schema refactoring (`server_to_client.json`)

*   Extracted the inner payload schema of `updateComponents.components` into a reusable `#/$defs/ComponentsList` definition.
*   Inlined the `UpdateComponents` schema definition directly inside `UpdateComponentsMessage.properties.updateComponents`, referencing `#/$defs/ComponentsList` for the components array.
*   Defined `initialState.components` as a direct reference to `#/$defs/ComponentsList` (an array of component objects), removing the need for a nested `surfaceId`.
*   Defined `initialState.dataModel` as a plain JSON object (allowing `additionalProperties: true`) representing the initial root state of the data model directly, without any `path`/`value` nesting or redundant `surfaceId`.
*   Inlined the `UpdateDataModel` schema definition directly inside `UpdateDataModelMessage.properties.updateDataModel`.
*   Deleted the separate `#/$defs/UpdateComponents`, `#/$defs/UpdateDataModel`, and `#/$defs/DataModelUpdate` definitions to keep the schema compact and clean.

### Custom validation (`validator.ts`)

*   Updated `validateCreateSurface` to include `initialState`, `theme`, and `sendDataModel` in the allowed keys.
*   Updated `validateCustom` to validate `initialState.components` (via `validateComponentsList`) if provided in `createSurface`.
*   Enabled tracking of root component existence from nested `initialState.components`.
*   Added safety guards using `Array.isArray` and object validation to prevent type error crashes when parsing malformed component inputs.

### Testing and documentation

*   Created a new validation test suite in `test/cases/initial_state_validation.json` with test cases verifying correct schema validation for various valid and invalid `initialState` structures.
*   Added regression test cases covering malformed nested components (e.g. non-array formats, array containing null values) to ensure they fail validation gracefully.
*   Updated `docs/a2ui_protocol.md` to document the new `initialState` properties and added a complete JSON example illustrating a `CreateSurfaceMessage` using both components and a data model.
