### PR TITLE
Migrate docs workflow to use uv and local python setup action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,23 +66,17 @@ jobs:
           git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Setup Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        uses: ./.github/actions/setup-python
         with:
-          python-version: 3.13
-
-      - name: Restore pip cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-docs.txt') }}
-          path: ~/.cache/pip
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          python-version: "3.13"
 
       - name: Install documentation dependencies
-        run: pip install -r requirements-docs.txt
+        run: |
+          uv venv
+          uv pip install -r requirements-docs.txt
 
       - name: Validate documentation conversion script
-        run: pip install pytest && pytest docs/scripts/test_convert_docs.py
+        run: uv run pytest docs/scripts/test_convert_docs.py
 
       - name: Copy schemas to documentation
         run: |
@@ -95,11 +89,11 @@ jobs:
           done
 
       - name: Convert Admonitions in Documentation
-        run: python docs/scripts/convert_docs.py
+        run: uv run python docs/scripts/convert_docs.py
 
       - name: Build Documentation (PR Check)
         if: github.event_name == 'pull_request'
-        run: mkdocs build
+        run: uv run mkdocs build
 
       # Pre-submit only: verify that links in every Markdown file resolve,
       # catching broken internal paths and dead external URLs. Placeholder URLs
@@ -130,4 +124,4 @@ jobs:
       - name: Deploy development version from main branch
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          mkdocs gh-deploy
+          uv run mkdocs gh-deploy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,7 @@ on:
     paths:
       - ".github/workflows/docs.yml"
       - "requirements-docs.txt"
+      - "pyproject.toml"
       - "mkdocs.yml"
       - "docs/**"
   pull_request:
@@ -37,6 +38,7 @@ on:
     paths:
       - ".github/workflows/docs.yml"
       - "requirements-docs.txt"
+      - "pyproject.toml"
       - "mkdocs.yml"
       - "lychee.toml"
       - "docs/**"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,7 @@ on:
       - ".github/workflows/docs.yml"
       - "requirements-docs.txt"
       - "pyproject.toml"
+      - "lychee.toml"
       - "mkdocs.yml"
       - "docs/**"
   pull_request:

--- a/lychee.toml
+++ b/lychee.toml
@@ -52,8 +52,6 @@ exclude = [
   "flutter/genui/blob/main/examples/e2e/",
   # Flaky. See: https://github.com/a2ui-project/a2ui/issues/1747
   "https://ojs\\.aaai\\.org",
-  # Placeholder / illustrative URLs from dependencies
-  "https://via\\.placeholder\\.com",
 ]
 
 # Don't descend into dependency or build-output directories.

--- a/lychee.toml
+++ b/lychee.toml
@@ -52,6 +52,8 @@ exclude = [
   "flutter/genui/blob/main/examples/e2e/",
   # Flaky. See: https://github.com/a2ui-project/a2ui/issues/1747
   "https://ojs\\.aaai\\.org",
+  # Placeholder / illustrative URLs from dependencies
+  "https://via\\.placeholder\\.com",
 ]
 
 # Don't descend into dependency or build-output directories.
@@ -67,4 +69,7 @@ exclude_path = [
   # checking them directly is a false positive. Anchored to the source root so
   # the docs/specification/ copies are still verified.
   "^specification",
+  # Exclude Python virtual environment directories
+  "\\.venv",
+  "venv",
 ]


### PR DESCRIPTION
Fixes https://github.com/a2ui-project/a2ui/issues/1823

## Cause of the Issue

The introduction of a workspace-level pyproject.toml configuration at the root of the repository in #1804 configured global pytest options (like testpaths and import options) for the whole project. In the Docs CI workflow, pytest was run under the global python environment without virtual environment encapsulation, which conflicted with the workspace layout and dependency structure.

## Solution

Update `.github/workflows/docs.yml` to align with other Python workflows.

- Replaced the generic `actions/setup-python` step with the repository's local `./.github/actions/setup-python` composite action to enable uv caching.
- Removed the manual pip caching step as setup-uv manages dependency caching automatically.
- Configured `uv venv` and `uv pip` to install documentation dependencies safely within a virtual environment.
- Updated the test validation, admonition conversion, and mkdocs build/deployment commands to execute via `uv run` to guarantee that they run inside the controlled virtual environment.
