### PR TITLE
docs(spec): clarify catalogId as string identifier across protocol v0.9, v0.9.1, and v1.0

### DIFF
--- a/specification/v0_9/docs/a2ui_protocol.md
+++ b/specification/v0_9/docs/a2ui_protocol.md
@@ -184,7 +184,7 @@ One of the components in one of the component lists MUST have an `id` of `root` 
 **Properties:**
 
 - `surfaceId` (string, required): The unique identifier for the UI surface to be rendered. This must be globally unique for the renderer's lifetime.
-- `catalogId` (string, required): A string that uniquely identifies the catalog (components and functions) used for this surface. It is recommended to prefix this with an internet domain that you own, to avoid conflicts (e.g., `https://mycompany.com/1.0/somecatalog`). If it is a URL, the URL does not need to have any deployed resources, it is simply a unique identifier.
+- `catalogId` (string, required): A string that uniquely identifies the catalog (components and functions) used for this surface. Note that `catalogId` is a string identifier, not a resolvable URI; while it is conventionally formatted as a URI (e.g., `https://mycompany.com/1.0/somecatalog`) to avoid naming collisions across organizations, it does not need to point to any deployed resource or downloadable file. Client and server developers must agree on shared catalogs with well-known IDs in order to build systems that are compatible with each other.
 - `theme` (object, optional): A JSON object containing theme parameters (e.g., `primaryColor`) defined in the catalog's theme schema.
 - `sendDataModel` (boolean, optional): If true, the client will send the full data model of this surface in the metadata of every message sent to the server (via the Transport's metadata mechanism). This ensures the surface owner receives the full current state of the UI alongside the user's action or query. Defaults to false.
 
@@ -311,6 +311,12 @@ This structure is designed to be both flexible and strictly validated.
 ### The component catalog
 
 The set of available UI components and functions is defined in a **Catalog**. The basic catalog is defined in [`catalogs/basic/catalog.json`]. While the Basic Catalog is useful for starting out, most production applications will define their own catalog to reflect their specific design system. The server must generate messages that conform to the catalog understood by the client.
+
+#### Catalog Identification & Compatibility
+
+Each catalog is identified by a `catalogId` string. The `catalogId` is a string identifier used for matching catalogs between the client and server. While it is conventional to format catalog IDs as URIs (e.g., `https://mycompany.com/catalogs/v1`) to prevent naming collisions across organizations, a `catalogId` is not required to be a resolvable network resource.
+
+It is up to client and server developers to agree on shared catalogs with well-known IDs in order to build systems that are compatible with each other.
 
 ### UI composition: the adjacency list model
 
@@ -840,7 +846,7 @@ The `a2uiClientCapabilities` object in the metadata follows the [`client_capabil
 
 **Properties:**
 
-- `supportedCatalogIds` (array of strings, required): URIs of supported catalogs.
+- `supportedCatalogIds` (array of strings, required): String identifiers of supported catalogs.
 - `inlineCatalogs`: An array of inline catalog definitions provided directly by the client (useful for custom or ad-hoc components and functions).
 
 #### Client data model

--- a/specification/v0_9/docs/evolution_guide.md
+++ b/specification/v0_9/docs/evolution_guide.md
@@ -81,7 +81,7 @@ Version 0.9 represents a fundamental philosophical shift from "Structured Output
 - **Purpose**: `createSurface` signals the client to create a new surface and prepare for rendering.
 - **Theme Information**: `createSurface` includes a `theme` property to specify theme parameters (like `primaryColor`). This replaces the `styles` property in v0.8.
 - **Root Rule**: The rule is: "There must be exactly one component with the `ComponentId` 'root'." The "root" attribute that `beginRendering` had has been removed. The client is expected to render as soon as it has a valid tree with a root component.
-- **New Requirement**: `createSurface` now requires a **`catalogId`** (URI) to explicitly state which unified catalog (components and functions) is being used.
+- **New Requirement**: `createSurface` now requires a **`catalogId`** (string identifier) to explicitly state which unified catalog (components and functions) is being used.
 
 **Example:**
 

--- a/specification/v0_9/docs/renderer_guide.md
+++ b/specification/v0_9/docs/renderer_guide.md
@@ -395,7 +395,7 @@ interface FunctionImplementation extends FunctionApi {
 }
 
 class Catalog<T extends ComponentApi> {
-  readonly id: string; // Unique catalog URI
+  readonly id: string; // Unique catalog ID (string identifier)
   readonly components: ReadonlyMap<string, T>;
   readonly functions?: ReadonlyMap<string, FunctionImplementation>;
   readonly themeSchema?: Schema;

--- a/specification/v0_9/json/client_capabilities.json
+++ b/specification/v0_9/json/client_capabilities.json
@@ -11,7 +11,7 @@
       "properties": {
         "supportedCatalogIds": {
           "type": "array",
-          "description": "The URI of each of the component and function catalogs that is supported by the client.",
+          "description": "An array of string identifiers for each of the component and function catalogs supported by the client.",
           "items": {"type": "string"}
         },
         "inlineCatalogs": {

--- a/specification/v0_9_1/docs/a2ui_protocol.md
+++ b/specification/v0_9_1/docs/a2ui_protocol.md
@@ -181,7 +181,7 @@ This message signals the client to create a new surface and begin rendering it. 
 **Properties:**
 
 - `surfaceId` (string, required): The unique identifier for the UI surface to be rendered.
-- `catalogId` (string, required): A string that uniquely identifies the catalog (components and functions) used for this surface. It is recommended to prefix this with an internet domain that you own, to avoid conflicts (e.g., `https://mycompany.com/1.0/somecatalog`). If it is a URL, the URL does not need to have any deployed resources, it is simply a unique identifier.
+- `catalogId` (string, required): A string that uniquely identifies the catalog (components and functions) used for this surface. Note that `catalogId` is a string identifier, not a resolvable URI; while it is conventionally formatted as a URI (e.g., `https://mycompany.com/1.0/somecatalog`) to avoid naming collisions across organizations, it does not need to point to any deployed resource or downloadable file. Client and server developers must agree on shared catalogs with well-known IDs in order to build systems that are compatible with each other.
 - `theme` (object, optional): A JSON object containing theme parameters (e.g., `primaryColor`) defined in the catalog's theme schema.
 - `sendDataModel` (boolean, optional): If true, the client will send the full data model of this surface in the metadata of every message sent to the server (via the Transport's metadata mechanism). This ensures the surface owner receives the full current state of the UI alongside the user's action or query. Defaults to false.
 
@@ -308,6 +308,12 @@ This structure is designed to be both flexible and strictly validated.
 ### The component catalog
 
 The set of available UI components and functions is defined in a **Catalog**. The basic catalog is defined in [`catalogs/basic/catalog.json`]. While the Basic Catalog is useful for starting out, most production applications will define their own catalog to reflect their specific design system. The server must generate messages that conform to the catalog understood by the client.
+
+#### Catalog Identification & Compatibility
+
+Each catalog is identified by a `catalogId` string. The `catalogId` is a string identifier used for matching catalogs between the client and server. While it is conventional to format catalog IDs as URIs (e.g., `https://mycompany.com/catalogs/v1`) to prevent naming collisions across organizations, a `catalogId` is not required to be a resolvable network resource.
+
+It is up to client and server developers to agree on shared catalogs with well-known IDs in order to build systems that are compatible with each other.
 
 ### UI composition: the adjacency list model
 
@@ -837,7 +843,7 @@ The `a2uiClientCapabilities` object in the A2A `Message`'s `metadata` field foll
 
 **Properties:**
 
-- `supportedCatalogIds` (array of strings, required): URIs of supported catalogs.
+- `supportedCatalogIds` (array of strings, required): String identifiers of supported catalogs.
 - `inlineCatalogs`: An array of inline catalog definitions provided directly by the client (useful for custom or ad-hoc components and functions).
 
 #### Client data model

--- a/specification/v0_9_1/docs/core_sdk_spec.md
+++ b/specification/v0_9_1/docs/core_sdk_spec.md
@@ -336,7 +336,7 @@ interface FunctionImplementation extends FunctionApi {
 }
 
 class Catalog<T extends ComponentApi> {
-  readonly id: string; // Unique catalog URI
+  readonly id: string; // Unique catalog ID (string identifier)
   readonly components: ReadonlyMap<string, T>;
   readonly functions?: ReadonlyMap<string, FunctionImplementation>;
   readonly themeSchema?: Schema;

--- a/specification/v0_9_1/json/client_capabilities.json
+++ b/specification/v0_9_1/json/client_capabilities.json
@@ -11,7 +11,7 @@
       "properties": {
         "supportedCatalogIds": {
           "type": "array",
-          "description": "The URI of each of the component and function catalogs that is supported by the client.",
+          "description": "An array of string identifiers for each of the component and function catalogs supported by the client.",
           "items": {"type": "string"}
         },
         "inlineCatalogs": {

--- a/specification/v1_0/docs/a2ui_protocol.md
+++ b/specification/v1_0/docs/a2ui_protocol.md
@@ -181,7 +181,7 @@ One of the components in one of the component lists MUST have an `id` of `root` 
 **Properties:**
 
 - `surfaceId` (string, required): The unique identifier for the UI surface to be rendered. This must be globally unique for the renderer's lifetime.
-- `catalogId` (string, required): A string that uniquely identifies the catalog (components and functions) used for this surface. It is recommended to prefix this with an internet domain that you own, to avoid conflicts (e.g., `https://mycompany.com/1.0/somecatalog`). If it is a URL, the URL does not need to have any deployed resources, it is simply a unique identifier.
+- `catalogId` (string, required): A string that uniquely identifies the catalog (components and functions) used for this surface. Note that `catalogId` is a string identifier, not a resolvable URI; while it is conventionally formatted as a URI (e.g., `https://mycompany.com/1.0/somecatalog`) to avoid naming collisions across organizations, it does not need to point to any deployed resource or downloadable file. Client and server developers must agree on shared catalogs with well-known IDs in order to build systems that are compatible with each other.
 - `surfaceProperties` (object, optional): A JSON object containing surface properties (e.g., `agentDisplayName`) defined in the catalog's surfaceProperties schema.
 - `sendDataModel` (boolean, optional): If true, the client will send the full data model of this surface in the metadata of every message sent to the server (via the Transport's metadata mechanism). This ensures the surface owner receives the full current state of the UI alongside the user's action or query. Defaults to false.
 - `components` (array, optional): A list containing UI components for the surface, allowing the client to build and populate the UI tree immediately on surface creation. Conforms to the `ComponentsList` schema.
@@ -440,7 +440,7 @@ The set of available UI components and functions is defined in a **Catalog**. Th
 
 Every catalog follows the standard `Catalog` object definition:
 
-- **catalogId** (string, required): A unique identifier URI for this catalog.
+- **catalogId** (string, required): A unique string identifier for this catalog. While conventionally formatted as a URI to avoid naming collisions across organizations, it is an arbitrary string ID and not a resolvable URI. Client and server developers must agree on shared catalogs with well-known IDs in order to build systems that are compatible with each other.
 - **instructions** (string, optional): Markdown-formatted design principles, rules, or developer guidelines specific to this catalog. These rules guide LLMs when generating UI layouts under this catalog.
 - **components** (object, optional): A map of supported UI components, where each key is the component type (e.g., `Text`) and its value is its JSON Schema definition. All keys MUST conform to the UAX #31 entity naming rules defined below.
 - **functions** (object, optional): A map of client-side validation or utility functions supported by the catalog, where each key is the function name and its value is its definition. All function names MUST conform to the UAX #31 entity naming rules defined below. The client determines a function's execution boundary (e.g., clientOnly status) at runtime by reading its configuration from the active catalog definition.
@@ -1282,7 +1282,7 @@ The `a2uiClientCapabilities` object in the transport metadata follows the [`clie
 **Properties:**
 
 - `v1.0` (object, required): The capability structure for version 1.0 of the A2UI protocol.
-  - `supportedCatalogIds` (array of strings, required): The URIs of supported component and function catalogs.
+  - `supportedCatalogIds` (array of strings, required): The string identifiers of supported component and function catalogs.
   - `inlineCatalogs` (array, optional): An array of custom catalog definitions provided inline by the client. Functions defined within inline catalogs support declaring execution boundaries (`callableFrom: "clientOnly" | "remoteOnly" | "clientOrRemote"`) to statically specify remote invocation safety.
 
 ### Client data model

--- a/specification/v1_0/docs/core_sdk_spec.md
+++ b/specification/v1_0/docs/core_sdk_spec.md
@@ -336,7 +336,7 @@ interface FunctionImplementation extends FunctionApi {
 }
 
 class Catalog<T extends ComponentApi> {
-  readonly id: string; // Unique catalog URI
+  readonly id: string; // Unique catalog ID (string identifier)
   readonly components: ReadonlyMap<string, T>;
   readonly functions?: ReadonlyMap<string, FunctionImplementation>;
   readonly themeSchema?: Schema;

--- a/specification/v1_0/extensions/a2a/docs/a2ui_extension_specification.md
+++ b/specification/v1_0/extensions/a2a/docs/a2ui_extension_specification.md
@@ -67,7 +67,7 @@ The client sends its capabilities to the server in an `a2uiClientCapabilities` o
 
 The `a2uiClientCapabilities` object contains a `v1.0` object with the following properties:
 
-- `v1.0.supportedCatalogIds` (array of strings, required): The URIs of supported component and function catalogs.
+- `v1.0.supportedCatalogIds` (array of strings, required): The string identifiers of supported component and function catalogs.
 - `v1.0.inlineCatalogs` (array, optional): An array of custom catalog definitions provided inline by the client. Functions defined within inline catalogs support declaring execution boundaries (`callableFrom: "clientOnly" | "remoteOnly" | "clientOrRemote"`) to statically specify remote invocation safety.
 
 ---

--- a/specification/v1_0/json/client_capabilities.json
+++ b/specification/v1_0/json/client_capabilities.json
@@ -11,7 +11,7 @@
       "properties": {
         "supportedCatalogIds": {
           "type": "array",
-          "description": "The URI of each of the component and function catalogs that is supported by the client.",
+          "description": "An array of string identifiers for each of the component and function catalogs supported by the client.",
           "items": {"type": "string"}
         },
         "inlineCatalogs": {


### PR DESCRIPTION
## Description of Changes
- Clarified in `a2ui_protocol.md` (v0.9, v0.9.1, v1.0) that `catalogId` is an arbitrary string identifier (not a resolvable URI), though it is conventionally formatted as a URI to prevent naming collisions.
- Added explicit documentation in `a2ui_protocol.md` emphasizing that client and server developers must agree on shared catalogs with well-known IDs to ensure compatibility.
- Simplified schema descriptions and reference guides in v0.9, v0.9.1, and v1.0 (`client_capabilities.json`, `evolution_guide.md`, `core_sdk_spec.md`, `renderer_guide.md`, `a2ui_extension_specification.md`) to refer cleanly to string IDs/identifiers.

## Rationale
Previous references implied that `catalogId` is a URI, which could mislead implementers into expecting resolvable network endpoints rather than an arbitrary string matching mechanism.