### PR TITLE
add docs on surfaceid conflicts

### DIFF
--- a/docs/reference/messages.md
+++ b/docs/reference/messages.md
@@ -374,7 +374,8 @@ Add or update components within a surface.
 
 | Error                  | Cause                                  | Solution                                                                                                               |
 | ---------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Surface not found      | `surfaceId` does not exist             | Ensure a unique `surfaceId` is used consistently for a given surface. Surfaces are implicitly created on first update. |
+| Surface already exists | `surfaceId` is already in use          | Ensure a unique `surfaceId` is used for `createSurface`. If using an orchestrator with subagents, the orchestrator is empowered to manage surface IDs as they wish to avoid conflicts. |
+| Surface not found      | `surfaceId` does not exist             | Ensure `surfaceId` matches the created surface. In v0.8, surfaces are implicit, but v0.9 requires `createSurface`.     |
 | Invalid component type | Unknown component type                 | Check component type exists in the negotiated catalog.                                                                 |
 | Invalid property       | Property doesn't exist for this type   | Verify against catalog schema.                                                                                         |
 | Circular reference     | Component references itself as a child | Fix component hierarchy.                                                                                               |

--- a/specification/v0_10/docs/a2ui_protocol.md
+++ b/specification/v0_10/docs/a2ui_protocol.md
@@ -175,7 +175,7 @@ The envelope defines several message types, and every message streamed by the se
 
 This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated.
 
-It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (eg, prefixing the subagent's name to the `surfaceId`).
+It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (eg, requiring UUIDs or prefixing the subagent's name to the `surfaceId or requiring subagents to use UUIDs).
 
 One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 

--- a/specification/v0_10/docs/a2ui_protocol.md
+++ b/specification/v0_10/docs/a2ui_protocol.md
@@ -173,7 +173,11 @@ The envelope defines several message types, and every message streamed by the se
 
 ### `createSurface`
 
-This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated. It is an error to send `createSurface` for a `surfaceId` that already exists without first deleting it. One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
+This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated.
+
+It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (eg, prefixing the subagent's name to the `surfaceId`).
+
+One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 
 **Properties:**
 

--- a/specification/v0_9/docs/a2ui_protocol.md
+++ b/specification/v0_9/docs/a2ui_protocol.md
@@ -178,7 +178,7 @@ The envelope defines four primary message types, and every message streamed by t
 
 This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated.
 
-It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (eg, prefixing the subagent's name to the `surfaceId`).
+It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (eg, prefixing the subagent's name to the `surfaceId` or requiring subagents use UUIDs).
 
 One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 

--- a/specification/v0_9/docs/a2ui_protocol.md
+++ b/specification/v0_9/docs/a2ui_protocol.md
@@ -178,7 +178,7 @@ The envelope defines four primary message types, and every message streamed by t
 
 This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated.
 
-It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (eg., prefixing the subagent's name to the `surfaceId`).
+It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (eg, prefixing the subagent's name to the `surfaceId`).
 
 One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 

--- a/specification/v0_9/docs/a2ui_protocol.md
+++ b/specification/v0_9/docs/a2ui_protocol.md
@@ -176,7 +176,11 @@ The envelope defines four primary message types, and every message streamed by t
 
 ### `createSurface`
 
-This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated. It is an error to send `createSurface` for a `surfaceId` that already exists without first deleting it. One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
+This message signals the client to create a new surface and begin rendering it. A surface must be created before any `updateComponents` or `updateDataModel` messages can be sent to it. While typically achieved by the agent sending a `createSurface` message, an agent may skip this if it knows the surface has already been created (e.g., by another agent). Once a surface is created, its `surfaceId` and `catalogId` are fixed; to reconfigure them, the surface must be deleted and recreated.
+
+It is an error to try to create a surface with a `surfaceId` that already exists without first deleting it. Orchestrators with subagents are empowered to manage surface IDs as they wish to prevent conflicts (eg., prefixing the subagent's name to the `surfaceId`).
+
+One of the components in one of the component lists MUST have an `id` of `root` to serve as the root of the component tree.
 
 **Properties:**
 


### PR DESCRIPTION
## Summary of Changes

This pull request updates the documentation to provide clearer guidance on handling `surfaceId` conflicts when creating surfaces. It emphasizes that attempting to create a surface with an existing ID is an error and provides recommendations for orchestrators to manage these IDs effectively in multi-agent environments.

### Highlights

* **Documentation Updates**: Clarified the error handling behavior for `surfaceId` conflicts across the protocol documentation and reference messages.
* **Orchestrator Guidance**: Added explicit guidance for orchestrators managing subagents to prevent `surfaceId` collisions, suggesting strategies like prefixing or UUIDs.

Fixes https://github.com/a2ui-project/a2ui/issues/1275