### PR TITLE
ci(license): ignore generated files in license checks

### DIFF
--- a/.github/workflows/presubmit-lint.yml
+++ b/.github/workflows/presubmit-lint.yml
@@ -66,6 +66,7 @@ jobs:
             -ignore "**/package-lock.json" \
             -ignore "**/yarn.lock" \
             -ignore "eval/datasets/*.yaml" \
+            -ignore "**/generated/**" \
             .; then
             echo "License check failed."
             exit 1

--- a/scripts/fix_licenses.sh
+++ b/scripts/fix_licenses.sh
@@ -48,4 +48,5 @@ addlicense \
   -ignore "**/node_modules/**" \
   -ignore "**/build/**" \
   -ignore "**/.dart_tool/**" \
+  -ignore "**/generated/**" \
   .


### PR DESCRIPTION
Excludes all '**/generated/**' directories from the addlicense tool checks both locally and in the presubmit lint workflow.