### PR TITLE
Prepare web_core v0.10.4, angular v0.10.3 release (re-land: #1938)

### DIFF
--- a/renderers/angular/CHANGELOG.md
+++ b/renderers/angular/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.10.3
+
 - (v0_9) Export Angular test utilities under `@a2ui/angular/testing` and secondary entry point `@a2ui/angular/v0_9/testing`. [#1737](https://github.com/a2ui-project/a2ui/pull/1737)
 
 ## 0.10.2

--- a/renderers/angular/package.json
+++ b/renderers/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/angular",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "license": "Apache-2.0",
   "homepage": "https://a2ui.org/",
   "repository": {

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## 0.10.4
+
+- (v0_9) Support JSON Pointer escaping (RFC 6901) in DataModel ([#1796](https://github.com/a2ui-project/a2ui/pull/1796)).
 - (v0_8) Export `UserAction` as `ClientEventUserAction` from `types.ts` ([#1942](https://github.com/a2ui-project/a2ui/pull/1942)).
 
 ## 0.10.3

--- a/renderers/web_core/package.json
+++ b/renderers/web_core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/web_core",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "A2UI Core Library",
   "homepage": "https://a2ui.org/",
   "repository": {


### PR DESCRIPTION
# Description

This PR updates the versions and CHANGELOG of:

* web_core (to 0.10.4)
* angular (to 0.10.3)

So they can be released to NPM.

This is a re-land of PR #1938 that also bumped markdown-it, but that needed a separate release, so it got reverted and split into this one and #1962

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have built and run at least one [sample].

For this PR:

- [x] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
