### PR TITLE
Update evolution guide

### DIFF
--- a/specification/v0_10/docs/evolution_guide.md
+++ b/specification/v0_10/docs/evolution_guide.md
@@ -17,63 +17,44 @@ Version 1.0 differs from 0.9 in the following ways:
 
 ### 2.1. Catalog definition schema
 
-- Added `posterUrl` property to the `Video` component in `catalogs/basic/catalog.json`, allowing a preview image to be displayed before the video plays.
-- Added `placeholder` prop to the `TextField` component schema.
-- Added a `steps` property to the `Slider` component schema to snap values to discrete intervals.
-- Renamed `svgPath` to `path` in the custom SVG icon definition object schema.
-- Renamed the `$defs/theme` schema to `$defs/surfaceProperties` in both the basic and minimal catalogs, and removed the `primaryColor` property.
+- Renamed the `$defs/theme` schema to `$defs/surfaceProperties` in the Catalog schema, and removed the `primaryColor` property.
 - Changed the `functions` property in the Catalog schema from a list to a map object, keyed by function name.
 - Added `callableFrom` (enum: `clientOnly`, `remoteOnly`, `clientOrRemote`) to `FunctionDefinition` to restrict where a function can be invoked.
 - Added an optional `instructions` field to the `Catalog` schema to embed design guidelines and component usage rules directly in the catalog, replacing the external `rules.txt` file.
 - Supported standard JSON Schema metadata fields (`$schema`, `$id`, `title`, and `description`) in the Catalog object definition. Since the Catalog schema restricts properties with `additionalProperties: false`, this ensures inline catalogs containing standard schema metadata do not fail schema validation.
 
-### 2.2. Server-to-client message list schema
+### 2.2. Standard catalogs (basic and minimal)
 
-- Added `ActionResponseMessage` to allow the server to respond to a specific action call using an `actionId`.
-- Added `CallFunctionMessage` to support server-initiated function execution.
-- Updated `CreateSurfaceMessage` to allow `components` and `dataModel` directly inside the `createSurface` parameters.
-- Updated all references from version `v0.9` or `v0.9.1` to `v1.0`.
+- Added `posterUrl` property to the `Video` component in `catalogs/basic/catalog.json`, allowing a preview image to be displayed before the video plays.
+- Added `placeholder` prop to the `TextField` component schema.
+- Added a `steps` property to the `Slider` component schema to snap values to discrete intervals.
+- Renamed `svgPath` to `path` in the custom SVG icon definition object schema.
+- Renamed `$defs/theme` to `$defs/surfaceProperties` in both the basic and minimal catalogs.
 
-### 2.3. Client-to-server message list schema
+### 2.3. Server-to-client messages
 
-- Added `actionId` to the `action` message properties, which the client generates if a response is expected (`wantResponse: true`).
-- Added `functionResponse` message type.
+- Added `actionResponse` message structure (`ActionResponseMessage`) to allow the server to respond to a specific action call using a unique `actionId` with a `value` or `error`.
+- Added `callFunction` message structure (`CallFunctionMessage`) to support server-initiated function execution.
+- Updated the `createSurface` message (`CreateSurfaceMessage`) to rename the `theme` field to `surfaceProperties`, and allowed passing initial `components` and `dataModel` directly inside the payload.
+
+### 2.4. Client-to-server events
+
+- Added `actionId` to the `action` message properties, which the client generates when `wantResponse` is true.
+- Added `functionResponse` message type to return execution results of server-initiated function calls.
 - Added optional `functionCallId` to client-side `error` messages.
 - Enforced mutual exclusivity of `surfaceId` and `functionCallId` in `error` payloads.
-- Updated all references from version `v0.9` or `v0.9.1` to `v1.0`.
+- Updated `Action` type in `common_types.json` to include `wantResponse` and `responsePath`.
+- Removed the `returnType` property from the wire-level `FunctionCall` definition in `common_types.json`.
 
-### 2.4. Client capabilities schema
-
-- Renamed `theme` capability block to `surfaceProperties` within the Catalog definition in `client_capabilities.json`.
-- Added an optional `instructions` field to the `Catalog` object definition in `client_capabilities.json` to support design principles or component rules associated with a catalog.
-- Updated required capability key from `v0.9` to `v1.0`.
-
-### 2.5. Agent card
-
-- Standardized the official MIME type to `application/a2ui+json` to conform to IANA media type guidelines.
-- Updated capabilities namespace in transport metadata and A2A metadata `params` from `v0.9`/`v0.9.1` to `v1.0`.
-
-### 2.6. Data encoding
+### 2.5. Data encoding
 
 - Standardized data deletion behavior in `updateDataModel`. Setting a path's value to `null` deletes the key at that path. Removing or omitting keys in `updateDataModel` is no longer used for deletion.
 - Removed returnType validation constraints from dynamic value schemas in `common_types.json`, deferring boundary checking to runtime execution.
 
-### 2.7. Processing rules
+### 2.6. Processing rules
 
 - Explicitly specified that `surfaceId` must be globally unique per client session. Creating a surface with an ID that already exists (without first deleting it) is an error.
 - Enforced runtime lookup of function execution boundaries. If a client receives a remote call to a function configured as `clientOnly` or if the function is unregistered, it rejects the call and returns an error with the code `INVALID_FUNCTION_CALL`.
-
-### 2.8. Server-to-client messages
-
-- Added `actionResponse` message structure to support synchronous responses with a `value` or `error`.
-- Added `callFunction` message structure to support server-initiated function execution.
-- Updated the `createSurface` message to rename the `theme` field to `surfaceProperties`, and allowed passing initial `components` and `dataModel` directly inside the payload.
-
-### 2.9. Client-to-server events
-
-- Updated `action` message to include `actionId`.
-- Updated `Action` type in `common_types.json` to include `wantResponse` and `responsePath`.
-- Removed the `returnType` property from the wire-level `FunctionCall` definition in `common_types.json`.
 
 ## 3. Migration guide
 
@@ -81,22 +62,9 @@ This section outlines the steps required to migrate existing applications and co
 
 ### For agents and servers
 
-- **Update version strings**: Set the `version` field in all streamed JSON envelopes to `"v1.0"`.
-- **Update MIME types**: Change the MIME type of A2UI payloads in transport layers from `application/json+a2ui` to `application/a2ui+json`.
-- **Update surface creation**:
-  - Rename the `theme` field to `surfaceProperties` in the `createSurface` message.
-  - Remove `primaryColor` from the properties object.
-  - Optionally, include the initial `components` and `dataModel` directly in the `createSurface` payload instead of sending them in separate `updateComponents` and `updateDataModel` messages.
-- **Update catalog definitions**:
-  - Convert the `functions` property from an array of function definitions to a JSON object map, where each key is the function name.
-  - Rename the `$defs/theme` definition to `$defs/surfaceProperties`, and remove the `primaryColor` field.
-  - For any function that the server needs to call remotely, add the `callableFrom` metadata field set to `"remoteOnly"` or `"clientOrRemote"`. If omitted, the default is `"clientOnly"`.
-- **Update components**:
-  - For `Icon` components using custom paths, rename `svgPath` to `path` in the custom SVG icon definition object.
-  - Update `Video` components to optionally specify `posterUrl`.
-  - Update `TextField` components to optionally specify `placeholder`.
-  - Update `Slider` components to optionally specify `steps`.
-- **Handle data deletion**: In `updateDataModel` messages, explicitly set values to `null` to delete keys at the specified path. Do not omit keys or send undefined to indicate deletion.
+- If doing inference directly based on JSON schema, update the pointers to load v1.0 schemas instead of v0.9.
+- If returning pre-generated content, or using examples, update the examples to conform to the 1.0 schemas, and set up validation tests to verify this.
+- If using an alternative inference format (e.g. DSL), update it to convert the 1.0 catalog format to the DSL prompt, and convert the DSL output to A2UI 1.0 format.
 
 ### For renderers and clients
 
@@ -107,5 +75,7 @@ This section outlines the steps required to migrate existing applications and co
 - **Support synchronous action responses**:
   - When executing a component action with `wantResponse: true`, generate a unique `actionId` and send it in the client-to-server `action` message.
   - Listen for `actionResponse` messages matching the generated `actionId`. If `responsePath` is specified on the component action, write the returned value into the local data model at that JSON Pointer path.
+- **Support simultaneous version handling**:
+  - When supporting v0.9.x and v1.0 simultaneously, implement branching logic based on protocol version handshakes (inspecting the `version` property during session initialization) to route payloads to version-specific message parsers and controllers.
 - **Enforce surface uniqueness**: Raise an error if a `createSurface` message is received for a `surfaceId` that already exists in the current session.
 - **Update error reporting**: Update the client-to-server error message parser and generator to handle `functionCallId` and enforce mutual exclusivity with `surfaceId`.

--- a/specification/v0_10/docs/evolution_guide.md
+++ b/specification/v0_10/docs/evolution_guide.md
@@ -7,11 +7,13 @@ This document serves as a comprehensive guide to the changes between A2UI versio
 Version 1.0 differs from 0.9 in the following ways:
 
 - A new client-to-server RPC mechanism allows synchronous responses to client actions (`actionResponse`) using a unique `actionId`.
-- Server-to-client RPC function calls are supported via the `callFunction` message. Clients return execution results via the `functionResponse` message. Runtime execution boundaries can be defined in catalogs using the `callableFrom` property.
+- Server-to-client RPC function calls are supported via the `callFunction` message. Clients return execution results via the `functionResponse` message. Runtime execution boundaries and return types are defined in catalogs and verified at runtime, rather than being validated on the wire.
 - The `theme` property in the catalog and surface creation message is replaced by `surfaceProperties`, and `primaryColor` is removed to separate layout from branding.
 - Components and initial data model states can be defined directly within the `createSurface` parameters. This allows for the creation of entire UIs in a single message, rather than a create followed by separate updates.
 - The `functions` field in a Catalog is now defined as a map of function name to its definition, instead of a list.
 - Standard JSON Schema metadata fields (`$schema`, `$id`, `title`, and `description`) are supported in catalogs, preventing validation failures on inline catalogs with strict property checks.
+- Identifier naming rules across all catalog entities (component names, function names, and argument keys) must conform to Unicode Standard Annex #31 (UAX #31).
+- The `@index` built-in function dynamically retrieves iteration indices during list template rendering. The `@` prefix is reserved for core system context evaluations.
 
 ## 2. Changes
 
@@ -22,6 +24,7 @@ Version 1.0 differs from 0.9 in the following ways:
 - Added `callableFrom` (enum: `clientOnly`, `remoteOnly`, `clientOrRemote`) to `FunctionDefinition` to restrict where a function can be invoked.
 - Added an optional `instructions` field to the `Catalog` schema to embed design guidelines and component usage rules directly in the catalog, replacing the external `rules.txt` file.
 - Supported standard JSON Schema metadata fields (`$schema`, `$id`, `title`, and `description`) in the Catalog object definition. Since the Catalog schema restricts properties with `additionalProperties: false`, this ensures inline catalogs containing standard schema metadata do not fail schema validation.
+- Enforced Unicode Standard Annex #31 (UAX #31) identifier naming constraints (`XID_Start`, `XID_Continue`) across component names, function names, and argument keys.
 
 ### 2.2. Standard catalogs (basic and minimal)
 
@@ -35,28 +38,33 @@ Version 1.0 differs from 0.9 in the following ways:
 ### 2.3. Server-to-client messages
 
 - Added `actionResponse` message structure (`ActionResponseMessage`) to allow the server to respond to a specific action call using a unique `actionId` with a `value` or `error`.
-- Added `callFunction` message structure (`CallFunctionMessage`) to support server-initiated function execution.
+- Added `callFunction` message structure (`CallFunctionMessage`) to support server-initiated function execution. Removed `callableFrom` and `returnType` properties from the wire payload, relying on runtime catalog verification.
 - Updated the `createSurface` message (`CreateSurfaceMessage`) to rename the `theme` field to `surfaceProperties`, and allowed passing initial `components` and `dataModel` directly inside the payload.
 
 ### 2.4. Client-to-server events
 
 - Added `actionId` to the `action` message properties, which the client generates if a response is expected (`wantResponse: true`).
-- <TBD>
+- Added `functionResponse` message structure (`FunctionResponseMessage`) to return the execution result (`value` or `error`) of a server-initiated function call.
+- Updated client `error` messages to support `functionCallId` when reporting function execution failures, enforcing mutual exclusivity with `surfaceId`.
 
-### 2.4. Client Capabilities Schema
+### 2.5. Client capabilities schema
 
 - Added an optional `instructions` field to the `Catalog` object definition (`client_capabilities.json`) as a relative file URI reference (with format hint of `uri-reference`) to support external rules files associated with a catalog.
 - Renamed `theme` capability block to `surfaceProperties` within the Catalog definition in `client_capabilities.json`.
+- Added static `callableFrom` and `returnType` metadata properties to `FunctionDefinition` inside `client_capabilities.json` to advertise execution boundaries and return types to the server.
 
-### 2.5. Data encoding
+### 2.6. Data encoding
 
 - Standardized data deletion behavior in `updateDataModel`. Setting a path's value to `null` deletes the key at that path. Removing or omitting keys in `updateDataModel` is no longer used for deletion.
-- Removed returnType validation constraints from dynamic value schemas in `common_types.json`, deferring boundary checking to runtime execution.
+- Removed `callableFrom` and `returnType` properties and validation constraints from `FunctionCall` and dynamic value schemas in `common_types.json`, deferring boundary checking and return type validation entirely to runtime execution.
+- Added built-in `@index` function (with optional `offset` parameter) under `FunctionCall` to retrieve the iteration index during list template rendering. Reserved the `@` prefix for core system context evaluations.
 
-### 2.6. Processing rules
+### 2.7. Processing rules
 
 - Explicitly specified that `surfaceId` must be globally unique per client session. Creating a surface with an ID that already exists (without first deleting it) is an error.
-- Enforced runtime lookup of function execution boundaries. If a client receives a remote call to a function configured as `clientOnly` or if the function is unregistered, it rejects the call and returns an error with the code `INVALID_FUNCTION_CALL`.
+- Enforced runtime lookup of function execution boundaries and return types. If a client receives a remote call to a function configured as `clientOnly` or if the function is unregistered, it rejects the call and returns an error with the code `INVALID_FUNCTION_CALL`.
+- Enforced catalog entity naming compliance with Unicode Standard Annex #31 (UAX #31).
+- Restricted `@index` evaluation scope strictly to template instantiation loops (Collection Scope). Calling `@index` outside of template iteration results in an evaluation error.
 
 ## 3. Migration guide
 
@@ -67,17 +75,15 @@ This section outlines the steps required to migrate existing applications and co
 - If doing inference directly based on JSON schema, update the pointers to load v1.0 schemas instead of v0.9.
 - If returning pre-generated content, or using examples, update the examples to conform to the 1.0 schemas, and set up validation tests to verify this.
 - If using an alternative inference format (e.g. DSL), update it to convert the 1.0 catalog format to the DSL prompt, and convert the DSL output to A2UI 1.0 format.
+- Ensure all generated catalog entity names conform to UAX #31 identifier rules.
+- Do not include `callableFrom` or `returnType` properties in wire-level `FunctionCall` payloads.
 
 ### For renderers and clients
 
-- **Implement function execution**:
-  - Add support for parsing and executing `callFunction` messages.
-  - Retrieve the function's boundary definition from the catalog. If `callableFrom` is `"clientOnly"` (or omitted) and the server attempts to call it, immediately reject the call and return a client-to-server `error` message with the code `"INVALID_FUNCTION_CALL"`.
-  - If `wantResponse` is true, return a `functionResponse` message containing the execution result value.
-- **Support synchronous action responses**:
-  - When executing a component action with `wantResponse: true`, generate a unique `actionId` and send it in the client-to-server `action` message.
-  - Listen for `actionResponse` messages matching the generated `actionId`. If `responsePath` is specified on the component action, write the returned value into the local data model at that JSON Pointer path.
-- **Support simultaneous version handling**:
-  - When supporting v0.9.x and v1.0 simultaneously, implement branching logic based on protocol version handshakes (inspecting the `version` property during session initialization) to route payloads to version-specific message parsers and controllers.
-- **Enforce surface uniqueness**: Raise an error if a `createSurface` message is received for a `surfaceId` that already exists in the current session.
-- **Update error reporting**: Update the client-to-server error message parser and generator to handle `functionCallId` and enforce mutual exclusivity with `surfaceId`.
+- Implement function execution by adding support for parsing `callFunction` messages, checking boundary definitions in the catalog (`callableFrom`), rejecting invalid calls with `INVALID_FUNCTION_CALL`, and returning `functionResponse` messages.
+- Support synchronous action responses by generating `actionId` for actions with `wantResponse: true` and writing returned values from `actionResponse` messages into the data model.
+- Support simultaneous version handling during session initialization by inspecting the `version` property to route payloads to version-specific controllers.
+- Enforce surface uniqueness by raising an error if `createSurface` is received for an existing `surfaceId`.
+- Update error reporting to handle `functionCallId` and enforce mutual exclusivity with `surfaceId`.
+- Enforce Unicode identifier naming by verifying that all catalog entity names (components, functions, prop keys) conform to UAX #31 identifier rules.
+- Support built-in `@index` evaluation during list template rendering (Collection Scope) to provide the 0-based iteration index, adjusted by any `offset` parameter.

--- a/specification/v0_10/docs/evolution_guide.md
+++ b/specification/v0_10/docs/evolution_guide.md
@@ -1,59 +1,111 @@
-# A2UI Protocol Evolution Guide: v0.9 to v0.10
+# A2UI Protocol Evolution Guide: v0.9 to v1.0
 
-This document serves as a comprehensive guide to the changes between A2UI version 0.9 and version 0.10. It details the shifts in philosophy, architecture, and implementation, providing a reference for stakeholders and developers migrating between versions.
+This document serves as a comprehensive guide to the changes between A2UI version 0.9 (including 0.9.1) and version 1.0. It details the shifts in philosophy, architecture, and implementation, providing a reference for stakeholders and developers migrating between versions.
 
-## 1. Executive Summary
+## 1. Executive summary
 
-Version 0.10 differs from 0.9 in the following ways:
+Version 1.0 differs from 0.9 in the following ways:
 
-- **Client-to-Server RPC**: Introduced `actionResponse` enabling synchronous responses to client-initiated actions. Added `actionId` for response correlation.
-- **Surface Properties Refactoring**: Renamed `theme` to `surfaceProperties` at both the message and catalog level. Removed the `primaryColor` property entirely to decouple structural UI layout and branding customization from surface definition.
+- A new client-to-server RPC mechanism allows synchronous responses to client actions (`actionResponse`) using a unique `actionId`.
+- Server-to-client RPC function calls are supported via the `callFunction` message. Clients return execution results via the `functionResponse` message. Runtime execution boundaries can be defined in catalogs using the `callableFrom` property.
+- The `theme` property in the catalog and surface creation message is replaced by `surfaceProperties`, and `primaryColor` is removed to separate layout from branding.
+- Components and initial data model states can be defined directly within the `createSurface` parameters. This allows for the creation of entire UIs in a single message, rather than a create followed by separate updates.
+- The `functions` field in a Catalog is now defined as a map of function name to its definition, instead of a list.
+- Standard JSON Schema metadata fields (`$schema`, `$id`, `title`, and `description`) are supported in catalogs, preventing validation failures on inline catalogs with strict property checks.
 
 ## 2. Changes
 
-### 2.1. Catalog Definition Schema
+### 2.1. Catalog definition schema
 
 - Added `posterUrl` property to the `Video` component in `catalogs/basic/catalog.json`, allowing a preview image to be displayed before the video plays.
 - Added `placeholder` prop to the `TextField` component schema.
-- Renamed the `$defs/theme` schema to `$defs/surfaceProperties` in both the basic and minimal catalogs, and removed the `primaryColor` property from it.
+- Added a `steps` property to the `Slider` component schema to snap values to discrete intervals.
+- Renamed `svgPath` to `path` in the custom SVG icon definition object schema.
+- Renamed the `$defs/theme` schema to `$defs/surfaceProperties` in both the basic and minimal catalogs, and removed the `primaryColor` property.
+- Changed the `functions` property in the Catalog schema from a list to a map object, keyed by function name.
+- Added `callableFrom` (enum: `clientOnly`, `remoteOnly`, `clientOrRemote`) to `FunctionDefinition` to restrict where a function can be invoked.
+- Added an optional `instructions` field to the `Catalog` schema to embed design guidelines and component usage rules directly in the catalog, replacing the external `rules.txt` file.
+- Supported standard JSON Schema metadata fields (`$schema`, `$id`, `title`, and `description`) in the Catalog object definition. Since the Catalog schema restricts properties with `additionalProperties: false`, this ensures inline catalogs containing standard schema metadata do not fail schema validation.
 
-### 2.2. Server-to-Client Message List Schema
+### 2.2. Server-to-client message list schema
 
 - Added `ActionResponseMessage` to allow the server to respond to a specific action call using an `actionId`.
-- <TBD>
+- Added `CallFunctionMessage` to support server-initiated function execution.
+- Updated `CreateSurfaceMessage` to allow `components` and `dataModel` directly inside the `createSurface` parameters.
+- Updated all references from version `v0.9` or `v0.9.1` to `v1.0`.
 
-### 2.3. Client-to-Server Message List Schema
+### 2.3. Client-to-server message list schema
 
 - Added `actionId` to the `action` message properties, which the client generates if a response is expected (`wantResponse: true`).
-- <TBD>
+- Added `functionResponse` message type.
+- Added optional `functionCallId` to client-side `error` messages.
+- Enforced mutual exclusivity of `surfaceId` and `functionCallId` in `error` payloads.
+- Updated all references from version `v0.9` or `v0.9.1` to `v1.0`.
 
-### 2.4. Client Capabilities Schema
+### 2.4. Client capabilities schema
 
 - Renamed `theme` capability block to `surfaceProperties` within the Catalog definition in `client_capabilities.json`.
+- Added an optional `instructions` field to the `Catalog` object definition in `client_capabilities.json` to support design principles or component rules associated with a catalog.
+- Updated required capability key from `v0.9` to `v1.0`.
 
-### 2.5. AgentCard
+### 2.5. Agent card
 
-- <TBD>
+- Standardized the official MIME type to `application/a2ui+json` to conform to IANA media type guidelines.
+- Updated capabilities namespace in transport metadata and A2A metadata `params` from `v0.9`/`v0.9.1` to `v1.0`.
 
-### 2.6. Data Encoding
+### 2.6. Data encoding
 
-- <TBD>
+- Standardized data deletion behavior in `updateDataModel`. Setting a path's value to `null` deletes the key at that path. Removing or omitting keys in `updateDataModel` is no longer used for deletion.
+- Removed returnType validation constraints from dynamic value schemas in `common_types.json`, deferring boundary checking to runtime execution.
 
-### 2.7. Processing Rules
+### 2.7. Processing rules
 
-- <TBD>
+- Explicitly specified that `surfaceId` must be globally unique per client session. Creating a surface with an ID that already exists (without first deleting it) is an error.
+- Enforced runtime lookup of function execution boundaries. If a client receives a remote call to a function configured as `clientOnly` or if the function is unregistered, it rejects the call and returns an error with the code `INVALID_FUNCTION_CALL`.
 
-### 2.8. Server-to-Client Messages
+### 2.8. Server-to-client messages
 
 - Added `actionResponse` message structure to support synchronous responses with a `value` or `error`.
-- Updated `createSurface` message to rename the `theme` field to `surfaceProperties` (pointing to catalog surface properties definitions).
+- Added `callFunction` message structure to support server-initiated function execution.
+- Updated the `createSurface` message to rename the `theme` field to `surfaceProperties`, and allowed passing initial `components` and `dataModel` directly inside the payload.
 
-### 2.9. Client-to-Server Events
+### 2.9. Client-to-server events
 
 - Updated `action` message to include `actionId`.
-- Updated `Action` type in `common_types.json` to include `wantResponse` and `responsePath` on event triggers.
-- <TBD>
+- Updated `Action` type in `common_types.json` to include `wantResponse` and `responsePath`.
+- Removed the `returnType` property from the wire-level `FunctionCall` definition in `common_types.json`.
 
-## 3. Migration Guide
+## 3. Migration guide
 
-- <TBD>
+This section outlines the steps required to migrate existing applications and components from version 0.9 (including 0.9.1) to version 1.0.
+
+### For agents and servers
+
+- **Update version strings**: Set the `version` field in all streamed JSON envelopes to `"v1.0"`.
+- **Update MIME types**: Change the MIME type of A2UI payloads in transport layers from `application/json+a2ui` to `application/a2ui+json`.
+- **Update surface creation**:
+  - Rename the `theme` field to `surfaceProperties` in the `createSurface` message.
+  - Remove `primaryColor` from the properties object.
+  - Optionally, include the initial `components` and `dataModel` directly in the `createSurface` payload instead of sending them in separate `updateComponents` and `updateDataModel` messages.
+- **Update catalog definitions**:
+  - Convert the `functions` property from an array of function definitions to a JSON object map, where each key is the function name.
+  - Rename the `$defs/theme` definition to `$defs/surfaceProperties`, and remove the `primaryColor` field.
+  - For any function that the server needs to call remotely, add the `callableFrom` metadata field set to `"remoteOnly"` or `"clientOrRemote"`. If omitted, the default is `"clientOnly"`.
+- **Update components**:
+  - For `Icon` components using custom paths, rename `svgPath` to `path` in the custom SVG icon definition object.
+  - Update `Video` components to optionally specify `posterUrl`.
+  - Update `TextField` components to optionally specify `placeholder`.
+  - Update `Slider` components to optionally specify `steps`.
+- **Handle data deletion**: In `updateDataModel` messages, explicitly set values to `null` to delete keys at the specified path. Do not omit keys or send undefined to indicate deletion.
+
+### For renderers and clients
+
+- **Implement function execution**:
+  - Add support for parsing and executing `callFunction` messages.
+  - Retrieve the function's boundary definition from the catalog. If `callableFrom` is `"clientOnly"` (or omitted) and the server attempts to call it, immediately reject the call and return a client-to-server `error` message with the code `"INVALID_FUNCTION_CALL"`.
+  - If `wantResponse` is true, return a `functionResponse` message containing the execution result value.
+- **Support synchronous action responses**:
+  - When executing a component action with `wantResponse: true`, generate a unique `actionId` and send it in the client-to-server `action` message.
+  - Listen for `actionResponse` messages matching the generated `actionId`. If `responsePath` is specified on the component action, write the returned value into the local data model at that JSON Pointer path.
+- **Enforce surface uniqueness**: Raise an error if a `createSurface` message is received for a `surfaceId` that already exists in the current session.
+- **Update error reporting**: Update the client-to-server error message parser and generator to handle `functionCallId` and enforce mutual exclusivity with `surfaceId`.


### PR DESCRIPTION
# Description

Update the evolution guide from 0.9 to v1.0 (which 0.10 is now called).

Will update all the other v0.10 assets to be called 1.0 in another PR.