### PR TITLE
refactor: Consolidate common python dev dependencies at workspace root

### DIFF
--- a/agent_sdks/python/a2ui_agent/pyproject.toml
+++ b/agent_sdks/python/a2ui_agent/pyproject.toml
@@ -78,9 +78,6 @@ pyink-annotation-pragmas = [
 
 [dependency-groups]
 dev = [
-    "pytest>=9.0.2",
-    "pytest-asyncio>=1.3.0",
-    "pyink>=24.10.0",
     "antlr4-tools>=0.2.1",
     "hatchling>=1.30.1",
 ]

--- a/agent_sdks/python/a2ui_core/pyproject.toml
+++ b/agent_sdks/python/a2ui_core/pyproject.toml
@@ -26,11 +26,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "pytest>=8.0.0",
-    "pyink>=24.10.0",
     "pyyaml>=6.0.3",
-    "mypy>=1.14.0",
-    "types-jsonschema",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
     "pyink>=25.12.0",
     "pytest>=9.1.1",
     "mypy>=1.14.0",
-    "types-jsonschema",
+    "types-jsonschema>=4.26.0",
     "pytest-asyncio>=1.3.0",
 ]
 release = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ members = [
 dev = [
     "pyink>=25.12.0",
     "pytest>=9.1.1",
+    "mypy>=1.14.0",
+    "types-jsonschema",
+    "pytest-asyncio>=1.3.0",
 ]
 release = [
     "hatch>=1.14.0",

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -57,44 +57,38 @@ else
 fi
 
 echo "Running Pyink for Python Agent SDK..."
-cd "$REPO_ROOT/agent_sdks/python/a2ui_agent" || exit 1
 if [ "$CHECK_ONLY" = true ]; then
-  uv run pyink --check .
+  uv run pyink --check agent_sdks/python/a2ui_agent
 else
-  uv run pyink .
+  uv run pyink agent_sdks/python/a2ui_agent
 fi
 
 echo "Running Pyink for Python Core SDK..."
-cd "$REPO_ROOT/agent_sdks/python/a2ui_core" || exit 1
 if [ "$CHECK_ONLY" = true ]; then
-  uv run pyink --check .
+  uv run pyink --check agent_sdks/python/a2ui_core
 else
-  uv run pyink .
+  uv run pyink agent_sdks/python/a2ui_core
 fi
 
 echo "Running Pyink for Python Samples..."
-cd "$REPO_ROOT/samples/agent/adk"
 if [ "$CHECK_ONLY" = true ]; then
-  uv run pyink --check .
+  uv run pyink --check samples/agent/adk
 else
-  uv run pyink .
+  uv run pyink samples/agent/adk
 fi
 
 echo "Running Pyink for Python Eval..."
-cd "$REPO_ROOT/eval" || exit 1
 if [ "$CHECK_ONLY" = true ]; then
-  uv run pyink --check .
+  uv run pyink --check eval
 else
-  uv run pyink .
+  uv run pyink eval
 fi
 
-
 echo "Running Pyink for Python Specification Proposals..."
-cd "$REPO_ROOT"
 if [ "$CHECK_ONLY" = true ]; then
-  uv run pyink --check "$REPO_ROOT/specification/proposals"
+  uv run pyink --check specification/proposals
 else
-  uv run pyink "$REPO_ROOT/specification/proposals"
+  uv run pyink specification/proposals
 fi
 
 echo "Running Dart format..."

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -115,10 +115,22 @@ if command -v dart >/dev/null 2>&1; then
     dart pub get >/dev/null 2>&1 || true
   fi
 
-  if [ "$CHECK_ONLY" = true ]; then
-    dart format --output=none --set-exit-if-changed .
+  TARGETS=()
+  if [ -d "samples/client/flutter" ]; then
+    TARGETS+=("samples/client/flutter")
+  fi
+  if [ -d "renderers/flutter" ]; then
+    TARGETS+=("renderers/flutter")
+  fi
+
+  if [ ${#TARGETS[@]} -gt 0 ]; then
+    if [ "$CHECK_ONLY" = true ]; then
+      dart format --output=none --set-exit-if-changed "${TARGETS[@]}"
+    else
+      dart format "${TARGETS[@]}"
+    fi
   else
-    dart format .
+    echo "No Dart directories found to format."
   fi
 else
   echo "Warning: dart command not found. Skipping Dart formatting."

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -115,22 +115,10 @@ if command -v dart >/dev/null 2>&1; then
     dart pub get >/dev/null 2>&1 || true
   fi
 
-  TARGETS=()
-  if [ -d "samples/client/flutter" ]; then
-    TARGETS+=("samples/client/flutter")
-  fi
-  if [ -d "renderers/flutter" ]; then
-    TARGETS+=("renderers/flutter")
-  fi
-
-  if [ ${#TARGETS[@]} -gt 0 ]; then
-    if [ "$CHECK_ONLY" = true ]; then
-      dart format --output=none --set-exit-if-changed "${TARGETS[@]}"
-    else
-      dart format "${TARGETS[@]}"
-    fi
+  if [ "$CHECK_ONLY" = true ]; then
+    dart format --output=none --set-exit-if-changed .
   else
-    echo "No Dart directories found to format."
+    dart format .
   fi
 else
   echo "Warning: dart command not found. Skipping Dart formatting."

--- a/tools/build_catalog/pyproject.toml
+++ b/tools/build_catalog/pyproject.toml
@@ -23,10 +23,7 @@ dependencies = []
 url = "https://pypi.org/simple"
 default = true
 
-[dependency-groups]
-dev = [
-    "pytest>=9.0.3",
-]
+
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/uv.lock
+++ b/uv.lock
@@ -417,7 +417,7 @@ dev = [
     { name = "pyink", specifier = ">=25.12.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "types-jsonschema" },
+    { name = "types-jsonschema", specifier = ">=4.26.0" },
 ]
 release = [
     { name = "hatch", specifier = ">=1.14.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -74,9 +74,6 @@ dependencies = [
 dev = [
     { name = "antlr4-tools" },
     { name = "hatchling" },
-    { name = "pyink" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -93,9 +90,6 @@ requires-dist = [
 dev = [
     { name = "antlr4-tools", specifier = ">=0.2.1" },
     { name = "hatchling", specifier = ">=1.30.1" },
-    { name = "pyink", specifier = ">=24.10.0" },
-    { name = "pytest", specifier = ">=9.0.2" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
 ]
 
 [[package]]
@@ -170,11 +164,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "mypy" },
-    { name = "pyink" },
-    { name = "pytest" },
     { name = "pyyaml" },
-    { name = "types-jsonschema" },
 ]
 
 [package.metadata]
@@ -185,13 +175,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [
-    { name = "mypy", specifier = ">=1.14.0" },
-    { name = "pyink", specifier = ">=24.10.0" },
-    { name = "pytest", specifier = ">=8.0.0" },
-    { name = "pyyaml", specifier = ">=6.0.3" },
-    { name = "types-jsonschema" },
-]
+dev = [{ name = "pyyaml", specifier = ">=6.0.3" }]
 
 [[package]]
 name = "a2ui-custom-components-example"
@@ -405,16 +389,6 @@ name = "a2ui-scripts"
 version = "0.1.0"
 source = { virtual = "tools/build_catalog" }
 
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-]
-
-[package.metadata]
-
-[package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.3" }]
-
 [[package]]
 name = "a2ui-workspace"
 version = "0.1.0"
@@ -422,8 +396,11 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "pyink" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "types-jsonschema" },
 ]
 release = [
     { name = "hatch" },
@@ -436,8 +413,11 @@ release = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "mypy", specifier = ">=1.14.0" },
     { name = "pyink", specifier = ">=25.12.0" },
     { name = "pytest", specifier = ">=9.1.1" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "types-jsonschema" },
 ]
 release = [
     { name = "hatch", specifier = ">=1.14.0" },


### PR DESCRIPTION
Consolidate pytest, pyink, mypy, types-jsonschema, and pytest-asyncio into the root pyproject.toml dev dependency group. Remove redundant definitions from member packages.

For https://github.com/a2ui-project/a2ui/pull/1814

Depends on https://github.com/a2ui-project/a2ui/pull/1907

TAG=agy

CONV=8c04c054-fd60-43d6-afde-3e11e99c21e6
