### PR TITLE
Fix peer dependency of @a2ui/web_core in @a2ui/markdown-it

### DIFF
--- a/renderers/markdown/markdown-it/CHANGELOG.md
+++ b/renderers/markdown/markdown-it/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.5
+
+- Removed `@a2ui/web_core` from `peerDependencies` to resolve installation conflicts.
+- Switched to `import type` for `@a2ui/web_core` imports.
+
 ## 0.0.2
 
 - Made the markdown renderer async to support async markdown renderers.

--- a/renderers/markdown/markdown-it/package.json
+++ b/renderers/markdown/markdown-it/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/markdown-it",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A Markdown renderer using markdown-it and dompurify.",
   "repository": {
     "directory": "renderers/markdown/markdown-it",
@@ -59,9 +59,6 @@
     "prettier": "^3.8.4",
     "typescript": "5.9.3",
     "wireit": "^0.15.0-pre.2"
-  },
-  "peerDependencies": {
-    "@a2ui/web_core": "workspace:*"
   },
   "wireit": {
     "build": {

--- a/renderers/markdown/markdown-it/src/markdown.ts
+++ b/renderers/markdown/markdown-it/src/markdown.ts
@@ -16,7 +16,7 @@
 
 import {rawMarkdownRenderer} from './raw-markdown.js';
 import {sanitize} from './sanitizer.js';
-import * as Types from '@a2ui/web_core';
+import type * as Types from '@a2ui/web_core';
 
 /**
  * A Markdown to HTML renderer using markdown-it and dompurify.

--- a/renderers/markdown/markdown-it/src/raw-markdown.ts
+++ b/renderers/markdown/markdown-it/src/raw-markdown.ts
@@ -15,7 +15,7 @@
  */
 
 import markdownit from 'markdown-it';
-import * as Types from '@a2ui/web_core';
+import type * as Types from '@a2ui/web_core';
 
 /**
  * A pre-configured instance of markdown-it to render markdown in A2UI web.

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,8 +228,6 @@ __metadata:
     prettier: "npm:^3.8.4"
     typescript: "npm:5.9.3"
     wireit: "npm:^0.15.0-pre.2"
-  peerDependencies:
-    "@a2ui/web_core": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Removed `@a2ui/web_core` from `peerDependencies` of `@a2ui/markdown-it` to resolve installation conflicts (ERESOLVE) when upgrading other packages to version `0.10.1`. Since `@a2ui/markdown-it` only imports types from `@a2ui/web_core`, the imports have been updated to `import type` to ensure no runtime dependency exists. Resolves #1766.