### PR TITLE
fix(ci): restore git credential persistence in Docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Configure Git Credentials
         run: |


### PR DESCRIPTION
This PR fixes a deployment failure in the Docs workflow.

### Cause of Regression
The regression was introduced in PR #1752 (https://github.com/a2ui-project/a2ui/pull/1752), which updated the `actions/checkout` step to use `persist-credentials: false` as part of security hardening.

### Why this fix is needed
The Docs workflow includes a deployment step (`uv run mkdocs gh-deploy`) that builds the docs and pushes them to the `gh-pages` branch. This push action requires write permissions and active Git credentials. With `persist-credentials: false`, the local Git configuration does not have the token, causing `git push origin gh-pages` to fail with:
```
fatal: could not read Username for 'https://github.com': No such device or address
```

Setting `persist-credentials: true` restores credential persistence, enabling successful deployment to GitHub Pages.

TAG=agy
CONV=f3098806-0c35-46e4-931b-2103cd81c0e6