### PR TITLE
docs(restaurant_finder): fix inaccurate Python version prerequisite

### DIFF
--- a/samples/agent/adk/restaurant_finder/README.md
+++ b/samples/agent/adk/restaurant_finder/README.md
@@ -4,7 +4,7 @@ This sample uses the Agent Development Kit (ADK) along with the A2A protocol to 
 
 ## Prerequisites
 
-- Python 3.9 or higher
+- Python — see `requires-python` in `pyproject.toml`
 - [UV](https://docs.astral.sh/uv/)
 - Access to an LLM and API Key
 


### PR DESCRIPTION
contributes to https://github.com/flutter/genui/issues/907

## What was wrong

The `samples/agent/adk/restaurant_finder/README.md` Prerequisites section listed **"Python 3.9 or higher"**, but the example's `pyproject.toml` declares `requires-python = ">=3.14"`. A reader following the README on Python 3.9–3.13 would hit an unmet-version error from `uv`.

## Fix

Replace the hardcoded version with a reference to `requires-python` in `pyproject.toml` (the single source of truth), so the prerequisite stays accurate as the floor changes. No other README content changed — the steps were already correct, ordered, copy-pasteable, and concise, and the Disclaimer is preserved.
