### PR TITLE
refactor(react): use declarative HTML for known Text variants

### DIFF
--- a/renderers/react/CHANGELOG.md
+++ b/renderers/react/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - (v0_9) Tighten resolved child list types in the basic catalog layout components.
+- (v0_9) Render known Text variants (h1–h5, caption) with declarative HTML instead of Markdown. [#1516](https://github.com/google/A2UI/issues/1516)
 
 ## 0.10.0
 

--- a/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
@@ -25,6 +25,7 @@ import styles from './Text.module.css';
 /** Variants rendered with declarative HTML instead of the Markdown pipeline. */
 const NON_MARKDOWN_VARIANTS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'caption']);
 
+/** Renders text through the Markdown pipeline for unknown/default variants. */
 function MarkdownText({
   text,
   className,
@@ -37,13 +38,40 @@ function MarkdownText({
   const renderedHtml = useMarkdown(text);
   const classes = renderedHtml === null ? `${className} no-markdown-renderer` : className;
   const contentProps =
-    renderedHtml !== null
-      ? {dangerouslySetInnerHTML: {__html: renderedHtml}}
-      : {children: text};
+    renderedHtml !== null ? {dangerouslySetInnerHTML: {__html: renderedHtml}} : {children: text};
 
   return <div className={classes} style={style} {...contentProps} />;
 }
 
+/** Renders known variants (h1–h5, caption) as native HTML elements without Markdown. */
+function NonMarkdownText({
+  text,
+  variant,
+  className,
+  style,
+}: {
+  text: string;
+  variant: string;
+  className: string;
+  style: React.CSSProperties;
+}) {
+  const isCaption = variant === 'caption';
+  const HeadingTag = isCaption ? 'em' : (variant as 'h1' | 'h2' | 'h3' | 'h4' | 'h5');
+  if (isCaption) {
+    return (
+      <span className={className} style={style}>
+        <HeadingTag>{text}</HeadingTag>
+      </span>
+    );
+  }
+  return (
+    <div className={className} style={style}>
+      <HeadingTag>{text}</HeadingTag>
+    </div>
+  );
+}
+
+/** Renders text content, using the Markdown pipeline for rich text or native HTML elements for known typographic variants. */
 export const Text = createComponentImplementation(TextApi, ({props}) => {
   useBasicCatalogStyles();
   const text = typeof props.text === 'string' ? props.text : String(props.text ?? '');
@@ -56,22 +84,8 @@ export const Text = createComponentImplementation(TextApi, ({props}) => {
 
   if (variant && NON_MARKDOWN_VARIANTS.has(variant)) {
     const isCaption = variant === 'caption';
-    const className = [styles.a2uiText, isCaption ? styles.a2uiCaption : variant || 'body'].join(
-      ' ',
-    );
-    const HeadingTag = isCaption ? 'em' : (variant as 'h1' | 'h2' | 'h3' | 'h4' | 'h5');
-    if (isCaption) {
-      return (
-        <span className={className} style={style}>
-          <HeadingTag>{text}</HeadingTag>
-        </span>
-      );
-    }
-    return (
-      <div className={className} style={style}>
-        <HeadingTag>{text}</HeadingTag>
-      </div>
-    );
+    const className = [styles.a2uiText, isCaption ? styles.a2uiCaption : variant].join(' ');
+    return <NonMarkdownText text={text} variant={variant} className={className} style={style} />;
   }
 
   const className = [styles.a2uiText, variant || 'body'].join(' ');

--- a/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/Text.tsx
@@ -22,54 +22,58 @@ import {useMarkdown} from '../hooks/useMarkdown';
 // Import CSS Module
 import styles from './Text.module.css';
 
-/**
- * Wraps the plain text with appropriate Markdown syntax based on the requested variant.
- *
- * @param text The plain text to be wrapped.
- * @param variant The typography variant (e.g., 'h1', 'caption').
- * @returns The text wrapped in Markdown syntax.
- */
-const handleVariant = (text: string, variant?: string): string => {
-  switch (variant) {
-    case 'h1':
-      return `# ${text}`;
-    case 'h2':
-      return `## ${text}`;
-    case 'h3':
-      return `### ${text}`;
-    case 'h4':
-      return `#### ${text}`;
-    case 'h5':
-      return `##### ${text}`;
-    case 'caption':
-      return `*${text}*`;
-    default:
-      return text;
-  }
-};
+/** Variants rendered with declarative HTML instead of the Markdown pipeline. */
+const NON_MARKDOWN_VARIANTS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'caption']);
+
+function MarkdownText({
+  text,
+  className,
+  style,
+}: {
+  text: string;
+  className: string;
+  style: React.CSSProperties;
+}) {
+  const renderedHtml = useMarkdown(text);
+  const classes = renderedHtml === null ? `${className} no-markdown-renderer` : className;
+  const contentProps =
+    renderedHtml !== null
+      ? {dangerouslySetInnerHTML: {__html: renderedHtml}}
+      : {children: text};
+
+  return <div className={classes} style={style} {...contentProps} />;
+}
 
 export const Text = createComponentImplementation(TextApi, ({props}) => {
   useBasicCatalogStyles();
   const text = typeof props.text === 'string' ? props.text : String(props.text ?? '');
-  const markdownText = handleVariant(text, props.variant);
-  const renderedHtml = useMarkdown(markdownText);
+  const variant = props.variant;
+
   const style: React.CSSProperties = {
     ...getBaseLeafStyle(),
     ...getWeightStyle(props.weight),
   };
 
-  const isCaption = props.variant === 'caption';
-  const classes = [styles.a2uiText, isCaption ? styles.a2uiCaption : props.variant || 'body'];
-  if (renderedHtml === null) {
-    classes.push('no-markdown-renderer');
+  if (variant && NON_MARKDOWN_VARIANTS.has(variant)) {
+    const isCaption = variant === 'caption';
+    const className = [styles.a2uiText, isCaption ? styles.a2uiCaption : variant || 'body'].join(
+      ' ',
+    );
+    const HeadingTag = isCaption ? 'em' : (variant as 'h1' | 'h2' | 'h3' | 'h4' | 'h5');
+    if (isCaption) {
+      return (
+        <span className={className} style={style}>
+          <HeadingTag>{text}</HeadingTag>
+        </span>
+      );
+    }
+    return (
+      <div className={className} style={style}>
+        <HeadingTag>{text}</HeadingTag>
+      </div>
+    );
   }
-  const contentProps =
-    renderedHtml !== null
-      ? {dangerouslySetInnerHTML: {__html: renderedHtml}}
-      : {children: markdownText};
 
-  if (isCaption) {
-    return <span className={classes.join(' ')} style={style} {...contentProps} />;
-  }
-  return <div className={classes.join(' ')} style={style} {...contentProps} />;
+  const className = [styles.a2uiText, variant || 'body'].join(' ');
+  return <MarkdownText text={text} className={className} style={style} />;
 });

--- a/renderers/react/tests/v0_9/catalog-components.test.tsx
+++ b/renderers/react/tests/v0_9/catalog-components.test.tsx
@@ -68,7 +68,7 @@ describe('Basic Catalog Components', () => {
       const {view} = renderA2uiComponent(Text, 't1', {text: 'Title', variant: 'h1'});
       const h1 = view.container.querySelector('div.h1');
       expect(h1).not.toBeNull();
-      expect(h1?.textContent).toBe('# Title');
+      expect(h1?.textContent).toBe('Title');
     });
   });
 

--- a/renderers/react/tests/v0_9/catalog-components.test.tsx
+++ b/renderers/react/tests/v0_9/catalog-components.test.tsx
@@ -66,7 +66,7 @@ describe('Basic Catalog Components', () => {
 
     it('renders with correct heading tag based on variant', () => {
       const {view} = renderA2uiComponent(Text, 't1', {text: 'Title', variant: 'h1'});
-      const h1 = view.container.querySelector('div.h1');
+      const h1 = view.container.querySelector('div.h1 h1');
       expect(h1).not.toBeNull();
       expect(h1?.textContent).toBe('Title');
     });

--- a/renderers/react/tests/v0_9/integration-scenarios.test.tsx
+++ b/renderers/react/tests/v0_9/integration-scenarios.test.tsx
@@ -38,7 +38,7 @@ describe('Gallery Integration Tests', () => {
       </React.StrictMode>,
     );
 
-    expect(screen.getByText('### Markdown Rendering')).toBeInTheDocument();
+    expect(screen.getByText('Markdown Rendering')).toBeInTheDocument();
   });
 
   it('renders Task Card -> content visibility', async () => {
@@ -54,8 +54,8 @@ describe('Gallery Integration Tests', () => {
       </React.StrictMode>,
     );
 
-    expect(screen.getByText('### Review pull request')).toBeInTheDocument();
-    expect(screen.getByText('*Backend*')).toBeInTheDocument();
+    expect(screen.getByText('Review pull request')).toBeInTheDocument();
+    expect(screen.getByText('Backend')).toBeInTheDocument();
   });
 
   it('handles Login form -> input updates data model', async () => {


### PR DESCRIPTION
# Description

Refactors React v0.9 Text component to render known variants (h1–h5, caption) using declarative HTML elements instead of prepending Markdown syntax (`# `, `## `, `*...*`) and relying on the injected MarkdownRenderer. This aligns the React renderer with the Angular fix in #1502.

Markdown rendering is still used for unknown/default variants (like 'body').

* Fixes: #1516

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
