### PR TITLE
docs: Add README for react/shell sample

### DIFF
--- a/samples/agent/adk/uv.lock
+++ b/samples/agent/adk/uv.lock
@@ -118,7 +118,7 @@ requires-dist = [
     { name = "litellm" },
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
-    { name = "starlette", specifier = ">=1.3.1" },
+    { name = "starlette", specifier = ">=0.50.0" },
     { name = "uvicorn", specifier = ">=0.40.0" },
 ]
 

--- a/samples/client/react/shell/README.md
+++ b/samples/client/react/shell/README.md
@@ -46,7 +46,7 @@ yarn dev
 Vite serves the app on http://localhost:5003 and proxies `/a2a` requests to the
 agent running on `localhost:10002`.
 
-### Open UI
+### 4. Open the UI
 
 Open http://localhost:5003 in your browser (or follow the link printed in the
 console).

--- a/samples/client/react/shell/README.md
+++ b/samples/client/react/shell/README.md
@@ -6,7 +6,7 @@ Agent-to-Agent (A2A) protocol.
 
 ## Prerequisites
 
-- [nodejs](https://nodejs.org/en)
+- [Node.js](https://nodejs.org/en)
 - [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - Python — see `requires-python` in the agent's
   [pyproject.toml](../../../agent/adk/restaurant_finder/pyproject.toml)

--- a/samples/client/react/shell/README.md
+++ b/samples/client/react/shell/README.md
@@ -1,0 +1,62 @@
+# Restaurant finder - React UI with Python agent
+
+A React shell that renders A2UI surfaces streamed from the
+[Restaurant Finder Agent](../../../agent/adk/restaurant_finder/) over the
+Agent-to-Agent (A2A) protocol.
+
+## Prerequisites
+
+- [nodejs](https://nodejs.org/en)
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
+- Python — see `requires-python` in the agent's
+  [pyproject.toml](../../../agent/adk/restaurant_finder/pyproject.toml)
+
+## Running
+
+### 1. Install and build dependencies
+
+From the repository root, install dependencies and build all packages:
+
+```bash
+yarn install
+yarn build:all
+```
+
+### 2. Run the agent
+
+In one terminal, start the
+[Restaurant Finder Agent](../../../agent/adk/restaurant_finder/) on its default
+port (`10002`):
+
+```bash
+cd samples/agent/adk/restaurant_finder
+cp .env.example .env   # then edit .env and set GEMINI_API_KEY (do not commit .env)
+uv run .
+```
+
+### 3. Run the dev server
+
+In another terminal, start the React dev server:
+
+```bash
+cd samples/client/react/shell
+yarn dev
+```
+
+Vite serves the app on http://localhost:5003 and proxies `/a2a` requests to the
+agent running on `localhost:10002`.
+
+### Open UI
+
+Open http://localhost:5003 in your browser (or follow the link printed in the
+console).
+
+## Security Notice
+
+Important: The sample code provided is for demonstration purposes and illustrates the mechanics of A2UI and the Agent-to-Agent (A2A) protocol. When building production applications, it is critical to treat any agent operating outside of your direct control as a potentially untrusted entity.
+
+All operational data received from an external agent—including its AgentCard, messages, artifacts, and task statuses—should be handled as untrusted input. For example, a malicious agent could provide crafted data in its fields (e.g., name, skills.description) that, if used without sanitization to construct prompts for a Large Language Model (LLM), could expose your application to prompt injection attacks.
+
+Similarly, any UI definition or data stream received must be treated as untrusted. Malicious agents could attempt to spoof legitimate interfaces to deceive users (phishing), inject malicious scripts via property values (XSS), or generate excessive layout complexity to degrade client performance (DoS). If your application supports optional embedded content (such as iframes or web views), additional care must be taken to prevent exposure to malicious external sites.
+
+Developer Responsibility: Failure to properly validate data and strictly sandbox rendered content can introduce severe vulnerabilities. Developers are responsible for implementing appropriate security measures—such as input sanitization, Content Security Policies (CSP), strict isolation for optional embedded content, and secure credential handling—to protect their systems and users.


### PR DESCRIPTION
contributes to https://github.com/flutter/genui/issues/907

## What

The `@a2ui/react-shell` sample (`samples/client/react/shell`) had no README, leaving users with no documented way to run it. This adds one modeled on the sibling `samples/client/lit/shell/README.md` (same structure and voice).

The README covers:
- Prerequisites (nodejs, uv, and Python referenced via `requires-python` in the agent's pyproject rather than a hardcoded version)
- Install + build from the repo root (`yarn install`, `yarn build:all`)
- Running the restaurant_finder agent (default port 10002)
- Running the vite dev server (`yarn dev`, serves on :5003 and proxies `/a2a` to the agent)
- Opening the UI
- The standard Security Notice

## Verification

Validated end-to-end from a clean worktree:
- `yarn install` and built the workspace deps (`@a2ui/web_core`, `@a2ui/markdown-it`, `@a2ui/react`) with no errors.
- Started the restaurant_finder agent and confirmed `GET /.well-known/agent-card.json` -> 200.
- Started `yarn dev`; `GET http://localhost:5003/` -> 200, vite started with no errors.
- `POST /a2a` with a text query streamed back A2UI JSON from the agent (`createSurface` / `updateComponents` v0.9 surfaces), confirming the full client->proxy->agent flow.


https://github.com/user-attachments/assets/18d3e57d-8817-4b27-a31c-3a4018b87eea

