### PR TITLE
docs(mcp): clarify micro-app build requirement and Python prereq in a2ui-in-mcpapps README

### DIFF
--- a/samples/community/mcp/a2ui-in-mcpapps/README.md
+++ b/samples/community/mcp/a2ui-in-mcpapps/README.md
@@ -52,7 +52,7 @@ sequenceDiagram
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) (LTS recommended)
-- [Python 3.10+](https://www.python.org/) with `uv`
+- [Python](https://www.python.org/) with [`uv`](https://docs.astral.sh/uv/) (the required version is pinned in `server/.python-version`; `uv` fetches it automatically)
 
 ### ⚠️ IMPORTANT: Install Repository Dependencies
 
@@ -80,9 +80,9 @@ yarn build:sandbox
 
 _(Generates `client/public/sandbox_iframe/sandbox.{js,html}`)_
 
-### 2. Rebuild Micro-Apps (Optional)
+### 2. Build the Micro-Apps
 
-The server serves single-file HTML artifacts located in `server/apps/public/`. Choose the app you want to build:
+The server serves single-file HTML artifacts from `server/apps/public/`. These artifacts are git-ignored and are **not** included in a fresh checkout, so you must build at least one app before its surface can load (the server itself still starts without them). Choose the app(s) you want to build:
 
 #### Option A: The Editor App
 

--- a/samples/community/mcp/a2ui-in-mcpapps/README.md
+++ b/samples/community/mcp/a2ui-in-mcpapps/README.md
@@ -52,7 +52,7 @@ sequenceDiagram
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) (LTS recommended)
-- [Python](https://www.python.org/) with [`uv`](https://docs.astral.sh/uv/) (the required version is pinned in `server/.python-version`; `uv` fetches it automatically)
+- [uv](https://docs.astral.sh/uv/) (Python is managed automatically by uv using the version pinned in server/.python-version)
 
 ### ⚠️ IMPORTANT: Install Repository Dependencies
 


### PR DESCRIPTION
contributes to https://github.com/flutter/genui/issues/907

## What was unclear

While validating `samples/community/mcp/a2ui-in-mcpapps/README.md` end-to-end in a fresh worktree, two things were misleading:

1. **Micro-app build framed as purely "Optional."** The server reads its surfaces from `server/apps/public/{app,editor}.html`, but those single-file artifacts are git-ignored and **absent** in a fresh checkout. Following the README literally (skipping the "optional" step) starts the server but the Basic/Editor surfaces fail to load (`Resource file not found`). Reworded to state the build is required for a surface to render, while noting the server itself still starts without it.

2. **Hardcoded "Python 3.10+".** Replaced with a pointer to `server/.python-version` (the source of truth, which `uv` fetches automatically) so the doc doesn't drift from the actual pin.

## What still works (verified, left unchanged)

- `yarn install` (repo root) — OK
- `cd client && yarn install && yarn build:sandbox` — generates `client/public/sandbox_iframe/sandbox.{js,html}`
- `cd server && uv sync && uv run python server.py --transport sse --port 8000` — `--transport sse`/`--port` valid; `/sse` returns HTTP 200 `text/event-stream`
- `cd client && yarn start` (ng serve) — index served HTTP 200 with `<app-root>`
- `cd server/apps/src && yarn build:all` — generates `server/apps/public/app.html`

Architecture, mermaid diagram, and communication-flow sections preserved. No code changes.
