### PR TITLE
ci: Adjust publish_npm.mjs for yarn

### DIFF
--- a/eval/DESIGN.md
+++ b/eval/DESIGN.md
@@ -167,7 +167,7 @@ By implementing these strategies, the A2UI project ensures that its evaluation d
 - [How to securely handle API keys and secrets in a GitHub repository? \- GitHub Discussions](https://github.com/orgs/community/discussions/190912)
 - [How to Test and Evaluate AI? \- GitHub Pages](https://testing-ai-standards.github.io/cross-gov-ai-testing-framework/)
 - [Inspect AI](https://inspect.aisi.org.uk/)
-- [LatestEval: Addressing Data Contamination in Language Model Evaluation \- AAAI Publications](https://ojs.aaai.org/index.php/AAAI/article/view/29822/31427)
+- [LatestEval: Addressing Data Contamination in Language Model Evaluation \- AAAI Publications](https://ojs.aaai.org/index.php/AAAI/article/view/29822)
 - [LLM Evaluation: Frameworks, Metrics, and Best Practices \- SuperAnnotate](https://www.superannotate.com/blog/llm-evaluation-guide)
 - [LLM Evaluation: Key Concepts & Best Practices \- Nexla](https://nexla.com/ai-readiness/llm-evaluation/)
 - [LLM Testing: A Practical Guide to Automated Testing for LLM Applications \- Langfuse](https://langfuse.com/blog/2025-10-21-testing-llm-applications)

--- a/eval/DESIGN.md
+++ b/eval/DESIGN.md
@@ -167,7 +167,7 @@ By implementing these strategies, the A2UI project ensures that its evaluation d
 - [How to securely handle API keys and secrets in a GitHub repository? \- GitHub Discussions](https://github.com/orgs/community/discussions/190912)
 - [How to Test and Evaluate AI? \- GitHub Pages](https://testing-ai-standards.github.io/cross-gov-ai-testing-framework/)
 - [Inspect AI](https://inspect.aisi.org.uk/)
-- [LatestEval: Addressing Data Contamination in Language Model Evaluation \- AAAI Publications](https://ojs.aaai.org/index.php/AAAI/article/view/29822)
+- [LatestEval: Addressing Data Contamination in Language Model Evaluation \- AAAI Publications](https://ojs.aaai.org/index.php/AAAI/article/view/29822/31427)
 - [LLM Evaluation: Frameworks, Metrics, and Best Practices \- SuperAnnotate](https://www.superannotate.com/blog/llm-evaluation-guide)
 - [LLM Evaluation: Key Concepts & Best Practices \- Nexla](https://nexla.com/ai-readiness/llm-evaluation/)
 - [LLM Testing: A Practical Guide to Automated Testing for LLM Applications \- Langfuse](https://langfuse.com/blog/2025-10-21-testing-llm-applications)

--- a/renderers/docs/web_publishing.md
+++ b/renderers/docs/web_publishing.md
@@ -90,7 +90,6 @@ gcloud storage cp manifest.json gs://oss-exit-gate-prod-projects-bucket/a2ui/npm
 
 The internal release infrastructure monitors the GCS bucket for new manifests. Once a manifest is uploaded, it triggers a series of checks and then publishes the specified versions to the public npm registry.
 
-
 ### 🏢 Internal Artifact Registry Setup (Exit Gate) - For Yarn Modern
 
 The monorepo is fully configured in `.yarnrc.yml` to route `@a2ui` scoped packages to the internal Google Artifact Registry. Authentication is automatically injected via `gcloud` when running `./renderers/scripts/publish_npm.mjs`.
@@ -208,7 +207,7 @@ Googlers can visit [go/a2ui-oss-exit-gate-artifacts](https://go/a2ui-oss-exit-ga
 
 ## Troubleshooting
 
-* If you get authorization errors, make sure you're logged in in the `gcloud` CLI. This can take
+- If you get authorization errors, make sure you're logged in in the `gcloud` CLI. This can take
   a few seconds to propagate after you're authenticated.
-* If you get weird build errors but everything passed in CI, your working copy is probably dirty.
+- If you get weird build errors but everything passed in CI, your working copy is probably dirty.
   Try running `yarn clean:all` to remove old build artifacts.

--- a/renderers/docs/web_publishing.md
+++ b/renderers/docs/web_publishing.md
@@ -10,7 +10,7 @@ The following scripts in `renderers/scripts/` automate the versioning, building,
 
 _(Note: Only Googlers will be able to publish to the internal registry. Authentication is handled automatically when running release scripts.)_
 
-Ensure you are logged into `gcloud` with your corporate credentials:
+In addition to being able to build the package (using `yarn` through `corepack`), ensure you are logged into `gcloud` CLI with your corporate credentials:
 
 ```sh
 gcloud auth login
@@ -36,6 +36,8 @@ This script will:
 - Scan the entire mono-repo for internal dependents (via `file:` links).
 - Run `yarn install` in those dependents to update their lockfiles.
 
+Then, prepare a PR with the changes to the `package.json` files, and have it landed into `main`.
+
 ### 2. Publish to Staging (Artifact Registry)
 
 Once versions are updated and merged into `main`, use the `publish_npm` script to build, test, and upload the packages to Google's internal Artifact Registry.
@@ -47,19 +49,17 @@ Once versions are updated and merged into `main`, use the `publish_npm` script t
 
 This script will:
 
-- Automatically obtain a Google Artifact Registry token via `gcloud auth print-access-token`.
+- Obtain a token to interact with registry via `gcloud auth print-access-token`.
 - Sort packages topologically (e.g., publishing `web_core` before `lit`).
-- Verify that if a renderer is being published, `web_core` is also included (use `--force` to skip).
-- Run pre-flight checks against existing `npmjs` versions and prompt for confirmation.
+- Verify that core packages (`web_core` and `markdown-it`) are available on the registry, and publish them if they're not.
+- Skip packages that already exist on the registry, with a warning.
 - For each package: `yarn install` -> `yarn test` -> `yarn run publish:package`.
 
-**Advanced Flags for publish_npm.mjs:**
+**CLI parameters for publish_npm.mjs:**
 
-- `--force`: Skips the `web_core` inclusion warning.
-- `--yes`: Bypasses the manual user confirmation prompt (useful for CI).
-- `--dry-run`: Simulates the process, printing the commands it _would_ execute without actually running them.
-- `--skip-tests`: Skips the `yarn test` phase before publishing.
-- `--test-only`: Runs the full build and test suite in topological order, but skips the final `yarn run publish:package` step. Useful for verifying that packages build and tests pass before performing a real release.
+- `--package=<name>`: The name of the package to publish (e.g: `--package=lit`). It can be passed multiple times to publish more than one package at a time.
+- `--no-dry-run`: Actually uploads the packages to the artifact registry. By default, the script runs in dry-run mode.
+- `--skip-tests`: Skips the `yarn test` phase before publishing. Not recommended.
 
 ### 3. Upload Manifest
 
@@ -71,41 +71,31 @@ Finally, trigger the public release to npmjs.com by uploading a manifest file:
 
 This generates a `manifest.json` with the current versions of all renderer packages and uploads it to GCS to trigger the internal release infrastructure. You should receive an email from exit-gate noting that publishing has commenced.
 
+**CLI parameters for upload_manifest.mjs:**
+
+- `--package=<name>`: The name of the package to include in the manifest (e.g: `--package=lit`). It can be passed multiple times to publish more than one package at a time.
+- `--no-dry-run`: Actually uploads the manifest to trigger the exit gate process. By default, the script runs in dry-run mode.
+
 #### Manual alternative
 
-You can also do this step manually, if you are authenticated with `gcloud` with a corporate Google account in the correct groups:
+You can upload the manifest manually, being authenticated with `gcloud` with:
 
-1. Create a new manifest.json file with these contents:
-
-   ```json
-   {
-     "publish_all": true
-   }
-   ```
-
-2. Upload the file
-
-   ```sh
-   gcloud storage cp manifest.json gs://oss-exit-gate-prod-projects-bucket/a2ui/npm/manifests/manifest.json
-   ```
+```sh
+gcloud storage cp manifest.json gs://oss-exit-gate-prod-projects-bucket/a2ui/npm/manifests/manifest.json
+```
 
 ---
 
-## Internal Release Process
+## Internal Release Process (Exit Gate)
 
 The internal release infrastructure monitors the GCS bucket for new manifests. Once a manifest is uploaded, it triggers a series of checks and then publishes the specified versions to the public npm registry.
 
-Export your token in your terminal:
-
-```sh
-export NPM_TOKEN="npm_YourSecretTokenHere"
-```
 
 ### 🏢 Internal Artifact Registry Setup (Exit Gate) - For Yarn Modern
 
 The monorepo is fully configured in `.yarnrc.yml` to route `@a2ui` scoped packages to the internal Google Artifact Registry. Authentication is automatically injected via `gcloud` when running `./renderers/scripts/publish_npm.mjs`.
 
-If you need to manually publish or run commands locally requiring registry access, export a token in your terminal:
+If you need to manually `yarn` publish or info commands that require registry access, export a token in your terminal:
 
 ```sh
 export NPM_TOKEN=$(gcloud auth print-access-token)
@@ -215,3 +205,10 @@ Googlers can visit [go/a2ui-oss-exit-gate-artifacts](https://go/a2ui-oss-exit-ga
    git push origin v0.8.0
    ```
 3. Create a GitHub Release mapping to the new tag.
+
+## Troubleshooting
+
+* If you get authorization errors, make sure you're logged in in the `gcloud` CLI. This can take
+  a few seconds to propagate after you're authenticated.
+* If you get weird build errors but everything passed in CI, your working copy is probably dirty.
+  Try running `yarn clean:all` to remove old build artifacts.

--- a/renderers/lit/a2ui_explorer/package.json
+++ b/renderers/lit/a2ui_explorer/package.json
@@ -29,16 +29,17 @@
       ]
     },
     "test": {
-      "command": "yarn generate-examples && karma start karma.conf.cjs --single-run=true",
+      "command": "karma start karma.conf.cjs --single-run=true",
       "dependencies": [
-        "../../web_core:build",
-        "../../markdown/markdown-it:build",
-        "../:build",
+        "build",
         "test:vite-compilation"
       ]
     },
     "test:vite-compilation": {
-      "command": "vitest run --environment jsdom tests/smoke-test.spec.ts"
+      "command": "vitest run --environment jsdom tests/smoke-test.spec.ts",
+      "dependencies": [
+        "build"
+      ]
     },
     "test:ci": {
       "dependencies": [

--- a/renderers/scripts/lib/workspace.mjs
+++ b/renderers/scripts/lib/workspace.mjs
@@ -29,6 +29,7 @@ export const ansi = {
   yellow: '\x1b[33m',
   red: '\x1b[31m',
   green: '\x1b[32m',
+  bold: '\x1b[1m',
   reset: '\x1b[0m',
 };
 

--- a/renderers/scripts/publish_npm.mjs
+++ b/renderers/scripts/publish_npm.mjs
@@ -25,37 +25,37 @@ import {parseArgs} from 'node:util';
 const {yellow, red, green, reset} = ansi;
 
 /**
- * Topologically sorts package names based on their internal dependencies.
+ * Topologically sorts package objects based on their internal dependencies.
  *
- * @param {string[]} packageNames - The package names to sort.
- * @param {Object} graph - The package graph.
- * @returns {string[]} The sorted package names.
+ * @param {Object[]} packageObjects - The package objects to sort.
+ * @returns {Object[]} The incoming package objects topologically sorted.
  */
-function topologicalSort(packageNames, graph) {
+function topologicalSort(packageObjects) {
   const sorted = [];
   const visited = new Set();
   const temp = new Set();
 
-  function visit(name) {
+  // Create a map from package name to its package object.
+  const objectMap = Object.fromEntries(packageObjects.map(p => [p.name, p]));
+
+  function visit(pkg) {
+    const name = pkg.name;
     if (temp.has(name)) throw new Error(`Circular dependency detected involving ${name}`);
     if (visited.has(name)) return;
 
     temp.add(name);
-    const pkg = graph[name];
-    if (pkg) {
-      for (const dep of pkg.internalDependencies) {
-        if (packageNames.includes(dep)) {
-          visit(dep);
-        }
+    for (const dep of pkg.internalDependencies) {
+      if (dep in objectMap) {
+        visit(objectMap[dep]);
       }
     }
     temp.delete(name);
     visited.add(name);
-    sorted.push(name);
+    sorted.push(pkg);
   }
 
-  for (const name of packageNames) {
-    visit(name);
+  for (const pkg of packageObjects) {
+    visit(pkg);
   }
   return sorted;
 }
@@ -63,11 +63,12 @@ function topologicalSort(packageNames, graph) {
 /**
  * Calculates the difference between two version strings.
  *
- * @param {string} oldV - The old version string.
+ * @param {string | null} oldV - The old version string.
  * @param {string} newV - The new version string.
  * @returns {string} The diff type (e.g., 'MAJOR', 'MINOR', 'PATCH', 'SAME', etc.)
  */
 function getVersionDiff(oldV, newV) {
+  if (oldV == null) return 'NEW';
   if (oldV === newV) return 'SAME';
   const [oCore, ...oPreArr] = oldV.split('-');
   const [nCore, ...nPreArr] = newV.split('-');
@@ -135,83 +136,87 @@ function checkGitProvenance(exec) {
 }
 
 /**
- * Validates that core dependencies are included when publishing renderers.
+ * Ensures that web_core and markdown-it are present in artifact registry so they can be resolved
+ * when preparing the dist build of packageNames.
  *
  * @param {string[]} packageNames - The package names to check.
+ * @returns {string[]} The package names including web_core and markdown-it.
  */
-function checkCoreDependencies(packageNames) {
-  const webCoreName = '@a2ui/web_core';
-  const markdownItName = '@a2ui/markdown-it';
-  const renderers = ['@a2ui/lit', '@a2ui/angular', '@a2ui/react'];
-  const requestedRenderers = packageNames.filter(p => renderers.includes(p));
+function ensureCoreDependencies(packageNames) {
+  const corePackages = ['@a2ui/markdown-it', '@a2ui/web_core'];
 
-  if (requestedRenderers.length > 0) {
-    const missingCores = [];
-    if (!packageNames.includes(webCoreName)) missingCores.push(webCoreName);
-    if (!packageNames.includes(markdownItName)) missingCores.push(markdownItName);
+  const resolvedPackages = [...packageNames];
+  const missingCore = corePackages.filter(name => !resolvedPackages.includes(name));
 
-    if (missingCores.length > 0) {
-      console.warn(
-        `${yellow}WARNING: You are publishing renderers but NOT ${missingCores.join(' and ')}.${reset}`,
-      );
-      console.warn(
-        `${yellow}This can lead to broken versions if shared dependencies have changed.${reset}`,
-      );
-      console.warn(`${yellow}Use --no-check-core-dependencies to override this check.${reset}`);
-      throw new Error(
-        `Safety check failed: ${missingCores.join(' and ')} missing from publish list.`,
-      );
-    }
+  resolvedPackages.push(...missingCore);
+  if (missingCore.length > 0) {
+    console.warn(
+      `${yellow}Automatically added: ${missingCore.join(' and ')} to packages to publish.${reset}`,
+    );
+  }
+  return resolvedPackages;
+}
+
+/**
+ * Gets the version of a package on npm.
+ *
+ * @param {Object} pkg - The package to check.
+ * @param {Function} exec - The execSync function to use.
+ * @returns {string|null} The version of the package on npm, or null if it does not exist.
+ */
+function getNpmVersion(pkg, npmToken, exec) {
+  try {
+    const remoteVersionJson = exec(`yarn npm info ${pkg.name} --fields version --json`, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+      env: {...process.env, NPM_TOKEN: npmToken},
+    }).trim();
+    const remoteVersion = JSON.parse(remoteVersionJson)?.version;
+    return remoteVersion;
+  } catch (e) {
+    return null;
   }
 }
 
 /**
- * Checks package versions against npmjs.
+ * Filters the incoming packages list, and returns another one with the packages that should be published.
+ *
+ * This method skips packages that are published in the same version, fails if the published version
+ * is newwer than the local version, and congratulates the user in other cases.
  *
  * @param {Object[]} packages - The package objects to check.
  * @param {Function} exec - The execSync function to use.
  */
-function checkNpmVersions(packages, exec) {
-  console.log('--- Pre-flight Version Checks ---');
+function filterPublishablePackages(packages, npmToken, exec) {
+  const packagesToPublish = [];
   for (const pkg of packages) {
     const localVersion = pkg.version;
-    let remoteVersion;
-
-    try {
-      remoteVersion = exec(`yarn npm info ${pkg.name} --fields version`, {
-        encoding: 'utf8',
-        stdio: ['pipe', 'pipe', 'ignore'],
-      }).trim();
-    } catch (e) {
-      remoteVersion = null;
-    }
-
-    if (!remoteVersion) {
-      console.log(
-        `✅ [NEW PACKAGE] ${pkg.name}: Will be published for the first time as ${localVersion}`,
-      );
-      continue;
-    }
-
-    if (remoteVersion === localVersion) {
-      console.error(`\n❌ ERROR: ${pkg.name} version ${localVersion} is already published on npm!`);
-      console.error(
-        `Please increment the version (e.g., using increment_version.mjs) before publishing.`,
-      );
-      throw new Error(`Version ${localVersion} already published.`);
-    }
-
+    const remoteVersion = getNpmVersion(pkg, npmToken, exec);
     const diff = getVersionDiff(remoteVersion, localVersion);
-    if (diff === 'OLDER_OR_UNKNOWN') {
-      console.error(
-        `\n❌ ERROR: ${pkg.name} local version (${localVersion}) appears older or invalid compared to npm version (${remoteVersion})!`,
-      );
-      throw new Error(`Invalid version progression for ${pkg.name}.`);
+    switch (diff) {
+      case 'NEW':
+        console.log(
+          `✅ [NEW PACKAGE] ${pkg.name}: Will be published for the first time as ${localVersion}`,
+        );
+        packagesToPublish.push(pkg);
+        break;
+      case 'SAME':
+        console.warn(
+          `⚠️ WARNING: ${pkg.name} version ${localVersion} is already published on npm. Skipping.`,
+        );
+        break;
+      case 'OLDER_OR_UNKNOWN':
+        console.error(
+          `❌ ERROR: ${pkg.name} local version (${localVersion}) appears older or invalid compared to npm version (${remoteVersion})!`,
+        );
+        throw new Error(`Invalid version progression for ${pkg.name}.`);
+      default:
+        console.log(`✅ [${diff}] ${pkg.name}: ${remoteVersion} -> ${localVersion}`);
+        packagesToPublish.push(pkg);
+        break;
     }
-
-    console.log(`✅ [${diff}] ${pkg.name}: ${remoteVersion} -> ${localVersion}`);
   }
-  console.log('\nPre-flight checks passed.');
+  return packagesToPublish;
 }
 
 /**
@@ -254,11 +259,6 @@ export async function main(args, mocks = {}) {
       multiple: true,
       default: [],
     },
-    'check-core-dependencies': {
-      type: 'boolean',
-      default: true,
-    },
-
     'dry-run': {
       type: 'boolean',
       default: true,
@@ -299,8 +299,7 @@ Examples:
   ./publish_npm.mjs -p web_core -p react --no-dry-run --skip-tests`);
     return;
   }
-  const packagesToPublish = values.package;
-  const checkCoreDeps = values['check-core-dependencies'];
+  let packagesToPublish = values.package;
 
   const dryRun = values['dry-run'];
   const skipTests = values['skip-tests'];
@@ -310,6 +309,9 @@ Examples:
       'Usage: publish_npm --package=pkg1 --package=pkg2 [--no-check-core-dependencies] [--no-dry-run] [--skip-tests]',
     );
   }
+
+  // Ensure the core packages are published.
+  packagesToPublish = ensureCoreDependencies(packagesToPublish);
 
   // Checks the status of the current git branch.
   const commitHash = checkGitProvenance(exec);
@@ -322,19 +324,26 @@ Examples:
     if (!pkg) {
       throw new Error(`Package "${name}" not found in workspace.`);
     }
-    return pkg.name;
+    return pkg;
   });
 
-  // Check that core dependencies are being published.
-  if (checkCoreDeps) {
-    checkCoreDependencies(resolvedPackages);
+  let npmToken = process.env.NPM_TOKEN;
+  if (!npmToken) {
+    console.log(`- Obtaining fresh Artifact Registry token via gcloud CLI`);
+    try {
+      npmToken = exec('gcloud auth print-access-token', {encoding: 'utf8'}).trim();
+    } catch (e) {
+      console.warn(
+        `${yellow}⚠️ Could not obtain gcloud access token. Ensure you are logged in (${reset}gcloud auth login${yellow}).${reset}`,
+      );
+    }
   }
-  // Sort package names topologically (by dependency graph order).
-  const sortedPackages = topologicalSort(resolvedPackages, graph);
-  // Expands the list of topologically-sorted package names to package objects with additional dependency graph info.
-  const packageObjects = sortedPackages.map(name => graph[name]);
-  // Check the NPM versions of the packages we're about to publish.
-  checkNpmVersions(packageObjects, exec);
+
+  // Sort packages topologically (by dependency graph order).
+  const packageObjects = topologicalSort(
+    filterPublishablePackages(resolvedPackages, npmToken, exec),
+  );
+
   // Ensure packages can be built and tested.
   buildAndTestPackages(packageObjects, runCmd, skipTests);
 
@@ -342,18 +351,6 @@ Examples:
 
   for (const pkg of packageObjects) {
     console.log(`\n=== Publishing ${pkg.name} (${pkg.version}) ===`);
-
-    let npmToken = process.env.NPM_TOKEN || '';
-    if (!dryRun && !npmToken) {
-      console.log(`- Obtaining fresh Artifact Registry token via gcloud CLI for ${pkg.name}...`);
-      try {
-        npmToken = exec('gcloud auth print-access-token', {encoding: 'utf8'}).trim();
-      } catch (e) {
-        console.warn(
-          `${yellow}⚠️ Could not obtain gcloud access token. Ensure you are logged in (${reset}gcloud auth login${yellow}).${reset}`,
-        );
-      }
-    }
 
     console.log(`- Running publish:package in ${pkg.dir}`);
     maybeRunCommand(
@@ -367,7 +364,10 @@ Examples:
     );
   }
 
-  console.log(`\n${green}Done.${reset}`);
+  if (!dryRun) {
+    console.log('Uploaded artifacts to: go/a2ui-oss-exit-gate-artifacts');
+  }
+  console.log(`${green}Done.${reset}`);
 }
 
 // Only run the script if this file is executed directly.

--- a/renderers/scripts/publish_npm.mjs
+++ b/renderers/scripts/publish_npm.mjs
@@ -15,14 +15,19 @@
  * limitations under the License.
  */
 
-import {ansi, getPackageGraph, maybeRunCommand, runCommand} from './lib/workspace.mjs';
+import {
+  ansi,
+  getPackageGraph,
+  maybeRunCommand,
+  runCommand as defaultRunCommand,
+} from './lib/workspace.mjs';
 import {execSync} from 'node:child_process';
 import {readFileSync} from 'node:fs';
 import {join} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {parseArgs} from 'node:util';
 
-const {yellow, red, green, reset} = ansi;
+const {yellow, red, green, reset, bold} = ansi;
 
 /**
  * Topologically sorts package objects based on their internal dependencies.
@@ -100,7 +105,7 @@ function getVersionDiff(oldV, newV) {
  * @returns {string} The current commit hash.
  */
 function checkGitProvenance(exec) {
-  console.log('\n--- Git Provenance Check ---');
+  console.log(`\n${bold}Checking Git provenance${reset}\n`);
   let currentBranch = 'unknown';
   let commitHash = 'unknown';
   let isDirty = false;
@@ -111,60 +116,78 @@ function checkGitProvenance(exec) {
     const status = exec('git status --porcelain', {encoding: 'utf8'}).trim();
     isDirty = status.length > 0;
   } catch (e) {
-    // TODO: Should this throw an Error with {cause: e}?
+    // Should this throw an Error with {cause: e}?
     console.warn(
       `${yellow}⚠️ Could not verify Git status. Ensure you are in a valid Git repository.${reset}`,
     );
   }
 
   if (isDirty) {
+    // Should this block the process unless --no-git-check or similar is passed?
     console.warn(
-      `${yellow}\n⚠️  WARNING: Your Git working tree is DIRTY (you have uncommitted changes).${reset}`,
+      `${yellow}⚠️  WARNING: Your Git working tree is DIRTY (you have uncommitted changes).${reset}`,
     );
     console.warn(
-      `${yellow}Publishing from a dirty tree means the published code will NOT exactly match the commit history.${reset}`,
+      `   Publishing from a dirty tree means the published code will NOT exactly match the commit history.`,
     );
     console.warn(
-      `${yellow}It is highly recommended to commit or stash your changes before publishing.${reset}`,
+      `   It is highly recommended to commit or stash your changes before publishing.\n`,
     );
   }
 
-  console.log(`Publishing from branch: ${currentBranch}`);
-  console.log(`Commit hash: ${commitHash}`);
+  console.log(`- Publishing from branch: ${currentBranch}`);
+  console.log(`- Commit hash: ${commitHash}`);
 
   return commitHash;
 }
 
 /**
- * Ensures that web_core and markdown-it are present in artifact registry so they can be resolved
- * when preparing the dist build of packageNames.
+ * Adds missing internal workspace dependencies for the given package objects.
  *
- * @param {string[]} packageNames - The package names to check.
- * @returns {string[]} The package names including web_core and markdown-it.
+ * @param {Object[]} packageObjects - The list of starting package objects.
+ * @param {Object} graph - The package graph.
+ * @returns {Object[]} The list of package objects including all transitively required workspace dependencies.
  */
-function ensureCoreDependencies(packageNames) {
-  const corePackages = ['@a2ui/markdown-it', '@a2ui/web_core'];
+function ensureWorkspaceDependencies(packageObjects, graph) {
+  console.log(`\n${bold}Checking package dependencies${reset}\n`);
 
-  const resolvedPackages = [...packageNames];
-  const missingCore = corePackages.filter(name => !resolvedPackages.includes(name));
-
-  resolvedPackages.push(...missingCore);
-  if (missingCore.length > 0) {
-    console.warn(
-      `${yellow}Automatically added: ${missingCore.join(' and ')} to packages to publish.${reset}`,
-    );
+  const result = [...packageObjects];
+  // A set of the packages we've seen so far (the original packages plus any discovered dependencies)
+  const names = new Set(packageObjects.map(p => p.name));
+  // The queue of packages whose dependencies we need to check
+  const queue = [...packageObjects];
+  while (queue.length > 0) {
+    const pkg = queue.shift();
+    for (const depName of pkg.internalDependencies) {
+      if (!names.has(depName)) {
+        const depPkg = graph[depName];
+        if (depPkg) {
+          names.add(depName);
+          result.push(depPkg);
+          queue.push(depPkg);
+          console.warn(
+            `${yellow}⚠️  Added:${reset} ${depName} ${yellow}as a required workspace dependency of${reset} ${pkg.name}.`,
+          );
+        }
+      }
+    }
   }
-  return resolvedPackages;
+  if (result.length == packageObjects.length) {
+    console.log('All workspace dependencies are present.');
+  }
+  return result;
 }
 
 /**
  * Gets the version of a package on npm.
  *
  * @param {Object} pkg - The package to check.
- * @param {Function} exec - The execSync function to use.
+ * @param {Object} options - Options.
+ * @param {string|null} options.npmToken - The NPM token to use.
+ * @param {Function} options.exec - The execSync function to use.
  * @returns {string|null} The version of the package on npm, or null if it does not exist.
  */
-function getNpmVersion(pkg, npmToken, exec) {
+function getNpmVersion(pkg, {npmToken, exec}) {
   try {
     const remoteVersionJson = exec(`yarn npm info ${pkg.name} --fields version --json`, {
       encoding: 'utf8',
@@ -179,19 +202,47 @@ function getNpmVersion(pkg, npmToken, exec) {
 }
 
 /**
+ * Obtains an Artifact Registry token via gcloud if NPM_TOKEN is not in env.
+ *
+ * @param {Function} exec - The execSync function to use.
+ * @returns {string|null} The token string, or null if it could not be obtained.
+ */
+function getRegistryToken(exec) {
+  let npmToken = process.env.NPM_TOKEN;
+  if (!npmToken) {
+    console.log(`\n${bold}Obtaining Artifact Registry authentication token${reset}\n`);
+    try {
+      npmToken = exec('gcloud auth print-access-token', {encoding: 'utf8'}).trim();
+      console.log(
+        `Using token: ${npmToken.substring(0, 5)}...${npmToken.substring(npmToken.length - 5)}`,
+      );
+    } catch (e) {
+      console.warn(
+        `${yellow}⚠️ Could not obtain gcloud access token. Ensure you are logged in (${reset}gcloud auth login${yellow}).${reset}`,
+      );
+    }
+  }
+  return npmToken || null;
+}
+
+/**
  * Filters the incoming packages list, and returns another one with the packages that should be published.
  *
  * This method skips packages that are published in the same version, fails if the published version
  * is newwer than the local version, and congratulates the user in other cases.
  *
  * @param {Object[]} packages - The package objects to check.
- * @param {Function} exec - The execSync function to use.
+ * @param {Object} options - Option parameters.
+ * @param {string|null} options.npmToken - The NPM token to use.
+ * @param {Function} options.exec - The execSync function to use.
  */
-function filterPublishablePackages(packages, npmToken, exec) {
+function filterPublishablePackages(packages, {npmToken, exec}) {
+  console.log(`\n${bold}Checking package versions${reset}\n`);
+
   const packagesToPublish = [];
   for (const pkg of packages) {
     const localVersion = pkg.version;
-    const remoteVersion = getNpmVersion(pkg, npmToken, exec);
+    const remoteVersion = getNpmVersion(pkg, {npmToken, exec});
     const diff = getVersionDiff(remoteVersion, localVersion);
     switch (diff) {
       case 'NEW':
@@ -223,33 +274,53 @@ function filterPublishablePackages(packages, npmToken, exec) {
  * Builds and tests all targeted packages.
  *
  * @param {Object[]} packages - The package objects to build and test.
- * @param {Function} runCmd - The runCommand function to use.
  * @param {boolean} skipTests - Whether to skip tests.
+ * @param {Object} options - Options.
+ * @param {Function} options.runCommand - The runCommand function to use.
  */
-function buildAndTestPackages(packages, runCmd, skipTests) {
-  console.log('\n--- Building and Testing all packages ---');
+function buildAndTestPackages(packages, skipTests, {runCommand}) {
   for (const pkg of packages) {
-    console.log(`\n=== Preparing ${pkg.name} (${pkg.version}) ===`);
-
-    console.log(`- Running yarn install in ${pkg.dir}`);
-    runCmd('yarn', ['install'], {
+    console.log(`\n${bold}Testing ${pkg.name} (${pkg.version})${reset}\n`);
+    runCommand('yarn', ['install'], {
       cwd: pkg.dir,
     });
 
     if (skipTests) {
-      console.log(`- Skipping yarn test for ${pkg.name}`);
+      console.warn(`${yellow}⚠️  Skipping yarn test for ${pkg.name}${reset}`);
     } else {
       const pkgJson = JSON.parse(readFileSync(join(pkg.dir, 'package.json'), 'utf8'));
       const testScript = pkgJson.scripts && pkgJson.scripts['test:ci'] ? 'test:ci' : 'test';
-
-      console.log(`- Running yarn run ${testScript} in ${pkg.dir}`);
-      runCmd('yarn', ['run', testScript], {cwd: pkg.dir});
+      runCommand('yarn', ['run', testScript], {cwd: pkg.dir});
     }
   }
 }
 
+/**
+ * Publishes the topologically-sorted packages.
+ *
+ * @param {Object[]} packages - The package objects to publish.
+ * @param {Object} options - Options.
+ * @param {string|null} options.npmToken - The NPM token to use.
+ * @param {boolean} options.dryRun - Whether to perform a dry run.
+ * @param {Function} options.runCommand - The runner command to execute.
+ */
+function publishPackages(packages, {npmToken, dryRun, runCommand}) {
+  for (const pkg of packages) {
+    console.log(`\n${bold}Publishing ${pkg.name} (${pkg.version})${reset}\n`);
+    maybeRunCommand(
+      'yarn',
+      ['run', 'publish:package'],
+      {
+        cwd: pkg.dir,
+        env: {...process.env, NPM_TOKEN: npmToken},
+      },
+      {dryRun, runCommand},
+    );
+  }
+}
+
 export async function main(args, mocks = {}) {
-  const runCmd = mocks.runCommand || runCommand;
+  const runCommand = mocks.runCommand || defaultRunCommand;
   const exec = mocks.execSync || execSync;
 
   const options = {
@@ -310,8 +381,7 @@ Examples:
     );
   }
 
-  // Ensure the core packages are published.
-  packagesToPublish = ensureCoreDependencies(packagesToPublish);
+  const npmToken = getRegistryToken(exec);
 
   // Checks the status of the current git branch.
   const commitHash = checkGitProvenance(exec);
@@ -327,45 +397,19 @@ Examples:
     return pkg;
   });
 
-  let npmToken = process.env.NPM_TOKEN;
-  if (!npmToken) {
-    console.log(`- Obtaining fresh Artifact Registry token via gcloud CLI`);
-    try {
-      npmToken = exec('gcloud auth print-access-token', {encoding: 'utf8'}).trim();
-    } catch (e) {
-      console.warn(
-        `${yellow}⚠️ Could not obtain gcloud access token. Ensure you are logged in (${reset}gcloud auth login${yellow}).${reset}`,
-      );
-    }
-  }
+  // Ensure all workspace dependencies of the resolvedPackages are included.
+  const allPackages = ensureWorkspaceDependencies(resolvedPackages, graph);
 
   // Sort packages topologically (by dependency graph order).
-  const packageObjects = topologicalSort(
-    filterPublishablePackages(resolvedPackages, npmToken, exec),
-  );
+  const packageObjects = topologicalSort(filterPublishablePackages(allPackages, {npmToken, exec}));
 
   // Ensure packages can be built and tested.
-  buildAndTestPackages(packageObjects, runCmd, skipTests);
+  buildAndTestPackages(packageObjects, skipTests, {runCommand});
 
-  console.log('\n--- Proceeding to publish ---');
-
-  for (const pkg of packageObjects) {
-    console.log(`\n=== Publishing ${pkg.name} (${pkg.version}) ===`);
-
-    console.log(`- Running publish:package in ${pkg.dir}`);
-    maybeRunCommand(
-      'yarn',
-      ['run', 'publish:package'],
-      {
-        cwd: pkg.dir,
-        env: {...process.env, NPM_TOKEN: npmToken},
-      },
-      {dryRun, runCommand: runCmd},
-    );
-  }
+  publishPackages(packageObjects, {npmToken, dryRun, runCommand});
 
   if (!dryRun) {
-    console.log('Uploaded artifacts to: go/a2ui-oss-exit-gate-artifacts');
+    console.log(`\nUploaded artifacts to: ${bold}go/a2ui-oss-exit-gate-artifacts${reset}`);
   }
   console.log(`${green}Done.${reset}`);
 }

--- a/renderers/scripts/publish_npm.test.mjs
+++ b/renderers/scripts/publish_npm.test.mjs
@@ -59,7 +59,7 @@ describe('publish_npm script integration test', () => {
     assert.ok(markdownItInstallIndex < litInstallIndex, 'markdown-it must be prepared before lit');
   });
 
-  it('should default to dry-run mode (skip auth and publish)', async () => {
+  it('should default to dry-run mode (skip publish)', async () => {
     const executedCommands = [];
     let gcloudCalled = false;
     const mocks = {
@@ -78,7 +78,7 @@ describe('publish_npm script integration test', () => {
     const hasPublish = executedCommands.some(cmd => cmd.includes('publish:package'));
     const hasInstall = executedCommands.some(cmd => cmd.includes('yarn install'));
 
-    assert.strictEqual(gcloudCalled, false, 'Should NOT authenticate in dry-run');
+    assert.strictEqual(gcloudCalled, true, 'Should authenticate in dry-run to query yarn npm info');
     assert.strictEqual(hasPublish, false, 'Should NOT publish in dry-run');
     assert.ok(hasInstall, 'Should still run yarn install in dry-run by default');
   });
@@ -123,37 +123,31 @@ describe('publish_npm script integration test', () => {
     assert.strictEqual(hasTest, false, 'Should NOT run tests when --skip-tests is passed');
   });
 
-  it('should fail safety check if core dependencies are missing', async () => {
-    const mocks = {
-      runCommand: () => {},
-      execSync: () => '',
-    };
-
-    await assert.rejects(
-      async () => {
-        await main(['--package=lit'], mocks);
-      },
-      /.*/, // The script will emit an error with some details.
-      'Should fail when web_core and markdown-it are missing',
-    );
-  });
-
-  it('should bypass safety check when --no-check-core-dependencies is passed', async () => {
+  it('should automatically add core dependencies if missing', async () => {
     const executedCommands = [];
     const mocks = {
-      runCommand: (cmd, args) => {
-        executedCommands.push(`${cmd} ${args.join(' ')}`);
+      runCommand: (cmd, args, options) => {
+        executedCommands.push(
+          `${cmd} ${args.join(' ')} (in ${options?.cwd ? options.cwd.split('/').pop() : 'root'})`,
+        );
       },
       execSync: cmd => {
-        if (cmd.includes('npm info')) return '0.0.1\n';
+        if (cmd.includes('npm info')) return '{"version":"0.0.1"}\n';
         return '';
       },
     };
 
-    await main(['--package=lit', '--no-check-core-dependencies'], mocks);
+    await main(['--package=lit'], mocks);
 
-    const hasInstall = executedCommands.some(cmd => cmd.includes('yarn install'));
-    assert.ok(hasInstall, 'Should proceed to install with yarn');
+    const hasLitInstall = executedCommands.some(cmd => cmd.includes('yarn install (in lit)'));
+    const hasCoreInstall = executedCommands.some(cmd => cmd.includes('yarn install (in web_core)'));
+    const hasMdInstall = executedCommands.some(cmd =>
+      cmd.includes('yarn install (in markdown-it)'),
+    );
+
+    assert.ok(hasLitInstall, 'Should run yarn install in lit');
+    assert.ok(hasCoreInstall, 'Should run yarn install in web_core');
+    assert.ok(hasMdInstall, 'Should run yarn install in markdown-it');
   });
 
   it('should output help message and return early when --help is passed', async () => {


### PR DESCRIPTION
# Description

A few rough edges were found when publishing v0.10.1 (post-yarn migration).

This PR addresses these rough edges by:

* Updating the publish_npm.mjs so it works better with yarn, by:
  * Ensuring an npm token is fetched early
  * Parsing the yarn output correctly when retrieving versions of the published packages (which now require auth)
  * Ensuring internal dependencies are present in the artifact registry when publishing a package (for example, requesting to publish "react" automatically adds "markdown-it" and "web_core" to the list of packages to upload, so those are present in the artifact registry when attempting to build the "react" dist)
* De-spaghettified the `publish_npm.mjs` script by splitting it into more focused functions. Also, made most of the functions operate on a list of "packageObjects" rather than on a list of package names.
* Updated the `web_publishing.md` doc so it maps the current process more closely.
* BONUS: Update Lit's "vite compilation test" dependencies so it can run in a clean workspace.

* Fixes: https://github.com/a2ui-project/a2ui/issues/1701

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have built and run at least one [sample].

For this PR:

- [ ] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
