### PR TITLE
fix(ci): Restrict dart format to specific directories

### DIFF
--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -116,9 +116,9 @@ if command -v dart >/dev/null 2>&1; then
   fi
 
   if [ "$CHECK_ONLY" = true ]; then
-    dart format --output=none --set-exit-if-changed .
+    dart format --output=none --set-exit-if-changed samples/client/flutter renderers/flutter
   else
-    dart format .
+    dart format samples/client/flutter renderers/flutter
   fi
 else
   echo "Warning: dart command not found. Skipping Dart formatting."


### PR DESCRIPTION
Avoid running dart format on the repository root '.' which causes it to traverse the '.venv' directory and fail on broken symlinks or local virtualenv files. Target 'samples/client/flutter' and 'renderers/flutter' directly.

TAG=agy

CONV=8c04c054-fd60-43d6-afde-3e11e99c21e6
