### PR TITLE
fix(web_core): Ensure openUrl only accepts https/https protocol links.

### DIFF
--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 0.10.2
+
+- Updated `openUrl` to reject URLs with schema other than HTTP or HTTPs to fix a security issue where agents could execute arbitrary Javascript code.
+
 ## 0.10.1
 
 - Add locale support to basic catalog functions (`pluralize`, `formatNumber`, `formatCurrency`) in v0.9 via catalog-level configuration.

--- a/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.test.ts
@@ -472,15 +472,56 @@ describe('BASIC_FUNCTIONS', () => {
       // Set up mock window object
       const originalWindow = (global as any).window;
       let openedUrl = '';
+      let windowOpenSpecs = '';
       (global as any).window = {
-        open: (url: string) => {
+        location: { href: 'https://example.com/sub/page' },
+        open: (url: string, _target: string, specs: string) => {
           openedUrl = url;
+          windowOpenSpecs = specs;
         },
       };
 
       try {
-        invoke('openUrl', {url: 'https://google.com'}, context);
-        assert.strictEqual(openedUrl, 'https://google.com');
+        const validCases = [
+          { input: 'https://example.com', expected: 'https://example.com/' },
+          { input: 'http://example.com/path', expected: 'http://example.com/path' },
+          { input: 'https://sub.domain.co.uk:8080/p?q=1', expected: 'https://sub.domain.co.uk:8080/p?q=1' },
+          { input: '/relative-path', expected: 'https://example.com/relative-path' },
+          { input: 'relative/nested/path', expected: 'https://example.com/sub/relative/nested/path' },
+          { input: '../parent-path', expected: 'https://example.com/parent-path' },
+          { input: '?tab=profile', expected: 'https://example.com/sub/page?tab=profile' },
+        ];
+
+        const invalidCases = [
+          'javascript:alert(document.domain)',
+          '  javascript:alert(1)',
+          'javascript://%0Aalert(1)',
+          'data:text/html,<script>alert(1)</script>',
+          'vbscript:msgbox("hello")',
+          'file:///etc/passwd',
+          'chrome://settings',
+          'about:blank',
+        ];
+
+        // Verify valid cases
+        for (const { input, expected } of validCases) {
+          openedUrl = '';
+          windowOpenSpecs = '';
+          invoke('openUrl', { url: input }, context);
+          assert.strictEqual(openedUrl, expected, `Expected input "${input}" to resolve to "${expected}"`);
+          assert.strictEqual(windowOpenSpecs, 'noopener,noreferrer');
+        }
+
+        // Verify invalid cases
+        for (const input of invalidCases) {
+          assert.throws(
+            () => invoke('openUrl', { url: input }, context),
+            (err: any) => err instanceof A2uiExpressionError && err.message.includes('Unsupported URL scheme'),
+            `Expected input "${input}" to throw an Unsupported URL scheme error`
+          );
+        }
+
+        // Verify invalid structures cause error
         assert.throws(() => invoke('openUrl', {}, context), A2uiExpressionError);
       } finally {
         (global as any).window = originalWindow;

--- a/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.test.ts
@@ -474,7 +474,7 @@ describe('BASIC_FUNCTIONS', () => {
       let openedUrl = '';
       let windowOpenSpecs = '';
       (global as any).window = {
-        location: { href: 'https://example.com/sub/page' },
+        location: {href: 'https://example.com/sub/page'},
         open: (url: string, _target: string, specs: string) => {
           openedUrl = url;
           windowOpenSpecs = specs;
@@ -483,13 +483,16 @@ describe('BASIC_FUNCTIONS', () => {
 
       try {
         const validCases = [
-          { input: 'https://example.com', expected: 'https://example.com/' },
-          { input: 'http://example.com/path', expected: 'http://example.com/path' },
-          { input: 'https://sub.domain.co.uk:8080/p?q=1', expected: 'https://sub.domain.co.uk:8080/p?q=1' },
-          { input: '/relative-path', expected: 'https://example.com/relative-path' },
-          { input: 'relative/nested/path', expected: 'https://example.com/sub/relative/nested/path' },
-          { input: '../parent-path', expected: 'https://example.com/parent-path' },
-          { input: '?tab=profile', expected: 'https://example.com/sub/page?tab=profile' },
+          {input: 'https://example.com', expected: 'https://example.com/'},
+          {input: 'http://example.com/path', expected: 'http://example.com/path'},
+          {
+            input: 'https://sub.domain.co.uk:8080/p?q=1',
+            expected: 'https://sub.domain.co.uk:8080/p?q=1',
+          },
+          {input: '/relative-path', expected: 'https://example.com/relative-path'},
+          {input: 'relative/nested/path', expected: 'https://example.com/sub/relative/nested/path'},
+          {input: '../parent-path', expected: 'https://example.com/parent-path'},
+          {input: '?tab=profile', expected: 'https://example.com/sub/page?tab=profile'},
         ];
 
         const invalidCases = [
@@ -504,20 +507,25 @@ describe('BASIC_FUNCTIONS', () => {
         ];
 
         // Verify valid cases
-        for (const { input, expected } of validCases) {
+        for (const {input, expected} of validCases) {
           openedUrl = '';
           windowOpenSpecs = '';
-          invoke('openUrl', { url: input }, context);
-          assert.strictEqual(openedUrl, expected, `Expected input "${input}" to resolve to "${expected}"`);
+          invoke('openUrl', {url: input}, context);
+          assert.strictEqual(
+            openedUrl,
+            expected,
+            `Expected input "${input}" to resolve to "${expected}"`,
+          );
           assert.strictEqual(windowOpenSpecs, 'noopener,noreferrer');
         }
 
         // Verify invalid cases
         for (const input of invalidCases) {
           assert.throws(
-            () => invoke('openUrl', { url: input }, context),
-            (err: any) => err instanceof A2uiExpressionError && err.message.includes('Unsupported URL scheme'),
-            `Expected input "${input}" to throw an Unsupported URL scheme error`
+            () => invoke('openUrl', {url: input}, context),
+            (err: any) =>
+              err instanceof A2uiExpressionError && err.message.includes('Unsupported URL scheme'),
+            `Expected input "${input}" to throw an Unsupported URL scheme error`,
           );
         }
 

--- a/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -427,7 +427,24 @@ export const PluralizeImplementation = createPluralizeImplementation();
  */
 export const OpenUrlImplementation = createFunctionImplementation(OpenUrlApi, args => {
   if (args.url && typeof window !== 'undefined' && window.open) {
-    window.open(args.url, '_blank');
+    const baseHref = typeof window.location !== 'undefined' && window.location.href
+      ? window.location.href
+      : undefined;
+    
+    let url: URL;
+    try {
+      url = baseHref ? new URL(args.url, baseHref) : new URL(args.url);
+    } catch (e: any) {
+      throw new A2uiExpressionError(`Invalid URL specified: ${args.url}`, 'openUrl', e);
+    }
+
+    // Strict protocol allowlist: Only HTTP and HTTPS are permitted.
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+      throw new A2uiExpressionError(`Unsupported URL scheme: ${url.protocol}`, 'openUrl');
+    }
+
+    // Always use noopener and noreferrer to prevent reverse tab-nabbing
+    window.open(url.href, '_blank', 'noopener,noreferrer');
   }
 });
 

--- a/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -427,10 +427,11 @@ export const PluralizeImplementation = createPluralizeImplementation();
  */
 export const OpenUrlImplementation = createFunctionImplementation(OpenUrlApi, args => {
   if (args.url && typeof window !== 'undefined' && window.open) {
-    const baseHref = typeof window.location !== 'undefined' && window.location.href
-      ? window.location.href
-      : undefined;
-    
+    const baseHref =
+      typeof window.location !== 'undefined' && window.location.href
+        ? window.location.href
+        : undefined;
+
     let url: URL;
     try {
       url = baseHref ? new URL(args.url, baseHref) : new URL(args.url);

--- a/specification/v0_9/docs/basic_catalog_implementation_guide.md
+++ b/specification/v0_9/docs/basic_catalog_implementation_guide.md
@@ -270,6 +270,7 @@ Because `formatString` contains dynamic expressions embedded _within_ a string l
 
 **Security Constraints & Implementation Requirements (Mandatory):**
 To prevent DOM-Based Cross-Site Scripting (XSS) via `javascript:`, `data:`, or other non-HTTP schemes:
+
 1. **Resolve Relative URLs:** Before validation, resolve relative paths against the current environment context (e.g., `window.location.href` in browsers) using standard URL parsing.
 2. **Enforce Scheme Allowlist:** Strictly validate that the resolved URL protocol/scheme is either `https:` or `http:`. Throw an execution or runtime error (such as `A2uiExpressionError`) and abort the action if any other scheme is used.
 3. **Tab-Nabbing Protection:** When opening URLs in a new browser window/tab, always supply security attributes: `noopener,noreferrer` (e.g. `window.open(url, '_blank', 'noopener,noreferrer')`).

--- a/specification/v0_9/docs/basic_catalog_implementation_guide.md
+++ b/specification/v0_9/docs/basic_catalog_implementation_guide.md
@@ -268,6 +268,12 @@ Because `formatString` contains dynamic expressions embedded _within_ a string l
 
 **Logic:** Open `args.url` using the native platform's URL handler (e.g., opening in the system browser or deep-linking to an app). This function returns `void` and is executed as a side-effect.
 
+**Security Constraints & Implementation Requirements (Mandatory):**
+To prevent DOM-Based Cross-Site Scripting (XSS) via `javascript:`, `data:`, or other non-HTTP schemes:
+1. **Resolve Relative URLs:** Before validation, resolve relative paths against the current environment context (e.g., `window.location.href` in browsers) using standard URL parsing.
+2. **Enforce Scheme Allowlist:** Strictly validate that the resolved URL protocol/scheme is either `https:` or `http:`. Throw an execution or runtime error (such as `A2uiExpressionError`) and abort the action if any other scheme is used.
+3. **Tab-Nabbing Protection:** When opening URLs in a new browser window/tab, always supply security attributes: `noopener,noreferrer` (e.g. `window.open(url, '_blank', 'noopener,noreferrer')`).
+
 ### `and`
 
 **Description:** Logical AND operator.

--- a/specification/v0_9_1/docs/basic_catalog_implementation_guide.md
+++ b/specification/v0_9_1/docs/basic_catalog_implementation_guide.md
@@ -270,6 +270,7 @@ Because `formatString` contains dynamic expressions embedded _within_ a string l
 
 **Security Constraints & Implementation Requirements (Mandatory):**
 To prevent DOM-Based Cross-Site Scripting (XSS) via `javascript:`, `data:`, or other non-HTTP schemes:
+
 1. **Resolve Relative URLs:** Before validation, resolve relative paths against the current environment context (e.g., `window.location.href` in browsers) using standard URL parsing.
 2. **Enforce Scheme Allowlist:** Strictly validate that the resolved URL protocol/scheme is either `https:` or `http:`. Throw an execution or runtime error (such as `A2uiExpressionError`) and abort the action if any other scheme is used.
 3. **Tab-Nabbing Protection:** When opening URLs in a new browser window/tab, always supply security attributes: `noopener,noreferrer` (e.g. `window.open(url, '_blank', 'noopener,noreferrer')`).

--- a/specification/v0_9_1/docs/basic_catalog_implementation_guide.md
+++ b/specification/v0_9_1/docs/basic_catalog_implementation_guide.md
@@ -268,6 +268,12 @@ Because `formatString` contains dynamic expressions embedded _within_ a string l
 
 **Logic:** Open `args.url` using the native platform's URL handler (e.g., opening in the system browser or deep-linking to an app). This function returns `void` and is executed as a side-effect.
 
+**Security Constraints & Implementation Requirements (Mandatory):**
+To prevent DOM-Based Cross-Site Scripting (XSS) via `javascript:`, `data:`, or other non-HTTP schemes:
+1. **Resolve Relative URLs:** Before validation, resolve relative paths against the current environment context (e.g., `window.location.href` in browsers) using standard URL parsing.
+2. **Enforce Scheme Allowlist:** Strictly validate that the resolved URL protocol/scheme is either `https:` or `http:`. Throw an execution or runtime error (such as `A2uiExpressionError`) and abort the action if any other scheme is used.
+3. **Tab-Nabbing Protection:** When opening URLs in a new browser window/tab, always supply security attributes: `noopener,noreferrer` (e.g. `window.open(url, '_blank', 'noopener,noreferrer')`).
+
 ### `and`
 
 **Description:** Logical AND operator.

--- a/specification/v1_0/docs/basic_catalog_implementation_guide.md
+++ b/specification/v1_0/docs/basic_catalog_implementation_guide.md
@@ -288,6 +288,12 @@ Because `formatString` contains dynamic expressions embedded _within_ a string l
 
 **Logic:** Open `args.url` using the native platform's URL handler (e.g., opening in the system browser or deep-linking to an app). This function returns `void` and is executed as a side-effect.
 
+**Security Constraints & Implementation Requirements (Mandatory):**
+To prevent DOM-Based Cross-Site Scripting (XSS) via `javascript:`, `data:`, or other non-HTTP schemes:
+1. **Resolve Relative URLs:** Before validation, resolve relative paths against the current environment context (e.g., `window.location.href` in browsers) using standard URL parsing.
+2. **Enforce Scheme Allowlist:** Strictly validate that the resolved URL protocol/scheme is either `https:` or `http:`. Throw an execution or runtime error (such as `A2uiExpressionError`) and abort the action if any other scheme is used.
+3. **Tab-Nabbing Protection:** When opening URLs in a new browser window/tab, always supply security attributes: `noopener,noreferrer` (e.g. `window.open(url, '_blank', 'noopener,noreferrer')`).
+
 ### `and`
 
 **Description:** Logical AND operator.

--- a/specification/v1_0/docs/basic_catalog_implementation_guide.md
+++ b/specification/v1_0/docs/basic_catalog_implementation_guide.md
@@ -290,6 +290,7 @@ Because `formatString` contains dynamic expressions embedded _within_ a string l
 
 **Security Constraints & Implementation Requirements (Mandatory):**
 To prevent DOM-Based Cross-Site Scripting (XSS) via `javascript:`, `data:`, or other non-HTTP schemes:
+
 1. **Resolve Relative URLs:** Before validation, resolve relative paths against the current environment context (e.g., `window.location.href` in browsers) using standard URL parsing.
 2. **Enforce Scheme Allowlist:** Strictly validate that the resolved URL protocol/scheme is either `https:` or `http:`. Throw an execution or runtime error (such as `A2uiExpressionError`) and abort the action if any other scheme is used.
 3. **Tab-Nabbing Protection:** When opening URLs in a new browser window/tab, always supply security attributes: `noopener,noreferrer` (e.g. `window.open(url, '_blank', 'noopener,noreferrer')`).


### PR DESCRIPTION
# Description

This is a fix for https://github.com/a2ui-project/a2ui/security/advisories/GHSA-72qq-p3r5-f7wq

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have built and run at least one [sample].

For this PR:

- [x] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
