### PR TITLE
Rename indexSystemFunction to IndexSystemFunction

### DIFF
--- a/specification/v1_0/json/common_types.json
+++ b/specification/v1_0/json/common_types.json
@@ -157,7 +157,7 @@
         }
       ]
     },
-    "indexSystemFunction": {
+    "IndexSystemFunction": {
       "type": "object",
       "description": "Returns the 0-based index of the current item when rendering a dynamic list from a template. This function MUST ONLY be available when evaluating template items within a list context.",
       "returnType": "number",
@@ -207,7 +207,7 @@
       "required": ["call"],
       "oneOf": [
         {"$ref": "catalog.json#/$defs/anyFunction"},
-        {"$ref": "#/$defs/indexSystemFunction"}
+        {"$ref": "#/$defs/IndexSystemFunction"}
       ]
     },
     "CheckRule": {


### PR DESCRIPTION
Rename indexSystemFunction definition and its references to use upper camel case in common_types.json to match other declarations.

Closes #1809