### PR TITLE
ci(lit): Do not modify a2ui messages in testing harness

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-node_modules
-dist
-build
+**/node_modules
+**/dist
+**/build
+**/.wireit
+**/*.tsbuildinfo
 .git
 .dart_tool
 .venv

--- a/renderers/lit/a2ui_explorer/package.json
+++ b/renderers/lit/a2ui_explorer/package.json
@@ -16,8 +16,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "clean": "wireit",
-    "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format": "prettier --ignore-path ../../../.prettierignore --write .",
+    "format:check": "prettier --ignore-path ../../../.prettierignore --check ."
   },
   "wireit": {
     "build": {
@@ -68,6 +68,7 @@
     "karma-chrome-launcher": "^3.2.0",
     "karma-esbuild": "^2.3.0",
     "karma-jasmine": "^5.1.0",
+    "prettier": "^3.5.0",
     "typescript": "5.9.3",
     "vite": "^8.0.16",
     "vitest": "^3.0.0",

--- a/renderers/lit/a2ui_explorer/src/local-gallery.ts
+++ b/renderers/lit/a2ui_explorer/src/local-gallery.ts
@@ -120,7 +120,7 @@ export class LocalGallery extends LitElement {
 
     const modifiedToProcess = this.applyPrimaryColorToMessages(toProcess);
 
-    this.processor.processMessages(modifiedToProcess);
+    this.processor.processMessages(structuredClone(modifiedToProcess));
     this.processedMessageCount += toProcess.length;
 
     // Subscribe to data model on first advance if not already subscribed

--- a/renderers/lit/a2ui_explorer/tests/v0_9/30_live-invitation-builder.test.ts
+++ b/renderers/lit/a2ui_explorer/tests/v0_9/30_live-invitation-builder.test.ts
@@ -104,10 +104,13 @@ describe('Example: Live Invitation Builder', () => {
     expect(textInputs.length).toBeGreaterThanOrEqual(2);
 
     const nameInput = textInputs[0];
+    expect(nameInput.value).withContext('nameInput initial value').toBe('Summer Gala');
+    const guestInput = textInputs[1];
+    expect(guestInput.value).withContext('guestInput initial value').toBe('Alex Johnson');
+
     nameInput.value = 'Awesome Party';
     nameInput.dispatchEvent(new Event('input'));
 
-    const guestInput = textInputs[1];
     guestInput.value = 'Alex Johnson';
     guestInput.dispatchEvent(new Event('input'));
 
@@ -124,10 +127,13 @@ describe('Example: Live Invitation Builder', () => {
     expect(textInputs.length).toBeGreaterThanOrEqual(2);
 
     const nameInput = textInputs[0];
+    expect(nameInput.value).withContext('nameInput initial value 2').toBe('Summer Gala');
+    const guestInput = textInputs[1];
+    expect(guestInput.value).withContext('guestInput initial value 2').toBe('Alex Johnson');
+
     nameInput.value = 'Summer Gala';
     nameInput.dispatchEvent(new Event('input'));
 
-    const guestInput = textInputs[1];
     guestInput.value = 'John Doe';
     guestInput.dispatchEvent(new Event('input'));
 

--- a/renderers/lit/package.json
+++ b/renderers/lit/package.json
@@ -59,8 +59,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "clean": "wireit",
-    "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format": "prettier --ignore-path ../../.prettierignore --write .",
+    "format:check": "prettier --ignore-path ../../.prettierignore --check ."
   },
   "wireit": {
     "test": {
@@ -116,6 +116,7 @@
     "google-artifactregistry-auth": "^3.5.0",
     "gts": "^7.0.0",
     "jsdom": "^29.1.1",
+    "prettier": "^3.5.0",
     "typescript": "5.9.3",
     "wireit": "^0.15.0-pre.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,6 +159,7 @@ __metadata:
     karma-esbuild: "npm:^2.3.0"
     karma-jasmine: "npm:^5.1.0"
     lit: "npm:^3.3.3"
+    prettier: "npm:^3.5.0"
     typescript: "npm:5.9.3"
     vite: "npm:^8.0.16"
     vitest: "npm:^3.0.0"
@@ -197,6 +198,7 @@ __metadata:
     gts: "npm:^7.0.0"
     jsdom: "npm:^29.1.1"
     lit: "npm:^3.3.3"
+    prettier: "npm:^3.5.0"
     signal-utils: "npm:^0.21.1"
     typescript: "npm:5.9.3"
     wireit: "npm:^0.15.0-pre.2"
@@ -24828,21 +24830,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier@npm:^3.5.0, prettier@npm:^3.8.4":
+  version: 3.8.4
+  resolution: "prettier@npm:3.8.4"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/b90a0cbe75b88ac0af9c13fe0f359bd19926fabccd88483227b21f71f0c1cc42da056fc1ac3a361e665577c568371d5ccfb2c62c31c8a1186f8d1bd531a063e9
+  languageName: node
+  linkType: hard
+
 "prettier@npm:^3.6.2":
   version: 3.8.1
   resolution: "prettier@npm:3.8.1"
   bin:
     prettier: bin/prettier.cjs
   checksum: 10c0/33169b594009e48f570471271be7eac7cdcf88a209eed39ac3b8d6d78984039bfa9132f82b7e6ba3b06711f3bfe0222a62a1bfb87c43f50c25a83df1b78a2c42
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^3.8.4":
-  version: 3.8.4
-  resolution: "prettier@npm:3.8.4"
-  bin:
-    prettier: bin/prettier.cjs
-  checksum: 10c0/b90a0cbe75b88ac0af9c13fe0f359bd19926fabccd88483227b21f71f0c1cc42da056fc1ac3a361e665577c568371d5ccfb2c62c31c8a1186f8d1bd531a063e9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

While setting up the integration tests for React, I found some weird failures with some test cases that pointed to A2UI Messages being modified by the testing harness as tests executed.

The solution is to deep clone the test case messages when a test is initialized so they're always "fresh". See it in angular [here](https://github.com/a2ui-project/a2ui/blob/969f2c18655a1d1d58de123c1cbba3dca7713037/renderers/angular/a2ui_explorer/src/app/agent-stub-v09.service.ts#L115).

The problem also exists on the Lit testing harness, but it was being masked by the tests doing some sneaky initialization.

This PR removes the sneaky initialization of tests, and clones the messages so they pass as expected.

(It also adds a dependency on `prettier` and ensures that `yarn format` works, something that I found broken while attempting to format my changes before creating this PR)

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
