### PR TITLE
create a wrapper around messageprocessor.getclientdatamodel to avoid …

### DIFF
--- a/renderers/angular/src/v0_9/core/a2ui-renderer.service.ts
+++ b/renderers/angular/src/v0_9/core/a2ui-renderer.service.ts
@@ -21,6 +21,7 @@ import {
   ActionListener as ActionHandler,
   A2uiMessage,
   A2uiClientAction as Action,
+  A2uiClientDataModel,
 } from '@a2ui/web_core/v0_9';
 import {AngularComponentImplementation, AngularCatalog} from '../catalog/types';
 
@@ -89,5 +90,12 @@ export class A2uiRendererService implements OnDestroy {
 
   ngOnDestroy(): void {
     this._messageProcessor.model.dispose();
+  }
+
+  /**
+   * Returns the aggregated data model for all surfaces that have 'sendDataModel' enabled.
+   */
+  getClientDataModel(): A2uiClientDataModel | undefined {
+    return this._messageProcessor.getClientDataModel();
   }
 }


### PR DESCRIPTION
avoids code like

const a2uiClientDataModel = (
      this.a2uiRendererV09 as any
    )?._messageProcessor?.getClientDataModel();
