### PR TITLE
docs(spec): fix two v1.0 evolution guide inaccuracies (functionResponse, Icon.name)

### DIFF
--- a/specification/v1_0/docs/evolution_guide.md
+++ b/specification/v1_0/docs/evolution_guide.md
@@ -33,6 +33,7 @@ Version 1.0 differs from 0.9 in the following ways:
 - Added a `steps` property to the `Slider` component schema to snap values to discrete intervals.
 - Added an optional `instructions` field to the `Catalog` schema (`catalogs/basic/catalog.json`) to embed Markdown guidelines/rules directly, replacing the external `rules.txt` file.
 - Renamed `svgPath` to `path` in the custom SVG icon definition object schema.
+- Removed the `DataBinding` option from the `Icon` component's `name` property. Because `svgPath` was renamed to `path`, the custom-SVG object `{path}` became structurally identical to a `DataBinding` `{path}`, making the `name` `oneOf` ambiguous. As a result, `Icon.name` can no longer be data-bound; it must be a literal enum icon name or an inline custom SVG `{path}`.
 - Renamed `$defs/theme` to `$defs/surfaceProperties` in the basic catalog.
 
 ### 2.3. Server-to-client messages
@@ -45,7 +46,7 @@ Version 1.0 differs from 0.9 in the following ways:
 ### 2.4. Client-to-server events
 
 - Added `actionId` to the `action` message properties, which the client generates if a response is expected (`wantResponse: true`).
-- Added `functionResponse` message structure (`FunctionResponseMessage`) to return the execution result (`value` or `error`) of a server-initiated function call.
+- Added the `functionResponse` client-to-server message to return the successful result (`value`) of a server-initiated function call. Function execution failures are reported via the separate `error` message (see next item), not via `functionResponse`.
 - Updated client `error` messages to support `functionCallId` when reporting function execution failures, enforcing mutual exclusivity with `surfaceId`.
 - Updated all protocol version references from `v0.9` or `v0.9.1` to `v1.0`.
 
@@ -87,6 +88,7 @@ This section outlines the steps required to migrate existing applications and co
 - Ensure all generated catalog entity names conform to UAX #31 identifier rules.
 - Do not include `callableFrom` or `returnType` properties in wire-level `FunctionCall` payloads. Set static `callableFrom` and `returnType` metadata in catalog function definitions where needed.
 - Update custom SVG icon definitions in `Icon` components to rename `svgPath` to `path`. Update `Video`, `TextField`, and `Slider` components to support optional `posterUrl`, `placeholder`, and `steps` properties.
+- Stop data-binding the `Icon` component's `name` property; data binding on `name` is no longer supported. Use a literal enum icon name or an inline custom SVG `{path}`, and change an icon dynamically by resending the `Icon` component via `updateComponents`.
 - Explicitly set values to `null` in `updateDataModel` messages to delete keys at specified paths. Do not omit keys or send undefined to indicate deletion.
 
 ### For renderers and clients


### PR DESCRIPTION
# Description

Two documentation-only corrections to `specification/v1_0/docs/evolution_guide.md`.
Both align the guide with the existing v1.0 schema; no schema or code behavior changes, so no tracking issue was filed first.

### 1. `functionResponse` description (§ Client-to-server events)

The `functionResponse` entry is inaccurate in two ways:

- It references a type name `FunctionResponseMessage` that does not exist. `client_to_server.json` has no `$defs`; its messages are inlined as top-level properties (`action` / `functionResponse` / `error`), so there is no `FunctionResponseMessage` identifier. 
  `grep -c "FunctionResponseMessage" specification/v1_0/json/client_to_server.json` → `0`
- It says `functionResponse` returns "(`value` or `error`)", but the schema is `required: [functionCallId, call, value]` with `unevaluatedProperties: false` — it carries only a `value`, never an `error`. Function execution failures are reported via the separate `error` message (which carries a `functionCallId`), as already documented in the very next bullet of the same section.

Fixed: drop the non-existent name, state that `functionResponse` returns the successful `value`, and point to the separate `error` message for failures.

### 2. `Icon.name` DataBinding removal (§ Standard catalogs + Migration guide)

v1.0 renamed the custom-SVG field `svgPath` to `path`. As a side effect, the custom-SVG object `{path}` became structurally identical to a `DataBinding` `{path}`, making the `Icon.name` `oneOf` ambiguous. v1.0 therefore removed the `DataBinding` branch from `Icon.name`:

- v0.9.1 `Icon.name` = `oneOf[ enum, {svgPath}, DataBinding ]` (3 branches)
- v1.0   `Icon.name` = `oneOf[ enum, {path} ]` (2 branches; `DataBinding` removed)
- `grep -c "DataBinding" specification/v1_0/catalogs/basic/catalog.json` → `0`

This is a breaking capability change: in v0.9.1 `Icon.name` could be data-bound; in v1.0 it cannot. The guide previously recorded only the `svgPath` → `path` rename and never mentioned the `DataBinding` removal or the resulting loss of data-binding — an undocumented breaking change.

Fixed: add one entry under the basic-catalog changes and one note in the migration guide. The schema already reflects the removal; this only documents it.

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have built and run at least one [sample].

For this PR:

- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
