### PR TITLE
Fix warnings for fix_format.sh

### DIFF
--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -109,7 +109,9 @@ if command -v dart >/dev/null 2>&1; then
   # suppress that failure here so it doesn't cause the fix_format.sh script to
   # exit. The dart format run will still have warnings because pub get wasn't
   # run, but it won't affect the CI build outcome.
-  dart pub get >/dev/null 2>&1 || true
+  if [ ! -f ".dart_tool/package_config.json" ]; then
+    dart pub get >/dev/null 2>&1 || true
+  fi
 
   if [ "$CHECK_ONLY" = true ]; then
     dart format --output=none --set-exit-if-changed .

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -90,6 +90,27 @@ echo "Running Dart format..."
 cd "$REPO_ROOT"
 # Check if dart is available before running
 if command -v dart >/dev/null 2>&1; then
+
+  # Run "dart pub get" silently, to resolve Dart dependencies. This will resolve
+  # the analysis_options.yaml includes if the person running this script hasn't
+  # run dart or flutter "pub get" yet.
+  #
+  # Running "dart pub get" is not a NECESSARY thing for the formatting to work
+  # (dart format is entirely AST-based), but if someone runs the formatting
+  # script locally, then we don't want confusion about the warnings if they
+  # haven't run "dart pub get" (which is equivalent to "flutter pub get" if the
+  # dart executable is in a Flutter SDK directory).
+  #
+  # In CI, we want to be able to only install the lightweight Dart image, not
+  # the much heavier Flutter image, which quadruples the time it takes to run
+  # the formatting check. In that case, since the dart executable isn't part of
+  # a Flutter SDK directory, "dart pub get" will give errors about the monorepo
+  # depending on Flutter and not running "flutter pub get", so we want to
+  # suppress that failure here so it doesn't cause the fix_format.sh script to
+  # exit. The dart format run will still have warnings because pub get wasn't
+  # run, but it won't affect the CI build outcome.
+  dart pub get >/dev/null 2>&1 || true
+
   if [ "$CHECK_ONLY" = true ]; then
     dart format --output=none --set-exit-if-changed .
   else


### PR DESCRIPTION
## Summary
This PR adds a silent `dart pub get` step in `scripts/fix_format.sh` to resolve package dependencies prior to running `dart format`. This resolves warnings about missing includes in `analysis_options.yaml` (such as `package:lints/recommended.yaml`) when running the script in a clean tree, while maintaining lightweight and fast CI execution.

## Changes
- **`scripts/fix_format.sh`**:
  - Inserted a silent `dart pub get >/dev/null 2>&1 || true` step prior to running `dart format`.
  - Added a comprehensive comment detailing the reasoning behind the silent resolution, the path-detection behavior of the Dart SDK nested inside a Flutter SDK directory, and why the failure is suppressed to support lightweight, standalone Dart environments in CI.

## Impact & Risks
- **No Risks / Low Impact**: The step is fully silent and its failure is ignored (`|| true`). If `pub get` fails (e.g. in standalone Dart CI environments that lack the Flutter SDK), the script continues seamlessly, and the formatting check is completed correctly without affecting the build outcome.

## Testing
- Verified that running `./scripts/fix_format.sh` locally successfully resolves the workspace packages and formats the files without any package resolution warnings.
- Tested that the exit codes and formatting checks remain fully functional.
