### PR TITLE
Fix evals

### DIFF
--- a/agent_sdks/python/a2ui_agent/src/a2ui/schema/validator.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/schema/validator.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
 
-from .constants import VERSION_0_8, VERSION_0_9, VERSION_1_0
+from .constants import VERSION_0_8, VERSION_0_9, VERSION_0_9_1, VERSION_1_0
 from .validator_v08 import (
     LegacyA2uiValidatorV08,
     extract_component_required_fields as v08_req,
@@ -82,7 +82,7 @@ class A2uiValidatorWrapper:
 
 
 class A2uiValidatorWrapperV10:
-    """Validates v1.0 payloads dynamically using jsonschema and core component integrity checks."""
+    """Validates dynamic payloads (such as v0.9.1 and v1.0) using jsonschema and core component integrity checks."""
 
     def __init__(self, catalog: A2uiCatalog):
         self._catalog = catalog
@@ -226,6 +226,9 @@ class A2uiValidator:
         self.version = ver if isinstance(ver, str) else VERSION_0_8
         if self.version == VERSION_0_8:
             self._delegator = LegacyA2uiValidatorV08(catalog)
+        # TODO(a2ui-project/A2UI#1936): The V10 validator dynamically uses the `catalog` spec to validate. This should all be consolidated.
+        elif self.version == VERSION_0_9_1:
+            self._delegator = A2uiValidatorWrapperV10(catalog)
         elif self.version == VERSION_1_0:
             import os
 

--- a/samples/community/agent/adk/mcp_app_proxy/catalogs/0.9/mcp_app_catalog.json
+++ b/samples/community/agent/adk/mcp_app_proxy/catalogs/0.9/mcp_app_catalog.json
@@ -1,5 +1,7 @@
 {
-  "catalogId": "a2ui.org:a2ui/v0.9/mcp_app_catalog.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://a2ui.org/samples/community/agent/adk/mcp_app_proxy/catalogs/0.9/mcp_app_catalog.json",
+  "catalogId": "https://a2ui.org/samples/community/agent/adk/mcp_app_proxy/catalogs/0.9/mcp_app_catalog.json",
   "components": {
     "Column": {
       "type": "object",

--- a/samples/community/agent/adk/rizzcharts/catalog_schemas/0.9/rizzcharts_catalog_definition.json
+++ b/samples/community/agent/adk/rizzcharts/catalog_schemas/0.9/rizzcharts_catalog_definition.json
@@ -1,5 +1,7 @@
 {
-  "catalogId": "https://github.com/a2ui-project/a2ui/blob/main/samples/agent/adk/rizzcharts/rizzcharts_catalog_definition.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://a2ui.org/samples/community/agent/adk/rizzcharts/catalog_schemas/0.9/rizzcharts_catalog_definition.json",
+  "catalogId": "https://a2ui.org/samples/community/agent/adk/rizzcharts/catalog_schemas/0.9/rizzcharts_catalog_definition.json",
   "components": {
     "Text": {
       "type": "object",


### PR DESCRIPTION
Fix [a2ui-project/a2ui#1933](https://github.com/a2ui-project/a2ui/issues/1933). Breakage introduced in [a2ui-project/a2ui#1908](https://github.com/a2ui-project/a2ui/pull/1908)

We need to support v0.9.1 in the validators. Due to [a2ui-project/a2ui#1936](https://github.com/a2ui-project/a2ui/issues/1936) we need to introduce some tech debt.

Add `$schema` and `$id` fields to some of the catalogs used in the test so that json validation passes.

TAG=agy
CONV=434bb731-15b5-4e15-8474-68d4f4d14636