### PR TITLE
feat(agent-sdk): implement HTTP support for catalog and examples loading

### DIFF
--- a/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
@@ -20,6 +20,8 @@ import glob
 import json
 import logging
 import os
+import urllib.error
+import urllib.request
 from dataclasses import dataclass, field, replace
 from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 from urllib.parse import urlparse
@@ -27,7 +29,7 @@ from a2ui.core.catalog import Catalog
 from a2ui.core import A2uiCatalogError
 
 
-from .catalog_provider import A2uiCatalogProvider, FileSystemCatalogProvider
+from .catalog_provider import A2uiCatalogProvider, FileSystemCatalogProvider, HttpCatalogProvider
 from .constants import (
     A2UI_SCHEMA_BLOCK_START,
     A2UI_SCHEMA_BLOCK_END,
@@ -75,7 +77,7 @@ class CatalogConfig:
     if not parsed.scheme or parsed.scheme == "file":
       catalog_provider = FileSystemCatalogProvider(parsed.path)
     elif parsed.scheme in ["http", "https"]:
-      raise NotImplementedError("HTTP support is coming soon.")
+      catalog_provider = HttpCatalogProvider(catalog_path)
     else:
       raise A2uiCatalogError(f"Unsupported catalog URL scheme: {catalog_path}")
 
@@ -92,6 +94,8 @@ def resolve_examples_path(path: Optional[str]) -> Optional[str]:
     parsed = urlparse(path)
     if not parsed.scheme or parsed.scheme == "file":
       return parsed.path
+    elif parsed.scheme in ["http", "https"]:
+      return path
     else:
       raise A2uiCatalogError(f"Unsupported examples URL scheme: {path}")
   return None
@@ -349,10 +353,33 @@ class A2uiCatalog:
 
     return "\n\n".join(all_schemas)
 
+  def _load_examples_from_http(self, url: str, validate: bool = False) -> str:
+    """Fetches a single examples JSON file from an HTTP/HTTPS URL."""
+    try:
+      request = urllib.request.Request(url, headers={"Accept": "application/json"})
+      with urllib.request.urlopen(request, timeout=30.0) as response:
+        charset = response.headers.get_content_charset() or ENCODING
+        content = response.read().decode(charset)
+    except (urllib.error.URLError, ValueError, LookupError) as e:
+      raise A2uiCatalogError(f"Could not load examples from {url}: {e}") from e
+
+    basename = (
+        os.path.splitext(urlparse(url).path.rstrip("/").split("/")[-1])[0] or "examples"
+    )
+
+    if validate:
+      self._validate_example(url, content)
+
+    return f"---BEGIN {basename}---\n{content}\n---END {basename}---"
+
   def load_examples(self, path: Optional[str], validate: bool = False) -> str:
-    """Loads and validates examples from a directory or a glob pattern."""
+    """Loads and validates examples from a directory, glob pattern, or HTTP URL."""
     if not path:
       return ""
+
+    parsed = urlparse(path)
+    if parsed.scheme in ["http", "https"]:
+      return self._load_examples_from_http(path, validate)
 
     # If it's a directory, support backward compatibility by appending /*.json
     if os.path.isdir(path):

--- a/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog_provider.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog_provider.py
@@ -15,6 +15,8 @@
 """Module for providing A2UI catalog schemas and resources."""
 
 import json
+import urllib.error
+import urllib.request
 from abc import ABC, abstractmethod
 from json.decoder import JSONDecodeError
 from typing import Any, Dict
@@ -46,3 +48,21 @@ class FileSystemCatalogProvider(A2uiCatalogProvider):
         return json.load(f)
     except (FileNotFoundError, JSONDecodeError) as e:
       raise IOError(f"Could not load schema from {self.path}: {e}") from e
+
+
+class HttpCatalogProvider(A2uiCatalogProvider):
+  """Loads catalog definition from an HTTP or HTTPS URL."""
+
+  def __init__(self, url: str, timeout: float = 30.0):
+    self.url = url
+    self.timeout = timeout
+
+  def load(self) -> Dict[str, Any]:
+    try:
+      request = urllib.request.Request(self.url, headers={"Accept": "application/json"})
+      with urllib.request.urlopen(request, timeout=self.timeout) as response:
+        charset = response.headers.get_content_charset() or ENCODING
+        body = response.read().decode(charset)
+      return json.loads(body)
+    except (urllib.error.URLError, ValueError, LookupError) as e:
+      raise IOError(f"Could not load schema from {self.url}: {e}") from e

--- a/agent_sdks/python/a2ui_agent/tests/schema/test_catalog.py
+++ b/agent_sdks/python/a2ui_agent/tests/schema/test_catalog.py
@@ -14,9 +14,12 @@
 
 import json
 import os
+import urllib.error
 import pytest
 from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
 from a2ui.schema.catalog import A2uiCatalog
+from a2ui.schema.catalog_provider import HttpCatalogProvider
 from a2ui.schema.constants import (
     A2UI_SCHEMA_BLOCK_START,
     A2UI_SCHEMA_BLOCK_END,
@@ -60,8 +63,13 @@ def test_resolve_examples_path_handling():
   assert resolve_examples_path("/absolute/examples") == "/absolute/examples"
   assert resolve_examples_path("file:///absolute/examples") == "/absolute/examples"
 
+  assert (
+      resolve_examples_path("https://a2ui.org/examples") == "https://a2ui.org/examples"
+  )
+  assert resolve_examples_path("http://a2ui.org/examples") == "http://a2ui.org/examples"
+
   with pytest.raises(ValueError, match="Unsupported examples URL scheme"):
-    resolve_examples_path("https://a2ui.org/examples")
+    resolve_examples_path("ftp://a2ui.org/examples")
 
 
 def test_catalog_config_from_path_schemes():
@@ -78,11 +86,19 @@ def test_catalog_config_from_path_schemes():
   )
   assert config.provider.path == "/absolute_path/to/catalog.json"
 
-  # Test HTTP raises NotImplementedError
-  with pytest.raises(NotImplementedError, match="HTTP support is coming soon."):
-    CatalogConfig.from_path(
-        name="test_http", catalog_path="http://a2ui.org/catalog.json"
-    )
+  # Test HTTP returns an HttpCatalogProvider
+  config = CatalogConfig.from_path(
+      name="test_http", catalog_path="http://a2ui.org/catalog.json"
+  )
+  assert isinstance(config.provider, HttpCatalogProvider)
+  assert config.provider.url == "http://a2ui.org/catalog.json"
+
+  # Test HTTPS also works
+  config = CatalogConfig.from_path(
+      name="test_https", catalog_path="https://a2ui.org/catalog.json"
+  )
+  assert isinstance(config.provider, HttpCatalogProvider)
+  assert config.provider.url == "https://a2ui.org/catalog.json"
 
   # Test unsupported scheme raises ValueError
   with pytest.raises(ValueError, match="Unsupported catalog URL scheme"):
@@ -112,3 +128,87 @@ def test_basic_catalog_id_retrieval_methods():
 
   with pytest.raises(ValueError, match="Unsupported version: 0.7"):
     BasicCatalog.get_catalog_id("0.7")
+
+
+def test_http_catalog_provider_load_success():
+  catalog_data = {"catalogId": "test-id", "components": {}}
+  fake_response = MagicMock()
+  fake_response.headers.get_content_charset.return_value = "utf-8"
+  fake_response.read.return_value = json.dumps(catalog_data).encode("utf-8")
+  fake_response.__enter__ = lambda s: s
+  fake_response.__exit__ = MagicMock(return_value=False)
+
+  with patch("urllib.request.urlopen", return_value=fake_response):
+    provider = HttpCatalogProvider("https://a2ui.org/catalog.json")
+    result = provider.load()
+
+  assert result == catalog_data
+
+
+def test_http_catalog_provider_load_url_error():
+  with patch(
+      "urllib.request.urlopen",
+      side_effect=urllib.error.URLError("Connection refused"),
+  ):
+    provider = HttpCatalogProvider("https://a2ui.org/catalog.json")
+    with pytest.raises(
+        IOError, match="Could not load schema from https://a2ui.org/catalog.json"
+    ):
+      provider.load()
+
+
+def test_http_examples_load_success():
+  example_content = '{"surfaceId": "s1", "root": {"id": "1", "component": "Text"}}'
+  fake_response = MagicMock()
+  fake_response.headers.get_content_charset.return_value = "utf-8"
+  fake_response.read.return_value = example_content.encode("utf-8")
+  fake_response.__enter__ = lambda s: s
+  fake_response.__exit__ = MagicMock(return_value=False)
+
+  catalog = A2uiCatalog(
+      version="0.9",
+      name="test",
+      s2c_schema={},
+      common_types_schema={},
+      catalog_schema={"catalogId": "test-id"},
+  )
+  with patch("urllib.request.urlopen", return_value=fake_response):
+    result = catalog.load_examples("https://a2ui.org/examples/contact.json")
+
+  assert "---BEGIN contact---" in result
+  assert example_content in result
+  assert "---END contact---" in result
+
+
+def test_http_examples_load_error():
+  catalog = A2uiCatalog(
+      version="0.9",
+      name="test",
+      s2c_schema={},
+      common_types_schema={},
+      catalog_schema={"catalogId": "test-id"},
+  )
+  with patch(
+      "urllib.request.urlopen",
+      side_effect=urllib.error.URLError("Connection refused"),
+  ):
+    with pytest.raises(
+        ValueError,
+        match="Could not load examples from https://a2ui.org/examples/contact.json",
+    ):
+      catalog.load_examples("https://a2ui.org/examples/contact.json")
+
+
+def test_http_catalog_provider_load_invalid_json():
+  fake_response = MagicMock()
+  fake_response.headers.get_content_charset.return_value = "utf-8"
+  fake_response.read.return_value = b"not valid json {"
+  fake_response.__enter__ = lambda s: s
+  fake_response.__exit__ = MagicMock(return_value=False)
+
+  with patch("urllib.request.urlopen", return_value=fake_response):
+    provider = HttpCatalogProvider("https://a2ui.org/catalog.json")
+    with pytest.raises(
+        IOError, match="Could not load schema from https://a2ui.org/catalog.json"
+    ):
+      provider.load()


### PR DESCRIPTION
## Summary

- Adds `HttpCatalogProvider` to `catalog_provider.py`, enabling `CatalogConfig.from_path()` to load custom component catalogs from `http://` and `https://` URLs using stdlib `urllib.request` (no new dependency).
- Adds HTTP support for `examples_path`: `resolve_examples_path()` now accepts HTTP URLs and `A2uiCatalog.load_examples()` fetches a single JSON examples file from the given URL.
- Both previously raised `NotImplementedError` / `A2uiCatalogError("HTTP support is coming soon.")`.

Exception handling covers `(URLError, ValueError, LookupError)` to handle malformed URLs, invalid charsets, `UnicodeDecodeError`, and `JSONDecodeError` uniformly.

## Cross-language sync

Kotlin SDK has the same stubs at `schema/Catalog.kt:72`. Tracked in #1913.

## Test plan

- [x] `uv run pytest tests/schema/test_catalog.py -v` — 11/11 passed
- [x] `uv run pyink --check .` — clean on all touched files