### PR TITLE
feat(web-core): allow signal implementations to be swapped out

### DIFF
--- a/renderers/angular/src/v0_8/components/card.spec.ts
+++ b/renderers/angular/src/v0_8/components/card.spec.ts
@@ -96,10 +96,6 @@ describe('Card Component', () => {
     fixture.componentRef.setInput('child', childNode);
     fixture.detectChanges();
 
-    console.log('--- CARD INNER HTML ---');
-    console.log(fixture.nativeElement.innerHTML);
-    console.log('--- END CARD INNER HTML ---');
-
     // Use Static instances tracker instead of debug query!
     expect(MockRenderer.instances.length).toBe(1);
   });

--- a/renderers/angular/src/v0_8/components/text.spec.ts
+++ b/renderers/angular/src/v0_8/components/text.spec.ts
@@ -102,7 +102,6 @@ describe('Text Component', () => {
 
   it('should apply correct classes based on usageHint', () => {
     const sectionEl = fixture.debugElement.query(By.css('section'));
-    console.log('--- classes() output ---', (component as any).classes());
     expect(sectionEl.nativeElement.className).toContain('base-all');
     expect(sectionEl.nativeElement.className).toContain('style-body'); // Initially set in beforeEach
 

--- a/renderers/angular/src/v0_9/core/component-binder.service.ts
+++ b/renderers/angular/src/v0_9/core/component-binder.service.ts
@@ -15,7 +15,7 @@
  */
 
 import {DestroyRef, Injectable, inject, NgZone} from '@angular/core';
-import {ComponentContext, computed} from '@a2ui/web_core/v0_9';
+import {ComponentContext, computed, getValue} from '@a2ui/web_core/v0_9';
 import {toAngularSignal} from './utils';
 import {BoundProperty, ComponentTemplate} from './types';
 
@@ -64,7 +64,7 @@ export class ComponentBinder {
         const listSig = context.dataContext.resolveSignal({path: value.path});
         const listContext = context.dataContext.nested(value.path);
         preactSig = computed(() => {
-          const arr = listSig.value;
+          const arr = getValue(listSig);
           const currentArr = Array.isArray(arr) ? arr : [];
           return currentArr.map((_, i) => ({
             id: value.componentId,
@@ -78,7 +78,7 @@ export class ComponentBinder {
       if (['child', 'trigger', 'content'].includes(key)) {
         const originalSig = preactSig;
         preactSig = computed(() => {
-          const val = originalSig.value;
+          const val = getValue(originalSig);
           if (!val) return null;
           if (typeof val === 'object' && val !== null && 'id' in val) {
             return val;
@@ -93,7 +93,7 @@ export class ComponentBinder {
           template = {id, path};
         }
         preactSig = computed(() => {
-          const val = originalSig.value;
+          const val = getValue(originalSig);
           const arr = Array.isArray(val) ? val : [];
           return arr.map(item => {
             if (typeof item === 'object' && item !== null && 'id' in item) {

--- a/renderers/angular/src/v0_9/core/utils.spec.ts
+++ b/renderers/angular/src/v0_9/core/utils.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {signal as preactSignal} from '@preact/signals-core';
+import {signal as preactSignal, setValue} from '@a2ui/web_core/v0_9';
 import {DestroyRef} from '@angular/core';
 import {toAngularSignal, getNormalizedPath} from './utils';
 
@@ -44,7 +44,7 @@ describe('toAngularSignal', () => {
 
     expect(angSig()).toBe('initial');
 
-    pSig.value = 'updated';
+    setValue(pSig, 'updated');
     expect(angSig()).toBe('updated');
   });
 
@@ -57,7 +57,7 @@ describe('toAngularSignal', () => {
     // Trigger cleanup
     onDestroyCallback();
 
-    pSig.value = 'updated';
+    setValue(pSig, 'updated');
     // Angular signal should NOT update after disposal
     expect(angSig()).toBe('initial');
   });
@@ -88,7 +88,7 @@ describe('toAngularSignal', () => {
     expect(mockNgZone.run).toHaveBeenCalled();
 
     mockNgZone.run.calls.reset();
-    pSig.value = 'updated';
+    setValue(pSig, 'updated');
 
     expect(angSig()).toBe('updated');
     expect(mockNgZone.run).toHaveBeenCalled();

--- a/renderers/angular/src/v0_9/core/utils.ts
+++ b/renderers/angular/src/v0_9/core/utils.ts
@@ -15,46 +15,52 @@
  */
 
 import {DestroyRef, Signal, signal as angularSignal} from '@angular/core';
-import {Signal as PreactSignal, effect, signal as preactSignal} from '@a2ui/web_core/v0_9';
+import {
+  Signal as CoreSignal,
+  effect,
+  signal as preactSignal,
+  getValue,
+  peekValue,
+} from '@a2ui/web_core/v0_9';
+import {NgZone} from '@angular/core';
+
 export {preactSignal};
 
 /**
- * Bridges a Preact Signal (from A2UI web_core) to a reactive Angular Signal.
+ * Bridges a signal from A2UI web_core to an Angular Signal.
  *
  * This utility handles the lifecycle mapping between Preact and Angular,
  * ensuring that updates from the A2UI data model are propagated correctly
  * to Angular's change detection, and resources are cleaned up when the
  * component is destroyed.
  *
- * @param preactSignal The source Preact Signal.
+ * @param coreSignal The source Preact Signal.
  * @param destroyRef Angular DestroyRef for lifecycle management.
  * @param ngZone Optional NgZone to ensure updates run within the Angular zone
  *               (necessary for correct change detection in OnPush components).
  * @returns A read-only Angular Signal.
  */
-import {NgZone} from '@angular/core';
-
 export function toAngularSignal<T>(
-  preactSignal: PreactSignal<T>,
+  coreSignal: CoreSignal<T>,
   destroyRef: DestroyRef,
   ngZone?: NgZone,
 ): Signal<T> {
-  const s = angularSignal(preactSignal.peek());
+  const s = angularSignal(peekValue(coreSignal));
 
   const dispose = effect(() => {
+    const value = getValue(coreSignal);
+
     if (ngZone) {
-      ngZone.run(() => s.set(preactSignal.value));
+      ngZone.run(() => s.set(value));
     } else {
-      s.set(preactSignal.value);
+      s.set(value);
     }
   });
 
   destroyRef.onDestroy(() => {
     dispose();
     // Some signals returned by DataContext.resolveSignal have a custom unsubscribe for AbortControllers
-    if ((preactSignal as any).unsubscribe) {
-      (preactSignal as any).unsubscribe();
-    }
+    coreSignal.unsubscribe?.();
   });
 
   return s.asReadonly();

--- a/renderers/angular/tsconfig.json
+++ b/renderers/angular/tsconfig.json
@@ -15,6 +15,7 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "bundler",
+    "types": ["jasmine"],
     "paths": {
       "@a2ui/angular/v0_8": ["./src/v0_8/public-api.ts"],
       "@a2ui/angular/v0_9": ["./src/v0_9/public-api.ts"],

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Added the ability to swap out the signals implementation through the `setSignalImplementation` function.
+
 ## 0.10.2
 
 - Updated `openUrl` to reject URLs with schema other than HTTP or HTTPs to fix a security issue where agents could execute arbitrary Javascript code.

--- a/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.test.ts
@@ -16,7 +16,7 @@
 
 import {describe, it} from 'node:test';
 import * as assert from 'node:assert';
-import {effect, Signal} from '@preact/signals-core';
+import {effect, Signal, getValue} from '../../reactivity/signals.js';
 
 import {BASIC_FUNCTIONS, createBasicCatalogFunctions} from './basic_functions.js';
 import {DataModel} from '../../state/data-model.js';
@@ -219,7 +219,7 @@ describe('BASIC_FUNCTIONS', () => {
       // worth cleaning up at some point.
       // eslint-disable-next-line prefer-const
       cleanup = effect(() => {
-        const val = result.value;
+        const val = getValue(result);
         assert.strictEqual(val, 'hello world');
         if (cleanup) cleanup();
         done();
@@ -236,7 +236,7 @@ describe('BASIC_FUNCTIONS', () => {
       // worth cleaning up at some point.
       // eslint-disable-next-line prefer-const
       cleanup = effect(() => {
-        const val = result.value;
+        const val = getValue(result);
         try {
           if (emitCount === 0) {
             assert.strictEqual(val, 'Value: 10');
@@ -278,7 +278,7 @@ describe('BASIC_FUNCTIONS', () => {
       // worth cleaning up at some point.
       // eslint-disable-next-line prefer-const
       cleanup = effect(() => {
-        const val = result.value;
+        const val = getValue(result);
         assert.strictEqual(val, 'Result: 12');
         if (cleanup) cleanup();
         done();
@@ -294,7 +294,7 @@ describe('BASIC_FUNCTIONS', () => {
       let cleanup: (() => void) | undefined;
       // eslint-disable-next-line prefer-const
       cleanup = effect(() => {
-        const val = result.value;
+        const val = getValue(result);
         assert.strictEqual(val, 'User: {"name":"Alice","age":30}');
         if (cleanup) cleanup();
         done();
@@ -310,7 +310,7 @@ describe('BASIC_FUNCTIONS', () => {
       let cleanup: (() => void) | undefined;
       // eslint-disable-next-line prefer-const
       cleanup = effect(() => {
-        const val = result.value;
+        const val = getValue(result);
         assert.strictEqual(val, 'Tags: ["swift","ios"]');
         if (cleanup) cleanup();
         done();
@@ -335,7 +335,7 @@ describe('BASIC_FUNCTIONS', () => {
       let cleanup: (() => void) | undefined;
       // eslint-disable-next-line prefer-const
       cleanup = effect(() => {
-        const val = result.value;
+        const val = getValue(result);
         assert.strictEqual(val, 'M = [[1,2],[3,4]]');
         if (cleanup) cleanup();
         done();
@@ -351,7 +351,7 @@ describe('BASIC_FUNCTIONS', () => {
       let cleanup: (() => void) | undefined;
       // eslint-disable-next-line prefer-const
       cleanup = effect(() => {
-        const val = result.value;
+        const val = getValue(result);
         assert.strictEqual(val, 'V = [1,null,3]');
         if (cleanup) cleanup();
         done();
@@ -367,7 +367,7 @@ describe('BASIC_FUNCTIONS', () => {
       let cleanup: (() => void) | undefined;
       // eslint-disable-next-line prefer-const
       cleanup = effect(() => {
-        const val = result.value;
+        const val = getValue(result);
         assert.strictEqual(val, 'val=end');
         if (cleanup) cleanup();
         done();

--- a/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -15,12 +15,8 @@
  */
 
 import {ExpressionParser} from '../expressions/expression_parser.js';
-import {computed} from '@preact/signals-core';
-import {
-  createFunctionImplementation,
-  FunctionImplementation,
-  isSignal,
-} from '../../catalog/types.js';
+import {computed, isSignal, getValue} from '../../reactivity/signals.js';
+import {createFunctionImplementation, FunctionImplementation} from '../../catalog/types.js';
 import {format} from 'date-fns';
 import {
   AddApi,
@@ -276,7 +272,7 @@ export const FormatStringImplementation = createFunctionImplementation(
     return computed(() => {
       return dynamicParts
         .map(p => {
-          const resolved = isSignal(p) ? p.value : p;
+          const resolved = isSignal(p) ? getValue(p) : p;
           return coerceToString(resolved);
         })
         .join('');

--- a/renderers/web_core/src/v0_9/catalog/types.ts
+++ b/renderers/web_core/src/v0_9/catalog/types.ts
@@ -16,15 +16,8 @@
 
 import {z} from 'zod';
 import {DataContext} from '../rendering/data-context.js';
-import {Signal} from '@preact/signals-core';
+import {Signal} from '../reactivity/signals.js';
 import {A2uiExpressionError} from '../errors.js';
-
-/**
- * Robust check for a Preact Signal that works across package boundaries.
- */
-export function isSignal(val: any): val is Signal<any> {
-  return val && typeof val === 'object' && 'value' in val && 'peek' in val;
-}
 
 export type A2uiReturnType = 'string' | 'number' | 'boolean' | 'array' | 'object' | 'any' | 'void';
 

--- a/renderers/web_core/src/v0_9/index.ts
+++ b/renderers/web_core/src/v0_9/index.ts
@@ -37,7 +37,19 @@ export * from './state/surface-model.js';
 export * from './errors.js';
 export * from './basic_catalog/index.js';
 
-export {effect, Signal, signal, computed} from '@preact/signals-core';
+export {
+  type Signal,
+  effect,
+  signal,
+  computed,
+  getValue,
+  peekValue,
+  batchWrite,
+  isSignal,
+  setValue,
+  setSignalImplementation,
+  type SignalImplementations,
+} from './reactivity/signals.js';
 
 import A2uiMessageSchemaRaw from './schemas/server_to_client.json' with {type: 'json'};
 

--- a/renderers/web_core/src/v0_9/reactivity/signals.test.ts
+++ b/renderers/web_core/src/v0_9/reactivity/signals.test.ts
@@ -15,131 +15,94 @@
  */
 
 import assert from 'node:assert';
-import {describe, it} from 'node:test';
-import {Signal as PSignal, computed as pComputed, effect as pEffect} from '@preact/signals-core';
+import {after, describe, it} from 'node:test';
 import {
   signal as aSignal,
   computed as aComputed,
   Signal as ASignal,
   WritableSignal as AWritableSignal,
-  isSignal,
+  isSignal as aIsSignal,
   effect as aEffect,
+  untracked as auntracked,
 } from '@angular/core';
 
-import {FrameworkSignal} from './signals';
+import {
+  setSignalImplementation,
+  signal,
+  computed,
+  effect,
+  isSignal,
+  Signal,
+  getValue,
+  setValue,
+  PREACT_SIGNAL_IMPLEMENTATION,
+} from './signals.js';
 
-declare module './signals' {
-  interface SignalKinds<T> {
-    angular: ASignal<T>;
-    preact: PSignal<T>;
-  }
-  interface WritableSignalKinds<T> {
-    angular: AWritableSignal<T>;
-    preact: PSignal<T>;
-  }
-}
+describe('Signals abstraction', () => {
+  after(() => {
+    setSignalImplementation(PREACT_SIGNAL_IMPLEMENTATION);
+  });
 
-describe('FrameworkSignal', () => {
-  // Test FrameworkSignal with two sample implemenations that wrap Angular and
-  // Preact signals. Angular and Preact signals are good representitive samples,
-  // because the two common patterns - `()` vs. `.value` - are represented by
-  // Angular and Preact respectively.
+  it('uses default (preact) implementation correctly', () => {
+    const s = signal('hello');
+    assert.strictEqual(getValue(s), 'hello');
 
-  describe('Angular variation', () => {
-    const AngularSignal: FrameworkSignal<'angular'> = {
-      computed: <T>(fn: () => T) => aComputed(fn),
-      isSignal: (val: unknown) => isSignal(val),
-      wrap: <T>(val: T) => aSignal(val),
-      unwrap: <T>(val: ASignal<T>) => val(),
-      set: <T>(signal: AWritableSignal<T>, value: T) => signal.set(value),
-      effect: (fn: () => void, cleanupCallback: () => void) => {
+    const c = computed(() => getValue(s) + ' world');
+    assert.strictEqual(getValue(c), 'hello world');
+
+    let effectCount = 0;
+    const cleanup = effect(() => {
+      getValue(s);
+      effectCount++;
+    });
+
+    assert.strictEqual(effectCount, 1);
+    setValue(s, 'bye');
+    assert.strictEqual(effectCount, 2);
+
+    cleanup();
+    assert.ok(isSignal(s));
+  });
+
+  it('can be overridden with Angular variation', () => {
+    setSignalImplementation({
+      computed: <T>(fn: () => T) => {
+        const c = aComputed(fn);
+        return c as unknown as Signal<T>;
+      },
+      isSignal: (val: any): val is Signal<any> => aIsSignal(val),
+      signal: <T>(initialValue: T) => {
+        const s = aSignal(initialValue);
+        return s as unknown as Signal<T>;
+      },
+      effect: (fn: () => void | (() => void)) => {
         const e = aEffect(cleanupRegisterFn => {
-          cleanupRegisterFn(cleanupCallback);
-          fn();
+          const cleanup = fn();
+          if (typeof cleanup === 'function') {
+            cleanupRegisterFn(cleanup);
+          }
         });
         return () => e.destroy();
       },
-    };
-
-    it('round trip wraps and unwraps successfully', () => {
-      const val = 'hello';
-      const wrapped = AngularSignal.wrap(val);
-      assert.strictEqual(AngularSignal.unwrap(wrapped), val);
+      getValue: <T>(s: Signal<T>) => (s as ASignal<T>)(),
+      setValue: <T>(s: Signal<T>, v: T) => (s as AWritableSignal<T>).set(v),
+      peekValue: <T>(s: Signal<T>) => auntracked(() => (s as ASignal<T>)()),
+      batchWrite: (batchFn: () => void) => {
+        batchFn();
+      },
     });
 
-    it('handles updates well', () => {
-      const signal = AngularSignal.wrap('first');
-      const computedVal = AngularSignal.computed(() => `prefix ${signal()}`);
+    const s = signal('first');
+    const computedVal = computed(() => `prefix ${getValue(s)}`);
 
-      assert.strictEqual(signal(), 'first');
-      assert.strictEqual(AngularSignal.unwrap(signal), 'first');
-      assert.strictEqual(computedVal(), 'prefix first');
-      assert.strictEqual(AngularSignal.unwrap(computedVal), 'prefix first');
+    assert.strictEqual(getValue(s), 'first');
+    assert.strictEqual(getValue(computedVal), 'prefix first');
 
-      AngularSignal.set(signal, 'second');
+    setValue(s, 'second');
 
-      assert.strictEqual(signal(), 'second');
-      assert.strictEqual(AngularSignal.unwrap(signal), 'second');
-      assert.strictEqual(computedVal(), 'prefix second');
-      assert.strictEqual(AngularSignal.unwrap(computedVal), 'prefix second');
-    });
+    assert.strictEqual(getValue(s), 'second');
+    assert.strictEqual(getValue(computedVal), 'prefix second');
 
-    describe('.isSignal()', () => {
-      it('validates a signal', () => {
-        const val = 'hello';
-        const wrapped = AngularSignal.wrap(val);
-        assert.ok(AngularSignal.isSignal(wrapped));
-      });
-
-      it('rejects a non-signal', () => {
-        assert.strictEqual(AngularSignal.isSignal('hello'), false);
-      });
-    });
-  });
-
-  describe('Preact variation', () => {
-    const PreactSignal: FrameworkSignal<'preact'> = {
-      computed: <T>(fn: () => T) => pComputed(fn),
-      isSignal: (val: unknown) => val instanceof PSignal,
-      wrap: <T>(val: T) => new PSignal(val),
-      unwrap: <T>(val: PSignal<T>) => val.value,
-      set: <T>(signal: PSignal<T>, value: T) => (signal.value = value),
-      effect: (fn: () => void) => pEffect(fn),
-    };
-
-    it('round trip wraps and unwraps successfully', () => {
-      const val = 'hello';
-      const wrapped = PreactSignal.wrap(val);
-      assert.strictEqual(PreactSignal.unwrap(wrapped), val);
-    });
-
-    it('handles updates well', () => {
-      const signal = PreactSignal.wrap('first');
-      const computed = PreactSignal.computed(() => `prefix ${signal.value}`);
-
-      assert.strictEqual(signal.value, 'first');
-      assert.strictEqual(PreactSignal.unwrap(signal), 'first');
-      assert.strictEqual(computed.value, 'prefix first');
-      assert.strictEqual(PreactSignal.unwrap(computed), 'prefix first');
-
-      PreactSignal.set(signal, 'second');
-
-      assert.strictEqual(signal.value, 'second');
-      assert.strictEqual(PreactSignal.unwrap(signal), 'second');
-      assert.strictEqual(computed.value, 'prefix second');
-      assert.strictEqual(PreactSignal.unwrap(computed), 'prefix second');
-    });
-
-    describe('.isSignal()', () => {
-      it('validates a signal', () => {
-        const val = 'hello';
-        const wrapped = PreactSignal.wrap(val);
-        assert.ok(PreactSignal.isSignal(wrapped));
-      });
-
-      it('rejects a non-signal', () => {
-        assert.strictEqual(PreactSignal.isSignal('hello'), false);
-      });
-    });
+    assert.ok(isSignal(s));
   });
 });

--- a/renderers/web_core/src/v0_9/reactivity/signals.ts
+++ b/renderers/web_core/src/v0_9/reactivity/signals.ts
@@ -14,60 +14,105 @@
  * limitations under the License.
  */
 
-// SignalKinds and WritableSignalKinds are declared in such a way that
-// downstream library impls can dynamically provide their Signal implementations
-// in a type-safe way. Usage downstream might look something like:
-//
-// declare module '../reactivity/signals' {
-//   interface SignalKinds<T> {
-//     preact: Signal<T>;
-//   }
-//   interface WritableSignalKinds<T> {
-//     preact: Signal<T>;
-//   }
-// }
-//
-// This <T>, while unused, is required to pass through to a given Signal impl.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export interface SignalKinds<T> {}
+import {
+  signal as preactSignal,
+  computed as preactComputed,
+  effect as preactEffect,
+  batch as preactBatch,
+  Signal as PreactSignal,
+  Computed as PreactComputed,
+} from '@preact/signals-core';
 
-// This <T>, while unused, is required to pass through to a given Signal impl.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export interface WritableSignalKinds<T> {}
+export interface Signal<T = unknown> {
+  // Marker that prevents any value from being assigned as a signal.
+  // Without this any object can be assigned to a signal.
+  __signalBrand?: T;
+  unsubscribe?: () => void;
+}
+
+export interface SignalImplementations {
+  signal: <T>(initialValue: T) => Signal<T>;
+  computed: <T>(computeFn: () => T) => Signal<T>;
+  effect: (effectFn: () => void | (() => void)) => () => void;
+  batchWrite: (batchFn: () => void) => void;
+  isSignal: (val: unknown) => val is Signal<unknown>;
+  getValue: <T>(signal: Signal<T>) => T;
+  setValue: <T>(signal: Signal<T>, value: T) => void;
+  peekValue: <T>(signal: Signal<T>) => T;
+}
+
+let signalImpl: SignalImplementations['signal'];
+let computedImpl: SignalImplementations['computed'];
+let effectImpl: SignalImplementations['effect'];
+let batchWriteImpl: SignalImplementations['batchWrite'];
+let isSignalImpl: SignalImplementations['isSignal'];
+let getValueImpl: SignalImplementations['getValue'];
+let setValueImpl: SignalImplementations['setValue'];
+let peekValueImpl: SignalImplementations['peekValue'];
+
+/** Default signal implementations. Exported only for testing purposes. */
+export const PREACT_SIGNAL_IMPLEMENTATION: SignalImplementations = {
+  signal: preactSignal as SignalImplementations['signal'],
+  computed: preactComputed as SignalImplementations['computed'],
+  effect: preactEffect as SignalImplementations['effect'],
+  batchWrite: preactBatch as SignalImplementations['batchWrite'],
+  isSignal: (val: unknown): val is Signal<unknown> =>
+    !!val && typeof val === 'object' && 'value' in val && 'peek' in val,
+  getValue: <T>(signal: Signal<T>): T => (signal as PreactSignal<T>).value,
+  setValue: <T>(signal: Signal<T>, value: T): void => {
+    if (!(signal instanceof PreactComputed)) {
+      (signal as PreactSignal<T>).value = value;
+    }
+  },
+  peekValue: <T>(signal: Signal<T>): T => (signal as PreactSignal<T>).peek(),
+};
+
+setSignalImplementation(PREACT_SIGNAL_IMPLEMENTATION);
 
 /**
- * A generic representation of a Signal that could come from any framework.
- * For any library building on top of A2UI's web core lib, this must be
- * implemented for their associated signals implementation.
+ * Sets the implementations of the various signal-related functions.
+ * This allows for signal libraries to be swapped out.
  */
-export interface FrameworkSignal<K extends keyof SignalKinds<any>> {
-  /**
-   * Create a computed signal for this framework.
-   */
-  computed<T>(fn: () => T): SignalKinds<T>[K];
+export function setSignalImplementation(impl: SignalImplementations): void {
+  // Intentionally only store the functions so we ignore any mutations of the implementation.
+  signalImpl = impl.signal;
+  computedImpl = impl.computed;
+  effectImpl = impl.effect;
+  batchWriteImpl = impl.batchWrite;
+  isSignalImpl = impl.isSignal;
+  getValueImpl = impl.getValue;
+  setValueImpl = impl.setValue;
+  peekValueImpl = impl.peekValue;
+}
 
-  /**
-   * Run a reactive effect.
-   */
-  effect(fn: () => void, cleanupCallback?: () => void): () => void;
+export function signal<T>(initialValue: T): Signal<T> {
+  return signalImpl(initialValue);
+}
 
-  /**
-   * Check if an arbitrary object is a framework signal.
-   */
-  isSignal(val: unknown): val is SignalKinds<any>[K];
+export function computed<T>(computeFn: () => T): Signal<T> {
+  return computedImpl(computeFn);
+}
 
-  /**
-   * Wrap the value in a signal.
-   */
-  wrap<T>(val: T): WritableSignalKinds<T>[K];
+export function effect(effectFn: () => void | (() => void)): () => void {
+  return effectImpl(effectFn);
+}
 
-  /**
-   * Extract the value from a signal.
-   */
-  unwrap<T>(val: SignalKinds<T>[K]): T;
+export function batchWrite(batchFn: () => void): void {
+  return batchWriteImpl(batchFn);
+}
 
-  /**
-   * Sets the value of the provided framework signal.
-   */
-  set<T>(signal: WritableSignalKinds<T>[K], value: T): void;
+export function isSignal(val: unknown): val is Signal<unknown> {
+  return isSignalImpl(val);
+}
+
+export function getValue<T>(signal: Signal<T>): T {
+  return getValueImpl(signal);
+}
+
+export function setValue<T>(signal: Signal<T>, value: T): void {
+  setValueImpl(signal, value);
+}
+
+export function peekValue<T>(signal: Signal<T>): T {
+  return peekValueImpl(signal);
 }

--- a/renderers/web_core/src/v0_9/rendering/data-context.test.ts
+++ b/renderers/web_core/src/v0_9/rendering/data-context.test.ts
@@ -16,7 +16,7 @@
 
 import assert from 'node:assert';
 import {describe, it, beforeEach} from 'node:test';
-import {signal, computed} from '@preact/signals-core';
+import {signal, computed, peekValue, getValue, setValue} from '../reactivity/signals.js';
 import {z} from 'zod';
 import {DataModel} from '../state/data-model.js';
 import {DataContext} from './data-context.js';
@@ -171,11 +171,11 @@ describe('DataContext', () => {
     const sig = context.resolveSignal(obj as any);
 
     // It should be a literal signal containing the object
-    assert.deepStrictEqual(sig.peek(), obj);
+    assert.deepStrictEqual(peekValue(sig), obj);
 
     // Updating the path should NOT affect it
     context.set('name', 'Bob');
-    assert.deepStrictEqual(sig.peek(), obj);
+    assert.deepStrictEqual(peekValue(sig), obj);
   });
 
   it('subscribes to function calls with no args', () => {
@@ -374,7 +374,7 @@ describe('DataContext', () => {
       const fnInvoker = (name: string) => {
         if (name === 'inner') {
           return computed(() => {
-            if (trigger.value) throw new A2uiExpressionError('Inner failure', 'inner_func');
+            if (getValue(trigger)) throw new A2uiExpressionError('Inner failure', 'inner_func');
             return 'ok';
           });
         }
@@ -400,7 +400,7 @@ describe('DataContext', () => {
       assert.strictEqual(sub.value, 'outer-result');
       assert.strictEqual(dispatchedError, null);
 
-      trigger.value = true;
+      setValue(trigger, true);
       // Accessing sub.value or the effect running triggers the catch.
       assert.strictEqual(sub.value, undefined);
       assert.ok(dispatchedError);
@@ -412,7 +412,7 @@ describe('DataContext', () => {
       const fnInvoker = (name: string) => {
         if (name === 'inner') {
           return computed(() => {
-            if (trigger.value) throw new Error('Generic inner failure');
+            if (getValue(trigger)) throw new Error('Generic inner failure');
             return 'ok';
           });
         }
@@ -438,7 +438,7 @@ describe('DataContext', () => {
       assert.strictEqual(sub.value, 'outer-result');
       assert.strictEqual(dispatchedError, null);
 
-      trigger.value = true;
+      setValue(trigger, true);
       assert.strictEqual(sub.value, undefined);
       assert.ok(dispatchedError);
       assert.strictEqual((dispatchedError as any).code, 'EXPRESSION_ERROR');

--- a/renderers/web_core/src/v0_9/rendering/data-context.ts
+++ b/renderers/web_core/src/v0_9/rendering/data-context.ts
@@ -15,12 +15,20 @@
  * limitations under the License.
  */
 
-import {signal, computed, Signal, effect} from '@preact/signals-core';
+import {
+  signal,
+  computed,
+  Signal,
+  effect,
+  isSignal,
+  getValue,
+  setValue,
+  peekValue,
+} from '../reactivity/signals.js';
 import {z} from 'zod';
 import {DataModel, DataSubscription} from '../state/data-model.js';
 import type {DynamicValue, DataBinding, FunctionCall, Action} from '../schema/common-types.js';
 import {A2uiExpressionError} from '../errors.js';
-import {isSignal} from '../catalog/types.js';
 
 import {FunctionInvoker} from '../catalog/function_invoker.js';
 import {SurfaceModel} from '../state/surface-model.js';
@@ -107,7 +115,7 @@ export class DataContext {
         return undefined as any;
       }
 
-      return (isSignal(result) ? result.peek() : result) as V;
+      return (isSignal(result) ? peekValue(result) : result) as V;
     }
 
     return value as V;
@@ -132,10 +140,10 @@ export class DataContext {
     const sig = this.resolveSignal<V>(value);
 
     let isSync = true;
-    let currentValue = sig.peek();
+    let currentValue = peekValue(sig);
 
     const dispose = effect(() => {
-      const val = sig.value;
+      const val = getValue(sig);
       currentValue = val;
       if (!isSync) {
         onChange(val);
@@ -149,9 +157,7 @@ export class DataContext {
       },
       unsubscribe: () => {
         dispose();
-        if ((sig as any).unsubscribe) {
-          (sig as any).unsubscribe();
-        }
+        sig.unsubscribe?.();
       },
     };
   }
@@ -190,8 +196,8 @@ export class DataContext {
       if (Object.keys(argSignals).length === 0) {
         const abortController = new AbortController();
         const result = this.evaluateFunctionReactive<V>(call.call, {}, abortController.signal);
-        const sig = result instanceof Signal ? result : signal(result);
-        (sig as any).unsubscribe = () => abortController.abort();
+        const sig = isSignal(result) ? result : signal(result as V);
+        sig.unsubscribe = () => abortController.abort();
         return sig;
       }
 
@@ -203,14 +209,14 @@ export class DataContext {
       const argsSig = computed(() => {
         const argsRecord: Record<string, any> = {};
         for (let i = 0; i < keys.length; i++) {
-          argsRecord[keys[i]] = argSignals[keys[i]].value;
+          argsRecord[keys[i]] = getValue(argSignals[keys[i]]);
         }
         return argsRecord;
       });
 
       const stopper = effect(() => {
         try {
-          const args = argsSig.value;
+          const args = getValue(argsSig);
 
           if (abortController) abortController.abort();
           if (innerUnsubscribe) {
@@ -223,27 +229,24 @@ export class DataContext {
 
           if (isSignal(res)) {
             innerUnsubscribe = effect(() => {
-              resultSig.value = res.value;
+              setValue(resultSig, getValue(res));
             });
           } else {
-            resultSig.value = res;
+            setValue(resultSig, res);
           }
         } catch (e: any) {
           this.dispatchExpressionError(e, call.call);
           // In reactive mode, we should not throw. Instead, reset the signal value.
-          resultSig.value = undefined;
+          setValue(resultSig, undefined);
         }
       });
 
-      (resultSig as any).unsubscribe = () => {
+      resultSig.unsubscribe = () => {
         stopper();
         if (innerUnsubscribe) innerUnsubscribe();
         if (abortController) abortController.abort();
         for (let i = 0; i < keys.length; i++) {
-          const argSig = argSignals[keys[i]];
-          if ((argSig as any).unsubscribe) {
-            (argSig as any).unsubscribe();
-          }
+          argSignals[keys[i]].unsubscribe?.();
         }
       };
 

--- a/renderers/web_core/src/v0_9/state/data-model.ts
+++ b/renderers/web_core/src/v0_9/state/data-model.ts
@@ -16,7 +16,15 @@
 
 import {Subscription as BaseSubscription} from '../common/events.js';
 import {A2uiDataError} from '../errors.js';
-import {signal, Signal, batch, effect} from '@preact/signals-core';
+import {
+  signal,
+  Signal,
+  batchWrite,
+  effect,
+  getValue,
+  setValue,
+  peekValue,
+} from '../reactivity/signals.js';
 
 /**
  * Represents a reactive connection to a specific path in the data model.
@@ -183,10 +191,10 @@ export class DataModel {
   subscribe<T>(path: string, onChange: (value: T | undefined) => void): DataSubscription<T> {
     const sig = this.getSignal<T>(path);
     let isSync = true;
-    let currentValue = sig.peek();
+    let currentValue = peekValue(sig);
 
     const dispose = effect(() => {
-      const val = sig.value;
+      const val = getValue(sig);
       currentValue = val;
       if (!isSync) {
         onChange(val);
@@ -232,7 +240,7 @@ export class DataModel {
   private notifySignals(path: string): void {
     const normalizedPath = this.normalizePath(path);
 
-    batch(() => {
+    batchWrite(() => {
       this.updateSignal(normalizedPath);
 
       // Notify Ancestors
@@ -256,17 +264,17 @@ export class DataModel {
     if (sig) {
       const val = this.get(path);
       if (Array.isArray(val)) {
-        sig.value = [...val];
+        setValue(sig, [...val]);
       } else if (typeof val === 'object' && val !== null) {
-        sig.value = {...val};
+        setValue(sig, {...val});
       } else {
-        sig.value = val;
+        setValue(sig, val);
       }
     }
   }
 
   private notifyAllSignals(): void {
-    batch(() => {
+    batchWrite(() => {
       for (const path of this.signals.keys()) {
         this.updateSignal(path);
       }

--- a/renderers/web_core/src/v0_9/test/function_execution.spec.ts
+++ b/renderers/web_core/src/v0_9/test/function_execution.spec.ts
@@ -19,7 +19,7 @@ import assert from 'node:assert';
 import {DataModel} from '../state/data-model.js';
 import {DataContext} from '../rendering/data-context.js';
 
-import {signal} from '@preact/signals-core';
+import {signal, setValue} from '../reactivity/signals.js';
 
 const createTestDataContext = (
   model: DataModel,
@@ -45,7 +45,7 @@ describe('Function Execution in DataContext', () => {
       const subj = signal<string>('tick 0');
       let i = 1;
       const timerId = setInterval(() => {
-        subj.value = `tick ${i++}`;
+        setValue(subj, `tick ${i++}`);
       }, interval);
 
       abortSignal?.addEventListener('abort', () => {


### PR DESCRIPTION
Currently `web_core` uses Preact signals and it's up to the individual renderers to translate them to their own flavor of signals. At least for Angular, this is problematic for the following reasons:
1. It uses `effect` to synchronize a Preact signal and an Angular signal. Signals are meant to be synchronous, whereas effects are asynchronous and run on a scheduler. Using `effect` in this case can cause the Angular signal to miss some incoming values.
2. Angular signals can be used anywhere, whereas `toAngularSignal` needs to be run in an injection context in order to get a handle on `DestroyRef` and `NgZone`. This limits the places from which A2UI APIs can be invoked.
3. It relies on `NgZone` and we generally want to steer users towards zoneless.
