### PR TITLE
fix(@a2ui/markdown-it): widen web_core peer dep to >=0.9.2

### DIFF
--- a/renderers/markdown/markdown-it/package.json
+++ b/renderers/markdown/markdown-it/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/markdown-it",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A Markdown renderer using markdown-it and dompurify.",
   "repository": {
     "directory": "renderers/markdown/markdown-it",
@@ -61,7 +61,7 @@
     "wireit": "^0.15.0-pre.2"
   },
   "peerDependencies": {
-    "@a2ui/web_core": "workspace:*"
+    "@a2ui/web_core": ">=0.9.2"
   },
   "wireit": {
     "build": {


### PR DESCRIPTION
Fixes #1930.

`@a2ui/markdown-it@0.0.4` was published when `web_core` was at `0.9.2`, so `prepare-publish.mjs` baked in `^0.9.2` as the peer dep. Since then `web_core` shipped `0.10.x`, and any project that pulls in `@a2ui/react@^0.10` alongside `@a2ui/web_core@^0.10` gets an `ERESOLVE` override warning on every install:

```
npm warn ERESOLVE overriding peer dependency
npm warn peer @a2ui/web_core@"^0.9.2" from @a2ui/markdown-it@0.0.4
```

**The fix:** change `peerDependencies["@a2ui/web_core"]` from `workspace:*` (which `prepare-publish.mjs` resolves to `^<current-version>` at publish time) to an explicit `>=0.9.2`. This bypasses the workspace replacement and produces a wide range in the published package — no more peer conflict when `web_core` bumps again. Bumps to `0.0.5`.

The `devDependencies` entry is left as `workspace:*` so local builds continue to use the monorepo copy.