### PR TITLE
Angular Renderer Resilience & Reactivity Updates

### DIFF
--- a/renderers/angular/src/v0_9/core/component-host.component.spec.ts
+++ b/renderers/angular/src/v0_9/core/component-host.component.spec.ts
@@ -18,8 +18,13 @@ import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {ComponentHostComponent} from './component-host.component';
 import {A2uiRendererService} from './a2ui-renderer.service';
-import {ComponentModel, SurfaceComponentsModel, SurfaceModel} from '@a2ui/web_core/v0_9';
-import {Component, EnvironmentInjector, Input} from '@angular/core';
+import {
+  ComponentApi,
+  ComponentModel,
+  SurfaceComponentsModel,
+  SurfaceModel,
+} from '@a2ui/web_core/v0_9';
+import {Component, EnvironmentInjector, EventEmitter, Input, NgZone} from '@angular/core';
 import {initializeAngularReactivity} from './reactivity';
 
 @Component({
@@ -53,6 +58,7 @@ describe('ComponentHostComponent', () => {
     );
 
     mockSurface = {
+      id: 'surf1',
       componentsModel: mockSurfaceComponentsModel,
       catalog: mockCatalog,
     } as SurfaceModel<any>;
@@ -135,7 +141,44 @@ describe('ComponentHostComponent', () => {
 
       const childDebugElement = fixture.debugElement.query(By.directive(TestChildComponent));
       expect(childDebugElement).toBeFalsy();
-      expect(consoleWarnSpy).toHaveBeenCalledWith('Surface surf1 not found');
+      expect(consoleWarnSpy).toHaveBeenCalledWith('Surface surf1 not found. Waiting for it...');
+    });
+
+    it('should wait for surface creation and render component when surface arrives asynchronously', () => {
+      const surfaceCreatedEmitter = new EventEmitter<SurfaceModel<ComponentApi>>();
+      mockSurfaceGroup.onSurfaceCreated = surfaceCreatedEmitter;
+      mockSurfaceGroup.getSurface.and.returnValue(null);
+
+      fixture.detectChanges();
+      let childDebugElement = fixture.debugElement.query(By.directive(TestChildComponent));
+      expect(childDebugElement).toBeFalsy();
+
+      mockSurfaceGroup.getSurface.and.returnValue(mockSurface);
+      surfaceCreatedEmitter.emit(mockSurface);
+      fixture.detectChanges();
+
+      childDebugElement = fixture.debugElement.query(By.directive(TestChildComponent));
+      expect(childDebugElement).toBeTruthy();
+    });
+
+    it('should handle synchronous surface creation and unsubscribe cleanly', () => {
+      const mockSubscription = {unsubscribe: jasmine.createSpy('unsubscribe')};
+      mockSurfaceGroup.onSurfaceCreated = {
+        subscribe: jasmine
+          .createSpy('subscribe')
+          .and.callFake((callback: (s: SurfaceModel<any>) => void) => {
+            callback(mockSurface);
+            return mockSubscription;
+          }),
+      };
+      // First call returns null (not found), second recursive call returns mockSurface (found)
+      mockSurfaceGroup.getSurface.and.returnValues(null, mockSurface);
+
+      fixture.detectChanges();
+
+      const childDebugElement = fixture.debugElement.query(By.directive(TestChildComponent));
+      expect(childDebugElement).toBeTruthy();
+      expect(mockSubscription.unsubscribe).toHaveBeenCalledOnceWith();
     });
 
     it('should warn and return if component model not found', () => {
@@ -172,6 +215,35 @@ describe('ComponentHostComponent', () => {
 
       // Implicitly verifies no crash on destroy
       expect(component).toBeTruthy();
+    });
+
+    it('should execute setupComponent inside the Angular Zone when surface is created asynchronously', () => {
+      const surfaceCreatedEmitter = new EventEmitter<SurfaceModel<ComponentApi>>();
+      mockSurfaceGroup.onSurfaceCreated = surfaceCreatedEmitter;
+      mockSurfaceGroup.getSurface.and.returnValue(null);
+
+      fixture.detectChanges();
+
+      mockSurfaceGroup.getSurface.and.returnValue(mockSurface);
+
+      const ngZone = TestBed.inject(NgZone);
+      const runSpy = spyOn(ngZone, 'run').and.callThrough();
+
+      surfaceCreatedEmitter.emit(mockSurface);
+
+      expect(runSpy).toHaveBeenCalled();
+    });
+
+    it('should run property updates inside the Angular Zone when component model updates', () => {
+      fixture.detectChanges();
+
+      const ngZone = TestBed.inject(NgZone);
+      const runSpy = spyOn(ngZone, 'run').and.callThrough();
+
+      const compModel = mockSurface.componentsModel.get('comp1')!;
+      compModel.properties = {text: 'Hello', newProp: 'new value'};
+
+      expect(runSpy).toHaveBeenCalled();
     });
   });
 

--- a/renderers/angular/src/v0_9/core/component-host.component.ts
+++ b/renderers/angular/src/v0_9/core/component-host.component.ts
@@ -16,13 +16,14 @@
 
 import {
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   DestroyRef,
   Type,
   inject,
   input,
   effect,
+  signal,
+  NgZone,
 } from '@angular/core';
 import {NgComponentOutlet} from '@angular/common';
 import {ComponentContext, ComponentModel, SurfaceModel, Subscription} from '@a2ui/web_core/v0_9';
@@ -48,12 +49,12 @@ import {BoundProperty} from './types';
     style: 'display: contents;',
   },
   template: `
-    @if (componentType) {
+    @if (componentType()) {
       <ng-container
         *ngComponentOutlet="
-          componentType;
+          componentType()!;
           inputs: {
-            'props': props,
+            'props': props(),
             'surfaceId': surfaceId(),
             'componentId': resolvedComponentId,
             'dataContextPath': resolvedDataContextPath,
@@ -74,10 +75,10 @@ export class ComponentHostComponent {
   private readonly rendererService = inject(A2uiRendererService);
   private readonly binder = inject(ComponentBinder);
   private readonly destroyRef = inject(DestroyRef);
-  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly ngZone = inject(NgZone);
 
-  protected componentType: Type<unknown> | null = null;
-  protected props: Record<string, BoundProperty> = {};
+  protected readonly componentType = signal<Type<unknown> | null>(null);
+  protected readonly props = signal<Record<string, BoundProperty>>({});
   private context?: ComponentContext;
 
   protected resolvedComponentId: string = '';
@@ -85,17 +86,22 @@ export class ComponentHostComponent {
 
   private propsSub?: Subscription;
   private createSub?: Subscription;
+  private surfaceSub?: Subscription;
 
   constructor() {
     effect(() => {
       const key = this.componentKey();
       const surfaceId = this.surfaceId();
-      this.setupComponent(key, surfaceId);
+      if (key && surfaceId) {
+        this.resetState();
+        this.setupComponent(key, surfaceId);
+      }
     });
 
     this.destroyRef.onDestroy(() => {
       this.propsSub?.unsubscribe();
       this.createSub?.unsubscribe();
+      this.surfaceSub?.unsubscribe();
     });
   }
 
@@ -105,7 +111,28 @@ export class ComponentHostComponent {
     const surface = this.rendererService.surfaceGroup?.getSurface(surfaceId);
 
     if (!surface) {
-      console.warn(`Surface ${surfaceId} not found`);
+      console.warn(`Surface ${surfaceId} not found. Waiting for it...`);
+      this.surfaceSub?.unsubscribe();
+      let unsubscribed = false;
+      const sub = this.rendererService.surfaceGroup?.onSurfaceCreated?.subscribe(s => {
+        if (s.id === surfaceId) {
+          unsubscribed = true;
+          if (this.surfaceSub) {
+            this.surfaceSub.unsubscribe();
+            this.surfaceSub = undefined;
+          }
+          this.ngZone.run(() => {
+            this.setupComponent(key, surfaceId);
+          });
+        }
+      });
+      if (sub) {
+        this.surfaceSub = sub;
+        if (unsubscribed) {
+          this.surfaceSub.unsubscribe();
+          this.surfaceSub = undefined;
+        }
+      }
       return;
     }
 
@@ -154,21 +181,20 @@ export class ComponentHostComponent {
       console.error(`Component type "${componentModel.type}" not found in catalog "${catalog.id}"`);
       return;
     }
-    this.componentType = api.component;
+    this.componentType.set(api.component);
 
     // Create context
     this.context = new ComponentContext(surface, id, basePath);
-    this.props = this.binder.bind(this.context);
+    this.props.set(this.binder.bind(this.context));
     this.resolvedDataContextPath = this.context.dataContext.path;
 
     // Subscribes to updates to the component model properties, to get the
     // component to react when a new prop is added after creation.
     this.propsSub = componentModel.onUpdated.subscribe(() => {
-      this.props = this.binder.bind(this.context!);
-      this.cdr.markForCheck();
+      this.ngZone.run(() => {
+        this.props.set(this.binder.bind(this.context!));
+      });
     });
-
-    this.cdr.markForCheck();
   }
 
   /**
@@ -179,10 +205,10 @@ export class ComponentHostComponent {
   private resetState(): void {
     this.propsSub?.unsubscribe();
     this.createSub?.unsubscribe();
+    this.surfaceSub?.unsubscribe();
 
-    this.componentType = null;
-    this.props = {};
+    this.componentType.set(null);
+    this.props.set({});
     this.resolvedDataContextPath = '/';
-    this.cdr.markForCheck();
   }
 }


### PR DESCRIPTION
This pull request fixes critical reliability bugs and change-detection rendering skips in the Angular Renderer (`ComponentHostComponent`):

1. **Fix subscription memory leak:** Resolves a pattern where the component-host subscribes to `onSurfaceCreated` and attempts to unsubscribe self-referentially within the synchronous emission path, which evaluates to `undefined` and leaks listeners.
2. **Asynchronous surface resolution:** In progressive rendering or streaming environments, component host nodes can be mounted in the DOM before the surface itself is registered. Added a subscription to `onSurfaceCreated` to automatically bootstrap the component when the surface registers.
3. **Optimize reactivity (Signals upgrade):** Upgraded `componentType` and `props` to Angular Signals. In strict `OnPush` applications, asynchronous updates inside RxJS callbacks were not recognized by the change detector, leaving components unrendered.

## Pre-launch Checklist

- [x] I signed the CLA https://cla.developers.google.com/.
- [x] My code changes have tests.