### PR TITLE
feat(angular): export MarkdownRenderer in public API of v0.8

### DIFF
--- a/renderers/angular/src/v0_8/data/index.ts
+++ b/renderers/angular/src/v0_8/data/index.ts
@@ -16,4 +16,4 @@
 
 export * from './processor';
 export * from './types';
-export {provideMarkdownRenderer} from './markdown';
+export {MarkdownRenderer, provideMarkdownRenderer} from './markdown';


### PR DESCRIPTION
Export the MarkdownRenderer symbol in the public api file for angular v0.8 and v0.9. This improves 1P compatibility when dependents import MarkdownRenderer directly.

No changes to v0.9, because it already exports MarkdownRenderer