### PR TITLE
refactor: Decouple and deprecate core locale, plumb via catalog factory

### DIFF
--- a/renderers/angular/src/v0_9/catalog/basic/basic-catalog.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/basic-catalog.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {BasicCatalog, BASIC_CATALOG_OPTIONS} from './basic-catalog';
+
+describe('BasicCatalog', () => {
+  it('should be created with default options when no token is provided', () => {
+    TestBed.configureTestingModule({
+      providers: [BasicCatalog],
+    });
+
+    const catalog = TestBed.inject(BasicCatalog);
+    expect(catalog).toBeTruthy();
+    expect(catalog.id).toBe('https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json');
+  });
+
+  it('should be created with custom options when token is provided', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        BasicCatalog,
+        {
+          provide: BASIC_CATALOG_OPTIONS,
+          useValue: {
+            id: 'https://example.com/custom-catalog.json',
+          },
+        },
+      ],
+    });
+
+    const catalog = TestBed.inject(BasicCatalog);
+    expect(catalog).toBeTruthy();
+    expect(catalog.id).toBe('https://example.com/custom-catalog.json');
+  });
+});

--- a/renderers/angular/src/v0_9/catalog/basic/basic-catalog.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/basic-catalog.ts
@@ -37,6 +37,7 @@ import {DateTimeInputComponent} from './date-time-input.component';
 
 import {
   BASIC_FUNCTIONS,
+  createBasicCatalogFunctions,
   TextApi,
   RowApi,
   ColumnApi,
@@ -95,6 +96,11 @@ export interface BasicCatalogOptions {
   id?: string;
 
   /**
+   * An optional locale to configure catalog-level formatting.
+   */
+  locale?: string;
+
+  /**
    * Optional overrides for individual components in the catalog.
    */
   components?: Partial<{
@@ -131,7 +137,7 @@ export {BASIC_FUNCTIONS};
 export class BasicCatalogBase extends AngularCatalog {
   constructor(options: BasicCatalogOptions = {}) {
     const id = options.id ?? 'https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json';
-    const functions = options.functions ?? BASIC_FUNCTIONS;
+    const functions = options.functions ?? createBasicCatalogFunctions({ locale: options.locale });
 
     const overrides = options.components ?? {};
     const components: AngularComponentImplementation[] = [

--- a/renderers/angular/src/v0_9/catalog/basic/basic-catalog.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/basic-catalog.ts
@@ -137,7 +137,7 @@ export {BASIC_FUNCTIONS};
 export class BasicCatalogBase extends AngularCatalog {
   constructor(options: BasicCatalogOptions = {}) {
     const id = options.id ?? 'https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json';
-    const functions = options.functions ?? createBasicCatalogFunctions({ locale: options.locale });
+    const functions = options.functions ?? createBasicCatalogFunctions({locale: options.locale});
 
     const overrides = options.components ?? {};
     const components: AngularComponentImplementation[] = [

--- a/renderers/angular/src/v0_9/catalog/basic/basic-catalog.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/basic-catalog.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Injectable} from '@angular/core';
+import {Inject, Injectable, InjectionToken, Optional} from '@angular/core';
 import {AngularCatalog, AngularComponentImplementation} from '../types';
 import {TextComponent} from './text.component';
 import {RowComponent} from './row.component';
@@ -152,6 +152,10 @@ export class BasicCatalogBase extends AngularCatalog {
   }
 }
 
+export const BASIC_CATALOG_OPTIONS = new InjectionToken<BasicCatalogOptions>(
+  'BASIC_CATALOG_OPTIONS',
+);
+
 /**
  * A basic catalog of components and functions for v0.9 verification.
  *
@@ -163,7 +167,7 @@ export class BasicCatalogBase extends AngularCatalog {
   providedIn: 'root',
 })
 export class BasicCatalog extends BasicCatalogBase {
-  constructor() {
-    super();
+  constructor(@Optional() @Inject(BASIC_CATALOG_OPTIONS) options?: BasicCatalogOptions) {
+    super(options ?? {});
   }
 }

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## Unreleased
 
-- Add locale support to `SurfaceModel` and `DataContext` in v0.9.
-- Update `pluralize`, `formatNumber`, and `formatCurrency` to use the context locale instead of hardcoding 'en-US'.
+- Add locale support to basic catalog functions (`pluralize`, `formatNumber`, `formatCurrency`) in v0.9 via catalog-level configuration.
 - Remove `.passthrough()` from `PluralizeApi` schema for stricter validation.
 - Allow overriding hard-coded recursion depth in `DataValueSchema` for v0.8 by introducing `createDataValueSchema` factory function.
 - Fix `formatString` to JSON-stringify objects/arrays per spec instead of using JS default coercion.

--- a/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.test.ts
@@ -18,7 +18,7 @@ import {describe, it} from 'node:test';
 import * as assert from 'node:assert';
 import {effect, Signal} from '@preact/signals-core';
 
-import {BASIC_FUNCTIONS} from './basic_functions.js';
+import {BASIC_FUNCTIONS, createBasicCatalogFunctions} from './basic_functions.js';
 import {DataModel} from '../../state/data-model.js';
 import {DataContext} from '../../rendering/data-context.js';
 import {A2uiExpressionError} from '../../errors.js';
@@ -34,13 +34,11 @@ const createTestDataContext = (
   model: DataModel,
   path: string,
   functionInvoker: any = testCatalog.invoker,
-  locale?: string,
 ) => {
   const mockSurface = {
     dataModel: model,
     catalog: {invoker: functionInvoker},
     dispatchError: () => {},
-    locale: locale,
   } as any;
   return new DataContext(mockSurface, path);
 };
@@ -435,7 +433,8 @@ describe('BASIC_FUNCTIONS', () => {
     });
 
     it('pluralize with Welsh locale', () => {
-      const cyContext = createTestDataContext(dataModel, '/', testCatalog.invoker, 'cy');
+      const cyCatalog = new Catalog<ComponentApi>('test-cy', [], createBasicCatalogFunctions({ locale: 'cy' }));
+      const cyContext = createTestDataContext(dataModel, '/', cyCatalog.invoker);
       // Welsh for various numbers of "cat".  Welsh because all six cases have different rules.
       const args = {
         zero: 'cathod',
@@ -446,12 +445,12 @@ describe('BASIC_FUNCTIONS', () => {
         other: 'cath',
       };
 
-      assert.strictEqual(invoke('pluralize', {...args, value: 0}, cyContext), 'cathod');
-      assert.strictEqual(invoke('pluralize', {...args, value: 1}, cyContext), 'gath');
-      assert.strictEqual(invoke('pluralize', {...args, value: 2}, cyContext), 'gath');
-      assert.strictEqual(invoke('pluralize', {...args, value: 3}, cyContext), 'cath');
-      assert.strictEqual(invoke('pluralize', {...args, value: 6}, cyContext), 'chath');
-      assert.strictEqual(invoke('pluralize', {...args, value: 4}, cyContext), 'cath');
+      assert.strictEqual(cyCatalog.invoker('pluralize', {...args, value: 0}, cyContext), 'cathod');
+      assert.strictEqual(cyCatalog.invoker('pluralize', {...args, value: 1}, cyContext), 'gath');
+      assert.strictEqual(cyCatalog.invoker('pluralize', {...args, value: 2}, cyContext), 'gath');
+      assert.strictEqual(cyCatalog.invoker('pluralize', {...args, value: 3}, cyContext), 'cath');
+      assert.strictEqual(cyCatalog.invoker('pluralize', {...args, value: 6}, cyContext), 'chath');
+      assert.strictEqual(cyCatalog.invoker('pluralize', {...args, value: 4}, cyContext), 'cath');
     });
 
     it('pluralize fallback to other', () => {

--- a/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.test.ts
@@ -433,7 +433,11 @@ describe('BASIC_FUNCTIONS', () => {
     });
 
     it('pluralize with Welsh locale', () => {
-      const cyCatalog = new Catalog<ComponentApi>('test-cy', [], createBasicCatalogFunctions({ locale: 'cy' }));
+      const cyCatalog = new Catalog<ComponentApi>(
+        'test-cy',
+        [],
+        createBasicCatalogFunctions({locale: 'cy'}),
+      );
       const cyContext = createTestDataContext(dataModel, '/', cyCatalog.invoker);
       // Welsh for various numbers of "cat".  Welsh because all six cases have different rules.
       const args = {

--- a/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -307,19 +307,16 @@ function getNumberFormat(
  * Creates the number formatting function implementation.
  */
 export function createFormatNumberImplementation(locale?: string): FunctionImplementation {
-  return createFunctionImplementation(
-    FormatNumberApi,
-    (args, context) => {
-      if (isNaN(args.value)) return '';
-      try {
-        const activeLocale = locale ?? context.locale;
-        return getNumberFormat(activeLocale, args.decimals, args.grouping).format(args.value);
-      } catch (e) {
-        console.warn('Error formatting number:', e);
-        return args.decimals !== undefined ? args.value.toFixed(args.decimals) : String(args.value);
-      }
-    },
-  );
+  return createFunctionImplementation(FormatNumberApi, (args, context) => {
+    if (isNaN(args.value)) return '';
+    try {
+      const activeLocale = locale ?? context.locale;
+      return getNumberFormat(activeLocale, args.decimals, args.grouping).format(args.value);
+    } catch (e) {
+      console.warn('Error formatting number:', e);
+      return args.decimals !== undefined ? args.value.toFixed(args.decimals) : String(args.value);
+    }
+  });
 }
 
 /**
@@ -355,21 +352,18 @@ function getCurrencyFormat(
  * Creates the currency formatting function implementation.
  */
 export function createFormatCurrencyImplementation(locale?: string): FunctionImplementation {
-  return createFunctionImplementation(
-    FormatCurrencyApi,
-    (args, context) => {
-      if (isNaN(args.value)) return '';
-      try {
-        const activeLocale = locale ?? context.locale;
-        return getCurrencyFormat(activeLocale, args.currency, args.decimals, args.grouping).format(
-          args.value,
-        );
-      } catch (e) {
-        console.warn('Error formatting currency:', e);
-        return args.value.toFixed(args.decimals ?? 2);
-      }
-    },
-  );
+  return createFunctionImplementation(FormatCurrencyApi, (args, context) => {
+    if (isNaN(args.value)) return '';
+    try {
+      const activeLocale = locale ?? context.locale;
+      return getCurrencyFormat(activeLocale, args.currency, args.decimals, args.grouping).format(
+        args.value,
+      );
+    } catch (e) {
+      console.warn('Error formatting currency:', e);
+      return args.value.toFixed(args.decimals ?? 2);
+    }
+  });
 }
 
 /**
@@ -411,19 +405,16 @@ function getPluralRules(locale: string | undefined): Intl.PluralRules {
  * Creates the pluralization function implementation.
  */
 export function createPluralizeImplementation(locale?: string): FunctionImplementation {
-  return createFunctionImplementation(
-    PluralizeApi,
-    (args, context) => {
-      try {
-        const activeLocale = locale ?? context.locale;
-        const rule = getPluralRules(activeLocale).select(args.value);
-        return String((args as Record<string, unknown>)[rule] ?? args.other ?? '');
-      } catch (e) {
-        console.warn('Error in pluralize:', e);
-        return String(args.other ?? '');
-      }
-    },
-  );
+  return createFunctionImplementation(PluralizeApi, (args, context) => {
+    try {
+      const activeLocale = locale ?? context.locale;
+      const rule = getPluralRules(activeLocale).select(args.value);
+      return String((args as Record<string, unknown>)[rule] ?? args.other ?? '');
+    } catch (e) {
+      console.warn('Error in pluralize:', e);
+      return String(args.other ?? '');
+    }
+  });
 }
 
 /**
@@ -449,7 +440,7 @@ export const OpenUrlImplementation = createFunctionImplementation(OpenUrlApi, ar
  * @param options Configuration options.
  * @param options.locale Optional locale to close-over.
  */
-export function createBasicCatalogFunctions(options?: { locale?: string }): FunctionImplementation[] {
+export function createBasicCatalogFunctions(options?: {locale?: string}): FunctionImplementation[] {
   const locale = options?.locale;
   return [
     AddImplementation,

--- a/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -307,11 +307,10 @@ function getNumberFormat(
  * Creates the number formatting function implementation.
  */
 export function createFormatNumberImplementation(locale?: string): FunctionImplementation {
-  return createFunctionImplementation(FormatNumberApi, (args, context) => {
+  return createFunctionImplementation(FormatNumberApi, args => {
     if (isNaN(args.value)) return '';
     try {
-      const activeLocale = locale ?? context.locale;
-      return getNumberFormat(activeLocale, args.decimals, args.grouping).format(args.value);
+      return getNumberFormat(locale, args.decimals, args.grouping).format(args.value);
     } catch (e) {
       console.warn('Error formatting number:', e);
       return args.decimals !== undefined ? args.value.toFixed(args.decimals) : String(args.value);
@@ -352,11 +351,10 @@ function getCurrencyFormat(
  * Creates the currency formatting function implementation.
  */
 export function createFormatCurrencyImplementation(locale?: string): FunctionImplementation {
-  return createFunctionImplementation(FormatCurrencyApi, (args, context) => {
+  return createFunctionImplementation(FormatCurrencyApi, args => {
     if (isNaN(args.value)) return '';
     try {
-      const activeLocale = locale ?? context.locale;
-      return getCurrencyFormat(activeLocale, args.currency, args.decimals, args.grouping).format(
+      return getCurrencyFormat(locale, args.currency, args.decimals, args.grouping).format(
         args.value,
       );
     } catch (e) {
@@ -405,10 +403,9 @@ function getPluralRules(locale: string | undefined): Intl.PluralRules {
  * Creates the pluralization function implementation.
  */
 export function createPluralizeImplementation(locale?: string): FunctionImplementation {
-  return createFunctionImplementation(PluralizeApi, (args, context) => {
+  return createFunctionImplementation(PluralizeApi, args => {
     try {
-      const activeLocale = locale ?? context.locale;
-      const rule = getPluralRules(activeLocale).select(args.value);
+      const rule = getPluralRules(locale).select(args.value);
       return String((args as Record<string, unknown>)[rule] ?? args.other ?? '');
     } catch (e) {
       console.warn('Error in pluralize:', e);

--- a/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -304,21 +304,30 @@ function getNumberFormat(
 }
 
 /**
+ * Creates the number formatting function implementation.
+ */
+export function createFormatNumberImplementation(locale?: string): FunctionImplementation {
+  return createFunctionImplementation(
+    FormatNumberApi,
+    (args, context) => {
+      if (isNaN(args.value)) return '';
+      try {
+        const activeLocale = locale ?? context.locale;
+        return getNumberFormat(activeLocale, args.decimals, args.grouping).format(args.value);
+      } catch (e) {
+        console.warn('Error formatting number:', e);
+        return args.decimals !== undefined ? args.value.toFixed(args.decimals) : String(args.value);
+      }
+    },
+  );
+}
+
+/**
  * Implementation of the number formatting function.
  * Formats a number using Intl.NumberFormat with specified decimals and grouping.
  */
-export const FormatNumberImplementation = createFunctionImplementation(
-  FormatNumberApi,
-  (args, context) => {
-    if (isNaN(args.value)) return '';
-    try {
-      return getNumberFormat(context.locale, args.decimals, args.grouping).format(args.value);
-    } catch (e) {
-      console.warn('Error formatting number:', e);
-      return args.decimals !== undefined ? args.value.toFixed(args.decimals) : String(args.value);
-    }
-  },
-);
+export const FormatNumberImplementation = createFormatNumberImplementation();
+
 const currencyFormatCache = new Map<string, Intl.NumberFormat>();
 
 function getCurrencyFormat(
@@ -343,24 +352,32 @@ function getCurrencyFormat(
 }
 
 /**
+ * Creates the currency formatting function implementation.
+ */
+export function createFormatCurrencyImplementation(locale?: string): FunctionImplementation {
+  return createFunctionImplementation(
+    FormatCurrencyApi,
+    (args, context) => {
+      if (isNaN(args.value)) return '';
+      try {
+        const activeLocale = locale ?? context.locale;
+        return getCurrencyFormat(activeLocale, args.currency, args.decimals, args.grouping).format(
+          args.value,
+        );
+      } catch (e) {
+        console.warn('Error formatting currency:', e);
+        return args.value.toFixed(args.decimals ?? 2);
+      }
+    },
+  );
+}
+
+/**
  * Implementation of the currency formatting function.
  * Formats a number as currency using Intl.NumberFormat.
  * Falls back to toFixed if formatting fails.
  */
-export const FormatCurrencyImplementation = createFunctionImplementation(
-  FormatCurrencyApi,
-  (args, context) => {
-    if (isNaN(args.value)) return '';
-    try {
-      return getCurrencyFormat(context.locale, args.currency, args.decimals, args.grouping).format(
-        args.value,
-      );
-    } catch (e) {
-      console.warn('Error formatting currency:', e);
-      return args.value.toFixed(args.decimals ?? 2);
-    }
-  },
-);
+export const FormatCurrencyImplementation = createFormatCurrencyImplementation();
 /**
  * Implementation of the date formatting function.
  * Formats a date using date-fns or returns ISO string.
@@ -391,21 +408,29 @@ function getPluralRules(locale: string | undefined): Intl.PluralRules {
 }
 
 /**
+ * Creates the pluralization function implementation.
+ */
+export function createPluralizeImplementation(locale?: string): FunctionImplementation {
+  return createFunctionImplementation(
+    PluralizeApi,
+    (args, context) => {
+      try {
+        const activeLocale = locale ?? context.locale;
+        const rule = getPluralRules(activeLocale).select(args.value);
+        return String((args as Record<string, unknown>)[rule] ?? args.other ?? '');
+      } catch (e) {
+        console.warn('Error in pluralize:', e);
+        return String(args.other ?? '');
+      }
+    },
+  );
+}
+
+/**
  * Implementation of the pluralization function.
  * Selects the appropriate plural form based on the value using Intl.PluralRules.
  */
-export const PluralizeImplementation = createFunctionImplementation(
-  PluralizeApi,
-  (args, context) => {
-    try {
-      const rule = getPluralRules(context.locale).select(args.value);
-      return String((args as Record<string, unknown>)[rule] ?? args.other ?? '');
-    } catch (e) {
-      console.warn('Error in pluralize:', e);
-      return String(args.other ?? '');
-    }
-  },
-);
+export const PluralizeImplementation = createPluralizeImplementation();
 
 // Actions
 /**
@@ -419,33 +444,44 @@ export const OpenUrlImplementation = createFunctionImplementation(OpenUrlApi, ar
 });
 
 /**
+ * Creates standard function implementations for the Basic Catalog.
+ *
+ * @param options Configuration options.
+ * @param options.locale Optional locale to close-over.
+ */
+export function createBasicCatalogFunctions(options?: { locale?: string }): FunctionImplementation[] {
+  const locale = options?.locale;
+  return [
+    AddImplementation,
+    SubtractImplementation,
+    MultiplyImplementation,
+    DivideImplementation,
+    EqualsImplementation,
+    NotEqualsImplementation,
+    GreaterThanImplementation,
+    LessThanImplementation,
+    AndImplementation,
+    OrImplementation,
+    NotImplementation,
+    ContainsImplementation,
+    StartsWithImplementation,
+    EndsWithImplementation,
+    RequiredImplementation,
+    RegexImplementation,
+    LengthImplementation,
+    NumericImplementation,
+    EmailImplementation,
+    FormatStringImplementation,
+    createFormatNumberImplementation(locale),
+    createFormatCurrencyImplementation(locale),
+    FormatDateImplementation,
+    createPluralizeImplementation(locale),
+    OpenUrlImplementation,
+  ];
+}
+
+/**
  * Standard function implementations for the Basic Catalog.
  * These functions cover arithmetic, comparison, logic, string manipulation, validation, and formatting.
  */
-export const BASIC_FUNCTIONS: FunctionImplementation[] = [
-  AddImplementation,
-  SubtractImplementation,
-  MultiplyImplementation,
-  DivideImplementation,
-  EqualsImplementation,
-  NotEqualsImplementation,
-  GreaterThanImplementation,
-  LessThanImplementation,
-  AndImplementation,
-  OrImplementation,
-  NotImplementation,
-  ContainsImplementation,
-  StartsWithImplementation,
-  EndsWithImplementation,
-  RequiredImplementation,
-  RegexImplementation,
-  LengthImplementation,
-  NumericImplementation,
-  EmailImplementation,
-  FormatStringImplementation,
-  FormatNumberImplementation,
-  FormatCurrencyImplementation,
-  FormatDateImplementation,
-  PluralizeImplementation,
-  OpenUrlImplementation,
-];
+export const BASIC_FUNCTIONS: FunctionImplementation[] = createBasicCatalogFunctions();

--- a/renderers/web_core/src/v0_9/rendering/data-context.ts
+++ b/renderers/web_core/src/v0_9/rendering/data-context.ts
@@ -53,8 +53,6 @@ export class DataContext {
     this.functionInvoker = surface.catalog.invoker;
   }
 
-
-
   /**
    * Mutates the underlying DataModel at the specified path.
    *

--- a/renderers/web_core/src/v0_9/rendering/data-context.ts
+++ b/renderers/web_core/src/v0_9/rendering/data-context.ts
@@ -55,6 +55,8 @@ export class DataContext {
 
   /**
    * Gets the locale for this context, inherited from the surface.
+   *
+   * @deprecated The locale property on DataContext is deprecated and will be removed in a future release.
    */
   get locale(): string | undefined {
     return this.surface.locale;

--- a/renderers/web_core/src/v0_9/rendering/data-context.ts
+++ b/renderers/web_core/src/v0_9/rendering/data-context.ts
@@ -53,14 +53,7 @@ export class DataContext {
     this.functionInvoker = surface.catalog.invoker;
   }
 
-  /**
-   * Gets the locale for this context, inherited from the surface.
-   *
-   * @deprecated The locale property on DataContext is deprecated and will be removed in a future release.
-   */
-  get locale(): string | undefined {
-    return this.surface.locale;
-  }
+
 
   /**
    * Mutates the underlying DataModel at the specified path.

--- a/renderers/web_core/src/v0_9/state/surface-model.ts
+++ b/renderers/web_core/src/v0_9/state/surface-model.ts
@@ -53,18 +53,12 @@ export class SurfaceModel<T extends ComponentApi = ComponentApi> {
    * @param catalog The component catalog used by this surface.
    * @param theme The theme to apply to this surface.
    * @param sendDataModel If true, the client will send the full data model.
-   * @param locale The locale to use in locale-sensitive functions.
-   * @deprecated Configure the locale parameter at the catalog level instead.
    */
   constructor(
     readonly id: string,
     readonly catalog: Catalog<T>,
     readonly theme: any = {},
     readonly sendDataModel: boolean = false,
-    /**
-     * @deprecated Configure the locale parameter at the catalog level instead.
-     */
-    readonly locale?: string,
   ) {
     this.dataModel = new DataModel({});
     this.componentsModel = new SurfaceComponentsModel();

--- a/renderers/web_core/src/v0_9/state/surface-model.ts
+++ b/renderers/web_core/src/v0_9/state/surface-model.ts
@@ -54,12 +54,16 @@ export class SurfaceModel<T extends ComponentApi = ComponentApi> {
    * @param theme The theme to apply to this surface.
    * @param sendDataModel If true, the client will send the full data model.
    * @param locale The locale to use in locale-sensitive functions.
+   * @deprecated Configure the locale parameter at the catalog level instead.
    */
   constructor(
     readonly id: string,
     readonly catalog: Catalog<T>,
     readonly theme: any = {},
     readonly sendDataModel: boolean = false,
+    /**
+     * @deprecated Configure the locale parameter at the catalog level instead.
+     */
     readonly locale?: string,
   ) {
     this.dataModel = new DataModel({});


### PR DESCRIPTION
# Description

This Pull Request decouples the `locale` parameter from core models (`SurfaceModel` and `DataContext`) and plumbs it directly via a localized basic catalog function factory inside `@a2ui/web_core/v0_9/basic_catalog`. 

By deprecating the legacy, core-level parameters and providing a localized factory (`createBasicCatalogFunctions`), we:
1. Ensure the core rendering layer remains lightweight, catalog-agnostic, and unburdened by layout/formatting preferences.
2. Maintain full backward compatibility for existing catalogs and standard default functions (`BASIC_FUNCTIONS`).
3. Add native support for localizing basic catalogs downstream (such as in `@a2ui/angular`'s options).

Fixes #1609

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style