### PR TITLE
fix(lit): Small fixes to the adapter.

### DIFF
--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -6,6 +6,7 @@
 - (v0_9) Add missing CSS classes to the `Modal`, `Tabs` components to align with the Angular implementation and
   integration tests.
 - (v0_9) Avoid rendering an `A2uiLitElement` when its surface is disposed of or the component is removed.
+- (v0_9) Fix `DateTimeInput` to correctly render `datetime-local`, `date` and `time` input types.
 
 ## 0.10.0
 

--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -3,6 +3,7 @@
 - (v0_9) Tighten resolved child list types in the basic catalog layout components.
 - (v0_9) Narrow `A2uiChildRef` to the supported child reference shapes used by
   `renderNode`.
+- (v0_9) Add missing CSS classes to the `Modal` component to align with the Angular implementation.
 
 ## 0.10.0
 

--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -4,6 +4,7 @@
 - (v0_9) Narrow `A2uiChildRef` to the supported child reference shapes used by
   `renderNode`.
 - (v0_9) Add missing CSS classes to the `Modal` component to align with the Angular implementation.
+- (v0_9) Avoid rendering an `A2uiLitElement` when its surface is disposed of or the component is removed.
 
 ## 0.10.0
 

--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -3,7 +3,8 @@
 - (v0_9) Tighten resolved child list types in the basic catalog layout components.
 - (v0_9) Narrow `A2uiChildRef` to the supported child reference shapes used by
   `renderNode`.
-- (v0_9) Add missing CSS classes to the `Modal` component to align with the Angular implementation.
+- (v0_9) Add missing CSS classes to the `Modal`, `Tabs` components to align with the Angular implementation and
+  integration tests.
 - (v0_9) Avoid rendering an `A2uiLitElement` when its surface is disposed of or the component is removed.
 
 ## 0.10.0

--- a/renderers/lit/a2ui_explorer/src/local-gallery.ts
+++ b/renderers/lit/a2ui_explorer/src/local-gallery.ts
@@ -70,6 +70,9 @@ export class LocalGallery extends LitElement {
   }
 
   selectItem(index: number) {
+    // Delete the surface of the previous example, if any.
+    this.deleteActiveExampleSurface();
+    // Then load the new one
     this.activeItemIndex = index;
     this.reloadExample();
   }
@@ -85,10 +88,18 @@ export class LocalGallery extends LitElement {
       this.dataModelSubscription.unsubscribe();
       this.dataModelSubscription = undefined;
     }
+    this.deleteActiveExampleSurface();
+  }
 
-    const item = this.demoItems[this.activeItemIndex];
-    if (item && this.processor.model.getSurface(item.id)) {
-      this.processor.processMessages([{version: 'v0.9', deleteSurface: {surfaceId: item.id}}]);
+  /**
+   * Removes the surface of this.activeItemIndex, if still present.
+   */
+  deleteActiveExampleSurface() {
+    const surfaceId = this.demoItems[this.activeItemIndex]?.id;
+    if (surfaceId) {
+      if (this.processor.model.getSurface(surfaceId)) {
+        this.processor.processMessages([{version: 'v0.9', deleteSurface: {surfaceId}}]);
+      }
     }
   }
 

--- a/renderers/lit/a2ui_explorer/tests/utils/test-utils.ts
+++ b/renderers/lit/a2ui_explorer/tests/utils/test-utils.ts
@@ -134,3 +134,18 @@ export function getSurface(root: Element): HTMLElement {
   }
   return surface as HTMLElement;
 }
+
+/**
+ * Finds a button by its text content, traversing shadow DOMs.
+ */
+export async function findButtonByText(
+  surface: HTMLElement,
+  text: string,
+): Promise<HTMLButtonElement> {
+  const buttons = querySelectorAllDeep(surface, '.a2ui-button') as HTMLButtonElement[];
+  const found = buttons.find(b => getDeepTextContent(b).includes(text));
+  if (!found) {
+    throw new Error(`Button with text "${text}" not found`);
+  }
+  return found;
+}

--- a/renderers/lit/a2ui_explorer/tests/v0_9/02_email-compose.test.ts
+++ b/renderers/lit/a2ui_explorer/tests/v0_9/02_email-compose.test.ts
@@ -20,6 +20,7 @@ import {
   getDeepTextContent,
   querySelectorAllDeep,
   whenSettled,
+  findButtonByText,
 } from '../utils/test-utils';
 import {LocalGallery} from '../../src/local-gallery';
 
@@ -48,11 +49,9 @@ describe('Example: Email Compose', () => {
   });
 
   it('should handle Send button click', async () => {
-    const buttons = querySelectorAllDeep(surface, '.a2ui-button') as HTMLButtonElement[];
-    const sendBtn = buttons.find(b => getDeepTextContent(b).includes('Send'));
-    expect(sendBtn).toBeDefined();
+    const sendBtn = await findButtonByText(surface, 'Send');
 
-    sendBtn?.click();
+    sendBtn.click();
     await whenSettled(gallery);
 
     expect(gallery.actionLog.length).toBe(1);
@@ -60,11 +59,9 @@ describe('Example: Email Compose', () => {
   });
 
   it('should handle Discard button click', async () => {
-    const buttons = querySelectorAllDeep(surface, '.a2ui-button') as HTMLButtonElement[];
-    const discardBtn = buttons.find(b => getDeepTextContent(b).includes('Discard'));
-    expect(discardBtn).toBeDefined();
+    const discardBtn = await findButtonByText(surface, 'Discard');
 
-    discardBtn?.click();
+    discardBtn.click();
     await whenSettled(gallery);
 
     expect(gallery.actionLog.length).toBe(1);

--- a/renderers/lit/src/v0_9/a2ui-lit-element.ts
+++ b/renderers/lit/src/v0_9/a2ui-lit-element.ts
@@ -66,6 +66,16 @@ export abstract class A2uiLitElement<Api extends ComponentApi> extends LitElemen
     if (!childRef) return nothing;
     const {surface, path: parentPath} = this.context.dataContext;
 
+    // This guard handles cases where a render update is scheduled on a component
+    // (e.g., from a click or text input change), but the example is reloaded or
+    // the surface is deleted/disposed before the microtask runs. In these cases,
+    // the surface components map is cleared, so we return nothing early instead
+    // of attempting to resolve child components on a stale or disposed surface.
+    const surfaceContainsComponent = !!surface.componentsModel.get(this.context.componentModel.id);
+    if (!surfaceContainsComponent) {
+      return nothing;
+    }
+
     // Path resolution order: customPath > childRef.basePath > parentPath
     let componentId: ComponentId;
     let path = customPath;

--- a/renderers/lit/src/v0_9/catalogs/basic/components/DateTimeInput.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/DateTimeInput.ts
@@ -20,6 +20,35 @@ import {DateTimeInputApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {BasicCatalogA2uiLitElement} from '../basic-catalog-a2ui-lit-element.js';
 import {A2uiController} from '@a2ui/lit/v0_9';
 
+/**
+ * Normalizes an incoming ISO or partial date/time value into a format accepted by HTML5 inputs.
+ *
+ * HTML5 input elements (like type="date", type="time", and type="datetime-local") strictly reject
+ * timezone indicators (like "Z" or "+00:00") and trailing seconds/milliseconds in their .value property.
+ * If these are present, the browser will reset the input to an empty string. This function strips
+ * those specifiers using string splitting and substring manipulation without shifting timezones.
+ */
+function normalizeDateTimeValue(value: string | null | undefined, type: string): string | null {
+  if (!value) return null;
+
+  const hasT = value.includes('T');
+  // If the incoming value is not in ISO format (after a very cursory look), do not attempt to parse.
+  if (!hasT) return null;
+
+  const split = value.split('T');
+  const datePart = split[0].substring(0, 10);
+  const timePart = split[1].substring(0, 5);
+  switch (type) {
+    case 'date':
+      return datePart;
+    case 'time':
+      return timePart;
+    case 'datetime-local':
+      return `${datePart}T${timePart}`;
+  }
+  return null;
+}
+
 @customElement('a2ui-datetimeinput')
 export class A2uiDateTimeInputElement extends BasicCatalogA2uiLitElement<typeof DateTimeInputApi> {
   /**
@@ -58,14 +87,18 @@ export class A2uiDateTimeInputElement extends BasicCatalogA2uiLitElement<typeof 
   render() {
     const props = this.controller.props;
     if (!props) return nothing;
+    // If neither date or time are enabled, render nothing.
+    if (!(props.enableDate || props.enableTime)) return nothing;
 
-    const type =
+    const inputType =
       props.enableDate && props.enableTime ? 'datetime-local' : props.enableDate ? 'date' : 'time';
+    const normalizedValue = normalizeDateTimeValue(props.value, inputType);
+
     return html`
       ${props.label ? html`<label>${props.label}</label>` : nothing}
       <input
-        type=${type}
-        .value=${props.value || ''}
+        type=${inputType}
+        .value=${normalizedValue}
         @input=${(e: Event) => props.setValue?.((e.target as HTMLInputElement).value)}
       />
     `;

--- a/renderers/lit/src/v0_9/catalogs/basic/components/DateTimeInput.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/DateTimeInput.ts
@@ -28,16 +28,18 @@ import {A2uiController} from '@a2ui/lit/v0_9';
  * If these are present, the browser will reset the input to an empty string. This function strips
  * those specifiers using string splitting and substring manipulation without shifting timezones.
  */
-function normalizeDateTimeValue(value: string | null | undefined, type: string): string | null {
-  if (!value) return null;
+function normalizeDateTimeValue(value: string | null | undefined, type: string): string {
+  if (!value) return '';
 
   const hasT = value.includes('T');
-  // If the incoming value is not in ISO format (after a very cursory look), do not attempt to parse.
-  if (!hasT) return null;
-
   const split = value.split('T');
-  const datePart = split[0].substring(0, 10);
-  const timePart = split[1].substring(0, 5);
+
+  // If the incoming value is not in ISO format (not hasT), use the incoming value.
+  // It might be just a date: '2010-07-11' or a time: '13:37', so we use value as a
+  // the fallback to the split.
+  const datePart = (hasT ? split[0] : value)?.substring(0, 10) ?? '';
+  const timePart = (hasT ? split[1] : value)?.substring(0, 5) ?? '';
+
   switch (type) {
     case 'date':
       return datePart;
@@ -46,7 +48,7 @@ function normalizeDateTimeValue(value: string | null | undefined, type: string):
     case 'datetime-local':
       return `${datePart}T${timePart}`;
   }
-  return null;
+  return '';
 }
 
 @customElement('a2ui-datetimeinput')

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Modal.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Modal.ts
@@ -56,7 +56,11 @@ export class A2uiLitModal extends BasicCatalogA2uiLitElement<typeof ModalApi> {
     if (!props) return nothing;
 
     return html`
-      <div @click=${() => this.dialog?.showModal()} class="a2ui-modal-trigger" style="display: contents;">
+      <div
+        @click=${() => this.dialog?.showModal()}
+        class="a2ui-modal-trigger"
+        style="display: contents;"
+      >
         ${props.trigger ? html`${this.renderNode(props.trigger)}` : nothing}
       </div>
       <dialog class="a2ui-modal a2ui-modal-overlay">

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Modal.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Modal.ts
@@ -56,12 +56,12 @@ export class A2uiLitModal extends BasicCatalogA2uiLitElement<typeof ModalApi> {
     if (!props) return nothing;
 
     return html`
-      <div @click=${() => this.dialog?.showModal()} style="display: contents;">
+      <div @click=${() => this.dialog?.showModal()} class="a2ui-modal-trigger" style="display: contents;">
         ${props.trigger ? html`${this.renderNode(props.trigger)}` : nothing}
       </div>
-      <dialog class="a2ui-modal">
+      <dialog class="a2ui-modal a2ui-modal-overlay">
         <form method="dialog" style="text-align: right;">
-          <button>×</button>
+          <button class="a2ui-modal-close">×</button>
         </form>
         ${props.content ? html`${this.renderNode(props.content)}` : nothing}
       </dialog>

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Tabs.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Tabs.ts
@@ -81,6 +81,7 @@ export class A2uiLitTabs extends BasicCatalogA2uiLitElement<typeof TabsApi> {
             <button
               class=${classMap({
                 'a2ui-tabs-header': true,
+                'a2ui-tab-button': true,
                 active: i === this.activeIndex,
               })}
               @click=${() => (this.activeIndex = i)}

--- a/renderers/lit/src/v0_9/tests/a2ui-lit-element.test.ts
+++ b/renderers/lit/src/v0_9/tests/a2ui-lit-element.test.ts
@@ -20,15 +20,18 @@ import {describe, it, beforeEach, after, before} from 'node:test';
 
 import {ComponentContext, MessageProcessor} from '@a2ui/web_core/v0_9';
 
-let controllerCreatedCount = 0;
-let disposedCount = 0;
-
 /**
  * These tests ensure that:
  * - The element correctly instantiates an `A2uiController` when its ComponentContext is assigned.
  * - Changing the element's ComponentContext safely tears down the old controller and creates a new one.
  */
 describe('A2uiLitElement', () => {
+  let controllerCreatedCount = 0;
+  let disposedCount = 0;
+
+  // Tracks the return value of renderNode() in TestA2uiElement to verify rendering behavior in tests.
+  let lastRenderResult: any = null;
+
   let basicCatalog: any;
   before(async () => {
     setupTestDom();
@@ -50,7 +53,8 @@ describe('A2uiLitElement', () => {
       }
 
       render() {
-        return this.renderNode('child_id');
+        lastRenderResult = this.renderNode('child_id');
+        return lastRenderResult;
       }
     }
 
@@ -151,6 +155,56 @@ describe('A2uiLitElement', () => {
     // should have disposed the old and created a new one
     assert.strictEqual(disposedCount, 1);
     assert.strictEqual(controllerCreatedCount, 2);
+
+    document.body.removeChild(el);
+  });
+
+  it('should return nothing when component is removed from surface', async () => {
+    const {nothing} = await import('lit');
+
+    const el = document.createElement('test-a2ui-element') as any;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'root');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    // Remove the component from the surface components model
+    surface.componentsModel.removeComponent('root');
+
+    // Trigger update/render on the element by requesting an update.
+    // It should return nothing early and not throw.
+    await asyncUpdate(el, e => {
+      e.requestUpdate();
+    });
+
+    assert.strictEqual(lastRenderResult, nothing);
+
+    document.body.removeChild(el);
+  });
+
+  it('should return nothing when surface is disposed', async () => {
+    const {nothing} = await import('lit');
+
+    const el = document.createElement('test-a2ui-element') as any;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'root');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    // Dispose the surface
+    surface.dispose();
+
+    // Trigger update/render on the element by requesting an update.
+    // It should return nothing early and not throw.
+    await asyncUpdate(el, e => {
+      e.requestUpdate();
+    });
+
+    assert.strictEqual(lastRenderResult, nothing);
 
     document.body.removeChild(el);
   });


### PR DESCRIPTION
# Description

This PR addresses subtle v0.9 bugs in the Lit renderer that were uncovered by adding extra integration tests ([here](https://github.com/a2ui-project/a2ui/pull/1568)). In particular:

* Avoid rendering an `A2uiLitElement` when its surface is disposed of or the component is removed. This issue became apparent when unloading/reloading surfaces in the a2ui_explorer app during integration testing.
* Add missing CSS classes to the `Modal`, `Tabs` components to align with the Angular implementation and the integration tests.
* Fix `DateTimeInput` to correctly render `datetime-local`, `date` and `time` input types.

The a2ui_explorer app also receives a minor tweak, to ensure the active example is disposed of before loading the next one.

In the testing tools, added a method to locate buttons by their text (this code is repeated a TON in the integration tests)

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
