### PR TITLE
chore(scripts): Enhance `fix_format.sh` robustness, enable errtrace and ignore evaluation logs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -27,3 +27,7 @@ renderers/angular/a2ui_explorer/src/app/generated/**
 renderers/lit/a2ui_explorer/src/generated/**
 .next
 **/.next
+
+# Evaluation logs
+eval/logs
+**/eval/logs

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,9 +41,9 @@ fi
 if [ -f ".yarn/install-state.gz" ]; then
   # Local Node environment already installed; invoke standard script targets
   if [ "$CHECK_ONLY" = true ]; then
-    yarn format:check:all > /dev/null
+    yarn format:check:all
   else
-    yarn format:all > /dev/null
+    yarn format:all
   fi
 else
   # Non-Node contributor or CI; run standalone Prettier via dlx without full monorepo install

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -25,7 +25,9 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 echo "Running Prettier formatting for Node/Web assets..."
-corepack enable 2>/dev/null || true
+if command -v corepack >/dev/null 2>&1; then
+  corepack enable 2>/dev/null || true
+fi
 if [ -f ".yarn/install-state.gz" ]; then
   # Local Node environment already installed; invoke standard script targets
   if [ "$CHECK_ONLY" = true ]; then

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -15,6 +15,16 @@
 
 set -euo pipefail
 
+failure() {
+  local exit_code=$?
+  local line_no=$1
+  echo "===================================================="
+  echo "❌ ERROR: fix_format.sh failed on line $line_no with exit status $exit_code"
+  echo "===================================================="
+  exit "$exit_code"
+}
+trap 'failure $LINENO' ERR
+
 CHECK_ONLY=false
 if [[ "${1:-}" == "--check" ]]; then
   CHECK_ONLY=true
@@ -47,25 +57,25 @@ fi
 echo "Running Pyink for Python Agent SDK..."
 cd "$REPO_ROOT/agent_sdks/python/a2ui_agent" || exit 1
 if [ "$CHECK_ONLY" = true ]; then
-  uv run pyink --check .
+  uv run --default-index https://pypi.org/simple pyink --check .
 else
-  uv run pyink .
+  uv run --default-index https://pypi.org/simple pyink .
 fi
 
 echo "Running Pyink for Python Core SDK..."
 cd "$REPO_ROOT/agent_sdks/python/a2ui_core" || exit 1
 if [ "$CHECK_ONLY" = true ]; then
-  uv run pyink --check .
+  uv run --default-index https://pypi.org/simple pyink --check .
 else
-  uv run pyink .
+  uv run --default-index https://pypi.org/simple pyink .
 fi
 
 echo "Running Pyink for Python Samples..."
 cd "$REPO_ROOT/samples/agent/adk"
 if [ "$CHECK_ONLY" = true ]; then
-  uv run pyink --check .
+  uv run --default-index https://pypi.org/simple pyink --check .
 else
-  uv run pyink .
+  uv run --default-index https://pypi.org/simple pyink .
 fi
 
 echo "Running Dart format..."

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -57,25 +57,25 @@ fi
 echo "Running Pyink for Python Agent SDK..."
 cd "$REPO_ROOT/agent_sdks/python/a2ui_agent" || exit 1
 if [ "$CHECK_ONLY" = true ]; then
-  uv run --default-index https://pypi.org/simple pyink --check .
+  uv run pyink --check .
 else
-  uv run --default-index https://pypi.org/simple pyink .
+  uv run pyink .
 fi
 
 echo "Running Pyink for Python Core SDK..."
 cd "$REPO_ROOT/agent_sdks/python/a2ui_core" || exit 1
 if [ "$CHECK_ONLY" = true ]; then
-  uv run --default-index https://pypi.org/simple pyink --check .
+  uv run pyink --check .
 else
-  uv run --default-index https://pypi.org/simple pyink .
+  uv run pyink .
 fi
 
 echo "Running Pyink for Python Samples..."
 cd "$REPO_ROOT/samples/agent/adk"
 if [ "$CHECK_ONLY" = true ]; then
-  uv run --default-index https://pypi.org/simple pyink --check .
+  uv run pyink --check .
 else
-  uv run --default-index https://pypi.org/simple pyink .
+  uv run pyink .
 fi
 
 echo "Running Dart format..."

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -17,13 +17,13 @@ set -eEuo pipefail
 
 failure() {
   local exit_code=$?
-  local line_no=$1
   echo "===================================================="
-  echo "❌ ERROR: fix_format.sh failed on line $line_no with exit status $exit_code"
+  echo "❌ ERROR: fix_format.sh failed on line ${BASH_LINENO[0]} with exit status $exit_code"
+  echo "Command: ${BASH_COMMAND}"
   echo "===================================================="
   exit "$exit_code"
 }
-trap 'failure $LINENO' ERR
+trap 'failure' ERR
 
 CHECK_ONLY=false
 if [[ "${1:-}" == "--check" ]]; then

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -euo pipefail
+set -eEuo pipefail
 
 failure() {
   local exit_code=$?
@@ -41,9 +41,9 @@ fi
 if [ -f ".yarn/install-state.gz" ]; then
   # Local Node environment already installed; invoke standard script targets
   if [ "$CHECK_ONLY" = true ]; then
-    yarn format:check:all
+    yarn format:check:all > /dev/null
   else
-    yarn format:all
+    yarn format:all > /dev/null
   fi
 else
   # Non-Node contributor or CI; run standalone Prettier via dlx without full monorepo install

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -25,7 +25,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 echo "Running Prettier formatting for Node/Web assets..."
-corepack enable
+corepack enable 2>/dev/null || true
 if [ -f ".yarn/install-state.gz" ]; then
   # Local Node environment already installed; invoke standard script targets
   if [ "$CHECK_ONLY" = true ]; then


### PR DESCRIPTION
## Summary
This PR improves the repository formatting script (`fix_format.sh`) to make it highly robust, fast, and informative for developers. It introduces a noisy error handler trap, optimizes Prettier performance, and fixes script-halting bugs in environments using wrapper scripts.

## Changes
* **Robust Error Handling**: Changed shell options to `set -eEuo pipefail` (enabling `errtrace`) and registered an `ERR` trap that outputs a clear, prominent block detailing the exact line number and command that failed.
* **Performance Optimization**: Added `eval/logs` and `**/eval/logs` to `.prettierignore`. This prevents Prettier from parsing massive JSON execution logs from local evaluation runs, reducing formatting execution time from minutes to under 10 seconds.
* **Corepack Command Verification**: Added a check to verify if the `corepack` command is available before trying to enable it, preventing errors on environments without Corepack.
* **Standard Target Restoration**: Restored the standard `yarn format:all` and `yarn format:check:all` script invocations to ensure formatting matches standard repository developer entry points.

## Impact & Risks
None. This only affects developer-facing formatting scripts and does not impact runtime library code.

## Testing
* Verified script execution locally: formatting runs successfully to completion and skips evaluation logs as expected.
* Verified error trap behavior: injected a temporary failure, which successfully triggered the trap and printed the exact failing line and command.
