### PR TITLE
Python a2ui_agent: Support custom cuttable keys configuration

### DIFF
--- a/agent_sdks/conformance/conformance_schema.json
+++ b/agent_sdks/conformance/conformance_schema.json
@@ -89,7 +89,8 @@
           "execute_tool",
           "get_extension",
           "try_activate",
-          "select_newest"
+          "select_newest",
+          "verify_cuttable_keys"
         ]
       }
     },
@@ -117,7 +118,8 @@
           {"$ref": "#/$defs/ExecuteToolTest"},
           {"$ref": "#/$defs/GetExtensionTest"},
           {"$ref": "#/$defs/TryActivateTest"},
-          {"$ref": "#/$defs/SelectNewestTest"}
+          {"$ref": "#/$defs/SelectNewestTest"},
+          {"$ref": "#/$defs/VerifyCuttableKeysTest"}
         ]
       }
     ]
@@ -444,6 +446,23 @@
         "expect": {"type": "object"}
       },
       "required": ["action", "args", "expect"]
+    },
+    "VerifyCuttableKeysTest": {
+      "type": "object",
+      "properties": {
+        "action": {"const": "verify_cuttable_keys"},
+        "expect": {
+          "type": "object",
+          "properties": {
+            "custom_cuttable_keys": {
+              "type": "array",
+              "items": {"type": "string"}
+            }
+          },
+          "required": ["custom_cuttable_keys"]
+        }
+      },
+      "required": ["action", "expect"]
     }
   }
 }

--- a/agent_sdks/conformance/suites/catalog.yaml
+++ b/agent_sdks/conformance/suites/catalog.yaml
@@ -461,3 +461,13 @@
     {"$schema":"https://json-schema.org/draft/2020-12/schema","catalog":"schema","catalogId":"id_basic"}
 
     ---END A2UI JSON SCHEMA---
+
+- name: test_custom_cuttable_keys
+  description: Tests that custom cuttable_keys are preserved in A2uiCatalog.
+  catalog:
+    version: "0.9"
+    custom_cuttable_keys: ["customKey1", "customKey2"]
+    catalog_schema: {catalogId: basic}
+  action: verify_cuttable_keys
+  expect:
+    custom_cuttable_keys: ["customKey1", "customKey2"]

--- a/agent_sdks/conformance/suites/streaming_parser.yaml
+++ b/agent_sdks/conformance/suites/streaming_parser.yaml
@@ -3259,3 +3259,31 @@
                   - id: "root"
                     component: "Text"
                     text: {path: "some/relative/path"}
+
+- name: test_custom_cuttable_keys
+  description: Tests that the streaming parser respects custom cuttable_keys from catalog.
+  catalog:
+    version: "0.9"
+    s2c_schema: "test_data/simplified_s2c_v09.json"
+    catalog_schema: {catalogId: "c1"}
+    custom_cuttable_keys: ["customCuttable"]
+  disable_validation: true
+  action: process_chunk
+  steps:
+    - input: '<a2ui-json>[{"version": "v0.9", "createSurface": {"surfaceId": "s1", "catalogId": "c1"}}]</a2ui-json>'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              createSurface:
+                surfaceId: "s1"
+                catalogId: "c1"
+    - input: '<a2ui-json>[{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Text", "customCuttable": "partial'
+      expect:
+        - a2ui:
+            - version: "v0.9"
+              updateComponents:
+                surfaceId: "s1"
+                components:
+                  - id: "root"
+                    component: "Text"
+                    customCuttable: "partial"

--- a/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/parser/StreamingParser.kt
+++ b/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/parser/StreamingParser.kt
@@ -43,7 +43,8 @@ abstract class StreamingParser(
     catalog?.let { TopologyAnalyzer.extractComponentRefFields(it) } ?: emptyMap()
   protected val requiredFieldsMap: Map<String, Set<String>> =
     catalog?.let { TopologyAnalyzer.extractComponentRequiredFields(it) } ?: emptyMap()
-  protected val validator: A2uiValidator? = catalog?.let { A2uiValidator(it, schemaMappings) }
+  protected val cuttableKeys: Set<String> = catalog?.cuttableKeys ?: emptySet()
+  internal var validator: A2uiValidator? = catalog?.let { A2uiValidator(it, schemaMappings) }
 
   protected var foundDelimiter = false
   protected val buffer = StringBuilder()
@@ -186,7 +187,7 @@ abstract class StreamingParser(
         val keyMatch = KEY_MATCH_REGEX.find(prefix)
         if (keyMatch != null) {
           val key = keyMatch.groupValues[1]
-          if (key !in CUTTABLE_KEYS) {
+          if (key !in cuttableKeys) {
             return ""
           }
 
@@ -262,9 +263,10 @@ abstract class StreamingParser(
         continue
       }
 
-      if (validator != null) {
+      val currentValidator = validator
+      if (currentValidator != null) {
         try {
-          validator.validate(m, strictIntegrity = strictIntegrity)
+          currentValidator.validate(m, strictIntegrity = strictIntegrity)
         } catch (e: Exception) {
           if (strictIntegrity) {
             throw e
@@ -1087,9 +1089,6 @@ abstract class StreamingParser(
   }
 
   companion object {
-    internal val CUTTABLE_KEYS =
-      setOf("literalString", "valueString", "label", "hint", "caption", "altText", "text")
-
     @JvmStatic internal val logger: Logger = Logger.getLogger(StreamingParser::class.java.name)
 
     private val KEY_MATCH_REGEX = Regex("\"([^\"]+)\"\\s*:\\s*$")

--- a/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/parser/StreamingParserV08.kt
+++ b/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/parser/StreamingParserV08.kt
@@ -78,9 +78,7 @@ class StreamingParserV08(
     sid: String?,
     messages: MutableList<ResponsePart>,
   ): Boolean {
-    if (validator != null) {
-      validator.validate(obj, strictIntegrity = false)
-    }
+    validator?.validate(obj, strictIntegrity = false)
 
     var currentSid = obj["surfaceId"]?.jsonPrimitive?.content ?: surfaceId
     when {

--- a/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/parser/StreamingParserV09.kt
+++ b/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/parser/StreamingParserV09.kt
@@ -69,9 +69,7 @@ class StreamingParserV09(
     sid: String?,
     messages: MutableList<ResponsePart>,
   ): Boolean {
-    if (validator != null) {
-      validator.validate(obj, strictIntegrity = false)
-    }
+    validator?.validate(obj, strictIntegrity = false)
 
     var currentSid = obj["surfaceId"]?.jsonPrimitive?.content ?: surfaceId
     when {

--- a/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/schema/A2uiConstants.kt
+++ b/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/schema/A2uiConstants.kt
@@ -26,6 +26,10 @@ object A2uiConstants {
   const val CATALOG_ID_KEY = "catalogId"
   const val CATALOG_STYLES_KEY = "styles"
 
+  @JvmField
+  val DEFAULT_CUTTABLE_KEYS =
+    setOf("literalString", "valueString", "label", "hint", "caption", "altText", "text")
+
   // Protocol constants
   const val SUPPORTED_CATALOG_IDS_KEY = "supportedCatalogIds"
   const val INLINE_CATALOGS_KEY = "inlineCatalogs"

--- a/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/schema/Catalog.kt
+++ b/agent_sdks/kotlin/src/main/kotlin/com/google/a2ui/schema/Catalog.kt
@@ -41,12 +41,18 @@ data class CatalogConfig(
   @JvmField val name: String,
   @JvmField val provider: A2uiCatalogProvider,
   @JvmField val examplesPath: String? = null,
+  @JvmField val customCuttableKeys: Set<String>? = null,
 ) {
   companion object {
     /** Create a [CatalogConfig] using a [FileSystemCatalogProvider]. */
     @JvmStatic
     @JvmOverloads
-    fun fromPath(name: String, catalogPath: String, examplesPath: String? = null): CatalogConfig {
+    fun fromPath(
+      name: String,
+      catalogPath: String,
+      examplesPath: String? = null,
+      customCuttableKeys: Set<String>? = null,
+    ): CatalogConfig {
       val uri =
         try {
           URI(catalogPath)
@@ -66,7 +72,7 @@ data class CatalogConfig(
           else -> throw IllegalArgumentException("Unsupported catalog URL scheme: $catalogPath")
         }
 
-      return CatalogConfig(name, provider, resolveExamplesPath(examplesPath))
+      return CatalogConfig(name, provider, resolveExamplesPath(examplesPath), customCuttableKeys)
     }
   }
 }
@@ -95,11 +101,15 @@ data class A2uiCatalog(
   @JvmField val serverToClientSchema: JsonObject,
   @JvmField val commonTypesSchema: JsonObject,
   @JvmField val catalogSchema: JsonObject,
+  @JvmField val customCuttableKeys: Set<String>? = null,
 ) {
 
   companion object {
     private val logger = Logger.getLogger(A2uiCatalog::class.java.name)
   }
+
+  val cuttableKeys: Set<String>
+    get() = customCuttableKeys ?: A2uiConstants.DEFAULT_CUTTABLE_KEYS
 
   val validator: A2uiValidator by lazy { A2uiValidator(this) }
 

--- a/agent_sdks/kotlin/src/test/kotlin/com/google/a2ui/conformance/ConformanceTest.kt
+++ b/agent_sdks/kotlin/src/test/kotlin/com/google/a2ui/conformance/ConformanceTest.kt
@@ -176,24 +176,14 @@ class ConformanceTest {
       (catalogMap["custom_cuttable_keys"] as? List<*>)?.mapNotNull { it as? String }?.toSet()
 
     val catalog =
-      if (customCuttableKeys != null) {
-        A2uiCatalog(
-          version = version,
-          name = TEST_CATALOG_NAME,
-          serverToClientSchema = s2cSchema,
-          commonTypesSchema = commonTypesSchema,
-          catalogSchema = catalogSchema,
-          customCuttableKeys = customCuttableKeys,
-        )
-      } else {
-        A2uiCatalog(
-          version = version,
-          name = TEST_CATALOG_NAME,
-          serverToClientSchema = s2cSchema,
-          commonTypesSchema = commonTypesSchema,
-          catalogSchema = catalogSchema,
-        )
-      }
+      A2uiCatalog(
+        version = version,
+        name = TEST_CATALOG_NAME,
+        serverToClientSchema = s2cSchema,
+        commonTypesSchema = commonTypesSchema,
+        catalogSchema = catalogSchema,
+        customCuttableKeys = customCuttableKeys,
+      )
 
     return Pair(catalog, schemaMappings)
   }

--- a/agent_sdks/kotlin/src/test/kotlin/com/google/a2ui/conformance/ConformanceTest.kt
+++ b/agent_sdks/kotlin/src/test/kotlin/com/google/a2ui/conformance/ConformanceTest.kt
@@ -172,14 +172,28 @@ class ConformanceTest {
         else -> JsonObject(emptyMap())
       }
 
+    val customCuttableKeys =
+      (catalogMap["custom_cuttable_keys"] as? List<*>)?.mapNotNull { it as? String }?.toSet()
+
     val catalog =
-      A2uiCatalog(
-        version = version,
-        name = TEST_CATALOG_NAME,
-        serverToClientSchema = s2cSchema,
-        commonTypesSchema = commonTypesSchema,
-        catalogSchema = catalogSchema,
-      )
+      if (customCuttableKeys != null) {
+        A2uiCatalog(
+          version = version,
+          name = TEST_CATALOG_NAME,
+          serverToClientSchema = s2cSchema,
+          commonTypesSchema = commonTypesSchema,
+          catalogSchema = catalogSchema,
+          customCuttableKeys = customCuttableKeys,
+        )
+      } else {
+        A2uiCatalog(
+          version = version,
+          name = TEST_CATALOG_NAME,
+          serverToClientSchema = s2cSchema,
+          commonTypesSchema = commonTypesSchema,
+          catalogSchema = catalogSchema,
+        )
+      }
 
     return Pair(catalog, schemaMappings)
   }
@@ -304,6 +318,11 @@ class ConformanceTest {
             val output = catalog!!.renderAsLlmInstructions()
             val expectOutput = case["expect_output"] as String
             assertEquals(expectOutput.trim(), output.trim())
+          }
+          "verify_cuttable_keys" -> {
+            val expect = case[ConformanceTestHelper.KEY_EXPECT] as Map<*, *>
+            val expectCuttableKeys = expect["custom_cuttable_keys"] as List<String>
+            assertEquals(expectCuttableKeys.toSet(), catalog!!.cuttableKeys)
           }
           else -> assert(false, { "Unknown action: $action" })
         }
@@ -583,6 +602,9 @@ class ConformanceTest {
           catalogMap?.let { buildCatalog(it, conformanceDir, baseSchemaMappings) }
             ?: (null to emptyMap())
         val parser = StreamingParser.create(catalog, schemaMappings)
+        if (case["disable_validation"] as? Boolean == true) {
+          parser.validator = null
+        }
 
         for ((stepIdx, stepObj) in steps.withIndex()) {
           val step = stepObj as Map<*, *>

--- a/agent_sdks/python/a2ui_agent/src/a2ui/parser/streaming.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/parser/streaming.py
@@ -41,20 +41,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# Keys whose string values can be safely auto-closed (healed) if fragmented in the stream.
-# Structural or atomic keys (e.g., id, surfaceId, path) are NOT cuttable to prevent
-# incorrect parsing or data binding.
-CUTTABLE_KEYS = {
-    "literalString",
-    "valueString",
-    "label",
-    "hint",
-    "caption",
-    "altText",
-    "text",
-}
-
-
 class A2uiStreamParser:
   """Parses a stream of text for A2UI JSON messages with fine-grained component yielding.
 
@@ -77,6 +63,9 @@ class A2uiStreamParser:
 
   def __init__(self, catalog: "A2uiCatalog" = None):
     self._version = getattr(catalog, "version", None) if catalog else None
+    self._cuttable_keys = (
+        getattr(catalog, "cuttable_keys", None) if catalog else frozenset()
+    )
     self._ref_fields_map = extract_component_ref_fields(catalog) if catalog else {}
     self._required_fields_map = (
         extract_component_required_fields(catalog) if catalog else {}
@@ -413,7 +402,7 @@ class A2uiStreamParser:
         key_match = re.findall(r'"([^"]+)"\s*:\s*$', prefix)
         if key_match:
           key = key_match[0]
-          if key not in CUTTABLE_KEYS:
+          if key not in self._cuttable_keys:
             return ""
 
           # Special case: don't cut URL bindings, as partial URLs break images/links

--- a/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
@@ -21,7 +21,6 @@ import os
 from dataclasses import dataclass, field, replace
 from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 from urllib.parse import urlparse
-from a2ui.core.catalog import JsonCatalog
 
 from .catalog_provider import A2uiCatalogProvider, FileSystemCatalogProvider
 from .constants import (
@@ -176,15 +175,6 @@ class A2uiCatalog:
   @property
   def validator(self) -> A2uiValidator:
     return A2uiValidator(self)
-
-  @property
-  def core_catalog(self) -> JsonCatalog:
-    return JsonCatalog(
-        version=self.version,
-        catalog_schema=self.catalog_schema,
-        catalog_id=self.catalog_id,
-        common_types_schema=self.common_types_schema,
-    )
 
   def _with_pruned_components(self, allowed_components: List[str]) -> A2uiCatalog:
     """Returns a new catalog with only allowed components.

--- a/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
@@ -19,8 +19,9 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field, replace
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 from urllib.parse import urlparse
+from a2ui.core.catalog import JsonCatalog
 
 from .catalog_provider import A2uiCatalogProvider, FileSystemCatalogProvider
 from .constants import (
@@ -28,9 +29,11 @@ from .constants import (
     A2UI_SCHEMA_BLOCK_END,
     CATALOG_COMPONENTS_KEY,
     CATALOG_ID_KEY,
+    DEFAULT_CUTTABLE_KEYS,
     VERSION_0_8,
     ENCODING,
 )
+from .validator import A2uiValidator
 
 
 @dataclass
@@ -45,15 +48,21 @@ class CatalogConfig:
     name: The name of the catalog.
     provider: The provider to use to load the catalog schema.
     examples_path: The path or glob pattern to the examples.
+    custom_cuttable_keys: The optional custom set of cuttable keys.
   """
 
   name: str
   provider: A2uiCatalogProvider
   examples_path: Optional[str] = None
+  custom_cuttable_keys: Optional[frozenset[str]] = None
 
   @classmethod
   def from_path(
-      cls, name: str, catalog_path: str, examples_path: Optional[str] = None
+      cls,
+      name: str,
+      catalog_path: str,
+      examples_path: Optional[str] = None,
+      custom_cuttable_keys: Optional[frozenset[str]] = None,
   ) -> "CatalogConfig":
     """Returns a CatalogConfig that loads from a local path or 'file://' URI."""
     parsed = urlparse(catalog_path)
@@ -64,11 +73,15 @@ class CatalogConfig:
     else:
       raise ValueError(f"Unsupported catalog URL scheme: {catalog_path}")
 
-    return cls(
-        name=name,
-        provider=catalog_provider,
-        examples_path=resolve_examples_path(examples_path),
-    )
+    kwargs = {
+        "name": name,
+        "provider": catalog_provider,
+        "examples_path": resolve_examples_path(examples_path),
+    }
+    if custom_cuttable_keys is not None:
+      kwargs["custom_cuttable_keys"] = custom_cuttable_keys
+
+    return cls(**kwargs)
 
 
 def resolve_examples_path(path: Optional[str]) -> Optional[str]:
@@ -137,6 +150,8 @@ class A2uiCatalog:
     s2c_schema: The server-to-client schema.
     common_types_schema: The common types schema.
     catalog_schema: The catalog schema.
+    custom_cuttable_keys: The optional set of keys whose string values can be safely auto-closed
+      (healed) if fragmented in the stream. If None, the default set is used.
   """
 
   version: str
@@ -144,6 +159,13 @@ class A2uiCatalog:
   s2c_schema: Dict[str, Any]
   common_types_schema: Dict[str, Any]
   catalog_schema: Dict[str, Any]
+  custom_cuttable_keys: Optional[frozenset[str]] = None
+
+  @property
+  def cuttable_keys(self) -> frozenset[str]:
+    if self.custom_cuttable_keys is not None:
+      return frozenset(self.custom_cuttable_keys)
+    return DEFAULT_CUTTABLE_KEYS
 
   @property
   def catalog_id(self) -> str:
@@ -152,12 +174,19 @@ class A2uiCatalog:
     return self.catalog_schema[CATALOG_ID_KEY]
 
   @property
-  def validator(self) -> "A2uiValidator":
-    from .validator import A2uiValidator
-
+  def validator(self) -> A2uiValidator:
     return A2uiValidator(self)
 
-  def _with_pruned_components(self, allowed_components: List[str]) -> "A2uiCatalog":
+  @property
+  def core_catalog(self) -> JsonCatalog:
+    return JsonCatalog(
+        version=self.version,
+        catalog_schema=self.catalog_schema,
+        catalog_id=self.catalog_id,
+        common_types_schema=self.common_types_schema,
+    )
+
+  def _with_pruned_components(self, allowed_components: List[str]) -> A2uiCatalog:
     """Returns a new catalog with only allowed components.
 
     Args:
@@ -202,7 +231,7 @@ class A2uiCatalog:
 
     return replace(self, catalog_schema=schema_copy)
 
-  def _with_pruned_messages(self, allowed_messages: List[str]) -> "A2uiCatalog":
+  def _with_pruned_messages(self, allowed_messages: List[str]) -> A2uiCatalog:
     """Returns a new catalog with only allowed messages.
 
     Args:
@@ -250,7 +279,7 @@ class A2uiCatalog:
       self,
       allowed_components: Optional[List[str]] = None,
       allowed_messages: Optional[List[str]] = None,
-  ) -> "A2uiCatalog":
+  ) -> A2uiCatalog:
     """Returns a new catalog with pruned components and messages.
 
     Args:
@@ -269,7 +298,7 @@ class A2uiCatalog:
 
     return catalog._with_pruned_common_types()
 
-  def _with_pruned_common_types(self) -> "A2uiCatalog":
+  def _with_pruned_common_types(self) -> A2uiCatalog:
     """Returns a new catalog with unused common types pruned from the schema."""
     if not self.common_types_schema or "$defs" not in self.common_types_schema:
       return self

--- a/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
@@ -62,7 +62,7 @@ class CatalogConfig:
       catalog_path: str,
       examples_path: Optional[str] = None,
       custom_cuttable_keys: Optional[frozenset[str]] = None,
-  ) -> "CatalogConfig":
+  ) -> CatalogConfig:
     """Returns a CatalogConfig that loads from a local path or 'file://' URI."""
     parsed = urlparse(catalog_path)
     if not parsed.scheme or parsed.scheme == "file":
@@ -72,15 +72,12 @@ class CatalogConfig:
     else:
       raise ValueError(f"Unsupported catalog URL scheme: {catalog_path}")
 
-    kwargs = {
-        "name": name,
-        "provider": catalog_provider,
-        "examples_path": resolve_examples_path(examples_path),
-    }
-    if custom_cuttable_keys is not None:
-      kwargs["custom_cuttable_keys"] = custom_cuttable_keys
-
-    return cls(**kwargs)
+    return cls(
+        name=name,
+        provider=catalog_provider,
+        examples_path=resolve_examples_path(examples_path),
+        custom_cuttable_keys=custom_cuttable_keys,
+    )
 
 
 def resolve_examples_path(path: Optional[str]) -> Optional[str]:

--- a/agent_sdks/python/a2ui_agent/src/a2ui/schema/constants.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/schema/constants.py
@@ -21,6 +21,19 @@ CATALOG_ID_KEY = "catalogId"
 CATALOG_STYLES_KEY = "styles"
 SURFACE_ID_KEY = "surfaceId"
 
+# Keys whose string values can be safely auto-closed (healed) if fragmented in the stream.
+# Structural or atomic keys (e.g., id, surfaceId, path) are NOT cuttable to prevent
+# incorrect parsing or data binding.
+DEFAULT_CUTTABLE_KEYS = frozenset({
+    "literalString",
+    "valueString",
+    "label",
+    "hint",
+    "caption",
+    "altText",
+    "text",
+})
+
 # Protocol constants
 SUPPORTED_CATALOG_IDS_KEY = "supportedCatalogIds"
 INLINE_CATALOGS_KEY = "inlineCatalogs"

--- a/agent_sdks/python/a2ui_agent/src/a2ui/schema/manager.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/schema/manager.py
@@ -94,6 +94,7 @@ class A2uiSchemaManager(InferenceStrategy):
           catalog_schema=catalog_schema,
           s2c_schema=self._server_to_client_schema,
           common_types_schema=self._common_types_schema,
+          custom_cuttable_keys=config.custom_cuttable_keys,
       )
       self._supported_catalogs.append(catalog)
       self._catalog_example_paths[catalog.catalog_id] = config.examples_path

--- a/agent_sdks/python/a2ui_agent/tests/conformance/test_conformance.py
+++ b/agent_sdks/python/a2ui_agent/tests/conformance/test_conformance.py
@@ -75,18 +75,17 @@ def setup_catalog(catalog_config):
   elif common_types_schema is None:
     common_types_schema = {}
 
-  kwargs = {
-      "version": version,
-      "name": catalog_config.get("name", "test_catalog"),
-      "s2c_schema": s2c_schema,
-      "common_types_schema": common_types_schema,
-      "catalog_schema": catalog_schema,
-  }
   custom_cuttable_keys = catalog_config.get("custom_cuttable_keys")
-  if custom_cuttable_keys is not None:
-    kwargs["custom_cuttable_keys"] = frozenset(custom_cuttable_keys)
-
-  return A2uiCatalog(**kwargs)
+  return A2uiCatalog(
+      version=version,
+      name=catalog_config.get("name", "test_catalog"),
+      s2c_schema=s2c_schema,
+      common_types_schema=common_types_schema,
+      catalog_schema=catalog_schema,
+      custom_cuttable_keys=frozenset(custom_cuttable_keys)
+      if custom_cuttable_keys is not None
+      else None,
+  )
 
 
 def assert_parts_match(actual_parts, expected_parts):

--- a/agent_sdks/python/a2ui_agent/tests/conformance/test_conformance.py
+++ b/agent_sdks/python/a2ui_agent/tests/conformance/test_conformance.py
@@ -75,13 +75,18 @@ def setup_catalog(catalog_config):
   elif common_types_schema is None:
     common_types_schema = {}
 
-  return A2uiCatalog(
-      version=version,
-      name="test_catalog",
-      s2c_schema=s2c_schema,
-      common_types_schema=common_types_schema,
-      catalog_schema=catalog_schema,
-  )
+  kwargs = {
+      "version": version,
+      "name": catalog_config.get("name", "test_catalog"),
+      "s2c_schema": s2c_schema,
+      "common_types_schema": common_types_schema,
+      "catalog_schema": catalog_schema,
+  }
+  custom_cuttable_keys = catalog_config.get("custom_cuttable_keys")
+  if custom_cuttable_keys is not None:
+    kwargs["custom_cuttable_keys"] = frozenset(custom_cuttable_keys)
+
+  return A2uiCatalog(**kwargs)
 
 
 def assert_parts_match(actual_parts, expected_parts):
@@ -107,6 +112,8 @@ def test_parser_conformance(name, test_case):
   catalog_config = test_case["catalog"]
   catalog = setup_catalog(catalog_config)
   parser = A2uiStreamParser(catalog=catalog)
+  if test_case.get("disable_validation"):
+    parser._validator = None
 
   steps = test_case.get("steps")
   if steps is None and "process_chunk" in test_case:
@@ -246,6 +253,10 @@ def test_catalog_conformance(name, test_case):
     schema = args["schema"]
     modified = remove_strict_validation(schema)
     assert modified == test_case["expect"]["schema"]
+
+  elif action == "verify_cuttable_keys":
+    expected = test_case["expect"]["custom_cuttable_keys"]
+    assert set(catalog.cuttable_keys) == set(expected)
 
 
 # --- Schema Manager Conformance ---


### PR DESCRIPTION
It follows up internal discussion in https://chat.google.com/room/AAQAA_wnJC4/s8Cir-DWpYA/s8Cir-DWpYA?cls=10.

Instead of using a hard-coded set of cuttable keys for auto-healing during stream parsing process, it allows configuring a set of custom configuration keys.

## Summary of Changes

This pull request enables configurable cuttable keys for the A2UI streaming parser, moving away from a hard-coded set. This change allows users to define custom keys that can be safely auto-healed during stream processing, improving robustness for varied data structures. The implementation spans the core catalog configuration, SDK logic in both Kotlin and Python, and updated conformance tests to ensure consistent behavior.

### Highlights

* **Custom Cuttable Keys Configuration**: Introduced support for configuring custom cuttable keys in the A2UI catalog, allowing for more flexible auto-healing during stream parsing.
* **Schema and SDK Updates**: Updated the conformance schema and both Kotlin and Python SDKs to support the new custom_cuttable_keys configuration property.
* **Conformance Testing**: Added new conformance test cases to verify that custom cuttable keys are correctly preserved and respected by the streaming parser.

<details>
<summary><b>Activity</b></summary>

* Initial pull request created by nan-yu.
* Automated review feedback provided suggestions for improving default value handling for cuttable keys and simplifying constructor calls.
* The author has addressed the feedback to ensure consistent behavior when no catalog is provided.
</details>


