### PR TITLE
Update eval action to run transcrypt sooner

### DIFF
--- a/.github/workflows/run_evals.yml
+++ b/.github/workflows/run_evals.yml
@@ -52,6 +52,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Decrypt dataset
+        working-directory: eval
+        if: ${{ env.TRANSCRYPT_PASSWORD != '' }}
+        run: ./bin/transcrypt -p "$TRANSCRYPT_PASSWORD" -y
+
       - name: Install `uv` globally
         run: |
           python -m pip install --upgrade pip
@@ -60,11 +65,6 @@ jobs:
       - name: Run Unit Tests
         working-directory: eval
         run: uv run python -m pytest
-
-      - name: Decrypt dataset
-        working-directory: eval
-        if: ${{ env.TRANSCRYPT_PASSWORD != '' }}
-        run: ./bin/transcrypt -p "$TRANSCRYPT_PASSWORD" -y
 
       - name: Run Evals
         working-directory: eval


### PR DESCRIPTION
# Description

If transcrypt isn't run before the unit tests run, then uv.lock will be updated, and the git repo won't be clean when transcrypt runs.

Not sure why this started happening, but this will fix some failed evals:

Fixes #1647
Fixes #1649
Fixes #1650