### PR TITLE
docs(angular): Fix Angular client README to match available apps

### DIFF
--- a/docs/guides/client-setup.md
+++ b/docs/guides/client-setup.md
@@ -86,10 +86,10 @@ export const appConfig: ApplicationConfig = {
 
 ### Streaming
 
-By default, the Angular client uses the non-streaming API. To enable streaming, set the `ENABLE_STREAMING` environment variable to `true` before starting the app:
+By default, the Angular client uses the streaming API. To disable streaming, set the `ENABLE_STREAMING` environment variable to `false` before starting the app:
 
 ```bash
-export ENABLE_STREAMING=true
+export ENABLE_STREAMING=false
 yarn start -- restaurant
 ```
 

--- a/docs/guides/client-setup.md
+++ b/docs/guides/client-setup.md
@@ -90,7 +90,7 @@ By default, the Angular client uses the streaming API. To disable streaming, set
 
 ```bash
 export ENABLE_STREAMING=false
-yarn start -- restaurant
+yarn start restaurant
 ```
 
 > [!NOTE]

--- a/samples/agent/adk/uv.lock
+++ b/samples/agent/adk/uv.lock
@@ -118,7 +118,7 @@ requires-dist = [
     { name = "litellm" },
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
-    { name = "starlette", specifier = ">=1.3.1" },
+    { name = "starlette", specifier = ">=0.50.0" },
     { name = "uvicorn", specifier = ">=0.40.0" },
 ]
 

--- a/samples/client/angular/README.md
+++ b/samples/client/angular/README.md
@@ -21,16 +21,9 @@ yarn install
 yarn demo:restaurant
 ```
 
-Here are the instructions if you want to do each step manually.
-
-1. **Install dependencies:** `yarn install`
-2. **Start the backend A2A service:** run the [restaurant_finder](../../agent/adk/restaurant_finder/README.md) agent (listens on port 10002).
-3. **Run the client:** `yarn start restaurant`
-4. **Open** http://localhost:4200/
-
 ## Streaming
 
-By default, the Angular client uses the streaming API to communicate with the agent. To disable streaming, set the `ENABLE_STREAMING` environment variable to `false`:
+By default, the Angular client uses the streaming API to communicate with the agent. To disable streaming, set the `ENABLE_STREAMING` environment variable to `false`.
 
 ```bash
 export ENABLE_STREAMING=false

--- a/samples/client/angular/README.md
+++ b/samples/client/angular/README.md
@@ -30,6 +30,8 @@ export ENABLE_STREAMING=false
 yarn start restaurant
 ```
 
+## Security Disclaimer
+
 Important: The sample code provided is for demonstration purposes and illustrates the mechanics of A2UI and the Agent-to-Agent (A2A) protocol. When building production applications, it is critical to treat any agent operating outside of your direct control as a potentially untrusted entity.
 
 All operational data received from an external agent—including its AgentCard, messages, artifacts, and task statuses—should be handled as untrusted input. For example, a malicious agent could provide crafted data in its fields (e.g., name, skills.description) that, if used without sanitization to construct prompts for a Large Language Model (LLM), could expose your application to prompt injection attacks.

--- a/samples/client/angular/README.md
+++ b/samples/client/angular/README.md
@@ -14,7 +14,7 @@ Here is the quickstart for the restaurant app:
 ```bash
 # Set up your Gemini API key
 cp ../../agent/adk/restaurant_finder/.env.example ../../agent/adk/restaurant_finder/.env
-# Edit the .env file with your actual API key (do not commit .env)
+# Edit the .env file with your actual API key (.env is gitignored for security reasons)
 
 # Start the restaurant app frontend
 yarn install

--- a/samples/client/angular/README.md
+++ b/samples/client/angular/README.md
@@ -38,6 +38,7 @@ The restaurant app has two parts that run separately: the **agent backend** (a P
    - Angular frontend — serves on `http://localhost:4200`:
 
      ```bash
+     cd samples/client/angular
      yarn start restaurant
      ```
 

--- a/samples/client/angular/README.md
+++ b/samples/client/angular/README.md
@@ -9,17 +9,38 @@ These are sample implementations of A2UI in Angular.
 
 ## Running
 
-Here is the quickstart for the restaurant app:
+The restaurant app has two parts that run separately: the **agent backend** (a Python A2A server) and the **Angular frontend**.
 
-```bash
-# Set up your Gemini API key
-cp ../../agent/adk/restaurant_finder/.env.example ../../agent/adk/restaurant_finder/.env
-# Edit the .env file with your actual API key (.env is gitignored for security reasons)
+1. **Install and build dependencies.** From the repository root:
 
-# Start the restaurant app frontend
-yarn install
-yarn demo:restaurant
-```
+   ```bash
+   yarn install
+   yarn build:all
+   ```
+
+2. **Set up your Gemini API key:**
+
+   ```bash
+   cd samples/client/angular
+   cp ../../agent/adk/restaurant_finder/.env.example ../../agent/adk/restaurant_finder/.env
+   # Edit the .env file with your actual API key (.env is gitignored for security reasons)
+   ```
+
+3. **Start the servers in two separate terminals** (both from `samples/client/angular`):
+
+   - Agent backend — the Restaurant Finder agent, serves on `http://localhost:10002`:
+
+     ```bash
+     yarn serve:agent:restaurant
+     ```
+
+   - Angular frontend — serves on `http://localhost:4200`:
+
+     ```bash
+     yarn start restaurant
+     ```
+
+Then open the URL shown in the frontend output (typically http://localhost:4200).
 
 ## Streaming
 

--- a/samples/client/angular/README.md
+++ b/samples/client/angular/README.md
@@ -7,8 +7,6 @@ These are sample implementations of A2UI in Angular.
 1. [nodejs](https://nodejs.org/en)
 2. [uv](https://docs.astral.sh/uv/getting-started/installation/)
 
-NOTE: [For the rizzcharts app](../../agent/adk/rizzcharts/python/), you will need GoogleMap API ([How to get the API key](https://developers.google.com/maps/documentation/javascript/get-api-key)) to display Google Map custome components. Please refer to [Rizzcharts README](./projects/rizzcharts/README.md)
-
 ## Running
 
 Here is the quickstart for the restaurant app:
@@ -26,28 +24,16 @@ yarn demo:restaurant
 Here are the instructions if you want to do each step manually.
 
 1. **Install dependencies:** `yarn install`
-2. **Run the relevant client app (also requires running the relevant backend A2A service):**
-   - **Restaurant app:**
-     - Run backend server in [restaurant_finder](../../agent/adk/restaurant_finder/README.md)
-     - Run client: `yarn start restaurant`
-   - **Rizzcharts app:**
-     - Run backend server in [rizzcharts](../../agent/adk/rizzcharts/python/README.md)
-     - Run client: `yarn start rizzcharts`
-   - **Orchestrator app:**
-     - Run backend server in [orchestrator](../../agent/adk/orchestrator/README.md)
-     - Run client: `yarn start orchestrator`
-   - **MCP Calculator app:**
-     - Run client: `yarn build:sandbox && yarn start mcp_calculator`
-   - **Gallery app:** (Client-only, no server required)
-     - Run client: `yarn start gallery`
-3. **Open** http://localhost:4200/
+2. **Start the backend A2A service:** run the [restaurant_finder](../../agent/adk/restaurant_finder/README.md) agent (listens on port 10002).
+3. **Run the client:** `yarn start restaurant`
+4. **Open** http://localhost:4200/
 
 ## Streaming
 
-By default, the Angular client uses the non-streaming API to communicate with the agent. To enable streaming, set the `ENABLE_STREAMING` environment variable to `true`:
+By default, the Angular client uses the streaming API to communicate with the agent. To disable streaming, set the `ENABLE_STREAMING` environment variable to `false`:
 
 ```bash
-export ENABLE_STREAMING=true
+export ENABLE_STREAMING=false
 yarn start restaurant
 ```
 

--- a/samples/client/angular/README.md
+++ b/samples/client/angular/README.md
@@ -26,12 +26,13 @@ The restaurant app has two parts that run separately: the **agent backend** (a P
    # Edit the .env file with your actual API key (.env is gitignored for security reasons)
    ```
 
-3. **Start the servers in two separate terminals** (both from `samples/client/angular`):
+3. **Start the servers in two separate terminals**:
 
    - Agent backend — the Restaurant Finder agent, serves on `http://localhost:10002`:
 
      ```bash
-     yarn serve:agent:restaurant
+     cd samples/agent/adk/restaurant_finder
+     uv run .
      ```
 
    - Angular frontend — serves on `http://localhost:4200`:

--- a/samples/client/angular/package.json
+++ b/samples/client/angular/package.json
@@ -14,7 +14,7 @@
     "clean": "wireit",
     "build:renderer": "yarn workspace @a2ui/web_core build && yarn workspace @a2ui/markdown-it build && yarn workspace @a2ui/angular build",
     "serve:agent:restaurant": "cd ../../agent/adk/restaurant_finder && uv run .",
-    "demo:restaurant": "yarn build:renderer && concurrently -k -n \"AGENT,WEB\" -c \"magenta,blue\" \"yarn serve:agent:restaurant\" \"yarn start -- restaurant\"",
+    "demo:restaurant": "yarn build:renderer && concurrently -k -n \"AGENT,WEB\" -c \"magenta,blue\" \"yarn serve:agent:restaurant\" \"yarn start restaurant\"",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/samples/community/client/angular/projects/orchestrator/README.md
+++ b/samples/community/client/angular/projects/orchestrator/README.md
@@ -18,6 +18,6 @@ This angular app connects to an Orchastrator Agent which takes user messages and
 4. Run the A2A server for all of the agents. ([Link to instructions](../../../../agent/adk/orchestrator/README.md))
 5. Run the app:
 
-- `yarn start -- orchestrator`
+- `yarn start orchestrator`
 
 6. Open http://localhost:4200/


### PR DESCRIPTION
contributes to https://github.com/flutter/genui/issues/907

## What was wrong

The `samples/client/angular/README.md` documented several apps and paths that do not exist in this checkout. `angular.json` only defines the `lib` and `restaurant` projects, and the only ADK agent present is `restaurant_finder`.

Defects fixed:
- **Dead links**: the rizzcharts NOTE linked to `../../agent/adk/rizzcharts/python/` and `./projects/rizzcharts/README.md`, neither of which exists.
- **Non-existent apps**: the manual run list documented `rizzcharts`, `orchestrator`, `mcp_calculator`, and `gallery` apps. None have matching projects (in `angular.json`) or backend agents. Removed them, leaving accurate, focused steps for the restaurant app.
- **Streaming section inaccuracy**: the doc said streaming is off by default and enabled with `ENABLE_STREAMING=true`. The code (`projects/restaurant/src/server.ts`) sets `enableStreaming = process.env['ENABLE_STREAMING'] !== 'false'`, i.e. streaming is **on** by default and disabled via `ENABLE_STREAMING=false`. Corrected.

The Security/Disclaimer and Streaming sections are preserved (Streaming content corrected, not removed).


https://github.com/user-attachments/assets/1ba25c6f-f49a-4000-a8cd-c7692d15ab5e


