### PR TITLE
fix(samples): read restaurant data as utf-8

### DIFF
--- a/samples/agent/adk/restaurant_finder/tools.py
+++ b/samples/agent/adk/restaurant_finder/tools.py
@@ -36,7 +36,7 @@ def get_restaurants(
         try:
             script_dir = os.path.dirname(__file__)
             file_path = os.path.join(script_dir, "restaurant_data.json")
-            with open(file_path) as f:
+            with open(file_path, encoding="utf-8") as f:
                 restaurant_data_str = f.read()
                 if base_url := tool_context.state.get("base_url"):
                     restaurant_data_str = restaurant_data_str.replace(


### PR DESCRIPTION
Close #1451

## Summary
- Read the restaurant finder sample data with explicit UTF-8 encoding.