### PR TITLE
fix(eval): resolve catalog schema relative to common_types $id

### DIFF
--- a/agent_sdks/python/a2ui_core/src/a2ui/core/validating/catalog_schema_validator.py
+++ b/agent_sdks/python/a2ui_core/src/a2ui/core/validating/catalog_schema_validator.py
@@ -103,6 +103,19 @@ class CatalogSchemaValidator:
                     ),
                 )
             )
+            common_types_id = self.common_types_schema.get("$id")
+            if common_types_id:
+                from urllib.parse import urljoin
+
+                resolved_catalog_uri = urljoin(common_types_id, CATALOG_SCHEMA_FILE)
+                resources.append(
+                    (
+                        resolved_catalog_uri,
+                        Resource.from_contents(
+                            catalog_schema, default_specification=DRAFT202012
+                        ),
+                    )
+                )
         return Registry().with_resources(resources)
 
     def _get_validator(self, key: str, ref_path: str) -> Draft202012Validator:

--- a/eval/tests/test_scorers.py
+++ b/eval/tests/test_scorers.py
@@ -22,6 +22,65 @@ from inspect_ai.model import ModelOutput, ModelName
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 CATALOG_PATH = os.path.abspath(os.path.join(CURRENT_DIR, "../../specification/v0_9/catalogs/basic/catalog.json"))
+CATALOG_PATH_V091 = os.path.abspath(os.path.join(CURRENT_DIR, "../../specification/v0_9_1/catalogs/basic/catalog.json"))
+
+@pytest.mark.asyncio
+async def test_scorer_valid_json_v091():
+    scorer = a2ui_scorer(version="0.9.1")
+    valid_json = """
+    <a2ui-json>
+    [
+      {
+        "version": "v0.9",
+        "createSurface": {
+          "surfaceId": "main",
+          "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
+        }
+      },
+      {
+        "version": "v0.9",
+        "updateComponents": {
+          "surfaceId": "main",
+          "components": [
+            {
+              "id": "root",
+              "component": "Button",
+              "child": "button-text",
+              "action": {
+                "functionCall": {
+                  "call": "openUrl",
+                  "args": {
+                    "url": "https://google.com"
+                  }
+                }
+              }
+            },
+            {
+              "id": "button-text",
+              "component": "Text",
+              "text": "Click me"
+            }
+          ]
+        }
+      }
+    ]
+    </a2ui-json>
+    """
+    state = TaskState(
+        model=ModelName("mock/model"),
+        sample_id=1,
+        epoch=1,
+        input="test",
+        messages=[],
+        output=ModelOutput(model="mock/model", completion=valid_json),
+        metadata={
+            "catalog": str(CATALOG_PATH_V091)
+        }
+    )
+    
+    score = await scorer(state, Target(""))
+    assert score.value == 1.0
+    assert "Valid A2UI payload" in score.explanation
 
 @pytest.mark.asyncio
 async def test_scorer_valid_json():


### PR DESCRIPTION
## Summary
This pull request resolves a schema validation issue during `v0.9.1` evaluations where references to `catalog.json` from within `common_types.json` failed to resolve. Resolves #1789.

## Changes
* **`agent_sdks/python/a2ui_core/src/a2ui/core/validating/catalog_schema_validator.py`**:
  * Added logic to dynamically resolve and register the catalog schema under the URI relative to the `common_types_schema`'s `$id` in the validator's registry.
* **`eval/tests/test_scorers.py`**:
  * Added a unit test `test_scorer_valid_json_v091` that validates a `v0.9.1` payload containing a component with a client-side function call.

## Impact & risks
No breaking changes or risks. This is a backward-compatible fix to the Python validator in the A2UI Core SDK that restores correct validation behavior for the `v0.9.1` protocol version in evaluations.

## Testing
* Ran unit tests in `a2ui_core` and `a2ui_agent` to ensure no regressions.
* Verified that the new `test_scorer_valid_json_v091` test in `eval/` fails when the fix is reverted and passes when the fix is applied.
