### PR TITLE
feat(web_core): export basic_catalog in v0.9

### DIFF
--- a/renderers/web_core/src/v0_9/index.ts
+++ b/renderers/web_core/src/v0_9/index.ts
@@ -35,6 +35,7 @@ export * from './state/surface-components-model.js';
 export * from './state/surface-group-model.js';
 export * from './state/surface-model.js';
 export * from './errors.js';
+export * from './basic_catalog/index.js';
 
 export {effect, Signal, signal, computed} from '@preact/signals-core';
 


### PR DESCRIPTION
Exposes the basic catalog components under the v0.9 exports of @a2ui/web_core.

This is needed for 1P consumers that want to extend or compose the basic catalog.