### PR TITLE
fix(react): export v0_9/index.css in package.json

### DIFF
--- a/renderers/react/package.json
+++ b/renderers/react/package.json
@@ -55,6 +55,7 @@
         "default": "./dist/v0_9/index.cjs"
       }
     },
+    "./v0_9/index.css": "./dist/v0_9/index.css",
     "./styles": {
       "import": {
         "types": "./dist/styles/index.d.ts",


### PR DESCRIPTION
# Description

This PR resolves issue [#1690](https://github.com/a2ui-project/a2ui/issues/1690) by making the styles for version 0.9 of `@a2ui/react` importable.

### What is the issue?
When developers try to import the style sheet for the v0.9 React components using:
`import '@a2ui/react/v0_9/index.css'`

They get a resolution error:
`Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './v0_9/index.css' is not defined by "exports"`

### Why does this happen?
The package defines a strict list of allowed exports in its `package.json` file. The compiled stylesheet file (`dist/v0_9/index.css`) was missing from this list, causing modern code loaders and bundlers (like Node.js, Vite, and Webpack) to block imports to it.

### How is it resolved?
We added the missing mapping entry to the `"exports"` configuration inside `package.json`:
`"./v0_9/index.css": "./dist/v0_9/index.css"`


---

Fixes [#1690](https://github.com/a2ui-project/a2ui/issues/1690)

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have built and run at least one [sample].