### PR TITLE
ci: Exclude ojs.aai.org from Lychee check.

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -50,6 +50,8 @@ exclude = [
   "github\\.com/TanXudong-Vivo/A2UI-Android-Renderer",
   "github\\.com/orgs/community/discussions/187776",
   "flutter/genui/blob/main/examples/e2e/",
+  # Flaky. See: https://github.com/a2ui-project/a2ui/issues/1747
+  "https://ojs\\.aaai\\.org",
 ]
 
 # Don't descend into dependency or build-output directories.


### PR DESCRIPTION
# Description

Exclude https://ojs.aaai.org from lychee checks.

* Fixes https://github.com/a2ui-project/a2ui/issues/1747

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have built and run at least one [sample].

For this PR:

- [ ] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
