### PR TITLE
Updates the PartConverter to support versioning.

### DIFF
--- a/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
+++ b/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
@@ -68,7 +68,7 @@ class A2uiPartConverter:
       a2ui_catalog: A2uiCatalog,
       bypass_tool_check: bool = False,
       fallback_text: Optional[str] = None,
-      version: str = "0.8",
+      version: str = constants.VERSION_0_8,
   ):
     self._catalog = a2ui_catalog
     self._bypass_tool_check = bypass_tool_check

--- a/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
+++ b/agent_sdks/python/src/a2ui/adk/a2a/part_converter.py
@@ -55,6 +55,12 @@ class A2uiPartConverter:
   This converter handles both tool-based A2UI (via `send_a2ui_json_to_client`)
   and text-based A2UI (via A2UI delimiter tags). It uses the provided
   catalog to validate and fix JSON payloads.
+
+  Args:
+      a2ui_catalog: The A2UI catalog.
+      bypass_tool_check: If True, bypass tool validation.
+      fallback_text: Optional text to fall back on if parsing fails.
+      version: The A2UI version to use. Defaults to "0.8".
   """
 
   def __init__(
@@ -62,10 +68,12 @@ class A2uiPartConverter:
       a2ui_catalog: A2uiCatalog,
       bypass_tool_check: bool = False,
       fallback_text: Optional[str] = None,
+      version: str = "0.8",
   ):
     self._catalog = a2ui_catalog
     self._bypass_tool_check = bypass_tool_check
     self._fallback_text = fallback_text
+    self._version = version
 
   def convert(self, part: genai_types.Part) -> list[a2a_types.Part]:
     """Converts a GenAI part to A2A parts, with A2UI validation.
@@ -97,7 +105,10 @@ class A2uiPartConverter:
         ):
           json_data = response_dict.get(constants.A2UI_VALIDATED_JSON_KEY)
           if json_data:
-            return [create_a2ui_part(message) for message in json_data]
+            return [
+                create_a2ui_part(message, version=self._version)
+                for message in json_data
+            ]
 
         if is_send_a2ui_json_to_client_response:
           logger.info("No result in A2UI tool response")
@@ -111,6 +122,7 @@ class A2uiPartConverter:
               result,
               validator=self._catalog.validator,
               fallback_text=self._fallback_text,
+              version=self._version,
           )
 
     # 2. Handle Tool Calls (FunctionCall) - Skip sending to client
@@ -126,6 +138,7 @@ class A2uiPartConverter:
             text,
             validator=self._catalog.validator,
             fallback_text=self._fallback_text,
+            version=self._version,
         )
 
     # 4. Default conversion for other parts

--- a/agent_sdks/python/tests/adk/a2a/test_part_converter.py
+++ b/agent_sdks/python/tests/adk/a2a/test_part_converter.py
@@ -24,7 +24,7 @@ from a2ui.a2a.parts import create_a2ui_part
 from a2ui.adk.a2a.part_converter import A2uiPartConverter
 from a2ui.adk.send_a2ui_to_client_toolset import SendA2uiToClientToolset
 from a2ui.schema.catalog import A2uiCatalog
-from a2ui.schema.constants import A2UI_CLOSE_TAG, A2UI_OPEN_TAG
+from a2ui.schema.constants import A2UI_CLOSE_TAG, A2UI_OPEN_TAG, VERSION_0_8, VERSION_0_9_1
 from google.genai import types as genai_types
 
 
@@ -45,7 +45,27 @@ def test_converter_class_convert_valid_tool_response():
 
   a2a_parts = converter.convert(part)
   assert len(a2a_parts) == 1
-  assert a2a_parts[0] == create_a2ui_part(valid_a2ui)
+  assert a2a_parts[0] == create_a2ui_part(valid_a2ui, version=VERSION_0_8)
+
+
+def test_converter_class_convert_valid_tool_response_v0_9_1():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  converter = A2uiPartConverter(catalog_mock, version=VERSION_0_9_1)
+
+  valid_a2ui = {"type": "Text", "text": "Hello"}
+  function_response = genai_types.FunctionResponse(
+      name=SendA2uiToClientToolset._SendA2uiJsonToClientTool.TOOL_NAME,
+      response={
+          SendA2uiToClientToolset._SendA2uiJsonToClientTool.VALIDATED_A2UI_JSON_KEY: [
+              valid_a2ui
+          ]
+      },
+  )
+  part = genai_types.Part(function_response=function_response)
+
+  a2a_parts = converter.convert(part)
+  assert len(a2a_parts) == 1
+  assert a2a_parts[0] == create_a2ui_part(valid_a2ui, version=VERSION_0_9_1)
 
 
 def test_converter_class_convert_tool_error_response():
@@ -107,7 +127,26 @@ def test_converter_class_convert_text_with_a2ui():
   # Expect 2 parts: TextPart and A2UI DataPart
   assert len(a2a_parts) == 2
   assert a2a_parts[0].root.text == "Here is the UI:"
-  assert a2a_parts[1] == create_a2ui_part(valid_a2ui[0])
+  assert a2a_parts[1] == create_a2ui_part(valid_a2ui[0], version=VERSION_0_8)
+  catalog_mock.validator.validate.assert_called_once_with(valid_a2ui)
+
+
+def test_converter_class_convert_text_with_a2ui_v0_9_1():
+  catalog_mock = MagicMock(spec=A2uiCatalog)
+  converter = A2uiPartConverter(catalog_mock, version=VERSION_0_9_1)
+
+  valid_a2ui = [{"type": "Text", "text": "Hello"}]
+  catalog_mock.validator.validate.return_value = None
+
+  text = f"Here is the UI:\n{A2UI_OPEN_TAG}\n{json.dumps(valid_a2ui)}\n{A2UI_CLOSE_TAG}"
+  part = genai_types.Part(text=text)
+
+  a2a_parts = converter.convert(part)
+
+  # Expect 2 parts: TextPart and A2UI DataPart
+  assert len(a2a_parts) == 2
+  assert a2a_parts[0].root.text == "Here is the UI:"
+  assert a2a_parts[1] == create_a2ui_part(valid_a2ui[0], version=VERSION_0_9_1)
   catalog_mock.validator.validate.assert_called_once_with(valid_a2ui)
 
 
@@ -123,7 +162,7 @@ def test_converter_class_convert_text_empty_leading():
   a2a_parts = converter.convert(part)
 
   assert len(a2a_parts) == 1
-  assert a2a_parts[0] == create_a2ui_part(ui[0])
+  assert a2a_parts[0] == create_a2ui_part(ui[0], version=VERSION_0_8)
 
 
 def test_converter_class_convert_text_markdown_wrapped():
@@ -140,7 +179,7 @@ def test_converter_class_convert_text_markdown_wrapped():
 
   assert len(a2a_parts) == 2
   assert a2a_parts[0].root.text == "Behold:"
-  assert a2a_parts[1] == create_a2ui_part(ui[0])
+  assert a2a_parts[1] == create_a2ui_part(ui[0], version=VERSION_0_8)
   catalog_mock.validator.validate.assert_called_once_with(ui)
 
 
@@ -197,7 +236,7 @@ def test_converter_class_convert_tool_response_with_result_containing_a2ui():
   # Expect 2 parts: TextPart and A2UI DataPart
   assert len(a2a_parts) == 2
   assert a2a_parts[0].root.text == "Here is the result:"
-  assert a2a_parts[1] == create_a2ui_part(valid_a2ui[0])
+  assert a2a_parts[1] == create_a2ui_part(valid_a2ui[0], version=VERSION_0_8)
   catalog_mock.validator.validate.assert_called_once_with(valid_a2ui)
 
 


### PR DESCRIPTION
1. Adds a version parameter to the PartConverter constructor, defaulting to "0.8", the version used by Gemini Enterprise and most existing agents.
2. Propagates the version to calls to create_a2ui_part and parse_response_to_parts.