### PR TITLE
chore(ci): revert #1938. Release just markdown-it v0.1.0.

### DIFF
--- a/renderers/angular/CHANGELOG.md
+++ b/renderers/angular/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## Unreleased
 
-## 0.10.3
-
 - (v0_9) Export Angular test utilities under `@a2ui/angular/testing` and secondary entry point `@a2ui/angular/v0_9/testing`. [#1737](https://github.com/a2ui-project/a2ui/pull/1737)
 
 ## 0.10.2

--- a/renderers/angular/package.json
+++ b/renderers/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/angular",
-  "version": "0.10.3",
+  "version": "0.10.2",
   "license": "Apache-2.0",
   "homepage": "https://a2ui.org/",
   "repository": {

--- a/renderers/markdown/markdown-it/CHANGELOG.md
+++ b/renderers/markdown/markdown-it/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+## 0.1.0
+
+- Bump dependencies so the package is compatible with `@a2ui/web_core: ^0.10.3`.
+
 ## 0.0.2
 
 - Made the markdown renderer async to support async markdown renderers.

--- a/renderers/markdown/markdown-it/CHANGELOG.md
+++ b/renderers/markdown/markdown-it/CHANGELOG.md
@@ -1,9 +1,3 @@
-## Unreleased
-
-## 0.1.0
-
-- Widen `@a2ui/web_core` peer dependency range to `^0.9.2 || ^0.10.0` (#1766, #1930).
-
 ## 0.0.2
 
 - Made the markdown renderer async to support async markdown renderers.

--- a/renderers/markdown/markdown-it/package.json
+++ b/renderers/markdown/markdown-it/package.json
@@ -61,7 +61,7 @@
     "wireit": "^0.15.0-pre.2"
   },
   "peerDependencies": {
-    "@a2ui/web_core": "^0.9.2 || ^0.10.0"
+    "@a2ui/web_core": "workspace:*"
   },
   "wireit": {
     "build": {

--- a/renderers/markdown/markdown-it/package.json
+++ b/renderers/markdown/markdown-it/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/markdown-it",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "A Markdown renderer using markdown-it and dompurify.",
   "repository": {
     "directory": "renderers/markdown/markdown-it",

--- a/renderers/markdown/markdown-it/package.json
+++ b/renderers/markdown/markdown-it/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/markdown-it",
-  "version": "0.1.0",
+  "version": "0.0.4",
   "description": "A Markdown renderer using markdown-it and dompurify.",
   "repository": {
     "directory": "renderers/markdown/markdown-it",
@@ -61,7 +61,7 @@
     "wireit": "^0.15.0-pre.2"
   },
   "peerDependencies": {
-    "@a2ui/web_core": "^0.9.2 || ^0.10.0"
+    "@a2ui/web_core": "workspace:*"
   },
   "wireit": {
     "build": {

--- a/renderers/markdown/markdown-it/package.json
+++ b/renderers/markdown/markdown-it/package.json
@@ -61,7 +61,7 @@
     "wireit": "^0.15.0-pre.2"
   },
   "peerDependencies": {
-    "@a2ui/web_core": "workspace:*"
+    "@a2ui/web_core": "^0.9.2 || ^0.10.0"
   },
   "wireit": {
     "build": {

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## Unreleased
 
-## 0.10.4
-
-- Support JSON Pointer escaping (RFC 6901) in DataModel (#1796).
 - (v0_8) Export `UserAction` as `ClientEventUserAction` from `types.ts` ([#1942](https://github.com/a2ui-project/a2ui/pull/1942)).
 
 ## 0.10.3

--- a/renderers/web_core/package.json
+++ b/renderers/web_core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/web_core",
-  "version": "0.10.4",
+  "version": "0.10.3",
   "description": "A2UI Core Library",
   "homepage": "https://a2ui.org/",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,7 +228,7 @@ __metadata:
     typescript: "npm:5.9.3"
     wireit: "npm:^0.15.0-pre.2"
   peerDependencies:
-    "@a2ui/web_core": "workspace:*"
+    "@a2ui/web_core": ^0.9.2 || ^0.10.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,7 +228,7 @@ __metadata:
     typescript: "npm:5.9.3"
     wireit: "npm:^0.15.0-pre.2"
   peerDependencies:
-    "@a2ui/web_core": ^0.9.2 || ^0.10.0
+    "@a2ui/web_core": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Reverts https://github.com/a2ui-project/a2ui/pull/1938, and prepares `markdown-it` for release so it is compatible with the current version of web_core (^0.10.3), and not the next one.

* Fixes: https://github.com/a2ui-project/a2ui/issues/1930