### PR TITLE
chore: run uv pyink recursively from root in fix_format.sh and python CI

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -56,11 +56,7 @@ jobs:
         run: uv sync --all-packages
       - name: Check Formatting
         run: |
-          # TODO(jiahaog): Add evals here and merge into one command.
-          uv run pyink --check agent_sdks/python/a2ui_agent
-          uv run pyink --check agent_sdks/python/a2ui_core
-          uv run pyink --check agent_sdks/conformance
-          uv run pyink --check samples/agent/adk
+          uv run pyink --check .
       - name: Type Check
         run: |
           uv run mypy -p a2ui.core

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -56,39 +56,11 @@ else
   fi
 fi
 
-echo "Running Pyink for Python Agent SDK..."
+echo "Running Pyink for Python files..."
 if [ "$CHECK_ONLY" = true ]; then
-  uv run pyink --check agent_sdks/python/a2ui_agent
+  uv run pyink --check .
 else
-  uv run pyink agent_sdks/python/a2ui_agent
-fi
-
-echo "Running Pyink for Python Core SDK..."
-if [ "$CHECK_ONLY" = true ]; then
-  uv run pyink --check agent_sdks/python/a2ui_core
-else
-  uv run pyink agent_sdks/python/a2ui_core
-fi
-
-echo "Running Pyink for Python Samples..."
-if [ "$CHECK_ONLY" = true ]; then
-  uv run pyink --check samples/agent/adk
-else
-  uv run pyink samples/agent/adk
-fi
-
-echo "Running Pyink for Python Eval..."
-if [ "$CHECK_ONLY" = true ]; then
-  uv run pyink --check eval
-else
-  uv run pyink eval
-fi
-
-echo "Running Pyink for Python Specification Proposals..."
-if [ "$CHECK_ONLY" = true ]; then
-  uv run pyink --check specification/proposals
-else
-  uv run pyink specification/proposals
+  uv run pyink .
 fi
 
 echo "Running Dart format..."


### PR DESCRIPTION
Now that everything is formatted using the centralized pyink config (https://github.com/a2ui-project/a2ui/pull/1932), we can simplfiy all the scripts too.