### PR TITLE
Fix format script to work for Flutter packages

### DIFF
--- a/.github/workflows/enforce-formatting.yml
+++ b/.github/workflows/enforce-formatting.yml
@@ -39,8 +39,11 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Set up Dart SDK
-        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
+      - name: Set up Flutter SDK
+        uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e
+        with:
+          channel: stable
+          cache: true
 
       - name: Install `uv` globally
         run: |

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -52,7 +52,7 @@ cd "$REPO_ROOT"
 # Check if dart is available before running
 if command -v dart >/dev/null 2>&1; then
   echo "Resolving Dart workspace dependencies..."
-  flutter pub get || echo "Warning: 'dart pub get' failed. Formatting might have package resolution warnings."
+  flutter pub get || echo "Warning: 'flutter pub get' failed. Formatting might have package resolution warnings."
   if [ "$CHECK_ONLY" = true ]; then
     dart format --output=none --set-exit-if-changed .
   else

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -52,7 +52,7 @@ cd "$REPO_ROOT"
 # Check if dart is available before running
 if command -v dart >/dev/null 2>&1; then
   echo "Resolving Dart workspace dependencies..."
-  dart pub get || echo "Warning: 'dart pub get' failed. Formatting might have package resolution warnings."
+  flutter pub get || echo "Warning: 'dart pub get' failed. Formatting might have package resolution warnings."
   if [ "$CHECK_ONLY" = true ]; then
     dart format --output=none --set-exit-if-changed .
   else


### PR DESCRIPTION
# Description

Currently, the format script uses `dart pub get` to get the packages, but that doesn't work if the dart package is a Flutter package.  This fixes that.