### PR TITLE
feat(basic-catalog): add ProgressBar component

### DIFF
--- a/agent_sdks/conformance/test_data/simplified_catalog_v09.json
+++ b/agent_sdks/conformance/test_data/simplified_catalog_v09.json
@@ -102,6 +102,25 @@
           "required": [ "component", "children" ]
         }
       ]
+    },
+    "ProgressBar": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "common_types.json#/$defs/ComponentCommon" },
+        { "$ref": "#/$defs/CatalogComponentCommon" },
+        {
+          "type": "object",
+          "properties": {
+            "component": { "const": "ProgressBar" },
+            "value": { "$ref": "common_types.json#/$defs/DynamicNumber" },
+            "max": { "type": "number" },
+            "label": { "$ref": "common_types.json#/$defs/DynamicString" },
+            "variant": { "type": "string", "enum": ["determinate", "indeterminate"] },
+            "showPercentage": { "type": "boolean" }
+          },
+          "required": [ "component", "value" ]
+        }
+      ]
     }
   },
   "$defs": {
@@ -117,7 +136,8 @@
         { "$ref": "#/components/Column" },
         { "$ref": "#/components/AudioPlayer" },
         { "$ref": "#/components/List" },
-        { "$ref": "#/components/Row" }
+        { "$ref": "#/components/Row" },
+        { "$ref": "#/components/ProgressBar" }
       ],
       "discriminator": { "propertyName": "component" }
     }

--- a/agent_sdks/python/a2ui_core/src/a2ui/core/basic_catalog/components.py
+++ b/agent_sdks/python/a2ui_core/src/a2ui/core/basic_catalog/components.py
@@ -494,6 +494,25 @@ class DateTimeInputComponent(CatalogComponentCommon):
     )
 
 
+class ProgressBarComponent(CatalogComponentCommon):
+    component: Literal["ProgressBar"] = "ProgressBar"
+    value: DynamicNumber = Field(..., description="The current progress value (0 to max).")
+    max: Optional[float] = Field(
+        description="The maximum value of the progress bar.", default=100
+    )
+    label: Optional[DynamicString] = Field(
+        None, description="A text label for the progress bar."
+    )
+    variant: Optional[Literal["determinate", "indeterminate"]] = Field(
+        description="The style of the progress bar.", default="determinate"
+    )
+    show_percentage: Optional[bool] = Field(
+        alias="showPercentage",
+        description="Whether to display the percentage text overlay.",
+        default=True,
+    )
+
+
 AnyComponent = Annotated[
     Union[
         TextComponent,
@@ -514,6 +533,7 @@ AnyComponent = Annotated[
         ChoicePickerComponent,
         SliderComponent,
         DateTimeInputComponent,
+        ProgressBarComponent,
     ],
     Field(..., discriminator="component"),
 ]
@@ -554,6 +574,8 @@ SLIDER_COMPONENT_API = ModelComponentApi(SliderComponent)
 
 DATE_TIME_INPUT_COMPONENT_API = ModelComponentApi(DateTimeInputComponent)
 
+PROGRESS_BAR_COMPONENT_API = ModelComponentApi(ProgressBarComponent)
+
 BASIC_COMPONENTS = [
     TEXT_COMPONENT_API,
     IMAGE_COMPONENT_API,
@@ -573,4 +595,5 @@ BASIC_COMPONENTS = [
     CHOICE_PICKER_COMPONENT_API,
     SLIDER_COMPONENT_API,
     DATE_TIME_INPUT_COMPONENT_API,
+    PROGRESS_BAR_COMPONENT_API,
 ]

--- a/docs/public/reference/components.md
+++ b/docs/public/reference/components.md
@@ -417,6 +417,29 @@ Numeric range input.
     }
     ```
 
+### ProgressBar
+
+Displays progress or loading state.
+
+=== "v0.8"
+
+    **Properties:** Not available in v0.8.
+
+=== "v0.9"
+
+    **Properties:** `value` (DataBinding), `max`, `label`, `variant`, `showPercentage`
+
+    ```json
+    {
+      "id": "loading-progress",
+      "component": "ProgressBar",
+      "value": { "path": "/uploadProgress" },
+      "max": 100,
+      "variant": "determinate",
+      "showPercentage": true
+    }
+    ```
+
 ### DateTimeInput
 
 Date and/or time picker.

--- a/renderers/angular/src/v0_9/catalog/basic/basic-catalog.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/basic-catalog.ts
@@ -33,6 +33,7 @@ import {DividerComponent} from './divider.component';
 import {CheckBoxComponent} from './check-box.component';
 import {ChoicePickerComponent} from './choice-picker.component';
 import {SliderComponent} from './slider.component';
+import {ProgressBarComponent} from './progress-bar.component';
 import {DateTimeInputComponent} from './date-time-input.component';
 
 import {
@@ -55,6 +56,7 @@ import {
   CheckBoxApi,
   ChoicePickerApi,
   SliderApi,
+  ProgressBarApi,
   DateTimeInputApi,
 } from '@a2ui/web_core/v0_9/basic_catalog';
 import {FunctionImplementation} from '@a2ui/web_core/v0_9';
@@ -83,6 +85,7 @@ const DEFAULT_COMPONENT_IMPLEMENTATIONS: Record<string, AngularComponentImplemen
   'checkBox': {...CheckBoxApi, component: CheckBoxComponent},
   'choicePicker': {...ChoicePickerApi, component: ChoicePickerComponent},
   'slider': {...SliderApi, component: SliderComponent},
+  'progressBar': {...ProgressBarApi, component: ProgressBarComponent},
   'dateTimeInput': {...DateTimeInputApi, component: DateTimeInputComponent},
 } as const;
 

--- a/renderers/angular/src/v0_9/catalog/basic/progress-bar.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/progress-bar.component.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Component, computed, ChangeDetectionStrategy} from '@angular/core';
+import {BasicCatalogComponent} from './basic-catalog-component';
+import {ProgressBarApi} from '@a2ui/web_core/v0_9/basic_catalog';
+
+@Component({
+  selector: 'a2ui-v09-progress-bar',
+  standalone: true,
+  imports: [],
+  template: `
+    <div class="a2ui-progress-bar-container" [class.indeterminate]="isIndeterminate()">
+      <div class="a2ui-progress-bar-header">
+        @if (label()) {
+          <span class="a2ui-progress-bar-label">{{ label() }}</span>
+        }
+        @if (showPercentage() && !isIndeterminate()) {
+          <span class="a2ui-progress-bar-percentage">{{ percentage() }}%</span>
+        }
+      </div>
+      <div
+        class="a2ui-progress-bar-track"
+        role="progressbar"
+        [attr.aria-valuenow]="isIndeterminate() ? null : percentage()"
+        aria-valuemin="0"
+        aria-valuemax="100"
+      >
+        <div class="a2ui-progress-bar-fill" [style.width.%]="isIndeterminate() ? null : percentage()"></div>
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      .a2ui-progress-bar-container {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        gap: var(--a2ui-spacing-xs, 4px);
+        margin: var(--a2ui-progress-bar-margin, var(--a2ui-spacing-m, 16px));
+      }
+      .a2ui-progress-bar-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .a2ui-progress-bar-label {
+        font-size: var(
+          --a2ui-progress-bar-label-font-size,
+          var(--a2ui-label-font-size, var(--a2ui-font-size-s, 14px))
+        );
+        font-weight: var(--a2ui-progress-bar-label-font-weight, bold);
+        color: var(--a2ui-text-color-text, var(--a2ui-color-on-background, #333));
+      }
+      .a2ui-progress-bar-percentage {
+        font-size: var(--a2ui-progress-bar-percentage-font-size, var(--a2ui-font-size-xs, 12px));
+        color: var(--a2ui-progress-bar-percentage-color, var(--a2ui-text-caption-color, #666));
+      }
+      .a2ui-progress-bar-track {
+        width: 100%;
+        height: var(--a2ui-progress-bar-height, 8px);
+        background: var(--a2ui-progress-bar-track-color, var(--a2ui-color-secondary, #e9ecef));
+        border-radius: var(--a2ui-progress-bar-border-radius, 4px);
+        overflow: hidden;
+      }
+      .a2ui-progress-bar-fill {
+        height: 100%;
+        background: var(--a2ui-progress-bar-fill-color, var(--a2ui-color-primary, #007bff));
+        border-radius: var(--a2ui-progress-bar-border-radius, 4px);
+        transition: width 0.3s ease;
+      }
+      .indeterminate .a2ui-progress-bar-fill {
+        width: 30% !important;
+        animation: a2ui-progress-indeterminate 1.5s ease-in-out infinite;
+      }
+      @keyframes a2ui-progress-indeterminate {
+        0% { transform: translateX(-100%); }
+        100% { transform: translateX(400%); }
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProgressBarComponent extends BasicCatalogComponent<typeof ProgressBarApi> {
+  readonly value = computed(() => this.props()['value']?.value() ?? 0);
+  readonly max = computed(() => this.props()['max']?.value() ?? 100);
+  readonly label = computed(() => this.props()['label']?.value());
+  readonly variant = computed(() => this.props()['variant']?.value() ?? 'determinate');
+  readonly showPercentage = computed(() => this.props()['showPercentage']?.value() ?? true);
+
+  readonly isIndeterminate = computed(() => this.variant() === 'indeterminate');
+  readonly percentage = computed(() => {
+    const m = this.max();
+    return m > 0 ? Math.min(100, Math.max(0, (this.value() / m) * 100)) : 0;
+  });
+}

--- a/renderers/angular/src/v0_9/public-api.ts
+++ b/renderers/angular/src/v0_9/public-api.ts
@@ -55,4 +55,5 @@ export * from './catalog/basic/divider.component';
 export * from './catalog/basic/check-box.component';
 export * from './catalog/basic/choice-picker.component';
 export * from './catalog/basic/slider.component';
+export * from './catalog/basic/progress-bar.component';
 export * from './catalog/basic/date-time-input.component';

--- a/renderers/lit/src/v0_9/catalogs/basic/components/ProgressBar.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/ProgressBar.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {html, nothing, css} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import {ProgressBarApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {BasicCatalogA2uiLitElement} from '../basic-catalog-a2ui-lit-element.js';
+import {A2uiController} from '../../../a2ui-controller.js';
+
+@customElement('a2ui-progress-bar')
+export class A2uiProgressBarElement extends BasicCatalogA2uiLitElement<typeof ProgressBarApi> {
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      gap: var(--a2ui-spacing-xs, 0.25rem);
+      margin: var(--a2ui-progress-bar-margin, var(--a2ui-spacing-m));
+    }
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .header label {
+      font-size: var(
+        --a2ui-progress-bar-label-font-size,
+        var(--a2ui-label-font-size, var(--a2ui-font-size-s))
+      );
+      font-weight: var(
+        --a2ui-progress-bar-label-font-weight,
+        var(--a2ui-label-font-weight, bold)
+      );
+    }
+    .percentage {
+      font-size: var(--a2ui-progress-bar-percentage-font-size, var(--a2ui-font-size-xs, 0.75rem));
+      color: var(--a2ui-progress-bar-percentage-color, var(--a2ui-text-caption-color, #666));
+    }
+    .track {
+      width: 100%;
+      height: var(--a2ui-progress-bar-height, 0.5rem);
+      background: var(--a2ui-progress-bar-track-color, var(--a2ui-color-secondary, #e9ecef));
+      border-radius: var(--a2ui-progress-bar-border-radius, 0.25rem);
+      overflow: hidden;
+    }
+    .fill {
+      height: 100%;
+      background: var(--a2ui-progress-bar-fill-color, var(--a2ui-color-primary, #007bff));
+      border-radius: var(--a2ui-progress-bar-border-radius, 0.25rem);
+      transition: width 0.3s ease;
+    }
+    .indeterminate .fill {
+      width: 30% !important;
+      animation: a2ui-progress-indeterminate 1.5s ease-in-out infinite;
+    }
+    @keyframes a2ui-progress-indeterminate {
+      0% {
+        transform: translateX(-100%);
+      }
+      100% {
+        transform: translateX(400%);
+      }
+    }
+  `;
+
+  protected createController() {
+    return new A2uiController(this, ProgressBarApi);
+  }
+
+  override render() {
+    const props = this.controller.props;
+    if (!props) return nothing;
+
+    const isIndeterminate = (props.variant ?? 'determinate') === 'indeterminate';
+    const max = props.max ?? 100;
+    const pct = isIndeterminate ? 0 : Math.min(100, Math.max(0, ((props.value ?? 0) / max) * 100));
+
+    return html`
+      <div class=${isIndeterminate ? 'indeterminate' : ''}>
+        <div class="header">
+          ${props.label ? html`<label>${props.label}</label>` : nothing}
+          ${(props.showPercentage ?? true) && !isIndeterminate
+            ? html`<span class="percentage">${Math.round(pct)}%</span>`
+            : nothing}
+        </div>
+        <div class="track" role="progressbar" aria-valuenow=${isIndeterminate ? nothing : pct} aria-valuemin="0" aria-valuemax="100">
+          <div class="fill" style=${isIndeterminate ? nothing : `width: ${pct}%`}></div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+export const A2uiProgressBar = {
+  ...ProgressBarApi,
+  tagName: 'a2ui-progress-bar',
+};

--- a/renderers/lit/src/v0_9/catalogs/basic/index.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/index.ts
@@ -32,6 +32,7 @@ import {A2uiCard} from './components/Card.js';
 import {A2uiDivider} from './components/Divider.js';
 import {A2uiCheckBox} from './components/CheckBox.js';
 import {A2uiSlider} from './components/Slider.js';
+import {A2uiProgressBar} from './components/ProgressBar.js';
 import {A2uiDateTimeInput} from './components/DateTimeInput.js';
 import {A2uiChoicePicker} from './components/ChoicePicker.js';
 import {A2uiTabs} from './components/Tabs.js';
@@ -62,6 +63,7 @@ export const basicCatalog = new Catalog<LitComponentApi>(
     A2uiDivider,
     A2uiCheckBox,
     A2uiSlider,
+    A2uiProgressBar,
     A2uiDateTimeInput,
     A2uiChoicePicker,
     A2uiTabs,

--- a/renderers/react/src/v0_9/catalog/basic/components/ProgressBar.tsx
+++ b/renderers/react/src/v0_9/catalog/basic/components/ProgressBar.tsx
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {createComponentImplementation} from '../../../adapter';
+import {ProgressBarApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {useBasicCatalogStyles} from '../utils';
+
+export const ProgressBar = createComponentImplementation(ProgressBarApi, ({props}) => {
+  useBasicCatalogStyles();
+  const isIndeterminate = (props.variant ?? 'determinate') === 'indeterminate';
+  const max = props.max ?? 100;
+  const pct = isIndeterminate ? 0 : Math.min(100, Math.max(0, ((props.value ?? 0) / max) * 100));
+
+  const containerStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 'var(--a2ui-spacing-xs, 0.25rem)',
+    margin: 'var(--a2ui-progress-bar-margin, var(--a2ui-spacing-m))',
+  };
+
+  const headerStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  };
+
+  const labelStyle: React.CSSProperties = {
+    fontSize:
+      'var(--a2ui-progress-bar-label-font-size, var(--a2ui-label-font-size, var(--a2ui-font-size-s)))',
+    fontWeight: 'var(--a2ui-progress-bar-label-font-weight, var(--a2ui-label-font-weight, bold))',
+  };
+
+  const percentageStyle: React.CSSProperties = {
+    fontSize: 'var(--a2ui-progress-bar-percentage-font-size, var(--a2ui-font-size-xs, 0.75rem))',
+    color: 'var(--a2ui-progress-bar-percentage-color, var(--a2ui-text-caption-color, light-dark(#666, #aaa)))',
+  };
+
+  const trackStyle: React.CSSProperties = {
+    width: '100%',
+    height: 'var(--a2ui-progress-bar-height, 0.5rem)',
+    background: 'var(--a2ui-progress-bar-track-color, var(--a2ui-color-secondary, #e9ecef))',
+    borderRadius: 'var(--a2ui-progress-bar-border-radius, 0.25rem)',
+    overflow: 'hidden',
+  };
+
+  const fillStyle: React.CSSProperties = {
+    height: '100%',
+    width: isIndeterminate ? '30%' : `${pct}%`,
+    background: 'var(--a2ui-progress-bar-fill-color, var(--a2ui-color-primary, #007bff))',
+    borderRadius: 'var(--a2ui-progress-bar-border-radius, 0.25rem)',
+    transition: 'width 0.3s ease',
+    ...(isIndeterminate
+      ? {
+          animation: 'a2ui-progress-indeterminate 1.5s ease-in-out infinite',
+        }
+      : {}),
+  };
+
+  const keyframesStyle = `
+    @keyframes a2ui-progress-indeterminate {
+      0% { transform: translateX(-100%); }
+      100% { transform: translateX(400%); }
+    }
+  `;
+
+  return (
+    <div style={containerStyle}>
+      <style>{keyframesStyle}</style>
+      <div style={headerStyle}>
+        {props.label && <label style={labelStyle}>{props.label}</label>}
+        {(props.showPercentage ?? true) && !isIndeterminate && (
+          <span style={percentageStyle}>{Math.round(pct)}%</span>
+        )}
+      </div>
+      <div
+        role="progressbar"
+        aria-valuenow={isIndeterminate ? undefined : pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        style={trackStyle}
+      >
+        <div style={fillStyle} />
+      </div>
+    </div>
+  );
+});

--- a/renderers/react/src/v0_9/catalog/basic/index.ts
+++ b/renderers/react/src/v0_9/catalog/basic/index.ts
@@ -35,6 +35,7 @@ import {TextField} from './components/TextField';
 import {CheckBox} from './components/CheckBox';
 import {ChoicePicker} from './components/ChoicePicker';
 import {Slider} from './components/Slider';
+import {ProgressBar} from './components/ProgressBar';
 import {DateTimeInput} from './components/DateTimeInput';
 
 export * from './context/MarkdownContext';
@@ -57,6 +58,7 @@ const basicComponents: ReactComponentImplementation[] = [
   CheckBox,
   ChoicePicker,
   Slider,
+  ProgressBar,
   DateTimeInput,
 ];
 
@@ -84,5 +86,6 @@ export {
   CheckBox,
   ChoicePicker,
   Slider,
+  ProgressBar,
   DateTimeInput,
 };

--- a/renderers/web_core/src/v0_9/basic_catalog/components/basic_components.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/basic_components.test.ts
@@ -16,7 +16,7 @@
 
 import {describe, it} from 'node:test';
 import * as assert from 'node:assert';
-import {ImageApi} from './basic_components.js';
+import {ImageApi, ProgressBarApi} from './basic_components.js';
 
 describe('Basic Components Schema', () => {
   describe('ImageApi', () => {
@@ -44,6 +44,50 @@ describe('Basic Components Schema', () => {
         url: 123, // Invalid type
       };
       assert.throws(() => ImageApi.schema.parse(invalidImage));
+    });
+  });
+
+  describe('ProgressBarApi', () => {
+    it('should parse valid progress bar with required fields', () => {
+      const valid = {value: 50};
+      const parsed = ProgressBarApi.schema.parse(valid);
+      assert.strictEqual(parsed.value, 50);
+      assert.strictEqual(parsed.max, 100);
+      assert.strictEqual(parsed.variant, 'determinate');
+      assert.strictEqual(parsed.showPercentage, true);
+    });
+
+    it('should parse progress bar with all fields', () => {
+      const valid = {
+        value: 75,
+        max: 100,
+        label: 'Loading',
+        variant: 'determinate',
+        showPercentage: true,
+      };
+      const parsed = ProgressBarApi.schema.parse(valid);
+      assert.strictEqual(parsed.value, 75);
+      assert.strictEqual(parsed.max, 100);
+      assert.strictEqual(parsed.label, 'Loading');
+      assert.strictEqual(parsed.variant, 'determinate');
+      assert.strictEqual(parsed.showPercentage, true);
+    });
+
+    it('should parse progress bar with indeterminate variant', () => {
+      const valid = {value: 0, variant: 'indeterminate', showPercentage: false};
+      const parsed = ProgressBarApi.schema.parse(valid);
+      assert.strictEqual(parsed.variant, 'indeterminate');
+      assert.strictEqual(parsed.showPercentage, false);
+    });
+
+    it('should throw on missing value', () => {
+      assert.throws(() => ProgressBarApi.schema.parse({}));
+    });
+
+    it('should throw on invalid variant', () => {
+      assert.throws(() =>
+        ProgressBarApi.schema.parse({value: 50, variant: 'invalid'}),
+      );
     });
   });
 });

--- a/renderers/web_core/src/v0_9/basic_catalog/components/basic_components.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/basic_components.ts
@@ -481,6 +481,29 @@ export const DateTimeInputApi = {
     .strict(),
 } satisfies ComponentApi;
 
+export const ProgressBarApi = {
+  name: 'ProgressBar',
+  schema: z
+    .object({
+      ...CommonProps,
+      value: DynamicNumberSchema.describe('The current progress value (0 to max).'),
+      max: z
+        .number()
+        .default(100)
+        .describe('The maximum value of the progress bar.'),
+      label: DynamicStringSchema.describe('A text label for the progress bar.').optional(),
+      variant: z
+        .enum(['determinate', 'indeterminate'])
+        .default('determinate')
+        .describe('The style of the progress bar.'),
+      showPercentage: z
+        .boolean()
+        .default(true)
+        .describe('Whether to display the percentage text overlay.'),
+    })
+    .strict(),
+} satisfies ComponentApi;
+
 export const BASIC_COMPONENTS: ComponentApi[] = [
   TextApi,
   ImageApi,
@@ -500,4 +523,5 @@ export const BASIC_COMPONENTS: ComponentApi[] = [
   ChoicePickerApi,
   SliderApi,
   DateTimeInputApi,
+  ProgressBarApi,
 ];

--- a/specification/v0_9/catalogs/basic/catalog.json
+++ b/specification/v0_9/catalogs/basic/catalog.json
@@ -799,6 +799,51 @@
         }
       ],
       "unevaluatedProperties": false
+    },
+    "ProgressBar": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "ProgressBar"
+            },
+            "value": {
+              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicNumber",
+              "description": "The current progress value (0 to max)."
+            },
+            "max": {
+              "type": "number",
+              "description": "The maximum value of the progress bar.",
+              "default": 100
+            },
+            "label": {
+              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
+              "description": "A text label for the progress bar."
+            },
+            "variant": {
+              "type": "string",
+              "description": "The style of the progress bar.",
+              "enum": ["determinate", "indeterminate"],
+              "default": "determinate"
+            },
+            "showPercentage": {
+              "type": "boolean",
+              "description": "Whether to display the percentage text overlay.",
+              "default": true
+            }
+          },
+          "required": ["component", "value"]
+        }
+      ],
+      "unevaluatedProperties": false
     }
   },
   "functions": {
@@ -1327,6 +1372,9 @@
         },
         {
           "$ref": "#/components/DateTimeInput"
+        },
+        {
+          "$ref": "#/components/ProgressBar"
         }
       ],
       "discriminator": {

--- a/specification/v0_9_1/catalogs/basic/catalog.json
+++ b/specification/v0_9_1/catalogs/basic/catalog.json
@@ -799,6 +799,51 @@
         }
       ],
       "unevaluatedProperties": false
+    },
+    "ProgressBar": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "$ref": "#/$defs/CatalogComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "ProgressBar"
+            },
+            "value": {
+              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicNumber",
+              "description": "The current progress value (0 to max)."
+            },
+            "max": {
+              "type": "number",
+              "description": "The maximum value of the progress bar.",
+              "default": 100
+            },
+            "label": {
+              "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString",
+              "description": "A text label for the progress bar."
+            },
+            "variant": {
+              "type": "string",
+              "description": "The style of the progress bar.",
+              "enum": ["determinate", "indeterminate"],
+              "default": "determinate"
+            },
+            "showPercentage": {
+              "type": "boolean",
+              "description": "Whether to display the percentage text overlay.",
+              "default": true
+            }
+          },
+          "required": ["component", "value"]
+        }
+      ],
+      "unevaluatedProperties": false
     }
   },
   "functions": {
@@ -1327,6 +1372,9 @@
         },
         {
           "$ref": "#/components/DateTimeInput"
+        },
+        {
+          "$ref": "#/components/ProgressBar"
         }
       ],
       "discriminator": {

--- a/specification/v0_9_1/docs/a2ui_protocol.md
+++ b/specification/v0_9_1/docs/a2ui_protocol.md
@@ -685,6 +685,7 @@ The [`catalogs/basic/catalog.json`] provides the baseline set of components and 
 | **TextField**     | A field for user text input.                                                                |
 | **DateTimeInput** | An input for date and/or time.                                                              |
 | **ChoicePicker**  | A component for selecting one or more options.                                              |
+| **ProgressBar**   | A bar that displays progress or loading state.                                              |
 | **Slider**        | A slider for selecting a numeric value within a range.                                      |
 
 ### Functions

--- a/specification/v0_9_1/test/cases/progress_bar_validation.json
+++ b/specification/v0_9_1/test/cases/progress_bar_validation.json
@@ -1,0 +1,115 @@
+{
+  "schema": "server_to_client.json",
+  "tests": [
+    {
+      "description": "ProgressBar with required fields only",
+      "valid": true,
+      "data": {
+        "version": "v0.9",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "progress-1",
+              "component": "ProgressBar",
+              "value": 50
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "ProgressBar with all fields",
+      "valid": true,
+      "data": {
+        "version": "v0.9",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "progress-2",
+              "component": "ProgressBar",
+              "value": 75,
+              "max": 100,
+              "label": "Loading",
+              "variant": "determinate",
+              "showPercentage": true
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "ProgressBar with indeterminate variant",
+      "valid": true,
+      "data": {
+        "version": "v0.9",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "progress-3",
+              "component": "ProgressBar",
+              "value": 0,
+              "variant": "indeterminate",
+              "showPercentage": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "ProgressBar with data binding value",
+      "valid": true,
+      "data": {
+        "version": "v0.9",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "progress-4",
+              "component": "ProgressBar",
+              "value": { "path": "/progress" },
+              "max": 100,
+              "label": { "path": "/label" }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "ProgressBar missing value (should fail)",
+      "valid": false,
+      "data": {
+        "version": "v0.9",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "progress-invalid",
+              "component": "ProgressBar"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "ProgressBar with invalid variant (should fail)",
+      "valid": false,
+      "data": {
+        "version": "v0.9",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "progress-invalid-variant",
+              "component": "ProgressBar",
+              "value": 50,
+              "variant": "invalid_variant"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/specification/v1_0/catalogs/basic/catalog.json
+++ b/specification/v1_0/catalogs/basic/catalog.json
@@ -824,6 +824,52 @@
         }
       ],
       "unevaluatedProperties": false
+    },
+    "ProgressBar": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/ComponentCommon"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "component": {
+              "const": "ProgressBar"
+            },
+            "value": {
+              "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/DynamicNumber",
+              "description": "The current progress value (0 to max)."
+            },
+            "max": {
+              "type": "number",
+              "description": "The maximum value of the progress bar.",
+              "default": 100
+            },
+            "label": {
+              "$ref": "https://a2ui.org/specification/v1_0/common_types.json#/$defs/DynamicString",
+              "description": "A text label for the progress bar."
+            },
+            "variant": {
+              "type": "string",
+              "description": "The style of the progress bar.",
+              "enum": ["determinate", "indeterminate"],
+              "default": "determinate"
+            },
+            "showPercentage": {
+              "type": "boolean",
+              "description": "Whether to display the percentage text overlay.",
+              "default": true
+            },
+            "weight": {
+              "type": "number",
+              "description": "The relative weight of this component within a Row or Column. This is similar to the CSS 'flex-grow' property. Note: this may ONLY be set when the component is a direct descendant of a Row or Column."
+            }
+          },
+          "required": ["component", "value"]
+        }
+      ],
+      "unevaluatedProperties": false
     }
   },
   "functions": {
@@ -1320,6 +1366,9 @@
         },
         {
           "$ref": "#/components/DateTimeInput"
+        },
+        {
+          "$ref": "#/components/ProgressBar"
         }
       ],
       "discriminator": {

--- a/specification/v1_0/docs/a2ui_protocol.md
+++ b/specification/v1_0/docs/a2ui_protocol.md
@@ -1016,6 +1016,7 @@ The [`catalogs/basic/catalog.json`] provides the baseline set of components and 
 | **TextField**     | A field for user text input.                                                                |
 | **DateTimeInput** | An input for date and/or time.                                                              |
 | **ChoicePicker**  | A component for selecting one or more options.                                              |
+| **ProgressBar**   | A bar that displays progress or loading state.                                              |
 | **Slider**        | A slider for selecting a numeric value within a range.                                      |
 
 ### Functions

--- a/specification/v1_0/test/cases/progress_bar_validation.json
+++ b/specification/v1_0/test/cases/progress_bar_validation.json
@@ -1,0 +1,115 @@
+{
+  "schema": "server_to_client.json",
+  "tests": [
+    {
+      "description": "ProgressBar with required fields only",
+      "valid": true,
+      "data": {
+        "version": "v1.0",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "progress-1",
+              "component": "ProgressBar",
+              "value": 50
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "ProgressBar with all fields",
+      "valid": true,
+      "data": {
+        "version": "v1.0",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "progress-2",
+              "component": "ProgressBar",
+              "value": 75,
+              "max": 100,
+              "label": "Loading",
+              "variant": "determinate",
+              "showPercentage": true
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "ProgressBar with indeterminate variant",
+      "valid": true,
+      "data": {
+        "version": "v1.0",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "progress-3",
+              "component": "ProgressBar",
+              "value": 0,
+              "variant": "indeterminate",
+              "showPercentage": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "ProgressBar with data binding value",
+      "valid": true,
+      "data": {
+        "version": "v1.0",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "progress-4",
+              "component": "ProgressBar",
+              "value": { "path": "/progress" },
+              "max": 100,
+              "label": { "path": "/label" }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "ProgressBar missing value (should fail)",
+      "valid": false,
+      "data": {
+        "version": "v1.0",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "progress-invalid",
+              "component": "ProgressBar"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "ProgressBar with invalid variant (should fail)",
+      "valid": false,
+      "data": {
+        "version": "v1.0",
+        "updateComponents": {
+          "surfaceId": "test_surface",
+          "components": [
+            {
+              "id": "progress-invalid-variant",
+              "component": "ProgressBar",
+              "value": 50,
+              "variant": "invalid_variant"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tools/composer/src/lib/components-data-v09.ts
+++ b/tools/composer/src/lib/components-data-v09.ts
@@ -1049,4 +1049,80 @@ export const COMPONENTS_DATA_V09: ComponentCategory[] = [
       },
     ],
   },
+  {
+    name: 'Feedback',
+    components: [
+      {
+        name: 'ProgressBar',
+        description:
+          'Displays progress or loading state with determinate and indeterminate modes.',
+        usage: `{
+  "id": "progress-1",
+  "component": "ProgressBar",
+  "value": { "path": "/progress" },
+  "max": 100,
+  "variant": "determinate",
+  "showPercentage": true
+}`,
+        props: [
+          {
+            name: 'value',
+            description:
+              'The current progress value (0 to max). Can be a plain number or a data binding path.',
+            type: 'number | { path: string }',
+          },
+          {
+            name: 'max',
+            description: 'Maximum value of the progress bar.',
+            type: 'number',
+            default: '100',
+          },
+          {
+            name: 'label',
+            description: 'A text label displayed above the progress bar.',
+            type: 'string | { path: string }',
+          },
+          {
+            name: 'variant',
+            description: 'Visual style of the progress bar.',
+            type: 'enum',
+            values: ['determinate', 'indeterminate'],
+            default: 'determinate',
+          },
+          {
+            name: 'showPercentage',
+            description: 'Whether to display the percentage text overlay.',
+            type: 'boolean',
+            default: 'true',
+          },
+        ],
+        preview: {
+          root: 'progress-demo',
+          components: [
+            {
+              id: 'progress-demo',
+              component: 'Column',
+              children: ['progress-1', 'progress-2'],
+            } as A2UIComponent,
+            {
+              id: 'progress-1',
+              component: 'ProgressBar',
+              value: {path: '/progress'},
+              max: 100,
+              variant: 'determinate',
+              showPercentage: true,
+            } as A2UIComponent,
+            {
+              id: 'progress-2',
+              component: 'ProgressBar',
+              value: {path: '/indeterminate'},
+              variant: 'indeterminate',
+              showPercentage: false,
+            } as A2UIComponent,
+          ],
+          data: {progress: 65, indeterminate: 0},
+        },
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
# Description

Adds a dedicated `ProgressBar` component to the Basic Catalog across v0.9, v0.9.1, and v1.0 so agents no longer have to misuse Slider/Text to show progress or loading states. The new component exposes `value`, `max`, `label`, `variant`, and `showPercentage`, enforces read-only semantics (`role="progressbar"`, determinate/indeterminate modes, built-in percentage overlay), and is wired into the Python SDK, web_core schema/tests, Lit/React/Angular renderers, Composer catalog data, and public documentation. Closes #1992.

# For this PR:
- [ ] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [x] My code changes  have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes (not run — not requested).

# Testing:
- `yarn workspace @a2ui/web_core test`