### PR TITLE
feat(spec): Add built-in @index function for list templates

### DIFF
--- a/specification/v0_10/docs/a2ui_protocol.md
+++ b/specification/v0_10/docs/a2ui_protocol.md
@@ -820,8 +820,11 @@ The [`catalogs/basic/catalog.json`] provides the baseline set of components and 
 
 ### Functions
 
+> **System Namespace Rule (`@` Prefix)**: Function names beginning with `@` (e.g., `@index`) represent universal system context evaluations available across all catalogs. Custom catalogs MUST NOT define functions prefixed with `@`.
+
 | Function           | Description                                                              |
 | :----------------- | :----------------------------------------------------------------------- |
+| **@index**         | Returns the 0-based index of the current item during template rendering. |
 | **required**       | Checks that the value is not null, undefined, or empty.                  |
 | **regex**          | Checks that the value matches a regular expression string.               |
 | **length**         | Checks string length constraints.                                        |
@@ -905,6 +908,35 @@ When a non-string value is interpolated, the client converts it to a string:
 - **Numbers/Booleans**: Standard string representation.
 - **Null/Undefined**: An empty string `""`.
 - **Objects/Arrays**: Stringified as JSON to ensure consistency across different client implementations.
+
+### The `@index` function
+
+The `@index` function returns the 0-based index of the current item when rendering a dynamic list from a template. It is a universal system function available across all catalogs.
+
+#### `@index` scope restriction
+
+The `@index` function MUST ONLY be available when evaluating template items within a list rendering context (Collection Scope). When an expression evaluator encounters `@index()`, it inspects the active Evaluation Context chain. If a Collection Scope is present, it returns the tracked iteration index. If called outside of template iteration (e.g., directly in the Root Scope), the client MUST treat it as an error or evaluate it as invalid.
+
+#### `@index` arguments
+
+- `offset` (Optional, `number`): An offset added to the 0-based index. For example, `@index(offset: 1)` produces 1-based indexing (`1, 2, 3...`). Defaults to `0`.
+
+#### Example usage
+
+Displaying item positions inside a list row template:
+
+```json
+{
+  "id": "todo-index",
+  "component": "Text",
+  "text": {
+    "call": "formatString",
+    "args": {
+      "value": "#${@index(offset: 1)}"
+    }
+  }
+}
+```
 
 ## Usage pattern: the prompt-generate-validate loop
 

--- a/specification/v0_10/json/common_types.json
+++ b/specification/v0_10/json/common_types.json
@@ -157,6 +157,28 @@
         }
       ]
     },
+    "indexSystemFunction": {
+      "type": "object",
+      "description": "Returns the 0-based index of the current item when rendering a dynamic list from a template. This function MUST ONLY be available when evaluating template items within a list context.",
+      "returnType": "number",
+      "properties": {
+        "call": {
+          "const": "@index"
+        },
+        "args": {
+          "type": "object",
+          "properties": {
+            "offset": {
+              "$ref": "#/$defs/DynamicNumber",
+              "description": "Optional. An offset to add to the 0-based index (e.g., 1 for 1-based indexing). Defaults to 0."
+            }
+          },
+          "unevaluatedProperties": false
+        }
+      },
+      "required": ["call"],
+      "unevaluatedProperties": false
+    },
     "FunctionCall": {
       "type": "object",
       "description": "Invokes a named function on the client.",
@@ -182,7 +204,10 @@
         }
       },
       "required": ["call"],
-      "oneOf": [{"$ref": "catalog.json#/$defs/anyFunction"}]
+      "oneOf": [
+        {"$ref": "catalog.json#/$defs/anyFunction"},
+        {"$ref": "#/$defs/indexSystemFunction"}
+      ]
     },
     "CheckRule": {
       "type": "object",

--- a/specification/v0_10/json/common_types.json
+++ b/specification/v0_10/json/common_types.json
@@ -170,7 +170,8 @@
           "properties": {
             "offset": {
               "$ref": "#/$defs/DynamicNumber",
-              "description": "Optional. An offset to add to the 0-based index (e.g., 1 for 1-based indexing). Defaults to 0."
+              "description": "Optional. An offset to add to the 0-based index (e.g., 1 for 1-based indexing). Defaults to 0.",
+              "default": 0
             }
           },
           "unevaluatedProperties": false

--- a/specification/v0_10/test/cases/function_catalog_validation.json
+++ b/specification/v0_10/test/cases/function_catalog_validation.json
@@ -1220,6 +1220,81 @@
           ]
         }
       }
+    },
+    {
+      "description": "@index: Valid call",
+      "valid": true,
+      "data": {
+        "version": "v0.10",
+        "updateComponents": {
+          "surfaceId": "test",
+          "components": [
+            {
+              "id": "list1",
+              "component": "List",
+              "children": {
+                "componentId": "slider1",
+                "path": "/items"
+              }
+            },
+            {
+              "id": "slider1",
+              "component": "Slider",
+              "max": 10,
+              "value": {
+                "call": "@index",
+                "args": {
+                  "offset": 1
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "@index: Invalid args (string offset)",
+      "valid": false,
+      "data": {
+        "version": "v0.10",
+        "updateComponents": {
+          "surfaceId": "test",
+          "components": [
+            {
+              "id": "slider1",
+              "component": "Slider",
+              "max": 10,
+              "value": {
+                "call": "@index",
+                "args": {
+                  "offset": "1"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "@index: Invalid returnType",
+      "valid": false,
+      "data": {
+        "version": "v0.10",
+        "updateComponents": {
+          "surfaceId": "test",
+          "components": [
+            {
+              "id": "slider1",
+              "component": "Slider",
+              "max": 10,
+              "value": {
+                "call": "@index",
+                "returnType": "string"
+              }
+            }
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
# Description

Introduces the `@index` client-side built-in function to the A2UI v0.10 protocol specification, allowing dynamic retrieval of the 0-based iteration index during list template rendering.

Key architectural highlights:
- Universal Availability: Embedded `@index` directly into `common_types.json` under `FunctionCall`, ensuring universal inheritance across all active catalogs (Basic, Minimal, and third-party custom catalogs).
- System Namespace Standard: Reserved the `@` prefix for core system context evaluations to permanently prevent collisions with custom catalog utilities.
- Strict Scoping: Restricts `@index` availability strictly to Evaluation Contexts operating within a Collection Scope (template instantiation). Calling outside of template iteration results in an invalid evaluation / error.
- Offset Support: Supports an optional `offset` argument (e.g., `@index(offset: 1)`) for easy 1-based indexing.

Fixes: https://github.com/a2ui-project/a2ui/issues/1558
