### PR TITLE
Quote keys in ngComponentOutlet inputs to prevent minification renaming

### DIFF
--- a/renderers/angular/src/v0_9/core/component-host.component.ts
+++ b/renderers/angular/src/v0_9/core/component-host.component.ts
@@ -53,10 +53,10 @@ import {BoundProperty} from './types';
         *ngComponentOutlet="
           componentType;
           inputs: {
-            props: props,
-            surfaceId: surfaceId(),
-            componentId: resolvedComponentId,
-            dataContextPath: resolvedDataContextPath,
+            'props': props,
+            'surfaceId': surfaceId(),
+            'componentId': resolvedComponentId,
+            'dataContextPath': resolvedDataContextPath,
           }
         "
       ></ng-container>


### PR DESCRIPTION
In minified (production) builds, keys in the inputs object literal passed to ngComponentOutlet were renamed to match the minified property names on the components. However, the component's public input metadata preserved the original (public) name, causing a mismatch at runtime and resulting in inputs being silently ignored.

# Description

_Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots._

_List which issues are fixed by this PR. For larger changes, raising an issue first helps reduce redundant work._

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have built and run at least one [sample].

For this PR:

- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
