### PR TITLE
spec(v0_10): specify that surfaceId must be globally unique per client session

### DIFF
--- a/docs/reference/messages.md
+++ b/docs/reference/messages.md
@@ -374,7 +374,8 @@ Add or update components within a surface.
 
 | Error                  | Cause                                  | Solution                                                                                                               |
 | ---------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Surface not found      | `surfaceId` does not exist             | Ensure a unique `surfaceId` is used consistently for a given surface. Surfaces are implicitly created on first update. |
+| Surface already exists | `surfaceId` is already in use          | Ensure a unique `surfaceId` is used for `createSurface`. If using an orchestrator with subagents, the orchestrator is empowered to manage surface IDs as they wish to avoid conflicts. |
+| Surface not found      | `surfaceId` does not exist             | Ensure `surfaceId` matches the created surface. In v0.8, surfaces are implicit, but v0.9 requires `createSurface`.     |
 | Invalid component type | Unknown component type                 | Check component type exists in the negotiated catalog.                                                                 |
 | Invalid property       | Property doesn't exist for this type   | Verify against catalog schema.                                                                                         |
 | Circular reference     | Component references itself as a child | Fix component hierarchy.                                                                                               |

--- a/docs/reference/messages.md
+++ b/docs/reference/messages.md
@@ -372,13 +372,13 @@ Add or update components within a surface.
 
 ### Errors
 
-| Error                  | Cause                                  | Solution                                                                                                               |
-| ---------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Surface already exists | `surfaceId` is already in use          | Ensure `surfaceId` is globally unique for the renderer instance's lifetime. If using an orchestrator with subagents, the orchestrator is empowered to manage surface IDs as needed to avoid conflicts. |
-| Surface not found      | `surfaceId` does not exist             | Ensure `surfaceId` matches the created surface. In v0.8, surfaces are implicit, but v0.9+ requires `createSurface`.     |
-| Invalid component type | Unknown component type                 | Check component type exists in the negotiated catalog.                                                                 |
-| Invalid property       | Property doesn't exist for this type   | Verify against catalog schema.                                                                                         |
-| Circular reference     | Component references itself as a child | Fix component hierarchy.                                                                                               |
+| Error                  | Cause                                  | Solution                                                                                                                                                                                      |
+| ---------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Surface already exists | `surfaceId` is already in use          | Ensure `surfaceId` is globally unique for the renderer's lifetime. If using an orchestrator with subagents, the orchestrator is empowered to manage surface IDs as needed to avoid conflicts. |
+| Surface not found      | `surfaceId` does not exist             | Ensure `surfaceId` matches the created surface. In v0.8, surfaces are implicit, but v0.9+ requires `createSurface`.                                                                           |
+| Invalid component type | Unknown component type                 | Check component type exists in the negotiated catalog.                                                                                                                                        |
+| Invalid property       | Property doesn't exist for this type   | Verify against catalog schema.                                                                                                                                                                |
+| Circular reference     | Component references itself as a child | Fix component hierarchy.                                                                                                                                                                      |
 
 ---
 

--- a/docs/reference/messages.md
+++ b/docs/reference/messages.md
@@ -374,8 +374,8 @@ Add or update components within a surface.
 
 | Error                  | Cause                                  | Solution                                                                                                               |
 | ---------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Surface already exists | `surfaceId` is already in use          | Ensure `surfaceId` is globally unique for the renderer instance's lifetime. If using an orchestrator with subagents, the orchestrator is empowered to manage surface IDs to avoid conflicts. |
-| Surface not found      | `surfaceId` does not exist             | Ensure `surfaceId` matches the created surface. In v0.8, surfaces are implicit, but v0.9 requires `createSurface`.     |
+| Surface already exists | `surfaceId` is already in use          | Ensure `surfaceId` is globally unique for the renderer instance's lifetime. If using an orchestrator with subagents, the orchestrator is empowered to manage surface IDs as needed to avoid conflicts. |
+| Surface not found      | `surfaceId` does not exist             | Ensure `surfaceId` matches the created surface. In v0.8, surfaces are implicit, but v0.9+ requires `createSurface`.     |
 | Invalid component type | Unknown component type                 | Check component type exists in the negotiated catalog.                                                                 |
 | Invalid property       | Property doesn't exist for this type   | Verify against catalog schema.                                                                                         |
 | Circular reference     | Component references itself as a child | Fix component hierarchy.                                                                                               |

--- a/specification/v0_10/docs/a2ui_protocol.md
+++ b/specification/v0_10/docs/a2ui_protocol.md
@@ -175,7 +175,7 @@ The envelope defines several message types, and every message streamed by the se
 
 This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated.
 
-It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it; `surfaceId` must be globally unique for the renderer instance's lifetime. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (e.g., prefixing the subagent's name to the `surfaceId` or requiring subagents to use UUIDs).
+It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it; `surfaceId` must be globally unique for the renderer instance's lifetime. Orchestrators with subagents are empowered to manage surface IDs as needed to prevent conflicts (e.g., prefixing the subagent's name to the `surfaceId` or requiring subagents to use UUIDs).
 
 One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 

--- a/specification/v0_10/docs/a2ui_protocol.md
+++ b/specification/v0_10/docs/a2ui_protocol.md
@@ -175,7 +175,7 @@ The envelope defines several message types, and every message streamed by the se
 
 This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated.
 
-It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (eg, prefixing the subagent's name to the `surfaceId`).
+It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (eg, requiring UUIDs or prefixing the subagent's name to the `surfaceId or requiring subagents to use UUIDs).
 
 One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 

--- a/specification/v0_10/docs/a2ui_protocol.md
+++ b/specification/v0_10/docs/a2ui_protocol.md
@@ -175,13 +175,13 @@ The envelope defines several message types, and every message streamed by the se
 
 This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated.
 
-It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it; `surfaceId` must be globally unique for the renderer instance's lifetime. Orchestrators with subagents are empowered to manage surface IDs as needed to prevent conflicts (e.g., prefixing the subagent's name to the `surfaceId` or requiring subagents to use UUIDs).
+It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it; `surfaceId` must be globally unique for the renderer's lifetime. Orchestrators with subagents are empowered to manage surface IDs as needed to prevent conflicts (e.g., prefixing the subagent's name to the `surfaceId` or requiring subagents to use UUIDs).
 
 One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 
 **Properties:**
 
-- `surfaceId` (string, required): The unique identifier for the UI surface to be rendered. This must be globally unique for the renderer instance's lifetime.
+- `surfaceId` (string, required): The unique identifier for the UI surface to be rendered. This must be globally unique for the renderer's lifetime.
 - `catalogId` (string, required): A string that uniquely identifies the catalog (components and functions) used for this surface. It is recommended to prefix this with an internet domain that you own, to avoid conflicts (e.g., `https://mycompany.com/1.0/somecatalog`). If it is a URL, the URL does not need to have any deployed resources, it is simply a unique identifier.
 - `surfaceProperties` (object, optional): A JSON object containing surface properties (e.g., `agentDisplayName`) defined in the catalog's surfaceProperties schema.
 - `sendDataModel` (boolean, optional): If true, the client will send the full data model of this surface in the metadata of every message sent to the server (via the Transport's metadata mechanism). This ensures the surface owner receives the full current state of the UI alongside the user's action or query. Defaults to false.
@@ -225,7 +225,7 @@ This message provides a list of UI components to be added to or updated within a
 
 **Properties:**
 
-- `surfaceId` (string, required): The unique identifier for the UI surface to be updated. This must be globally unique for the renderer instance's lifetime.
+- `surfaceId` (string, required): The unique identifier for the UI surface to be updated. This must be globally unique for the renderer's lifetime.
 - `components` (array, required): A list of component objects. The components are provided as a flat list, and their relationships are defined by ID references in an adjacency list.
 
 **Example:**
@@ -262,7 +262,7 @@ This message is used to send or update the data that populates the UI components
 
 **Properties:**
 
-- `surfaceId` (string, required): The unique identifier for the UI surface this data model update applies to. This must be globally unique for the renderer instance's lifetime.
+- `surfaceId` (string, required): The unique identifier for the UI surface this data model update applies to. This must be globally unique for the renderer's lifetime.
 - `path` (string, optional): A JSON Pointer to the location in the data model to update. Defaults to `/`.
 - `value` (any, optional): The new value for the specified path. If omitted, the key at `path` is removed.
 
@@ -285,7 +285,7 @@ This message instructs the client to remove a surface and all its associated com
 
 **Properties:**
 
-- `surfaceId` (string, required): The unique identifier for the UI surface to be deleted. This must be globally unique for the renderer instance's lifetime.
+- `surfaceId` (string, required): The unique identifier for the UI surface to be deleted. This must be globally unique for the renderer's lifetime.
 
 **Example:**
 

--- a/specification/v0_10/docs/a2ui_protocol.md
+++ b/specification/v0_10/docs/a2ui_protocol.md
@@ -173,11 +173,11 @@ The envelope defines several message types, and every message streamed by the se
 
 ### `createSurface`
 
-This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated. It is an error to try to create a surface with the same ID twice without first deleting it; `surfaceId` must be globally unique per client session. One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
+This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated. It is an error to try to create a surface with the same ID twice without first deleting it; `surfaceId` must be globally unique for the renderer instance's lifetime. One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 
 **Properties:**
 
-- `surfaceId` (string, required): The unique identifier for the UI surface to be rendered. This must be globally unique within the client session.
+- `surfaceId` (string, required): The unique identifier for the UI surface to be rendered. This must be globally unique for the renderer instance's lifetime.
 - `catalogId` (string, required): A string that uniquely identifies the catalog (components and functions) used for this surface. It is recommended to prefix this with an internet domain that you own, to avoid conflicts (e.g., `https://mycompany.com/1.0/somecatalog`). If it is a URL, the URL does not need to have any deployed resources, it is simply a unique identifier.
 - `surfaceProperties` (object, optional): A JSON object containing surface properties (e.g., `agentDisplayName`) defined in the catalog's surfaceProperties schema.
 - `sendDataModel` (boolean, optional): If true, the client will send the full data model of this surface in the metadata of every message sent to the server (via the Transport's metadata mechanism). This ensures the surface owner receives the full current state of the UI alongside the user's action or query. Defaults to false.
@@ -221,7 +221,7 @@ This message provides a list of UI components to be added to or updated within a
 
 **Properties:**
 
-- `surfaceId` (string, required): The unique identifier for the UI surface to be updated. This must be globally unique within the client session.
+- `surfaceId` (string, required): The unique identifier for the UI surface to be updated. This must be globally unique for the renderer instance's lifetime.
 - `components` (array, required): A list of component objects. The components are provided as a flat list, and their relationships are defined by ID references in an adjacency list.
 
 **Example:**
@@ -258,7 +258,7 @@ This message is used to send or update the data that populates the UI components
 
 **Properties:**
 
-- `surfaceId` (string, required): The unique identifier for the UI surface this data model update applies to. This must be globally unique within the client session.
+- `surfaceId` (string, required): The unique identifier for the UI surface this data model update applies to. This must be globally unique for the renderer instance's lifetime.
 - `path` (string, optional): A JSON Pointer to the location in the data model to update. Defaults to `/`.
 - `value` (any, optional): The new value for the specified path. If omitted, the key at `path` is removed.
 
@@ -281,7 +281,7 @@ This message instructs the client to remove a surface and all its associated com
 
 **Properties:**
 
-- `surfaceId` (string, required): The unique identifier for the UI surface to be deleted. This must be globally unique within the client session.
+- `surfaceId` (string, required): The unique identifier for the UI surface to be deleted. This must be globally unique for the renderer instance's lifetime.
 
 **Example:**
 

--- a/specification/v0_10/docs/a2ui_protocol.md
+++ b/specification/v0_10/docs/a2ui_protocol.md
@@ -173,7 +173,11 @@ The envelope defines several message types, and every message streamed by the se
 
 ### `createSurface`
 
-This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated. It is an error to send `createSurface` for a `surfaceId` that already exists without first deleting it. One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
+This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated.
+
+It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (eg, prefixing the subagent's name to the `surfaceId`).
+
+One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 
 **Properties:**
 

--- a/specification/v0_10/docs/a2ui_protocol.md
+++ b/specification/v0_10/docs/a2ui_protocol.md
@@ -173,11 +173,11 @@ The envelope defines several message types, and every message streamed by the se
 
 ### `createSurface`
 
-This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated. It is an error to send `createSurface` for a `surfaceId` that already exists without first deleting it. One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
+This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated. It is an error to try to create a surface with the same ID twice without first deleting it; `surfaceId` must be globally unique per client session. One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 
 **Properties:**
 
-- `surfaceId` (string, required): The unique identifier for the UI surface to be rendered.
+- `surfaceId` (string, required): The unique identifier for the UI surface to be rendered. This must be globally unique within the client session.
 - `catalogId` (string, required): A string that uniquely identifies the catalog (components and functions) used for this surface. It is recommended to prefix this with an internet domain that you own, to avoid conflicts (e.g., `https://mycompany.com/1.0/somecatalog`). If it is a URL, the URL does not need to have any deployed resources, it is simply a unique identifier.
 - `surfaceProperties` (object, optional): A JSON object containing surface properties (e.g., `agentDisplayName`) defined in the catalog's surfaceProperties schema.
 - `sendDataModel` (boolean, optional): If true, the client will send the full data model of this surface in the metadata of every message sent to the server (via the Transport's metadata mechanism). This ensures the surface owner receives the full current state of the UI alongside the user's action or query. Defaults to false.
@@ -221,7 +221,7 @@ This message provides a list of UI components to be added to or updated within a
 
 **Properties:**
 
-- `surfaceId` (string, required): The unique identifier for the UI surface to be updated. This is typically a name with meaning (e.g. "user_profile_card"), and it has to be unique within the context of the GenUI session.
+- `surfaceId` (string, required): The unique identifier for the UI surface to be updated. This must be globally unique within the client session.
 - `components` (array, required): A list of component objects. The components are provided as a flat list, and their relationships are defined by ID references in an adjacency list.
 
 **Example:**
@@ -258,7 +258,7 @@ This message is used to send or update the data that populates the UI components
 
 **Properties:**
 
-- `surfaceId` (string, required): The unique identifier for the UI surface this data model update applies to.
+- `surfaceId` (string, required): The unique identifier for the UI surface this data model update applies to. This must be globally unique within the client session.
 - `path` (string, optional): A JSON Pointer to the location in the data model to update. Defaults to `/`.
 - `value` (any, optional): The new value for the specified path. If omitted, the key at `path` is removed.
 
@@ -281,7 +281,7 @@ This message instructs the client to remove a surface and all its associated com
 
 **Properties:**
 
-- `surfaceId` (string, required): The unique identifier for the UI surface to be deleted.
+- `surfaceId` (string, required): The unique identifier for the UI surface to be deleted. This must be globally unique within the client session.
 
 **Example:**
 

--- a/specification/v0_10/docs/evolution_guide.md
+++ b/specification/v0_10/docs/evolution_guide.md
@@ -41,7 +41,7 @@ Version 0.10 differs from 0.9 in the following ways:
 
 ### 2.7. Processing Rules
 
-- <TBD>
+- Explicitly specified that `surfaceId` must be globally unique per client session. Creating a surface with an ID that already exists (without first deleting it) is an error.
 
 ### 2.8. Server-to-Client Messages
 

--- a/specification/v0_10/docs/evolution_guide.md
+++ b/specification/v0_10/docs/evolution_guide.md
@@ -41,7 +41,7 @@ Version 0.10 differs from 0.9 in the following ways:
 
 ### 2.7. Processing Rules
 
-- Explicitly specified that `surfaceId` must be globally unique per client session. Creating a surface with an ID that already exists (without first deleting it) is an error.
+- <TBD>
 
 ### 2.8. Server-to-Client Messages
 

--- a/specification/v0_10/eval/src/test_validator.ts
+++ b/specification/v0_10/eval/src/test_validator.ts
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {Validator} from './validator';
+import {GeneratedResult} from './types';
+
+const schemaFiles = [
+  '../../json/common_types.json',
+  '../../catalogs/basic/catalog.json',
+  '../../json/server_to_client.json',
+];
+
+function loadSchemas(): Record<string, any> {
+  const schemas: Record<string, any> = {};
+  for (const file of schemaFiles) {
+    const schemaString = fs.readFileSync(path.join(__dirname, file), 'utf-8');
+    const schema = JSON.parse(schemaString);
+    const key = file.replace('../../', '');
+    schemas[key] = schema;
+  }
+
+  if (schemas['catalogs/basic/catalog.json']) {
+    const catalogSchema = JSON.parse(JSON.stringify(schemas['catalogs/basic/catalog.json']));
+    if (catalogSchema['$id']) {
+      catalogSchema['$id'] = catalogSchema['$id'].replace(
+        /catalogs\/basic\/catalog\.json$/,
+        'catalog.json',
+      );
+    }
+    schemas['catalog.json'] = catalogSchema;
+  }
+
+  return schemas;
+}
+
+async function runTests() {
+  const schemas = loadSchemas();
+  const validator = new Validator(schemas);
+
+  const mockPrompt = {name: 'test_prompt', systemPrompt: '', userPrompt: ''};
+
+  const testCases: {
+    name: string;
+    messages: any[];
+    expectedErrors: string[];
+  }[] = [
+    {
+      name: 'Valid flow (create, update components, update data model, delete)',
+      messages: [
+        {
+          version: 'v0.10',
+          createSurface: {
+            surfaceId: 'surf1',
+            catalogId: 'https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json',
+            components: [
+              {
+                id: 'root',
+                component: 'Text',
+                text: 'Hello World',
+              },
+            ],
+          },
+        },
+        {
+          version: 'v0.10',
+          updateComponents: {
+            surfaceId: 'surf1',
+            components: [
+              {
+                id: 'root',
+                component: 'Text',
+                text: 'Hello Updated',
+              },
+            ],
+          },
+        },
+        {
+          version: 'v0.10',
+          updateDataModel: {
+            surfaceId: 'surf1',
+            path: '/name',
+            value: 'Alice',
+          },
+        },
+        {
+          version: 'v0.10',
+          deleteSurface: {
+            surfaceId: 'surf1',
+          },
+        },
+      ],
+      expectedErrors: [],
+    },
+    {
+      name: 'Duplicate createSurface',
+      messages: [
+        {
+          version: 'v0.10',
+          createSurface: {
+            surfaceId: 'surf2',
+            catalogId: 'https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json',
+            components: [
+              {
+                id: 'root',
+                component: 'Text',
+                text: 'Hello',
+              },
+            ],
+          },
+        },
+        {
+          version: 'v0.10',
+          createSurface: {
+            surfaceId: 'surf2',
+            catalogId: 'https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json',
+            components: [
+              {
+                id: 'root',
+                component: 'Text',
+                text: 'Hello 2',
+              },
+            ],
+          },
+        },
+      ],
+      expectedErrors: [
+        "Duplicate createSurface message received for surface 'surf2' without prior deleteSurface.",
+      ],
+    },
+    {
+      name: 'updateComponents before createSurface',
+      messages: [
+        {
+          version: 'v0.10',
+          updateComponents: {
+            surfaceId: 'surf3',
+            components: [
+              {
+                id: 'root',
+                component: 'Text',
+                text: 'Hello',
+              },
+            ],
+          },
+        },
+      ],
+      expectedErrors: [
+        "updateComponents message received for surface 'surf3' before createSurface message.",
+        "updateComponents message received for inactive or deleted surface 'surf3'.",
+      ],
+    },
+    {
+      name: 'updateComponents after deleteSurface',
+      messages: [
+        {
+          version: 'v0.10',
+          createSurface: {
+            surfaceId: 'surf4',
+            catalogId: 'https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json',
+            components: [
+              {
+                id: 'root',
+                component: 'Text',
+                text: 'Hello',
+              },
+            ],
+          },
+        },
+        {
+          version: 'v0.10',
+          deleteSurface: {
+            surfaceId: 'surf4',
+          },
+        },
+        {
+          version: 'v0.10',
+          updateComponents: {
+            surfaceId: 'surf4',
+            components: [
+              {
+                id: 'root',
+                component: 'Text',
+                text: 'Updated Hello',
+              },
+            ],
+          },
+        },
+      ],
+      expectedErrors: [
+        "updateComponents message received for inactive or deleted surface 'surf4'.",
+      ],
+    },
+    {
+      name: 'updateDataModel after deleteSurface',
+      messages: [
+        {
+          version: 'v0.10',
+          createSurface: {
+            surfaceId: 'surf5',
+            catalogId: 'https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json',
+            components: [
+              {
+                id: 'root',
+                component: 'Text',
+                text: 'Hello',
+              },
+            ],
+          },
+        },
+        {
+          version: 'v0.10',
+          deleteSurface: {
+            surfaceId: 'surf5',
+          },
+        },
+        {
+          version: 'v0.10',
+          updateDataModel: {
+            surfaceId: 'surf5',
+            path: '/name',
+            value: 'Bob',
+          },
+        },
+      ],
+      expectedErrors: ["updateDataModel message received for inactive or deleted surface 'surf5'."],
+    },
+    {
+      name: 'deleteSurface twice',
+      messages: [
+        {
+          version: 'v0.10',
+          createSurface: {
+            surfaceId: 'surf6',
+            catalogId: 'https://a2ui.org/specification/v0_10/catalogs/basic/catalog.json',
+            components: [
+              {
+                id: 'root',
+                component: 'Text',
+                text: 'Hello',
+              },
+            ],
+          },
+        },
+        {
+          version: 'v0.10',
+          deleteSurface: {
+            surfaceId: 'surf6',
+          },
+        },
+        {
+          version: 'v0.10',
+          deleteSurface: {
+            surfaceId: 'surf6',
+          },
+        },
+      ],
+      expectedErrors: [
+        "deleteSurface message received for inactive or non-existent surface 'surf6'.",
+      ],
+    },
+  ];
+
+  let anyFailed = false;
+
+  for (const tc of testCases) {
+    const inputResult: GeneratedResult = {
+      modelName: 'test-model',
+      prompt: mockPrompt,
+      runNumber: 1,
+      components: tc.messages,
+      latency: 100,
+    };
+
+    const validated = await validator.run([inputResult]);
+    const validationErrors = validated[0].validationErrors;
+
+    const matchedAll =
+      tc.expectedErrors.every(expected => validationErrors.some(err => err.includes(expected))) &&
+      validationErrors.length === tc.expectedErrors.length;
+
+    if (matchedAll) {
+      console.log(`PASS: ${tc.name}`);
+    } else {
+      console.error(`FAIL: ${tc.name}`);
+      console.error(`  Expected errors containing: ${JSON.stringify(tc.expectedErrors)}`);
+      console.error(`  Actual validation errors:   ${JSON.stringify(validationErrors)}`);
+      anyFailed = true;
+    }
+  }
+
+  if (anyFailed) {
+    process.exit(1);
+  } else {
+    console.log('All validator unit tests passed!');
+  }
+}
+
+runTests().catch(console.error);

--- a/specification/v0_10/eval/src/test_validator.ts
+++ b/specification/v0_10/eval/src/test_validator.ts
@@ -52,7 +52,11 @@ async function runTests() {
   const schemas = loadSchemas();
   const validator = new Validator(schemas);
 
-  const mockPrompt = {name: 'test_prompt', systemPrompt: '', userPrompt: ''};
+  const mockPrompt = {
+    name: 'test_prompt',
+    description: 'test description',
+    promptText: 'test prompt',
+  };
 
   const testCases: {
     name: string;
@@ -161,7 +165,22 @@ async function runTests() {
       ],
       expectedErrors: [
         "updateComponents message received for surface 'surf3' before createSurface message.",
-        "updateComponents message received for inactive or deleted surface 'surf3'.",
+      ],
+    },
+    {
+      name: 'updateDataModel before createSurface',
+      messages: [
+        {
+          version: 'v0.10',
+          updateDataModel: {
+            surfaceId: 'surf3_dm',
+            path: '/name',
+            value: 'Bob',
+          },
+        },
+      ],
+      expectedErrors: [
+        "updateDataModel message received for surface 'surf3_dm' before createSurface message.",
       ],
     },
     {

--- a/specification/v0_10/eval/src/validator.ts
+++ b/specification/v0_10/eval/src/validator.ts
@@ -273,7 +273,7 @@ export class Validator {
             `updateComponents message received for surface '${surfaceId}' before createSurface message.`,
           );
         }
-        if (surfaceId && !activeSurfaces.has(surfaceId)) {
+        if (surfaceId && createdSurfaces.has(surfaceId) && !activeSurfaces.has(surfaceId)) {
           errors.push(
             `updateComponents message received for inactive or deleted surface '${surfaceId}'.`,
           );
@@ -322,15 +322,16 @@ export class Validator {
       } else if (message.updateDataModel) {
         this.validateUpdateDataModel(message.updateDataModel, errors);
         const surfaceId = message.updateDataModel.surfaceId;
-        if (surfaceId && !createdSurfaces.has(surfaceId)) {
-          errors.push(
-            `updateDataModel message received for surface '${surfaceId}' before createSurface message.`,
-          );
-        }
-        if (surfaceId && !activeSurfaces.has(surfaceId)) {
-          errors.push(
-            `updateDataModel message received for inactive or deleted surface '${surfaceId}'.`,
-          );
+        if (surfaceId) {
+          if (!createdSurfaces.has(surfaceId)) {
+            errors.push(
+              `updateDataModel message received for surface '${surfaceId}' before createSurface message.`,
+            );
+          } else if (!activeSurfaces.has(surfaceId)) {
+            errors.push(
+              `updateDataModel message received for inactive or deleted surface '${surfaceId}'.`,
+            );
+          }
         }
       } else if (message.deleteSurface) {
         this.validateDeleteSurface(message.deleteSurface, errors);

--- a/specification/v0_10/eval/src/validator.ts
+++ b/specification/v0_10/eval/src/validator.ts
@@ -262,6 +262,7 @@ export class Validator {
     let hasUpdateComponents = false;
     let hasRootComponent = false;
     const createdSurfaces = new Set<string>();
+    const activeSurfaces = new Set<string>();
 
     for (const message of messages) {
       if (message.updateComponents) {
@@ -270,6 +271,11 @@ export class Validator {
         if (surfaceId && !createdSurfaces.has(surfaceId)) {
           errors.push(
             `updateComponents message received for surface '${surfaceId}' before createSurface message.`,
+          );
+        }
+        if (surfaceId && !activeSurfaces.has(surfaceId)) {
+          errors.push(
+            `updateComponents message received for inactive or deleted surface '${surfaceId}'.`,
           );
         }
 
@@ -287,7 +293,13 @@ export class Validator {
         this.validateCreateSurface(message.createSurface, errors);
         const surfaceId = message.createSurface.surfaceId;
         if (surfaceId) {
+          if (activeSurfaces.has(surfaceId)) {
+            errors.push(
+              `Duplicate createSurface message received for surface '${surfaceId}' without prior deleteSurface.`,
+            );
+          }
           createdSurfaces.add(surfaceId);
+          activeSurfaces.add(surfaceId);
         }
 
         const createSurface = message.createSurface;
@@ -309,8 +321,28 @@ export class Validator {
         }
       } else if (message.updateDataModel) {
         this.validateUpdateDataModel(message.updateDataModel, errors);
+        const surfaceId = message.updateDataModel.surfaceId;
+        if (surfaceId && !createdSurfaces.has(surfaceId)) {
+          errors.push(
+            `updateDataModel message received for surface '${surfaceId}' before createSurface message.`,
+          );
+        }
+        if (surfaceId && !activeSurfaces.has(surfaceId)) {
+          errors.push(
+            `updateDataModel message received for inactive or deleted surface '${surfaceId}'.`,
+          );
+        }
       } else if (message.deleteSurface) {
         this.validateDeleteSurface(message.deleteSurface, errors);
+        const surfaceId = message.deleteSurface.surfaceId;
+        if (surfaceId) {
+          if (!activeSurfaces.has(surfaceId)) {
+            errors.push(
+              `deleteSurface message received for inactive or non-existent surface '${surfaceId}'.`,
+            );
+          }
+          activeSurfaces.delete(surfaceId);
+        }
       } else {
         errors.push(`Unknown message type in output: ${JSON.stringify(message)}`);
       }

--- a/specification/v0_10/json/client_to_server.json
+++ b/specification/v0_10/json/client_to_server.json
@@ -20,7 +20,7 @@
         },
         "surfaceId": {
           "type": "string",
-          "description": "The id of the surface where the event originated. It must be globally unique for the renderer instance's lifetime."
+          "description": "The id of the surface where the event originated. It must be globally unique for the renderer's lifetime."
         },
         "sourceComponentId": {
           "type": "string",
@@ -78,7 +78,7 @@
             },
             "surfaceId": {
               "type": "string",
-              "description": "The id of the surface where the error occurred. It must be globally unique for the renderer instance's lifetime."
+              "description": "The id of the surface where the error occurred. It must be globally unique for the renderer's lifetime."
             },
             "path": {
               "type": "string",
@@ -107,7 +107,7 @@
             },
             "surfaceId": {
               "type": "string",
-              "description": "The id of the surface where the error occurred. It must be globally unique for the renderer instance's lifetime."
+              "description": "The id of the surface where the error occurred. It must be globally unique for the renderer's lifetime."
             },
             "functionCallId": {
               "$ref": "common_types.json#/$defs/CallId",

--- a/specification/v0_10/json/client_to_server.json
+++ b/specification/v0_10/json/client_to_server.json
@@ -20,7 +20,7 @@
         },
         "surfaceId": {
           "type": "string",
-          "description": "The id of the surface where the event originated."
+          "description": "The id of the surface where the event originated. It must be globally unique within the client session."
         },
         "sourceComponentId": {
           "type": "string",
@@ -78,7 +78,7 @@
             },
             "surfaceId": {
               "type": "string",
-              "description": "The id of the surface where the error occurred."
+              "description": "The id of the surface where the error occurred. It must be globally unique within the client session."
             },
             "path": {
               "type": "string",
@@ -107,7 +107,7 @@
             },
             "surfaceId": {
               "type": "string",
-              "description": "The id of the surface where the error occurred."
+              "description": "The id of the surface where the error occurred. It must be globally unique within the client session."
             },
             "functionCallId": {
               "$ref": "common_types.json#/$defs/CallId",

--- a/specification/v0_10/json/client_to_server.json
+++ b/specification/v0_10/json/client_to_server.json
@@ -20,7 +20,7 @@
         },
         "surfaceId": {
           "type": "string",
-          "description": "The id of the surface where the event originated. It must be globally unique within the client session."
+          "description": "The id of the surface where the event originated. It must be globally unique for the renderer instance's lifetime."
         },
         "sourceComponentId": {
           "type": "string",
@@ -78,7 +78,7 @@
             },
             "surfaceId": {
               "type": "string",
-              "description": "The id of the surface where the error occurred. It must be globally unique within the client session."
+              "description": "The id of the surface where the error occurred. It must be globally unique for the renderer instance's lifetime."
             },
             "path": {
               "type": "string",
@@ -107,7 +107,7 @@
             },
             "surfaceId": {
               "type": "string",
-              "description": "The id of the surface where the error occurred. It must be globally unique within the client session."
+              "description": "The id of the surface where the error occurred. It must be globally unique for the renderer instance's lifetime."
             },
             "functionCallId": {
               "$ref": "common_types.json#/$defs/CallId",

--- a/specification/v0_10/json/server_to_client.json
+++ b/specification/v0_10/json/server_to_client.json
@@ -21,11 +21,11 @@
         },
         "createSurface": {
           "type": "object",
-          "description": "Signals the client to create a new surface and begin rendering it. It is an error to try to create a surface with the same ID twice without first deleting it; surfaceId MUST be globally unique per client session. When this message is sent, the client will expect 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId that define the component tree.",
+          "description": "Signals the client to create a new surface and begin rendering it. It is an error to try to create a surface with the same ID twice without first deleting it; surfaceId MUST be globally unique for the renderer instance's lifetime. When this message is sent, the client will expect 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId that define the component tree.",
           "properties": {
             "surfaceId": {
               "type": "string",
-              "description": "The unique identifier for the UI surface to be rendered. It must be globally unique within the client session."
+              "description": "The unique identifier for the UI surface to be rendered. It must be globally unique for the renderer instance's lifetime."
             },
             "catalogId": {
               "description": "A string that uniquely identifies this catalog. It is recommended to prefix this with an internet domain that you own, to avoid conflicts e.g. mycompany.com:somecatalog'.",
@@ -75,7 +75,7 @@
           "properties": {
             "surfaceId": {
               "type": "string",
-              "description": "The unique identifier for the UI surface to be updated. It must be globally unique within the client session."
+              "description": "The unique identifier for the UI surface to be updated. It must be globally unique for the renderer instance's lifetime."
             },
             "components": {
               "$ref": "#/$defs/ComponentsList"
@@ -100,7 +100,7 @@
           "properties": {
             "surfaceId": {
               "type": "string",
-              "description": "The unique identifier for the UI surface this data model update applies to. It must be globally unique within the client session."
+              "description": "The unique identifier for the UI surface this data model update applies to. It must be globally unique for the renderer instance's lifetime."
             },
             "path": {
               "type": "string",
@@ -130,7 +130,7 @@
           "properties": {
             "surfaceId": {
               "type": "string",
-              "description": "The unique identifier for the UI surface to be deleted. It must be globally unique within the client session."
+              "description": "The unique identifier for the UI surface to be deleted. It must be globally unique for the renderer instance's lifetime."
             }
           },
           "required": ["surfaceId"],

--- a/specification/v0_10/json/server_to_client.json
+++ b/specification/v0_10/json/server_to_client.json
@@ -21,11 +21,11 @@
         },
         "createSurface": {
           "type": "object",
-          "description": "Signals the client to create a new surface and begin rendering it. It is an error to try to create a surface with the same ID twice without first deleting it; surfaceId MUST be globally unique for the renderer instance's lifetime. When this message is sent, the client will expect 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId that define the component tree.",
+          "description": "Signals the client to create a new surface and begin rendering it. It is an error to try to create a surface with the same ID twice without first deleting it; surfaceId MUST be globally unique for the renderer's lifetime. When this message is sent, the client will expect 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId that define the component tree.",
           "properties": {
             "surfaceId": {
               "type": "string",
-              "description": "The unique identifier for the UI surface to be rendered. It must be globally unique for the renderer instance's lifetime."
+              "description": "The unique identifier for the UI surface to be rendered. It must be globally unique for the renderer's lifetime."
             },
             "catalogId": {
               "description": "A string that uniquely identifies this catalog. It is recommended to prefix this with an internet domain that you own, to avoid conflicts e.g. mycompany.com:somecatalog'.",
@@ -75,7 +75,7 @@
           "properties": {
             "surfaceId": {
               "type": "string",
-              "description": "The unique identifier for the UI surface to be updated. It must be globally unique for the renderer instance's lifetime."
+              "description": "The unique identifier for the UI surface to be updated. It must be globally unique for the renderer's lifetime."
             },
             "components": {
               "$ref": "#/$defs/ComponentsList"
@@ -100,7 +100,7 @@
           "properties": {
             "surfaceId": {
               "type": "string",
-              "description": "The unique identifier for the UI surface this data model update applies to. It must be globally unique for the renderer instance's lifetime."
+              "description": "The unique identifier for the UI surface this data model update applies to. It must be globally unique for the renderer's lifetime."
             },
             "path": {
               "type": "string",
@@ -130,7 +130,7 @@
           "properties": {
             "surfaceId": {
               "type": "string",
-              "description": "The unique identifier for the UI surface to be deleted. It must be globally unique for the renderer instance's lifetime."
+              "description": "The unique identifier for the UI surface to be deleted. It must be globally unique for the renderer's lifetime."
             }
           },
           "required": ["surfaceId"],

--- a/specification/v0_10/json/server_to_client.json
+++ b/specification/v0_10/json/server_to_client.json
@@ -21,11 +21,11 @@
         },
         "createSurface": {
           "type": "object",
-          "description": "Signals the client to create a new surface and begin rendering it. It is an error to send 'createSurface' for a surfaceId that already exists without first deleting it. When this message is sent, the client will expect 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId that define the component tree.",
+          "description": "Signals the client to create a new surface and begin rendering it. It is an error to try to create a surface with the same ID twice without first deleting it; surfaceId MUST be globally unique per client session. When this message is sent, the client will expect 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId that define the component tree.",
           "properties": {
             "surfaceId": {
               "type": "string",
-              "description": "The unique identifier for the UI surface to be rendered."
+              "description": "The unique identifier for the UI surface to be rendered. It must be globally unique within the client session."
             },
             "catalogId": {
               "description": "A string that uniquely identifies this catalog. It is recommended to prefix this with an internet domain that you own, to avoid conflicts e.g. mycompany.com:somecatalog'.",
@@ -75,7 +75,7 @@
           "properties": {
             "surfaceId": {
               "type": "string",
-              "description": "The unique identifier for the UI surface to be updated."
+              "description": "The unique identifier for the UI surface to be updated. It must be globally unique within the client session."
             },
             "components": {
               "$ref": "#/$defs/ComponentsList"
@@ -100,7 +100,7 @@
           "properties": {
             "surfaceId": {
               "type": "string",
-              "description": "The unique identifier for the UI surface this data model update applies to."
+              "description": "The unique identifier for the UI surface this data model update applies to. It must be globally unique within the client session."
             },
             "path": {
               "type": "string",
@@ -130,7 +130,7 @@
           "properties": {
             "surfaceId": {
               "type": "string",
-              "description": "The unique identifier for the UI surface to be deleted."
+              "description": "The unique identifier for the UI surface to be deleted. It must be globally unique within the client session."
             }
           },
           "required": ["surfaceId"],

--- a/specification/v0_9/docs/a2ui_protocol.md
+++ b/specification/v0_9/docs/a2ui_protocol.md
@@ -178,13 +178,13 @@ The envelope defines four primary message types, and every message streamed by t
 
 This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated.
 
-It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it; `surfaceId` must be globally unique for the renderer instance's lifetime. Orchestrators with subagents are empowered to manage surface IDs as needed to prevent conflicts (e.g., prefixing the subagent's name to the `surfaceId` or requiring subagents to use UUIDs).
+It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it; `surfaceId` must be globally unique for the renderer's lifetime. Orchestrators with subagents are empowered to manage surface IDs as needed to prevent conflicts (e.g., prefixing the subagent's name to the `surfaceId` or requiring subagents to use UUIDs).
 
 One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 
 **Properties:**
 
-- `surfaceId` (string, required): The unique identifier for the UI surface to be rendered. This must be globally unique for the renderer instance's lifetime.
+- `surfaceId` (string, required): The unique identifier for the UI surface to be rendered. This must be globally unique for the renderer's lifetime.
 - `catalogId` (string, required): A string that uniquely identifies the catalog (components and functions) used for this surface. It is recommended to prefix this with an internet domain that you own, to avoid conflicts (e.g., `https://mycompany.com/1.0/somecatalog`). If it is a URL, the URL does not need to have any deployed resources, it is simply a unique identifier.
 - `theme` (object, optional): A JSON object containing theme parameters (e.g., `primaryColor`) defined in the catalog's theme schema.
 - `sendDataModel` (boolean, optional): If true, the client will send the full data model of this surface in the metadata of every message sent to the server (via the Transport's metadata mechanism). This ensures the surface owner receives the full current state of the UI alongside the user's action or query. Defaults to false.

--- a/specification/v0_9/docs/a2ui_protocol.md
+++ b/specification/v0_9/docs/a2ui_protocol.md
@@ -178,7 +178,7 @@ The envelope defines four primary message types, and every message streamed by t
 
 This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated.
 
-It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (eg, prefixing the subagent's name to the `surfaceId`).
+It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (eg, prefixing the subagent's name to the `surfaceId` or requiring subagents use UUIDs).
 
 One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 

--- a/specification/v0_9/docs/a2ui_protocol.md
+++ b/specification/v0_9/docs/a2ui_protocol.md
@@ -178,7 +178,7 @@ The envelope defines four primary message types, and every message streamed by t
 
 This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated.
 
-It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (eg., prefixing the subagent's name to the `surfaceId`).
+It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (eg, prefixing the subagent's name to the `surfaceId`).
 
 One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 

--- a/specification/v0_9/docs/a2ui_protocol.md
+++ b/specification/v0_9/docs/a2ui_protocol.md
@@ -176,7 +176,11 @@ The envelope defines four primary message types, and every message streamed by t
 
 ### `createSurface`
 
-This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated. It is an error to send `createSurface` for a `surfaceId` that already exists without first deleting it. One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
+This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated.
+
+It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (eg., prefixing the subagent's name to the `surfaceId`).
+
+One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 
 **Properties:**
 

--- a/specification/v0_9/docs/a2ui_protocol.md
+++ b/specification/v0_9/docs/a2ui_protocol.md
@@ -178,7 +178,7 @@ The envelope defines four primary message types, and every message streamed by t
 
 This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated.
 
-It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it; `surfaceId` must be globally unique for the renderer instance's lifetime. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (e.g., prefixing the subagent's name to the `surfaceId` or requiring subagents to use UUIDs).
+It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it; `surfaceId` must be globally unique for the renderer instance's lifetime. Orchestrators with subagents are empowered to manage surface IDs as needed to prevent conflicts (e.g., prefixing the subagent's name to the `surfaceId` or requiring subagents to use UUIDs).
 
 One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 


### PR DESCRIPTION
# Description

Updates the protocol specification document, schema definitions, and evolution guide to define `surfaceId` as globally unique per renderer instance's lifetime. Updates the TS validator to verify active surfaces, enforce that duplicate surface creations without prior deletion are errors, and validate that messages are only sent to active surfaces. Adds a new unit test suite `test_validator.ts` for these validation rules.

Fixes https://github.com/a2ui-project/a2ui/issues/1275