### PR TITLE
Automated security fixes for github actions

### DIFF
--- a/.github/workflows/auto-assignment.yml
+++ b/.github/workflows/auto-assignment.yml
@@ -28,10 +28,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Run auto-assignment script
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const path = require('path');

--- a/.github/workflows/community_code.yml
+++ b/.github/workflows/community_code.yml
@@ -43,12 +43,14 @@ jobs:
       run:
         working-directory: samples/community
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
           cache: "yarn"
@@ -61,8 +63,10 @@ jobs:
   python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
       - name: uv sync each agent under samples/community

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,10 +54,11 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Configure Git Credentials
         run: |
@@ -65,12 +66,12 @@ jobs:
           git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: 3.13
 
       - name: Restore pip cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-docs.txt') }}
           path: ~/.cache/pip
@@ -105,7 +106,7 @@ jobs:
       # and tuning live in lychee.toml at the repository root.
       - name: Restore lychee link-check cache
         if: github.event_name == 'pull_request'
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .lycheecache
           key: lychee-${{ github.sha }}
@@ -113,7 +114,7 @@ jobs:
 
       - name: Verify Markdown links (PR Check)
         if: github.event_name == 'pull_request'
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
           args: >-
             --config lychee.toml

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -34,8 +34,10 @@ jobs:
           echo "GEMINI_API_KEY has ${#GEMINI_API_KEY} characters"
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       - name: Install Flutter
         # Before bumping, verify the new version is on the flutter org's
         # enterprise actions allowlist, or CI will fail with startup_failure.

--- a/.github/workflows/flutter_packages_test.yaml
+++ b/.github/workflows/flutter_packages_test.yaml
@@ -39,7 +39,9 @@ jobs:
       matrix: ${{ steps.generate_matrix.outputs.matrix }}
       flutter_version: ${{ steps.generate_matrix.outputs.flutter_version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Generate testing matrix
         id: generate_matrix
@@ -70,7 +72,9 @@ jobs:
   cycle-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-dart
       - name: Check for cycles across packages
         run: |
@@ -92,7 +96,9 @@ jobs:
         flutter_version: ${{ fromJson(needs.matrix.outputs.flutter_version) }}
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-dart
         with:
           channel: ${{ matrix.flutter_version }}

--- a/.github/workflows/kotlin_agent_sdk_build_and_test.yml
+++ b/.github/workflows/kotlin_agent_sdk_build_and_test.yml
@@ -37,10 +37,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           java-version: "21"
           distribution: "temurin"

--- a/.github/workflows/presubmit-lint.yml
+++ b/.github/workflows/presubmit-lint.yml
@@ -31,7 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Check for private index URL in uv.lock files
         run: |
@@ -50,7 +52,7 @@ jobs:
           fi
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.21"
 
@@ -75,7 +77,9 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-dart
@@ -85,7 +89,9 @@ jobs:
   workspace-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
       - name: Build all workspaces
         run: yarn build:all

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -44,7 +44,9 @@ jobs:
   agent-sdk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-python
       - name: Check Formatting
         working-directory: agent_sdks/python/a2ui_agent
@@ -62,7 +64,9 @@ jobs:
   core-sdk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-python
       - name: Check Formatting
         working-directory: agent_sdks/python/a2ui_core
@@ -77,7 +81,9 @@ jobs:
   conformance:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-python
       - name: Check Formatting
         working-directory: agent_sdks/conformance
@@ -92,7 +98,9 @@ jobs:
       matrix:
         sample: [restaurant_finder]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-python
       - name: Check Formatting
         working-directory: samples/agent/adk

--- a/.github/workflows/run_evals.yml
+++ b/.github/workflows/run_evals.yml
@@ -45,10 +45,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/swift_build_and_test.yml
+++ b/.github/workflows/swift_build_and_test.yml
@@ -36,6 +36,8 @@ jobs:
   test:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Run tests
         run: swift test --enable-swift-testing

--- a/.github/workflows/validate_specifications.yml
+++ b/.github/workflows/validate_specifications.yml
@@ -32,19 +32,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Enable Corepack
         run: corepack enable
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
           cache: "yarn"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/web_ci.yml
+++ b/.github/workflows/web_ci.yml
@@ -40,8 +40,10 @@ jobs:
       samples: ${{ steps.filter.outputs.samples }}
       other: ${{ steps.filter.outputs.other }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
           filters: |
@@ -79,7 +81,9 @@ jobs:
     # instead of running to the default 6h timeout (see issue #1637).
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
       - name: Build Renderers
         run: eval "yarn workspaces foreach -A $RENDERERS_INC -p --topological-dev run build"
@@ -93,7 +97,9 @@ jobs:
     if: ${{ needs.changes.outputs.tools == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
       - name: Build Tools
         run: eval "yarn workspaces foreach $TOOLS_INC -p --topological-dev -R run build"
@@ -105,7 +111,9 @@ jobs:
     if: ${{ needs.changes.outputs.samples == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
       - name: Build Samples
         run: eval "yarn workspaces foreach $SAMPLES_INC -p --topological-dev -R run build"
@@ -117,7 +125,9 @@ jobs:
     if: ${{ needs.changes.outputs.other == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
       - name: Build Other Workspaces
         run: |


### PR DESCRIPTION
# Description

This pre-applies fixes to the GitHub actions which Zizmor (a static analysis security tool) found and fixed.

This is to get ahead of the Google GitHub team enabling it by default on all Google-owned repos.  Googlers can see go/github-zizmor-help for more information.