### PR TITLE
fix(samples): restrict default input/output modes to valid MIME types

### DIFF
--- a/samples/agent/adk/gemini_enterprise/cloud_run/README.md
+++ b/samples/agent/adk/gemini_enterprise/cloud_run/README.md
@@ -119,7 +119,7 @@ cat <<EOF > agent_request.json
   "displayName": "$AGENT_DISPLAY_NAME",
   "description": "$AGENT_DESCRIPTION",
   "a2aAgentDefinition": {
-     "jsonAgentCard": "{\"protocolVersion\": \"0.3.0\", \"name\": \"$AGENT_NAME\", \"description\": \"$AGENT_DESCRIPTION\", \"url\": \"$AGENT_URL\", \"version\": \"1.0.0\", \"capabilities\": {\"streaming\": false, \"preferredTransport\": \"JSONRPC\", \"extensions\": [{\"uri\": \"https://a2ui.org/a2a-extension/a2ui/v0.8\", \"description\": \"Ability to render A2UI\", \"required\": false, \"params\": {\"supportedCatalogIds\": [\"https://a2ui.org/specification/v0_8/standard_catalog_definition.json\"]}}]}, \"skills\": [], \"defaultInputModes\": [\"text\", \"text/plain\"], \"defaultOutputModes\": [\"text\", \"text/plain\"]}"
+     "jsonAgentCard": "{\"protocolVersion\": \"0.3.0\", \"name\": \"$AGENT_NAME\", \"description\": \"$AGENT_DESCRIPTION\", \"url\": \"$AGENT_URL\", \"version\": \"1.0.0\", \"capabilities\": {\"streaming\": false, \"preferredTransport\": \"JSONRPC\", \"extensions\": [{\"uri\": \"https://a2ui.org/a2a-extension/a2ui/v0.8\", \"description\": \"Ability to render A2UI\", \"required\": false, \"params\": {\"supportedCatalogIds\": [\"https://a2ui.org/specification/v0_8/standard_catalog_definition.json\"]}}]}, \"skills\": [], \"defaultInputModes\": [\"text/plain\"], \"defaultOutputModes\": [\"text/plain\"]}"
   }
 }
 EOF

--- a/samples/agent/adk/gemini_enterprise/cloud_run/agent.py
+++ b/samples/agent/adk/gemini_enterprise/cloud_run/agent.py
@@ -49,7 +49,7 @@ from tools import get_contact_info
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_CONTENT_TYPES = ["text", "text/plain"]
+SUPPORTED_CONTENT_TYPES = ["text/plain"]
 
 dotenv.load_dotenv()
 


### PR DESCRIPTION
# Description

When registering an Agent-to-Agent (A2A) card with Gemini Enterprise, the system enforces strict validation on the input and output modes, requiring them to comply with standard MIME media types (RFC 2046).

Previously, the templates and implementation in samples/agent/adk/gemini_enterprise/ used  "text"  as a shorth and alongside  "text/plain" . Because  "text"  is not a valid RFC-compliant MIME type (which requires both a type and a subtype), Gemini Enterprise rejected the card registration. This PR resolves the registration validation failure by dropping the invalid "text" type and enforcing standard MIME types.

<img width="2924" height="1404" alt="image" src="https://github.com/user-attachments/assets/919e08b4-d38d-4124-aec6-519791c690da" />



## Pre-launch Checklist

- [v] I signed the [CLA].
- [v] I read the [Contributors Guide].
- [v] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [v] I updated/added relevant documentation.
- [v] My code changes (if any) have tests.
- [v] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
