### PR TITLE
feat(web_core): Parse both v0.9 and v0.9.1 messages.

### DIFF
--- a/renderers/angular/a2ui_explorer/package.json
+++ b/renderers/angular/a2ui_explorer/package.json
@@ -39,7 +39,7 @@
       "command": "node scripts/generate-examples.mjs",
       "files": [
         "../../../specification/v0_8/json/catalogs/**/*.json",
-        "../../../specification/v0_9_1/catalogs/**/*.json",
+        "../../../specification/v0_9/catalogs/**/*.json",
         "scripts/generate-examples.mjs"
       ],
       "output": [

--- a/renderers/angular/a2ui_explorer/scripts/generate-examples.mjs
+++ b/renderers/angular/a2ui_explorer/scripts/generate-examples.mjs
@@ -126,7 +126,7 @@ async function main() {
   const catalogs = values.catalog;
 
   const examplesV08 = readExamples('../../../specification/v0_8/json/catalogs', catalogs, '0.8');
-  const examplesV09 = readExamples('../../../specification/v0_9_1/catalogs', catalogs, '0.9');
+  const examplesV09 = readExamples('../../../specification/v0_9/catalogs', catalogs, '0.9');
 
   // Generate the file now!
   const tsContent = `/**

--- a/renderers/angular/src/v0_9/v0_9_integration.spec.ts
+++ b/renderers/angular/src/v0_9/v0_9_integration.spec.ts
@@ -281,3 +281,76 @@ describe('v0.9 Angular Renderer Integration', () => {
     });
   });
 });
+
+// TODO: Replace this by actual 0.9.1 tests by loading from the examples.
+// Note that this cannot be done now, because the v0_9_1 examples have the wrong
+// "version" field ("0.9" instead of "0.9.1").
+describe('v0.9.1 Angular Renderer Integration', () => {
+  let fixture: ComponentFixture<TestHost>;
+  let rendererService: A2uiRendererService;
+  let actionSpy: jasmine.Spy;
+
+  beforeEach(async () => {
+    actionSpy = jasmine.createSpy('actionHandler');
+
+    await TestBed.configureTestingModule({
+      imports: [TestHost],
+      providers: [
+        A2uiRendererService,
+        BasicCatalog,
+        {
+          provide: A2UI_RENDERER_CONFIG,
+          useFactory: (basicCatalog: BasicCatalog) => ({
+            catalogs: [basicCatalog],
+            actionHandler: actionSpy,
+          }),
+          deps: [BasicCatalog],
+        },
+        {
+          provide: MarkdownRenderer,
+          useValue: {
+            render: (val: string) => Promise.resolve(val),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHost);
+    rendererService = TestBed.inject(A2uiRendererService);
+  });
+
+  it('should process and render v0.9.1 messages', async () => {
+    const v091Messages: A2uiMessage[] = [
+      {
+        version: 'v0.9.1',
+        createSurface: {
+          surfaceId: 'v091-surface',
+          catalogId: 'https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json',
+        },
+      },
+      {
+        version: 'v0.9.1',
+        updateComponents: {
+          surfaceId: 'v091-surface',
+          components: [
+            {
+              id: 'root',
+              component: 'Text',
+              text: 'Hello from v0.9.1!',
+            },
+          ],
+        },
+      },
+    ];
+
+    rendererService.processMessages(v091Messages);
+    fixture.componentInstance.surfaceId = 'v091-surface';
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const textEl = fixture.nativeElement.querySelector('a2ui-v09-text');
+    expect(textEl).toBeTruthy();
+    expect(textEl.textContent).toContain('Hello from v0.9.1!');
+  });
+});

--- a/renderers/lit/a2ui_explorer/scripts/generate-examples.mjs
+++ b/renderers/lit/a2ui_explorer/scripts/generate-examples.mjs
@@ -19,7 +19,7 @@ import path from 'path';
 
 const SPEC_EXAMPLES_DIR = path.resolve(
   import.meta.dirname,
-  '../../../../specification/v0_9_1/catalogs/basic/examples',
+  '../../../../specification/v0_9/catalogs/basic/examples',
 );
 const OUT_FILE = path.resolve(import.meta.dirname, '../src/generated/examples-list.ts');
 
@@ -48,7 +48,7 @@ function generateExamplesBundle() {
 
   files.forEach((file, index) => {
     // Relative path from src/generated/examples-list.ts to the specification examples folder
-    const relativePath = `../../../../../specification/v0_9_1/catalogs/basic/examples/${file}`;
+    const relativePath = `../../../../../specification/v0_9/catalogs/basic/examples/${file}`;
     const variableName = `example_${index}`;
 
     imports.push(`import ${variableName} from '${relativePath}';`);

--- a/renderers/lit/src/v0_9/tests/basic-catalog-examples.test.ts
+++ b/renderers/lit/src/v0_9/tests/basic-catalog-examples.test.ts
@@ -89,3 +89,42 @@ describe('v0.9 Basic Catalog Examples', () => {
     });
   }
 });
+
+// TODO: Replace this by actual 0.9.1 tests by loading from the examples.
+// Note that this cannot be done now, because the v0_9_1 examples have the wrong
+// "version" field ("0.9" instead of "0.9.1").
+describe('v0.9.1 Basic Catalog Example Processing', () => {
+  it('should successfully process v0.9.1 messages using basic catalog', () => {
+    const processor = new MessageProcessor([basicCatalog]);
+    const messages = [
+      {
+        version: 'v0.9.1' as const,
+        createSurface: {
+          surfaceId: 'v091-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9.1' as const,
+        updateComponents: {
+          surfaceId: 'v091-surface',
+          components: [
+            {
+              id: 'root',
+              component: 'Text',
+              text: 'Hello from v0.9.1 in lit test!',
+            },
+          ],
+        },
+      },
+    ];
+
+    processor.processMessages(messages);
+    const surface = processor.model.getSurface('v091-surface');
+    assert.ok(surface, 'Surface v091-surface should exist');
+
+    const rootNode = surface.componentsModel.get('root');
+    assert.ok(rootNode, 'Surface should have a root component');
+    assert.strictEqual(rootNode.type, 'Text');
+  });
+});

--- a/renderers/react/a2ui_explorer/package.json
+++ b/renderers/react/a2ui_explorer/package.json
@@ -76,7 +76,7 @@
     "generate-examples": {
       "command": "node scripts/generate-examples.mjs",
       "files": [
-        "../../../specification/v0_9_1/catalogs/basic/examples/*.json",
+        "../../../specification/v0_9/catalogs/basic/examples/*.json",
         "scripts/generate-examples.mjs"
       ],
       "output": [

--- a/renderers/react/a2ui_explorer/scripts/generate-examples.mjs
+++ b/renderers/react/a2ui_explorer/scripts/generate-examples.mjs
@@ -19,7 +19,7 @@ import path from 'path';
 
 const SPEC_EXAMPLES_DIR = path.resolve(
   import.meta.dirname,
-  '../../../../specification/v0_9_1/catalogs/basic/examples',
+  '../../../../specification/v0_9/catalogs/basic/examples',
 );
 const OUT_FILE = path.resolve(import.meta.dirname, '../src/generated/examples-list.ts');
 
@@ -48,7 +48,7 @@ function generateExamplesBundle() {
 
   files.forEach((file, index) => {
     // Relative path from src/generated/examples-list.ts to the specification examples folder
-    const relativePath = `../../../../../specification/v0_9_1/catalogs/basic/examples/${file}`;
+    const relativePath = `../../../../../specification/v0_9/catalogs/basic/examples/${file}`;
     const variableName = `example_${index}`;
 
     imports.push(`import ${variableName} from '${relativePath}';`);

--- a/renderers/react/tests/v0_9/basic-catalog-examples.test.tsx
+++ b/renderers/react/tests/v0_9/basic-catalog-examples.test.tsx
@@ -73,3 +73,47 @@ describe('v0.9 Basic Catalog Examples Rendering', () => {
     });
   }
 });
+
+// TODO: Replace this by actual 0.9.1 tests by loading from the examples.
+// Note that this cannot be done now, because the v0_9_1 examples have the wrong
+// "version" field ("0.9" instead of "0.9.1").
+describe('v0.9.1 Basic Catalog Example Rendering', () => {
+  it('should successfully process and render v0.9.1 messages', () => {
+    const processor = new MessageProcessor([basicCatalog]);
+    const messages = [
+      {
+        version: 'v0.9.1' as const,
+        createSurface: {
+          surfaceId: 'v091-react-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9.1' as const,
+        updateComponents: {
+          surfaceId: 'v091-react-surface',
+          components: [
+            {
+              id: 'root',
+              component: 'Text',
+              text: 'Hello from v0.9.1 in React!',
+            },
+          ],
+        },
+      },
+    ];
+
+    processor.processMessages(messages);
+    const surface = processor.model.getSurface('v091-react-surface');
+    expect(surface).toBeTruthy();
+
+    const {container} = render(
+      <React.StrictMode>
+        <A2uiSurface surface={surface as any} />
+      </React.StrictMode>,
+    );
+
+    expect(container.firstChild).toBeTruthy();
+    expect(container.textContent).toContain('Hello from v0.9.1 in React!');
+  });
+});

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- (v0_9) Accept both `v0.9` and `v0.9.1` versions when parsing messages. Allow `A2uiClientCapabilities` to support simultaneous version capability advertising (`'v0.9'` and `'v0.9.1'`).
+
 ## 0.10.4
 
 - (v0_9) Support JSON Pointer escaping (RFC 6901) in DataModel ([#1796](https://github.com/a2ui-project/a2ui/pull/1796)).

--- a/renderers/web_core/src/v0_9/processing/message-processor.test.ts
+++ b/renderers/web_core/src/v0_9/processing/message-processor.test.ts
@@ -35,8 +35,8 @@ describe('MessageProcessor', () => {
 
   describe('getClientCapabilities', () => {
     it('generates basic client capabilities with supportedCatalogIds', () => {
-      const caps: any = processor.getClientCapabilities();
-      assert.strictEqual((caps['v0.9'] as any).inlineCatalogs, undefined);
+      const caps = processor.getClientCapabilities();
+      assert.strictEqual(caps['v0.9']?.inlineCatalogs, undefined);
       assert.deepStrictEqual(caps, {
         'v0.9': {
           supportedCatalogIds: ['test-catalog'],
@@ -54,12 +54,12 @@ describe('MessageProcessor', () => {
       const cat = new Catalog('cat-1', [buttonApi]);
       const proc = new MessageProcessor([cat]);
 
-      const caps = proc.getClientCapabilities({includeInlineCatalogs: true}) as {'v0.9': any};
-      const inlineCat = caps['v0.9'].inlineCatalogs![0];
+      const caps = proc.getClientCapabilities({includeInlineCatalogs: true});
+      const inlineCat = caps['v0.9']?.inlineCatalogs?.[0];
+      assert.strictEqual(inlineCat?.catalogId, 'cat-1');
 
-      assert.strictEqual(inlineCat.catalogId, 'cat-1');
-      const buttonSchema = inlineCat.components!.Button;
-
+      const buttonSchema = inlineCat?.components?.Button;
+      assert.ok(buttonSchema);
       assert.ok(buttonSchema.allOf);
       assert.strictEqual(buttonSchema.allOf[0].$ref, 'common_types.json#/$defs/ComponentCommon');
       assert.strictEqual(buttonSchema.allOf[1].properties.component.const, 'Button');
@@ -77,10 +77,10 @@ describe('MessageProcessor', () => {
       const cat = new Catalog('cat-ref', [customApi]);
       const proc = new MessageProcessor([cat]);
 
-      const caps = proc.getClientCapabilities({includeInlineCatalogs: true}) as {'v0.9': any};
+      const caps = proc.getClientCapabilities({includeInlineCatalogs: true});
       const titleSchema =
-        caps['v0.9'].inlineCatalogs![0].components!.Custom.allOf[1].properties.title;
-
+        caps['v0.9']?.inlineCatalogs?.[0].components?.Custom.allOf[1].properties.title;
+      assert.ok(titleSchema);
       assert.strictEqual(titleSchema.$ref, 'common_types.json#/$defs/DynamicString');
       assert.strictEqual(titleSchema.description, 'The title');
       // Ensure Zod's 'type: string' was removed
@@ -111,19 +111,17 @@ describe('MessageProcessor', () => {
       const cat = new Catalog('cat-full', [buttonApi], [addFn], themeSchema);
       const proc = new MessageProcessor([cat]);
 
-      const caps = proc.getClientCapabilities({includeInlineCatalogs: true}) as {'v0.9': any};
-      const inlineCat = caps['v0.9'].inlineCatalogs![0];
-
-      assert.strictEqual(inlineCat.catalogId, 'cat-full');
-
+      const caps = proc.getClientCapabilities({includeInlineCatalogs: true});
+      const inlineCat = caps['v0.9']?.inlineCatalogs?.[0];
+      assert.strictEqual(inlineCat?.catalogId, 'cat-full');
       // Verify Functions
       assert.ok(inlineCat.functions);
       assert.strictEqual(inlineCat.functions.length, 1);
+
       const fn = inlineCat.functions[0];
       assert.strictEqual(fn.name, 'add');
       assert.strictEqual(fn.returnType, 'number');
       assert.strictEqual(fn.parameters.properties.a.description, 'First number');
-
       // Verify Theme
       assert.ok(inlineCat.theme);
       assert.ok(inlineCat.theme.primaryColor);
@@ -135,10 +133,9 @@ describe('MessageProcessor', () => {
       const compApi: ComponentApi = {name: 'EmptyComp', schema: z.object({})};
       const cat = new Catalog('cat-empty', [compApi]);
       const proc = new MessageProcessor([cat]);
-      const caps = proc.getClientCapabilities({includeInlineCatalogs: true}) as {'v0.9': any};
-      const inlineCat = caps['v0.9'].inlineCatalogs![0];
-
-      assert.strictEqual(inlineCat.catalogId, 'cat-empty');
+      const caps = proc.getClientCapabilities({includeInlineCatalogs: true});
+      const inlineCat = caps['v0.9']?.inlineCatalogs?.[0];
+      assert.strictEqual(inlineCat?.catalogId, 'cat-empty');
       assert.strictEqual(inlineCat.functions, undefined);
       assert.strictEqual(inlineCat.theme, undefined);
     });
@@ -158,11 +155,12 @@ describe('MessageProcessor', () => {
       };
       const cat = new Catalog('cat-deep', [deepApi]);
       const proc = new MessageProcessor([cat]);
-      const caps = proc.getClientCapabilities({includeInlineCatalogs: true}) as {'v0.9': any};
+      const caps = proc.getClientCapabilities({includeInlineCatalogs: true});
 
-      const properties = caps['v0.9'].inlineCatalogs![0].components!.DeepComp.allOf[1].properties;
+      const properties = caps['v0.9']?.inlineCatalogs?.[0].components?.DeepComp.allOf[1].properties;
+      assert.ok(properties);
+
       const actionSchema = properties.items.items.properties.action;
-
       assert.strictEqual(actionSchema.$ref, 'common_types.json#/$defs/Action');
       assert.strictEqual(actionSchema.description, 'The action to perform');
       assert.strictEqual(actionSchema.type, undefined);
@@ -178,13 +176,13 @@ describe('MessageProcessor', () => {
       };
       const cat = new Catalog('cat-edge', [edgeApi]);
       const proc = new MessageProcessor([cat]);
-      const caps = proc.getClientCapabilities({includeInlineCatalogs: true}) as {'v0.9': any};
+      const caps = proc.getClientCapabilities({includeInlineCatalogs: true});
 
-      const properties = caps['v0.9'].inlineCatalogs![0].components!.EdgeComp.allOf[1].properties;
+      const properties = caps['v0.9']?.inlineCatalogs?.[0].components?.EdgeComp.allOf[1].properties;
+      assert.ok(properties);
 
       assert.strictEqual(properties.noPipe.$ref, 'common_types.json#/$defs/NoPipe');
       assert.strictEqual(properties.noPipe.description, undefined);
-
       assert.strictEqual(properties.multiPipe.$ref, 'common_types.json#/$defs/MultiPipe');
       assert.strictEqual(properties.multiPipe.description, 'First');
     });
@@ -203,16 +201,15 @@ describe('MessageProcessor', () => {
       const cat2 = new Catalog('cat-2', [], [addFn], themeSchema);
 
       const proc = new MessageProcessor([cat1, cat2]);
-      const caps = proc.getClientCapabilities({includeInlineCatalogs: true}) as {'v0.9': any};
+      const caps = proc.getClientCapabilities({includeInlineCatalogs: true});
+      assert.strictEqual(caps['v0.9']?.inlineCatalogs?.length, 2);
 
-      assert.strictEqual(caps['v0.9'].inlineCatalogs!.length, 2);
+      const inlineCat1 = caps['v0.9']?.inlineCatalogs?.[0];
+      assert.strictEqual(inlineCat1?.catalogId, 'cat-1');
+      assert.strictEqual(inlineCat1?.functions, undefined);
+      assert.strictEqual(inlineCat1?.theme, undefined);
 
-      const inlineCat1 = caps['v0.9'].inlineCatalogs![0];
-      assert.strictEqual(inlineCat1.catalogId, 'cat-1');
-      assert.strictEqual(inlineCat1.functions, undefined);
-      assert.strictEqual(inlineCat1.theme, undefined);
-
-      const inlineCat2 = caps['v0.9'].inlineCatalogs![1];
+      const inlineCat2 = caps['v0.9']?.inlineCatalogs?.[1];
       assert.strictEqual(inlineCat2.catalogId, 'cat-2');
       assert.strictEqual(inlineCat2.functions!.length, 1);
       assert.ok(inlineCat2.theme);
@@ -302,7 +299,7 @@ describe('MessageProcessor', () => {
     const v091Proc = new MessageProcessor([testCatalog], undefined, {version: 'v0.9.1'});
     assert.strictEqual(v091Proc.version, 'v0.9.1');
 
-    const caps: any = v091Proc.getClientCapabilities();
+    const caps = v091Proc.getClientCapabilities();
     assert.ok(caps['v0.9.1']);
     assert.strictEqual(caps['v0.9'], undefined);
 

--- a/renderers/web_core/src/v0_9/processing/message-processor.test.ts
+++ b/renderers/web_core/src/v0_9/processing/message-processor.test.ts
@@ -54,7 +54,7 @@ describe('MessageProcessor', () => {
       const cat = new Catalog('cat-1', [buttonApi]);
       const proc = new MessageProcessor([cat]);
 
-      const caps = proc.getClientCapabilities({includeInlineCatalogs: true});
+      const caps = proc.getClientCapabilities({includeInlineCatalogs: true}) as {'v0.9': any};
       const inlineCat = caps['v0.9'].inlineCatalogs![0];
 
       assert.strictEqual(inlineCat.catalogId, 'cat-1');
@@ -77,7 +77,7 @@ describe('MessageProcessor', () => {
       const cat = new Catalog('cat-ref', [customApi]);
       const proc = new MessageProcessor([cat]);
 
-      const caps = proc.getClientCapabilities({includeInlineCatalogs: true});
+      const caps = proc.getClientCapabilities({includeInlineCatalogs: true}) as {'v0.9': any};
       const titleSchema =
         caps['v0.9'].inlineCatalogs![0].components!.Custom.allOf[1].properties.title;
 
@@ -111,7 +111,7 @@ describe('MessageProcessor', () => {
       const cat = new Catalog('cat-full', [buttonApi], [addFn], themeSchema);
       const proc = new MessageProcessor([cat]);
 
-      const caps = proc.getClientCapabilities({includeInlineCatalogs: true});
+      const caps = proc.getClientCapabilities({includeInlineCatalogs: true}) as {'v0.9': any};
       const inlineCat = caps['v0.9'].inlineCatalogs![0];
 
       assert.strictEqual(inlineCat.catalogId, 'cat-full');
@@ -135,7 +135,7 @@ describe('MessageProcessor', () => {
       const compApi: ComponentApi = {name: 'EmptyComp', schema: z.object({})};
       const cat = new Catalog('cat-empty', [compApi]);
       const proc = new MessageProcessor([cat]);
-      const caps = proc.getClientCapabilities({includeInlineCatalogs: true});
+      const caps = proc.getClientCapabilities({includeInlineCatalogs: true}) as {'v0.9': any};
       const inlineCat = caps['v0.9'].inlineCatalogs![0];
 
       assert.strictEqual(inlineCat.catalogId, 'cat-empty');
@@ -158,7 +158,7 @@ describe('MessageProcessor', () => {
       };
       const cat = new Catalog('cat-deep', [deepApi]);
       const proc = new MessageProcessor([cat]);
-      const caps = proc.getClientCapabilities({includeInlineCatalogs: true});
+      const caps = proc.getClientCapabilities({includeInlineCatalogs: true}) as {'v0.9': any};
 
       const properties = caps['v0.9'].inlineCatalogs![0].components!.DeepComp.allOf[1].properties;
       const actionSchema = properties.items.items.properties.action;
@@ -178,7 +178,7 @@ describe('MessageProcessor', () => {
       };
       const cat = new Catalog('cat-edge', [edgeApi]);
       const proc = new MessageProcessor([cat]);
-      const caps = proc.getClientCapabilities({includeInlineCatalogs: true});
+      const caps = proc.getClientCapabilities({includeInlineCatalogs: true}) as {'v0.9': any};
 
       const properties = caps['v0.9'].inlineCatalogs![0].components!.EdgeComp.allOf[1].properties;
 
@@ -203,7 +203,7 @@ describe('MessageProcessor', () => {
       const cat2 = new Catalog('cat-2', [], [addFn], themeSchema);
 
       const proc = new MessageProcessor([cat1, cat2]);
-      const caps = proc.getClientCapabilities({includeInlineCatalogs: true});
+      const caps = proc.getClientCapabilities({includeInlineCatalogs: true}) as {'v0.9': any};
 
       assert.strictEqual(caps['v0.9'].inlineCatalogs!.length, 2);
 
@@ -296,6 +296,25 @@ describe('MessageProcessor', () => {
       },
     ]);
     assert.strictEqual(processor.getClientDataModel(), undefined);
+  });
+
+  it('uses configured processor version for getClientCapabilities and getClientDataModel', () => {
+    const v091Proc = new MessageProcessor([testCatalog], undefined, {version: 'v0.9.1'});
+    assert.strictEqual(v091Proc.version, 'v0.9.1');
+
+    const caps: any = v091Proc.getClientCapabilities();
+    assert.ok(caps['v0.9.1']);
+    assert.strictEqual(caps['v0.9'], undefined);
+
+    v091Proc.processMessages([
+      {
+        version: 'v0.9.1',
+        createSurface: {surfaceId: 's1', catalogId: 'test-catalog', sendDataModel: true},
+      },
+    ]);
+    const dataModel = v091Proc.getClientDataModel();
+    assert.ok(dataModel);
+    assert.strictEqual(dataModel.version, 'v0.9.1');
   });
 
   it('updates components on correct surface', () => {

--- a/renderers/web_core/src/v0_9/processing/message-processor.ts
+++ b/renderers/web_core/src/v0_9/processing/message-processor.ts
@@ -39,6 +39,16 @@ import {A2uiStateError, A2uiValidationError} from '../errors.js';
 export interface CapabilitiesOptions {
   /** If true, the full definition of all catalogs will be included. */
   includeInlineCatalogs?: boolean;
+  /** The protocol version to generate capabilities for. Defaults to the processor's configured version. */
+  version?: 'v0.9' | 'v0.9.1';
+}
+
+/**
+ * Options for configuring a MessageProcessor instance.
+ */
+export interface MessageProcessorOptions {
+  /** The default protocol version to use for capability generation and data model reporting. Defaults to 'v0.9'. */
+  version?: 'v0.9' | 'v0.9.1';
 }
 
 /**
@@ -47,18 +57,22 @@ export interface CapabilitiesOptions {
  */
 export class MessageProcessor<T extends ComponentApi> {
   readonly model: SurfaceGroupModel<T>;
+  readonly version: 'v0.9' | 'v0.9.1';
 
   /**
    * Creates a new message processor.
    *
    * @param catalogs A list of available catalogs.
    * @param actionHandler A global handler for actions from all surfaces.
+   * @param options Configuration options for the processor.
    */
   constructor(
     private catalogs: Catalog<T>[],
     private actionHandler?: ActionListener,
+    options?: MessageProcessorOptions,
   ) {
     this.model = new SurfaceGroupModel<T>();
+    this.version = options?.version ?? 'v0.9';
     if (this.actionHandler) {
       this.model.onAction.subscribe(this.actionHandler);
     }
@@ -71,17 +85,17 @@ export class MessageProcessor<T extends ComponentApi> {
    * @returns The capabilities object.
    */
   getClientCapabilities(options?: CapabilitiesOptions): A2uiClientCapabilities {
-    const capabilities: A2uiClientCapabilities = {
-      'v0.9': {
-        supportedCatalogIds: this.catalogs.map(c => c.id),
-      },
+    // `version` can be used to fine-tune the returned capabilities.
+    const version = options?.version ?? this.version;
+    const versionCaps: any = {
+      supportedCatalogIds: this.catalogs.map(c => c.id),
     };
 
     if (options?.includeInlineCatalogs) {
-      capabilities['v0.9'].inlineCatalogs = this.catalogs.map(c => this.generateInlineCatalog(c));
+      versionCaps.inlineCatalogs = this.catalogs.map(c => this.generateInlineCatalog(c));
     }
 
-    return capabilities;
+    return {[version]: versionCaps} as A2uiClientCapabilities;
   }
 
   private generateInlineCatalog(catalog: Catalog<T>): InlineCatalog {
@@ -181,7 +195,7 @@ export class MessageProcessor<T extends ComponentApi> {
   /**
    * Returns the aggregated data model for all surfaces that have 'sendDataModel' enabled.
    */
-  getClientDataModel(): A2uiClientDataModel | undefined {
+  getClientDataModel(version: 'v0.9' | 'v0.9.1' = this.version): A2uiClientDataModel | undefined {
     const surfaces: Record<string, any> = {};
 
     for (const surface of this.model.surfacesMap.values()) {
@@ -195,7 +209,7 @@ export class MessageProcessor<T extends ComponentApi> {
     }
 
     return {
-      version: 'v0.9',
+      version,
       surfaces,
     };
   }

--- a/renderers/web_core/src/v0_9/schema/client-capabilities.ts
+++ b/renderers/web_core/src/v0_9/schema/client-capabilities.ts
@@ -42,11 +42,16 @@ export interface InlineCatalog {
 }
 
 /**
+ * The supported capabilities for a specific protocol version.
+ */
+export interface A2uiVersionCapabilities {
+  supportedCatalogIds: string[];
+  inlineCatalogs?: InlineCatalog[];
+}
+
+/**
  * The capabilities structure sent from the client to the server as part of transport metadata.
  */
-export interface A2uiClientCapabilities {
-  'v0.9': {
-    supportedCatalogIds: string[];
-    inlineCatalogs?: InlineCatalog[];
-  };
-}
+export type A2uiClientCapabilities =
+  | {'v0.9': A2uiVersionCapabilities}
+  | {'v0.9.1': A2uiVersionCapabilities};

--- a/renderers/web_core/src/v0_9/schema/client-capabilities.ts
+++ b/renderers/web_core/src/v0_9/schema/client-capabilities.ts
@@ -53,5 +53,11 @@ export interface A2uiVersionCapabilities {
  * The capabilities structure sent from the client to the server as part of transport metadata.
  */
 export type A2uiClientCapabilities =
-  | {'v0.9': A2uiVersionCapabilities}
-  | {'v0.9.1': A2uiVersionCapabilities};
+  | {
+      'v0.9': A2uiVersionCapabilities;
+      'v0.9.1'?: A2uiVersionCapabilities;
+    }
+  | {
+      'v0.9'?: A2uiVersionCapabilities;
+      'v0.9.1': A2uiVersionCapabilities;
+    };

--- a/renderers/web_core/src/v0_9/schema/client-to-server.test.ts
+++ b/renderers/web_core/src/v0_9/schema/client-to-server.test.ts
@@ -19,58 +19,64 @@ import * as assert from 'node:assert';
 import {A2uiClientMessageSchema, A2uiClientDataModelSchema} from './client-to-server.js';
 
 describe('Client-to-Server Schema Verification', () => {
-  it('validates a valid action message', () => {
-    const validAction = {
-      version: 'v0.9',
-      action: {
-        name: 'submit',
-        surfaceId: 's1',
-        sourceComponentId: 'c1',
-        timestamp: new Date().toISOString(),
-        context: {foo: 'bar'},
-      },
-    };
-    const result = A2uiClientMessageSchema.safeParse(validAction);
-    assert.ok(result.success, result.success ? '' : result.error.message);
-  });
+  const versions = ['v0.9', 'v0.9.1'];
 
-  it('validates a valid error message (validation failed)', () => {
-    const validError = {
-      version: 'v0.9',
-      error: {
-        code: 'VALIDATION_FAILED',
-        surfaceId: 's1',
-        path: '/components/0/text',
-        message: 'Too short',
-      },
-    };
-    const result = A2uiClientMessageSchema.safeParse(validError);
-    assert.ok(result.success, result.success ? '' : result.error.message);
-  });
+  versions.forEach(version => {
+    describe(`Protocol ${version}`, () => {
+      it(`validates a valid action message`, () => {
+        const validAction = {
+          version,
+          action: {
+            name: 'submit',
+            surfaceId: 's1',
+            sourceComponentId: 'c1',
+            timestamp: new Date().toISOString(),
+            context: {foo: 'bar'},
+          },
+        };
+        const result = A2uiClientMessageSchema.safeParse(validAction);
+        assert.ok(result.success, result.success ? '' : result.error.message);
+      });
 
-  it('validates a valid error message (generic)', () => {
-    const validError = {
-      version: 'v0.9',
-      error: {
-        code: 'INTERNAL_ERROR',
-        message: 'Something went wrong',
-        surfaceId: 's1',
-      },
-    };
-    const result = A2uiClientMessageSchema.safeParse(validError);
-    assert.ok(result.success, result.success ? '' : result.error.message);
-  });
+      it(`validates a valid error message (validation failed)`, () => {
+        const validError = {
+          version,
+          error: {
+            code: 'VALIDATION_FAILED',
+            surfaceId: 's1',
+            path: '/components/0/text',
+            message: 'Too short',
+          },
+        };
+        const result = A2uiClientMessageSchema.safeParse(validError);
+        assert.ok(result.success, result.success ? '' : result.error.message);
+      });
 
-  it('validates a valid data model message', () => {
-    const validDataModel = {
-      version: 'v0.9',
-      surfaces: {
-        s1: {user: 'Alice'},
-        s2: {cart: []},
-      },
-    };
-    const result = A2uiClientDataModelSchema.safeParse(validDataModel);
-    assert.ok(result.success, result.success ? '' : result.error.message);
+      it(`validates a valid error message (generic)`, () => {
+        const validError = {
+          version,
+          error: {
+            code: 'INTERNAL_ERROR',
+            message: 'Something went wrong',
+            surfaceId: 's1',
+          },
+        };
+        const result = A2uiClientMessageSchema.safeParse(validError);
+        assert.ok(result.success, result.success ? '' : result.error.message);
+      });
+
+      it(`validates a valid data model message`, () => {
+        const validDataModel = {
+          version,
+          surfaces: {
+            s1: {user: 'Alice'},
+            s2: {cart: []},
+          },
+        };
+        const result = A2uiClientDataModelSchema.safeParse(validDataModel);
+        assert.ok(result.success, result.success ? '' : result.error.message);
+      });
+    });
   });
 
   it('fails on invalid version', () => {

--- a/renderers/web_core/src/v0_9/schema/client-to-server.ts
+++ b/renderers/web_core/src/v0_9/schema/client-to-server.ts
@@ -79,7 +79,7 @@ export const A2uiClientErrorSchema = z.union([A2uiValidationErrorSchema, A2uiGen
  */
 export const A2uiClientMessageSchema = z
   .object({
-    version: z.literal('v0.9'),
+    version: z.enum(['v0.9', 'v0.9.1']),
   })
   .and(
     z.union([z.object({action: A2uiClientActionSchema}), z.object({error: A2uiClientErrorSchema})]),
@@ -91,7 +91,7 @@ export const A2uiClientMessageSchema = z
  */
 export const A2uiClientDataModelSchema = z
   .object({
-    version: z.literal('v0.9'),
+    version: z.enum(['v0.9', 'v0.9.1']),
     surfaces: z
       .record(z.object({}).passthrough())
       .describe('A map of surface IDs to their current data models.'),

--- a/renderers/web_core/src/v0_9/schema/server-to-client.ts
+++ b/renderers/web_core/src/v0_9/schema/server-to-client.ts
@@ -17,9 +17,15 @@
 import {z} from 'zod';
 import {AnyComponentSchema} from './common-types.js';
 
+/**
+ * Supported protocol versions for this schema.
+ * v0.9 renderers transparently accept v0.9.1 messages as the catalog structure is identical.
+ */
+type SupportedVersion = 'v0.9' | 'v0.9.1';
+
 export const CreateSurfaceMessageSchema = z
   .object({
-    version: z.literal('v0.9'),
+    version: z.enum(['v0.9', 'v0.9.1']),
     createSurface: z
       .object({
         surfaceId: z.string().describe('The unique identifier for the UI surface to be rendered.'),
@@ -36,7 +42,7 @@ export const CreateSurfaceMessageSchema = z
 
 export const UpdateComponentsMessageSchema = z
   .object({
-    version: z.literal('v0.9'),
+    version: z.enum(['v0.9', 'v0.9.1']),
     updateComponents: z
       .object({
         surfaceId: z.string().describe('The unique identifier for the UI surface to be updated.'),
@@ -51,7 +57,7 @@ export const UpdateComponentsMessageSchema = z
 
 export const UpdateDataModelMessageSchema = z
   .object({
-    version: z.literal('v0.9'),
+    version: z.enum(['v0.9', 'v0.9.1']),
     updateDataModel: z
       .object({
         surfaceId: z
@@ -69,7 +75,7 @@ export const UpdateDataModelMessageSchema = z
 
 export const DeleteSurfaceMessageSchema = z
   .object({
-    version: z.literal('v0.9'),
+    version: z.enum(['v0.9', 'v0.9.1']),
     deleteSurface: z
       .object({
         surfaceId: z.string().describe('The unique identifier for the UI surface to be deleted.'),
@@ -79,7 +85,7 @@ export const DeleteSurfaceMessageSchema = z
   .strict();
 
 export declare interface CreateSurfaceMessage extends z.infer<typeof CreateSurfaceMessageSchema> {
-  version: 'v0.9';
+  version: SupportedVersion;
   createSurface: {
     surfaceId: string;
     catalogId: string;
@@ -90,7 +96,7 @@ export declare interface CreateSurfaceMessage extends z.infer<typeof CreateSurfa
 export declare interface UpdateComponentsMessage extends z.infer<
   typeof UpdateComponentsMessageSchema
 > {
-  version: 'v0.9';
+  version: SupportedVersion;
   updateComponents: {
     surfaceId: string;
     components: any[];
@@ -99,7 +105,7 @@ export declare interface UpdateComponentsMessage extends z.infer<
 export declare interface UpdateDataModelMessage extends z.infer<
   typeof UpdateDataModelMessageSchema
 > {
-  version: 'v0.9';
+  version: SupportedVersion;
   updateDataModel: {
     surfaceId: string;
     path?: string;
@@ -107,7 +113,7 @@ export declare interface UpdateDataModelMessage extends z.infer<
   };
 }
 export declare interface DeleteSurfaceMessage extends z.infer<typeof DeleteSurfaceMessageSchema> {
-  version: 'v0.9';
+  version: SupportedVersion;
   deleteSurface: {
     surfaceId: string;
   };

--- a/renderers/web_core/src/v0_9/schema/verify-schema.test.ts
+++ b/renderers/web_core/src/v0_9/schema/verify-schema.test.ts
@@ -33,6 +33,7 @@ const __dirname = dirname(__filename);
 
 // `__dirname` will be `dist/src/v0_9/schema` when run via `node --test dist/**/*.test.js`
 const SPEC_DIR_V0_9 = resolve(__dirname, '../../../../../../specification/v0_9/json');
+const SPEC_DIR_V0_9_1 = resolve(__dirname, '../../../../../../specification/v0_9_1/json');
 
 // Parse both so we can do structural comparison rather than formatting
 // Compare definitions specifically, ignoring descriptions
@@ -70,8 +71,11 @@ function getObjectDiff(obj1: any, obj2: any, path = ''): Record<string, any> {
     const val1 = obj1 ? obj1[key] : undefined;
     const val2 = obj2 ? obj2[key] : undefined;
 
-    // Zod emits `type: "string"` for consts, whereas JSON Schema infers it.
-    if (path.endsWith('version') && key === 'type' && val1 === 'string' && val2 === undefined) {
+    // `type: 'string'` and `const: 'v0.9'` and `enum: ['v0.9', 'v0.9.1']` are accepted here.
+    if (
+      (path.endsWith('version') || currentPath.includes('properties.version')) &&
+      (key === 'type' || key === 'const' || key === 'enum')
+    ) {
       continue;
     }
 
@@ -198,7 +202,7 @@ function verifySchema(
   console.log(`Zod schema structurally matches the ${version} JSON spec!`);
 }
 
-describe('A2UI Schema Verification v0.9', () => {
+describe('A2UI Schema Verification v0.9 & v0.9.1', () => {
   it('verifies v0.9 schema', () => {
     verifySchema('v0.9', A2uiMessageSchema, join(SPEC_DIR_V0_9, 'server_to_client.json'), {
       CreateSurfaceMessage: CreateSurfaceMessageSchema,
@@ -208,11 +212,28 @@ describe('A2UI Schema Verification v0.9', () => {
     });
   });
 
-  it('validates A2uiMessage wrapper', () => {
-    const msg = {
+  it('verifies v0.9.1 schema', () => {
+    verifySchema('v0.9.1', A2uiMessageSchema, join(SPEC_DIR_V0_9_1, 'server_to_client.json'), {
+      CreateSurfaceMessage: CreateSurfaceMessageSchema,
+      UpdateComponentsMessage: UpdateComponentsMessageSchema,
+      UpdateDataModelMessage: UpdateDataModelMessageSchema,
+      DeleteSurfaceMessage: DeleteSurfaceMessageSchema,
+    });
+  });
+
+  it('validates A2uiMessage v0.9 wrapper', () => {
+    const msgV09 = {
       version: 'v0.9',
       deleteSurface: {surfaceId: 'surface-1'},
     };
-    assert.deepStrictEqual(A2uiMessageSchema.parse(msg), msg);
+    assert.deepStrictEqual(A2uiMessageSchema.parse(msgV09), msgV09);
+  });
+
+  it('validates A2uiMessage v0.9.1 wrapper', () => {
+    const msgV091 = {
+      version: 'v0.9.1',
+      deleteSurface: {surfaceId: 'surface-2'},
+    };
+    assert.deepStrictEqual(A2uiMessageSchema.parse(msgV091), msgV091);
   });
 });

--- a/renderers/web_core/src/v0_9/schema/verify-schema.test.ts
+++ b/renderers/web_core/src/v0_9/schema/verify-schema.test.ts
@@ -33,7 +33,6 @@ const __dirname = dirname(__filename);
 
 // `__dirname` will be `dist/src/v0_9/schema` when run via `node --test dist/**/*.test.js`
 const SPEC_DIR_V0_9 = resolve(__dirname, '../../../../../../specification/v0_9/json');
-const SPEC_DIR_V0_9_1 = resolve(__dirname, '../../../../../../specification/v0_9_1/json');
 
 // Parse both so we can do structural comparison rather than formatting
 // Compare definitions specifically, ignoring descriptions
@@ -205,15 +204,6 @@ function verifySchema(
 describe('A2UI Schema Verification v0.9 & v0.9.1', () => {
   it('verifies v0.9 schema', () => {
     verifySchema('v0.9', A2uiMessageSchema, join(SPEC_DIR_V0_9, 'server_to_client.json'), {
-      CreateSurfaceMessage: CreateSurfaceMessageSchema,
-      UpdateComponentsMessage: UpdateComponentsMessageSchema,
-      UpdateDataModelMessage: UpdateDataModelMessageSchema,
-      DeleteSurfaceMessage: DeleteSurfaceMessageSchema,
-    });
-  });
-
-  it('verifies v0.9.1 schema', () => {
-    verifySchema('v0.9.1', A2uiMessageSchema, join(SPEC_DIR_V0_9_1, 'server_to_client.json'), {
       CreateSurfaceMessage: CreateSurfaceMessageSchema,
       UpdateComponentsMessage: UpdateComponentsMessageSchema,
       UpdateDataModelMessage: UpdateDataModelMessageSchema,


### PR DESCRIPTION
# Description

Updates the `web_core` message definitions and parser so it accepts `v0.9` and `v0.9.1` messages (which are identical, except for the `version` field).

This also updates tests in the three renderers to load examples from the v0_9 directory, since the ones in v0_9_1 of the specification are wrong; they don't use the correct "version" string. We don't need to release these to end users.

* Fixes https://github.com/a2ui-project/a2ui/issues/1749
* Supersedes https://github.com/a2ui-project/a2ui/pull/1973

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have built and run at least one [sample].

For this PR:

- [ ] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
