### PR TITLE
feat(specification): designate Unicode UAX #31 catalog entity naming rules.

### DIFF
--- a/specification/v0_10/docs/a2ui_protocol.md
+++ b/specification/v0_10/docs/a2ui_protocol.md
@@ -443,9 +443,31 @@ Every catalog follows the standard `Catalog` object definition:
 
 - **catalogId** (string, required): A unique identifier URI for this catalog.
 - **instructions** (string, optional): A relative file URI pointing to a Markdown file containing design principles, rules, or developer guidelines specific to this catalog (typically `instructions.md`). These rules guide LLMs when generating UI layouts under this catalog.
-- **components** (object, optional): A map of supported UI components, where each key is the component type (e.g., `Text`) and its value is its JSON Schema definition.
-- **functions** (array, optional): A list of client-side validation or utility functions supported by the catalog.
+- **components** (object, optional): A map of supported UI components, where each key is the component type (e.g., `Text`) and its value is its JSON Schema definition. All keys MUST conform to the UAX #31 entity naming rules defined below.
+- **functions** (array, optional): A list of client-side validation or utility functions supported by the catalog. All function names MUST conform to the UAX #31 entity naming rules defined below.
 - **surfaceProperties** (object, optional): A schema defining the catalog's customizable visual properties.
+
+#### Catalog Entity Naming Rules
+
+To ensure complete cross-language compatibility across client SDKs, parsers, and code generators, all catalog entity identifiers—specifically **component names**, **function names**, and **argument/property names**—MUST adhere strictly to [Unicode Standard Annex #31 (UAX #31)](https://www.unicode.org/reports/tr31/) variable naming rules.
+
+1. **Permitted Characters**: Identifiers must begin with a character in the Unicode property class `XID_Start` or an underscore (`_`, `U+005F`). Subsequent characters must belong to the Unicode property class `XID_Continue`.
+2. **Prohibited Initial Characters**: Identifiers MUST NOT begin with a decimal digit (Unicode general category `Nd`).
+3. **Prohibited Symbols and Whitespace**: Identifiers MUST NOT contain any whitespace or symbols matching the Unicode character property classes `Pattern_Syntax` or `Pattern_White_Space`, other than underscores.
+
+##### Canonical Regular Expression
+
+```regex
+^[\p{XID_Start}_][\p{XID_Continue}]*$
+```
+
+##### Examples
+
+- **Valid**: `UserProfileCard`, `submit_form`, `item_id_1`, `_internal_state`
+- **Invalid**:
+  - `User Card` (violates `Pattern_White_Space`)
+  - `1stItem` (violates initial `Nd`)
+  - `submit-form`, `user#name`, `calc$val` (violates `Pattern_Syntax`)
 
 ### UI composition: the adjacency list model
 

--- a/specification/v0_10/docs/a2ui_protocol.md
+++ b/specification/v0_10/docs/a2ui_protocol.md
@@ -444,7 +444,7 @@ Every catalog follows the standard `Catalog` object definition:
 - **catalogId** (string, required): A unique identifier URI for this catalog.
 - **instructions** (string, optional): A relative file URI pointing to a Markdown file containing design principles, rules, or developer guidelines specific to this catalog (typically `instructions.md`). These rules guide LLMs when generating UI layouts under this catalog.
 - **components** (object, optional): A map of supported UI components, where each key is the component type (e.g., `Text`) and its value is its JSON Schema definition. All keys MUST conform to the UAX #31 entity naming rules defined below.
-- **functions** (array, optional): A list of client-side validation or utility functions supported by the catalog. All function names MUST conform to the UAX #31 entity naming rules defined below.
+- **functions** (object, optional): A map of client-side validation or utility functions supported by the catalog, where each key is the function name and its value is its definition. All function names MUST conform to the UAX #31 entity naming rules defined below. The client determines a function's execution boundary (e.g., clientOnly status) at runtime by reading its configuration from the active catalog definition.
 - **surfaceProperties** (object, optional): A schema defining the catalog's customizable visual properties.
 
 #### Catalog Entity Naming Rules

--- a/specification/v0_10/docs/basic_catalog_implementation_guide.md
+++ b/specification/v0_10/docs/basic_catalog_implementation_guide.md
@@ -6,6 +6,18 @@ When building your framework-specific adapters (Layer 3) over the generic A2UI b
 
 ---
 
+## Mandatory Identifier Rules for Catalogs
+
+All entities defined in an A2UI v0.10 catalog—including **component types**, **function names**, and **argument/property names**—MUST strictly comply with [Unicode Standard Annex #31 (UAX #31)](https://www.unicode.org/reports/tr31/) rules for variable names:
+
+- Must begin with `XID_Start` or underscore (`_`). Cannot begin with a digit (`Nd`).
+- Must continue with `XID_Continue`.
+- Must strictly exclude symbols and whitespace (`Pattern_Syntax` and `Pattern_White_Space`).
+
+Canonical regex validation: `^[\p{XID_Start}_][\p{XID_Continue}]*$`
+
+---
+
 ## 1. Components
 
 ### Text

--- a/specification/v0_10/test/run_tests.py
+++ b/specification/v0_10/test/run_tests.py
@@ -294,20 +294,13 @@ def validate_catalogs_identifiers():
                 errors.append(f"Invalid component name: '{comp_name}'")
             check_schema_properties(comp_def)
 
-        functions = catalog.get("functions", [])
-        for func in functions:
-            if isinstance(func, str):
-                func_name = func
-            elif isinstance(func, dict):
-                func_name = func.get("call")
-                check_schema_properties(func)
-            else:
-                func_name = None
-
-            if func_name:
+        functions = catalog.get("functions", {})
+        if isinstance(functions, dict):
+            for func_name, func_def in functions.items():
                 check_name = func_name[1:] if func_name.startswith("@") else func_name
                 if not check_name.isidentifier():
                     errors.append(f"Invalid function name: '{func_name}'")
+                check_schema_properties(func_def)
 
         if errors:
             failed += 1

--- a/specification/v0_10/test/run_tests.py
+++ b/specification/v0_10/test/run_tests.py
@@ -240,6 +240,85 @@ def validate_catalogs_structure():
         if os.path.exists(temp_validator_path):
             os.remove(temp_validator_path)
 
+def validate_catalogs_identifiers():
+    """
+    Validates that all entity keys (components, functions) in all catalog files
+    strictly conform to Unicode UAX #31 identifier naming rules.
+    """
+    catalogs_to_validate = [
+        ("catalogs/basic/catalog.json", os.path.join(SPEC_DIR, "catalogs/basic/catalog.json")),
+        ("catalogs/minimal/catalog.json", os.path.join(SPEC_DIR, "catalogs/minimal/catalog.json")),
+        ("test/testing_catalog.json", os.path.join(TEST_DIR, "testing_catalog.json")),
+    ]
+
+    passed = 0
+    failed = 0
+
+    print("\nValidating catalog entities against Unicode UAX #31 identifier rules...")
+
+    for name, path in catalogs_to_validate:
+        if not os.path.exists(path):
+            print(f"  [FAIL] {name} (File not found)")
+            failed += 1
+            continue
+
+        with open(path, 'r') as f:
+            try:
+                catalog = json.load(f)
+            except json.JSONDecodeError as e:
+                print(f"  [FAIL] {name} (JSON Decode Error: {e})")
+                failed += 1
+                continue
+
+        errors = []
+
+        def check_schema_properties(obj):
+            if isinstance(obj, dict):
+                if "properties" in obj and isinstance(obj["properties"], dict):
+                    for prop_name, prop_def in obj["properties"].items():
+                        if not prop_name.isidentifier():
+                            errors.append(f"Invalid argument/property name: '{prop_name}'")
+                        check_schema_properties(prop_def)
+                for k, v in obj.items():
+                    if k != "properties":
+                        if isinstance(v, (dict, list)):
+                            check_schema_properties(v)
+            elif isinstance(obj, list):
+                for item in obj:
+                    if isinstance(item, (dict, list)):
+                        check_schema_properties(item)
+
+        components = catalog.get("components", {})
+        for comp_name, comp_def in components.items():
+            if not comp_name.isidentifier():
+                errors.append(f"Invalid component name: '{comp_name}'")
+            check_schema_properties(comp_def)
+
+        functions = catalog.get("functions", [])
+        for func in functions:
+            if isinstance(func, str):
+                func_name = func
+            elif isinstance(func, dict):
+                func_name = func.get("call")
+                check_schema_properties(func)
+            else:
+                func_name = None
+
+            if func_name:
+                check_name = func_name[1:] if func_name.startswith("@") else func_name
+                if not check_name.isidentifier():
+                    errors.append(f"Invalid function name: '{func_name}'")
+
+        if errors:
+            failed += 1
+            print(f"  [FAIL] {name}")
+            for err in errors:
+                print(f"         {err}")
+        else:
+            passed += 1
+
+    return passed, failed
+
 def main():
     if not os.path.exists(CASES_DIR):
         print(f"No cases directory found at {CASES_DIR}")
@@ -265,6 +344,11 @@ def main():
 
         # 3. Validate catalogs structural integrity
         p, f = validate_catalogs_structure()
+        total_passed += p
+        total_failed += f
+
+        # 4. Validate catalogs UAX #31 entity identifiers
+        p, f = validate_catalogs_identifiers()
         total_passed += p
         total_failed += f
 


### PR DESCRIPTION
# Description

Establish formal [Unicode Standard Annex `#31` (UAX `#31`)](https://www.unicode.org/reports/tr31/) variable naming constraints across all A2UI v0.10 catalog entities, including component names, function names, and argument keys.

- Update `a2ui_protocol.md` and `basic_catalog_implementation_guide.md` with explicit Unicode character property rules (`XID_Start`, `XID_Continue`) and canonical URLs.
- Implement exhaustive deep schema property verification in `specification/v0_10/test/run_tests.py` using Python's native `isidentifier()` validation.

Fixes https://github.com/a2ui-project/a2ui/issues/1571