### PR TITLE
refactor: Add CatalogInterface for v0.9

### DIFF
--- a/renderers/web_core/src/v0_9/catalog/types.ts
+++ b/renderers/web_core/src/v0_9/catalog/types.ts
@@ -112,9 +112,22 @@ export interface ComponentApi<Schema extends z.ZodTypeAny = z.ZodTypeAny> {
 export type InferredComponentApiSchemaType<Api extends ComponentApi> = z.infer<Api['schema']>;
 
 /**
+ * Interface for Catalog to prevent property renaming in 1P (Closure Compiler).
+ *
+ * This must declare all publicly accessed properties of Catalog.
+ */
+export declare interface CatalogInterface<T extends ComponentApi> {
+  readonly id: string;
+  readonly components: ReadonlyMap<string, T>;
+  readonly functions: ReadonlyMap<string, FunctionImplementation>;
+  readonly themeSchema?: z.ZodObject<any>;
+  readonly invoker: FunctionInvoker;
+}
+
+/**
  * A collection of available components and functions.
  */
-export class Catalog<T extends ComponentApi> {
+export class Catalog<T extends ComponentApi> implements CatalogInterface<T> {
   readonly id: string;
 
   /**


### PR DESCRIPTION
This is needed to prevent property renaming in 1P.