### PR TITLE
Reapply "clean up a2ui extension spec (#2000)" (#2006)

### DIFF
--- a/hooks.py
+++ b/hooks.py
@@ -84,7 +84,8 @@ def on_page_markdown(markdown, page, config, files):
 
             # Rewrite relative paths to json schemas regardless of depth (e.g. "../json/..." or "../../../json/...")
             if '/json/' in path:
-                return version_folder + path[path.index('/json/') :]
+                rel_prefix = '../' * file_depth
+                return rel_prefix + version_folder + path[path.index('/json/') :]
 
         # Check if the link points outside the docs folder
         up_count = 0

--- a/hooks.py
+++ b/hooks.py
@@ -82,9 +82,9 @@ def on_page_markdown(markdown, page, config, files):
             if mapped_name:
                 return mapped_name + anchor
 
-            # Rewrite relative paths inside same version (e.g. "../json/...") to the copied location
-            if path.startswith('../') and not path.startswith('../../'):
-                return version_folder + '/' + path[3:]
+            # Rewrite relative paths to json schemas regardless of depth (e.g. "../json/..." or "../../../json/...")
+            if '/json/' in path:
+                return version_folder + path[path.index('/json/'):]
 
         # Check if the link points outside the docs folder
         up_count = 0
@@ -102,6 +102,11 @@ def on_page_markdown(markdown, page, config, files):
                 path_parts.pop(0)
                 strip_count -= 1
             clean_path = '/'.join(path_parts)
+
+            # If the link points to another public documentation file, make it an internal link
+            if clean_path.startswith('docs/public/'):
+                rel_prefix = '../' * file_depth
+                return rel_prefix + clean_path[len('docs/public/'):]
 
             # Return the newly formatted absolute GitHub link
             return f'{github_base_url}/{clean_path}'

--- a/hooks.py
+++ b/hooks.py
@@ -84,7 +84,7 @@ def on_page_markdown(markdown, page, config, files):
 
             # Rewrite relative paths to json schemas regardless of depth (e.g. "../json/..." or "../../../json/...")
             if '/json/' in path:
-                return version_folder + path[path.index('/json/'):]
+                return version_folder + path[path.index('/json/') :]
 
         # Check if the link points outside the docs folder
         up_count = 0
@@ -106,7 +106,7 @@ def on_page_markdown(markdown, page, config, files):
             # If the link points to another public documentation file, make it an internal link
             if clean_path.startswith('docs/public/'):
                 rel_prefix = '../' * file_depth
-                return rel_prefix + clean_path[len('docs/public/'):]
+                return rel_prefix + clean_path[len('docs/public/') :]
 
             # Return the newly formatted absolute GitHub link
             return f'{github_base_url}/{clean_path}'

--- a/lychee.toml
+++ b/lychee.toml
@@ -61,12 +61,11 @@ exclude_path = [
   ".git",
   "dist",
   "build",
-  # The specification/ tree is copied into docs/specification/ at build time
-  # (see the "Copy schemas" step in docs.yml). Check only the published copies:
-  # the source files use asset paths that resolve only after that copy, so
-  # checking them directly is a false positive. Anchored to the source root so
-  # the docs/specification/ copies are still verified.
-  "^specification",
+  # The specification/ tree is copied into docs/public/specification/ at build time
+  # (see the "Copy schemas" step in docs.yml). Check only the original source copies
+  # because the published copies have broken relative links due to being nested
+  # deeper inside docs/public/.
+  "^docs/public/specification",
   # Exclude Python virtual environment directories
   "\\.venv",
   "venv",

--- a/specification/v0_8/docs/a2ui_protocol.md
+++ b/specification/v0_8/docs/a2ui_protocol.md
@@ -2,7 +2,7 @@
 <!-- markdownlint-disable MD033 -->
 <div style="text-align: center;">
   <div class="centered-logo-text-group">
-    <img src="../../../assets/A2UI_dark.svg" alt="A2UI Protocol Logo" width="100">
+    <img src="../../../docs/public/assets/A2UI_dark.svg" alt="A2UI Protocol Logo" width="100">
     <h1>A2UI (Agent to UI) Protocol</h1>
   </div>
 </div>

--- a/specification/v0_9/docs/a2ui_extension_specification.md
+++ b/specification/v0_9/docs/a2ui_extension_specification.md
@@ -1,92 +1,193 @@
-# A2UI (Agent-to-Agent UI) Extension spec v0.9
+# A2UI (Agent-to-Agent UI) Extension spec v0.9.1
 
 ## Overview
 
-This extension implements the A2UI (Agent-to-Agent UI) spec v0.9, a format for agents to send streaming, interactive user interfaces to clients.
+This document is intended for developers implementing the A2UI A2A extension. The extension adds A2UI v0.9.1 support to A2A, a format for agents to send streaming, interactive user interfaces to clients.
+
+Note that A2UI extension activation is optional as clients and agents can negotiate A2UI support using A2A `message.metadata["a2uiClientCapabilities"]` which is attached to every A2A message from the client and contains the supported protocol version and catalogs. Agents advertising A2UI support in their AgentCard is encouraged as clients may rely on it to determine if they should send `message.metadata["a2uiClientCapabilities"]`, however it is not explicitly required.
 
 ## Extension URI
 
 The URI of this extension is https://a2ui.org/a2a-extension/a2ui/v0.9
 
-This is the only URI accepted for this extension.
+This URI is the canonical way to communicate protocol versioning between clients and agents. The extension URI explicitly encodes the version (e.g., `v0.9.1`). A client requesting this specific URI indicates it supports the v0.9.1 schema format.
 
-## Core concepts
+## Agent Card
 
-The A2UI extension is built on the following main concepts:
+Agents are encouraged to advertise their A2UI capabilities in their AgentCard within the `AgentCapabilities.extensions` list. This advertisement is optional, but it informs the client whether to send `message.metadata["a2uiClientCapabilities"]`. The `params` object defines the agent's specific UI support and corresponds directly to the [Server Capabilities Schema](../json/server_capabilities.json).
 
-Surfaces: A "Surface" is a distinct, controllable region of the client's UI. The spec uses a surfaceId to direct updates to specific surfaces (e.g., a main content area, a side panel, or a new chat bubble). This allows a single agent stream to manage multiple UI areas independently.
-
-Catalog Definition Document: The a2ui extension is catalog-agnostic. All UI components (e.g., Text, Row, Button) and functions (e.g., required, email) are defined in a separate Catalog Definition Schema. This allows clients and servers to negotiate which catalog to use.
-
-Schemas: The a2ui extension is defined by several primary JSON schemas:
-
-- Catalog Definition Schema: A standard format for defining a library of components and functions.
-- Server-to-Client Message List Schema: The core wire format for messages sent from the agent to the client (e.g., updateComponents, updateDataModel).
-- Client-to-Server Message List Schema: The core wire format for messages sent from the client to the agent (e.g., action).
-- Server Capabilities Schema: The schema for the `a2uiServerCapabilities` object, used by servers to declare their UI generation capabilities.
-- Client Capabilities Schema: The schema for the `a2uiClientCapabilities` object.
-
-Client Capabilities: The client sends its capabilities to the server in an `a2uiClientCapabilities` object. This object is included in the `metadata` field of every A2A `Message` sent from the client to the server. This object allows the client to declare which catalogs it supports.
-
-## Agent Card details
-
-Agents advertise their A2UI capabilities in their AgentCard within the `AgentCapabilities.extensions` list. The `params` object defines the agent's specific UI support and corresponds directly to the **Server Capabilities Schema** (`server_capabilities.json`).
-
-Example AgentExtension block:
+Example AgentCard payload:
 
 ```json
 {
-  "uri": "https://a2ui.org/a2a-extension/a2ui/v0.9",
-  "description": "Ability to render A2UI v0.9",
-  "required": false,
-  "params": {
-    "supportedCatalogIds": [
-      "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
-      "https://my-company.com/a2ui/v0.9/my_custom_catalog.json"
-    ],
-    "acceptsInlineCatalogs": true
+  "name": "Dashboard Agent",
+  "description": "Agent capable of generating dynamic UI dashboards.",
+  "capabilities": {
+    "extensions": [
+      {
+        "uri": "https://a2ui.org/a2a-extension/a2ui/v0.9",
+        "description": "Ability to render A2UI v0.9.1",
+        "required": false,
+        "params": {
+          "supportedCatalogIds": [
+            "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json",
+            "https://my-company.com/a2ui/v0.9.1/my_custom_catalog.json"
+          ],
+          "acceptsInlineCatalogs": true
+        }
+      }
+    ]
   }
 }
 ```
 
-### Parameter definitions
+The `params` object corresponds to the `v0.9.1` object in the `server_capabilities.json` schema:
 
-The `params` object corresponds to the `v0.9` object in the `server_capabilities.json` schema:
+- `params.supportedCatalogIds` (optional): An array of strings, where each string is an ID identifying a Catalog Definition Schema that the agent can generate. This is not necessarily a resolvable URI.
+- `params.acceptsInlineCatalogs` (optional): A boolean indicating if the agent can accept an `inlineCatalogs` array in the client's `a2uiClientCapabilities`. If omitted, this defaults to `false`.
 
-- `params.supportedCatalogIds`: (OPTIONAL) An array of strings, where each string is an ID identifying a Catalog Definition Schema that the agent can generate. This is not necessarily a resolvable URI.
-- `params.acceptsInlineCatalogs`: (OPTIONAL) A boolean indicating if the agent can accept an `inlineCatalogs` array in the client's `a2uiClientCapabilities`. If omitted, this defaults to `false`.
+## A2A Extension activation
 
-## Extension activation
+Activating the A2UI extension is optional. Clients and agents can negotiate A2UI support using `message.metadata["a2uiClientCapabilities"]` A2A `DataPart.data.metadata["mimeType"] = "application/a2ui+json"`.
 
-Clients indicate their desire to use the A2UI extension by specifying it via the transport-defined A2A extension activation mechanism.
+Specifically:
 
-For JSON-RPC and HTTP transports, this is indicated via the X-A2A-Extensions HTTP header.
+- If a client includes `message.metadata["a2uiClientCapabilities"]`, the agent can use this object to determine the supported A2UI protocol version and catalogs.
+- If an agent returns A2A A2A `DataPart.data.metadata["mimeType"] = "application/a2ui+json"`, the client knows the payload contains A2UI messages.
 
-For gRPC, this is indicated via the X-A2A-Extensions metadata value.
+While explicit activation is not required, clients can still explicitly activate the extension using the transport-defined A2A extension activation mechanism. The [A2A Extensions Guide](https://a2a-protocol.org/latest/topics/extensions/) defines this process.
 
-Activating this extension implies that the server can send A2UI-specific messages (like updateComponents) and the client is expected to send A2UI-specific events (like action).
+Note: You should not use `accepted_output_modes: ['a2ui']` (which is not an A2UI standard) to trigger A2UI.
+
+### JSON-RPC and HTTP transports
+
+To activate the A2UI A2A Extension, the `X-A2A-Extensions` HTTP header includes the extension URI.
+
+**Example HTTP `SendMessageRequest`:**
+
+```http
+POST /v1/messages HTTP/1.1
+Host: agent.example.com
+X-A2A-Extensions: https://a2ui.org/a2a-extension/a2ui/v0.9
+Content-Type: application/json
+
+{
+  "message": {
+    "parts": [
+      {
+        "text": "Hello, show me the dashboard"
+      }
+    ]
+  }
+}
+```
+
+To see how the agent parses the extension URI, see [`extension.py`](../../../agent_sdks/python/a2ui_agent/src/a2ui/a2a/extension.py).
+
+### GRPC transport
+
+To activate the A2UI A2A Extension, the client adds the extension URI to A2A `sendMessageParams.metadata["X-A2A-Extensions"]`.
+
+**Example gRPC `SendMessageRequest`:**
+
+```json
+{
+  "metadata": {
+    "X-A2A-Extensions": "https://a2ui.org/a2a-extension/a2ui/v0.9"
+  },
+  "message": {
+    "parts": [
+      {
+        "text": "Hello, show me the dashboard"
+        }
+      ]
+    }
+  }
+}
+```
+
+## A2A Client to Server Metadata
+
+Clients attach `a2uiClientCapabilities` and `a2uiClientDataModel` to A2A messages to communicate their state and supported catalogs.
+
+### `a2uiClientCapabilities`
+
+The client sends `sendMessageRequest.message["a2uiClientCapabilities"]` = [Client Capabilities Schema](../json/client_capabilities.json) to advertise which catalogs the renderer supports.
+
+**Example `SendMessageRequest` with Capabilities:**
+
+```json
+{
+  "message": {
+    "parts": [
+      {
+        "text": "Show me the dashboard."
+      }
+    ],
+    "metadata": {
+      "a2uiClientCapabilities": {
+        "v0.9": {
+          "supportedCatalogIds": [
+            "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json",
+            "https://my-company.com/a2ui/v0.9.1/my_custom_catalog.json"
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### `a2uiClientDataModel`
+
+When a surface enables Data Model Sync, the client sends `sendMessageRequest.message["a2uiClientDataModel"]` = [Client Data Model Schema](../json/client_data_model.json) on every message. This model provides the agent with the latest UI state. For more details, see the [Actions Guide](../../../docs/public/concepts/actions.md).
+
+**Example `SendMessageRequest` with Data Model:**
+
+```json
+{
+  "message": {
+    "parts": [
+      {
+        "text": "Submit the form."
+      }
+    ],
+    "metadata": {
+      "a2uiClientDataModel": {
+        "version": "v0.9.1",
+        "surfaces": {
+          "main_surface_id": {
+            "user_id": "12345",
+            "email": "user@example.com"
+          }
+        }
+      }
+    }
+  }
+}
+```
 
 ## Data encoding
 
-A2UI messages are encoded as an A2A `DataPart`.
+Agents and clients encode A2UI messages as an A2A `DataPart`.
 
 To identify a `DataPart` as containing A2UI data, it must have the following metadata:
 
-- `mimeType`: `application/json+a2ui`
+- `DataPart.data.metadata["mimeType"] = "application/a2ui+json"`
 
-The `data` field of the `DataPart` contains a **list** of A2UI JSON messages (e.g., `createSurface`, `updateComponents`, `action`). It MUST be an array of messages.
+The `data` field of the `DataPart` contains a list of A2UI JSON messages (e.g., `createSurface`, `updateComponents`, `action`). It MUST be an array of messages.
 
 ### Processing Rules
 
-The `data` field contains a list of messages. This list is **NOT** a transactional unit. Receivers (both Clients and Agents) MUST process messages in the list sequentially.
+The `data` field contains a list of messages. This list is NOT a transactional unit. Receivers (both Clients and Agents) MUST process messages in the list sequentially.
 
 If a single message in the list fails to validate or apply (e.g., due to a schema violation or invalid reference), the receiver SHOULD report/log the error for that specific message and MUST continue processing the remaining messages in the list.
 
-Atomicity is guaranteed only at the **individual message** level. However, for a better user experience, a renderer SHOULD NOT repaint the UI until all messages in the list have been processed. This prevents intermediate states from flickering to the user.
+Atomicity is guaranteed only at the individual message level. However, for a better user experience, a renderer SHOULD NOT repaint the UI until all messages in the list have been processed. This prevents intermediate states from flickering to the user.
 
 ### Server-to-client messages
 
-When an agent sends a message to a client (or another agent acting as a client/renderer), the `data` payload must validate against the **Server-to-Client Message List Schema**.
+When an agent sends a message to a client (or another agent acting as a client/renderer), the `data` payload must validate against the [Server-to-Client Message List Schema](../json/server_to_client_list.json).
 
 Example DataPart:
 
@@ -94,14 +195,14 @@ Example DataPart:
 {
   "data": [
     {
-      "version": "v0.9",
+      "version": "v0.9.1",
       "createSurface": {
         "surfaceId": "example_surface",
-        "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
+        "catalogId": "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
       }
     },
     {
-      "version": "v0.9",
+      "version": "v0.9.1",
       "updateComponents": {
         "surfaceId": "example_surface",
         "components": [
@@ -117,14 +218,14 @@ Example DataPart:
   ],
   "kind": "data",
   "metadata": {
-    "mimeType": "application/json+a2ui"
+    "mimeType": "application/a2ui+json"
   }
 }
 ```
 
 ### Client-to-server events
 
-When a client (or an agent forwarding an event) sends a message to an agent, it also uses a `DataPart` with the same `application/json+a2ui` MIME type. However, the `data` payload must validate against the **Client-to-Server Message List Schema**.
+When a client (or an agent forwarding an event) sends a message to an agent, it also uses a `DataPart` with the same `application/a2ui+json` MIME type. However, the `data` payload must validate against the [Client-to-Server Message List Schema](../json/client_to_server_list.json).
 
 Example `action` DataPart:
 
@@ -132,7 +233,7 @@ Example `action` DataPart:
 {
   "data": [
     {
-      "version": "v0.9",
+      "version": "v0.9.1",
       "action": {
         "name": "submit_form",
         "surfaceId": "contact_form_1",
@@ -146,7 +247,7 @@ Example `action` DataPart:
   ],
   "kind": "data",
   "metadata": {
-    "mimeType": "application/json+a2ui"
+    "mimeType": "application/a2ui+json"
   }
 }
 ```

--- a/specification/v0_9/docs/a2ui_extension_specification.md
+++ b/specification/v0_9/docs/a2ui_extension_specification.md
@@ -1,8 +1,8 @@
-# A2UI (Agent-to-Agent UI) Extension spec v0.9.1
+# A2UI (Agent-to-Agent UI) Extension spec v0.9
 
 ## Overview
 
-This document is intended for developers implementing the A2UI A2A extension. The extension adds A2UI v0.9.1 support to A2A, a format for agents to send streaming, interactive user interfaces to clients.
+This document is intended for developers implementing the A2UI A2A extension. The extension adds A2UI v0.9 support to A2A, a format for agents to send streaming, interactive user interfaces to clients.
 
 Note that A2UI extension activation is optional as clients and agents can negotiate A2UI support using A2A `message.metadata["a2uiClientCapabilities"]` which is attached to every A2A message from the client and contains the supported protocol version and catalogs. Agents advertising A2UI support in their AgentCard is encouraged as clients may rely on it to determine if they should send `message.metadata["a2uiClientCapabilities"]`, however it is not explicitly required.
 
@@ -41,7 +41,7 @@ Example AgentCard payload:
 }
 ```
 
-The `params` object corresponds to the `v0.9.1` object in the `server_capabilities.json` schema:
+The `params` object corresponds to the `v0.9` object in the `server_capabilities.json` schema:
 
 - `params.supportedCatalogIds` (optional): An array of strings, where each string is an ID identifying a Catalog Definition Schema that the agent can generate. This is not necessarily a resolvable URI.
 - `params.acceptsInlineCatalogs` (optional): A boolean indicating if the agent can accept an `inlineCatalogs` array in the client's `a2uiClientCapabilities`. If omitted, this defaults to `false`.
@@ -154,7 +154,7 @@ When a surface enables Data Model Sync, the client sends `sendMessageRequest.mes
     ],
     "metadata": {
       "a2uiClientDataModel": {
-        "version": "v0.9.1",
+        "version": "v0.9",
         "surfaces": {
           "main_surface_id": {
             "user_id": "12345",

--- a/specification/v0_9/docs/a2ui_extension_specification.md
+++ b/specification/v0_9/docs/a2ui_extension_specification.md
@@ -10,7 +10,7 @@ Note that A2UI extension activation is optional as clients and agents can negoti
 
 The URI of this extension is https://a2ui.org/a2a-extension/a2ui/v0.9
 
-This URI is the canonical way to communicate protocol versioning between clients and agents. The extension URI explicitly encodes the version (e.g., `v0.9.1`). A client requesting this specific URI indicates it supports the v0.9.1 schema format.
+This URI is the canonical way to communicate protocol versioning between clients and agents. The extension URI explicitly encodes the version (e.g., `v0.9`). A client requesting this specific URI indicates it supports the v0.9 schema format.
 
 ## Agent Card
 
@@ -26,12 +26,12 @@ Example AgentCard payload:
     "extensions": [
       {
         "uri": "https://a2ui.org/a2a-extension/a2ui/v0.9",
-        "description": "Ability to render A2UI v0.9.1",
+        "description": "Ability to render A2UI v0.9",
         "required": false,
         "params": {
           "supportedCatalogIds": [
-            "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json",
-            "https://my-company.com/a2ui/v0.9.1/my_custom_catalog.json"
+            "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+            "https://my-company.com/a2ui/v0.9/my_custom_catalog.json"
           ],
           "acceptsInlineCatalogs": true
         }
@@ -128,8 +128,8 @@ The client sends `sendMessageRequest.message["a2uiClientCapabilities"]` = [Clien
       "a2uiClientCapabilities": {
         "v0.9": {
           "supportedCatalogIds": [
-            "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json",
-            "https://my-company.com/a2ui/v0.9.1/my_custom_catalog.json"
+            "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+            "https://my-company.com/a2ui/v0.9/my_custom_catalog.json"
           ]
         }
       }
@@ -195,14 +195,14 @@ Example DataPart:
 {
   "data": [
     {
-      "version": "v0.9.1",
+      "version": "v0.9",
       "createSurface": {
         "surfaceId": "example_surface",
-        "catalogId": "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
+        "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
       }
     },
     {
-      "version": "v0.9.1",
+      "version": "v0.9",
       "updateComponents": {
         "surfaceId": "example_surface",
         "components": [
@@ -233,7 +233,7 @@ Example `action` DataPart:
 {
   "data": [
     {
-      "version": "v0.9.1",
+      "version": "v0.9",
       "action": {
         "name": "submit_form",
         "surfaceId": "contact_form_1",

--- a/specification/v0_9/docs/a2ui_protocol.md
+++ b/specification/v0_9/docs/a2ui_protocol.md
@@ -3,7 +3,7 @@
 <!-- markdownlint-disable MD034 -->
 <div style="text-align: center;">
   <div class="centered-logo-text-group">
-    <img src="../../../assets/A2UI_dark.svg" alt="A2UI Protocol Logo" width="100">
+    <img src="../../../docs/public/assets/A2UI_dark.svg" alt="A2UI Protocol Logo" width="100">
     <h1>A2UI (Agent to UI) Protocol v0.9</h1>
   </div>
 </div>

--- a/specification/v0_9_1/docs/a2ui_extension_specification.md
+++ b/specification/v0_9_1/docs/a2ui_extension_specification.md
@@ -2,91 +2,192 @@
 
 ## Overview
 
-This extension implements the A2UI (Agent-to-Agent UI) spec v0.9.1, a format for agents to send streaming, interactive user interfaces to clients.
+This document is intended for developers implementing the A2UI A2A extension. The extension adds A2UI v0.9.1 support to A2A, a format for agents to send streaming, interactive user interfaces to clients.
+
+Note that A2UI extension activation is optional as clients and agents can negotiate A2UI support using A2A `message.metadata["a2uiClientCapabilities"]` which is attached to every A2A message from the client and contains the supported protocol version and catalogs. Agents advertising A2UI support in their AgentCard is encouraged as clients may rely on it to determine if they should send `message.metadata["a2uiClientCapabilities"]`, however it is not explicitly required.
 
 ## Extension URI
 
 The URI of this extension is https://a2ui.org/a2a-extension/a2ui/v0.9.1
 
-This is the only URI accepted for this extension.
+This URI is the canonical way to communicate protocol versioning between clients and agents. The extension URI explicitly encodes the version (e.g., `v0.9.1`). A client requesting this specific URI indicates it supports the v0.9.1 schema format.
 
-## Core concepts
+## Agent Card
 
-The A2UI extension is built on the following main concepts:
+Agents are encouraged to advertise their A2UI capabilities in their AgentCard within the `AgentCapabilities.extensions` list. This advertisement is optional, but it informs the client whether to send `message.metadata["a2uiClientCapabilities"]`. The `params` object defines the agent's specific UI support and corresponds directly to the [Server Capabilities Schema](../json/server_capabilities.json).
 
-Surfaces: A "Surface" is a distinct, controllable region of the client's UI. The spec uses a surfaceId to direct updates to specific surfaces (e.g., a main content area, a side panel, or a new chat bubble). This allows a single agent stream to manage multiple UI areas independently.
-
-Catalog Definition Document: The a2ui extension is catalog-agnostic. All UI components (e.g., Text, Row, Button) and functions (e.g., required, email) are defined in a separate Catalog Definition Schema. This allows clients and servers to negotiate which catalog to use.
-
-Schemas: The a2ui extension is defined by several primary JSON schemas:
-
-- Catalog Definition Schema: A standard format for defining a library of components and functions.
-- Server-to-Client Message List Schema: The core wire format for messages sent from the agent to the client (e.g., updateComponents, updateDataModel).
-- Client-to-Server Message List Schema: The core wire format for messages sent from the client to the agent (e.g., action).
-- Server Capabilities Schema: The schema for the `a2uiServerCapabilities` object, used by servers to declare their UI generation capabilities.
-- Client Capabilities Schema: The schema for the `a2uiClientCapabilities` object.
-
-Client Capabilities: The client sends its capabilities to the server in an `a2uiClientCapabilities` object. This object is included in the `metadata` field of every A2A `Message` sent from the client to the server. This object allows the client to declare which catalogs it supports.
-
-## Agent Card details
-
-Agents advertise their A2UI capabilities in their AgentCard within the `AgentCapabilities.extensions` list. The `params` object defines the agent's specific UI support and corresponds directly to the **Server Capabilities Schema** (`server_capabilities.json`).
-
-Example AgentExtension block:
+Example AgentCard payload:
 
 ```json
 {
-  "uri": "https://a2ui.org/a2a-extension/a2ui/v0.9.1",
-  "description": "Ability to render A2UI v0.9.1",
-  "required": false,
-  "params": {
-    "supportedCatalogIds": [
-      "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json",
-      "https://my-company.com/a2ui/v0.9.1/my_custom_catalog.json"
-    ],
-    "acceptsInlineCatalogs": true
+  "name": "Dashboard Agent",
+  "description": "Agent capable of generating dynamic UI dashboards.",
+  "capabilities": {
+    "extensions": [
+      {
+        "uri": "https://a2ui.org/a2a-extension/a2ui/v0.9.1",
+        "description": "Ability to render A2UI v0.9.1",
+        "required": false,
+        "params": {
+          "supportedCatalogIds": [
+            "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json",
+            "https://my-company.com/a2ui/v0.9.1/my_custom_catalog.json"
+          ],
+          "acceptsInlineCatalogs": true
+        }
+      }
+    ]
   }
 }
 ```
 
-### Parameter definitions
-
 The `params` object corresponds to the `v0.9.1` object in the `server_capabilities.json` schema:
 
-- `params.supportedCatalogIds`: (OPTIONAL) An array of strings, where each string is an ID identifying a Catalog Definition Schema that the agent can generate. This is not necessarily a resolvable URI.
-- `params.acceptsInlineCatalogs`: (OPTIONAL) A boolean indicating if the agent can accept an `inlineCatalogs` array in the client's `a2uiClientCapabilities`. If omitted, this defaults to `false`.
+- `params.supportedCatalogIds` (optional): An array of strings, where each string is an ID identifying a Catalog Definition Schema that the agent can generate. This is not necessarily a resolvable URI.
+- `params.acceptsInlineCatalogs` (optional): A boolean indicating if the agent can accept an `inlineCatalogs` array in the client's `a2uiClientCapabilities`. If omitted, this defaults to `false`.
 
-## Extension activation
+## A2A Extension activation
 
-Clients indicate their desire to use the A2UI extension by specifying it via the transport-defined A2A extension activation mechanism.
+Activating the A2UI extension is optional. Clients and agents can negotiate A2UI support using `message.metadata["a2uiClientCapabilities"]` A2A `DataPart.data.metadata["mimeType"] = "application/a2ui+json"`.
 
-For JSON-RPC and HTTP transports, this is indicated via the X-A2A-Extensions HTTP header.
+Specifically:
 
-For gRPC, this is indicated via the X-A2A-Extensions metadata value.
+- If a client includes `message.metadata["a2uiClientCapabilities"]`, the agent can use this object to determine the supported A2UI protocol version and catalogs.
+- If an agent returns A2A A2A `DataPart.data.metadata["mimeType"] = "application/a2ui+json"`, the client knows the payload contains A2UI messages.
 
-Activating this extension implies that the server can send A2UI-specific messages (like updateComponents) and the client is expected to send A2UI-specific events (like action).
+While explicit activation is not required, clients can still explicitly activate the extension using the transport-defined A2A extension activation mechanism. The [A2A Extensions Guide](https://a2a-protocol.org/latest/topics/extensions/) defines this process.
+
+Note: You should not use `accepted_output_modes: ['a2ui']` (which is not an A2UI standard) to trigger A2UI.
+
+### JSON-RPC and HTTP transports
+
+To activate the A2UI A2A Extension, the `X-A2A-Extensions` HTTP header includes the extension URI.
+
+**Example HTTP `SendMessageRequest`:**
+
+```http
+POST /v1/messages HTTP/1.1
+Host: agent.example.com
+X-A2A-Extensions: https://a2ui.org/a2a-extension/a2ui/v0.9.1
+Content-Type: application/json
+
+{
+  "message": {
+    "parts": [
+      {
+        "text": "Hello, show me the dashboard"
+      }
+    ]
+  }
+}
+```
+
+To see how the agent parses the extension URI, see [`extension.py`](../../../agent_sdks/python/a2ui_agent/src/a2ui/a2a/extension.py).
+
+### GRPC transport
+
+To activate the A2UI A2A Extension, the client adds the extension URI to A2A `sendMessageParams.metadata["X-A2A-Extensions"]`.
+
+**Example gRPC `SendMessageRequest`:**
+
+```json
+{
+  "metadata": {
+    "X-A2A-Extensions": "https://a2ui.org/a2a-extension/a2ui/v0.9.1"
+  },
+  "message": {
+    "parts": [
+      {
+        "text": "Hello, show me the dashboard"
+        }
+      ]
+    }
+  }
+}
+```
+
+## A2A Client to Server Metadata
+
+Clients attach `a2uiClientCapabilities` and `a2uiClientDataModel` to A2A messages to communicate their state and supported catalogs.
+
+### `a2uiClientCapabilities`
+
+The client sends `sendMessageRequest.message["a2uiClientCapabilities"]` = [Client Capabilities Schema](../json/client_capabilities.json) to advertise which catalogs the renderer supports.
+
+**Example `SendMessageRequest` with Capabilities:**
+
+```json
+{
+  "message": {
+    "parts": [
+      {
+        "text": "Show me the dashboard."
+      }
+    ],
+    "metadata": {
+      "a2uiClientCapabilities": {
+        "v0.9": {
+          "supportedCatalogIds": [
+            "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json",
+            "https://my-company.com/a2ui/v0.9.1/my_custom_catalog.json"
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### `a2uiClientDataModel`
+
+When a surface enables Data Model Sync, the client sends `sendMessageRequest.message["a2uiClientDataModel"]` = [Client Data Model Schema](../json/client_data_model.json) on every message. This model provides the agent with the latest UI state. For more details, see the [Actions Guide](../../../docs/public/concepts/actions.md).
+
+**Example `SendMessageRequest` with Data Model:**
+
+```json
+{
+  "message": {
+    "parts": [
+      {
+        "text": "Submit the form."
+      }
+    ],
+    "metadata": {
+      "a2uiClientDataModel": {
+        "version": "v0.9.1",
+        "surfaces": {
+          "main_surface_id": {
+            "user_id": "12345",
+            "email": "user@example.com"
+          }
+        }
+      }
+    }
+  }
+}
+```
 
 ## Data encoding
 
-A2UI messages are encoded as an A2A `DataPart`.
+Agents and clients encode A2UI messages as an A2A `DataPart`.
 
 To identify a `DataPart` as containing A2UI data, it must have the following metadata:
 
-- `mimeType`: `application/a2ui+json`
+- `DataPart.data.metadata["mimeType"] = "application/a2ui+json"`
 
-The `data` field of the `DataPart` contains a **list** of A2UI JSON messages (e.g., `createSurface`, `updateComponents`, `action`). It MUST be an array of messages.
+The `data` field of the `DataPart` contains a list of A2UI JSON messages (e.g., `createSurface`, `updateComponents`, `action`). It MUST be an array of messages.
 
 ### Processing Rules
 
-The `data` field contains a list of messages. This list is **NOT** a transactional unit. Receivers (both Clients and Agents) MUST process messages in the list sequentially.
+The `data` field contains a list of messages. This list is NOT a transactional unit. Receivers (both Clients and Agents) MUST process messages in the list sequentially.
 
 If a single message in the list fails to validate or apply (e.g., due to a schema violation or invalid reference), the receiver SHOULD report/log the error for that specific message and MUST continue processing the remaining messages in the list.
 
-Atomicity is guaranteed only at the **individual message** level. However, for a better user experience, a renderer SHOULD NOT repaint the UI until all messages in the list have been processed. This prevents intermediate states from flickering to the user.
+Atomicity is guaranteed only at the individual message level. However, for a better user experience, a renderer SHOULD NOT repaint the UI until all messages in the list have been processed. This prevents intermediate states from flickering to the user.
 
 ### Server-to-client messages
 
-When an agent sends a message to a client (or another agent acting as a client/renderer), the `data` payload must validate against the **Server-to-Client Message List Schema**.
+When an agent sends a message to a client (or another agent acting as a client/renderer), the `data` payload must validate against the [Server-to-Client Message List Schema](../json/server_to_client_list.json).
 
 Example DataPart:
 
@@ -124,7 +225,7 @@ Example DataPart:
 
 ### Client-to-server events
 
-When a client (or an agent forwarding an event) sends a message to an agent, it also uses a `DataPart` with the same `application/a2ui+json` MIME type. However, the `data` payload must validate against the **Client-to-Server Message List Schema**.
+When a client (or an agent forwarding an event) sends a message to an agent, it also uses a `DataPart` with the same `application/a2ui+json` MIME type. However, the `data` payload must validate against the [Client-to-Server Message List Schema](../json/client_to_server_list.json).
 
 Example `action` DataPart:
 

--- a/specification/v0_9_1/docs/a2ui_extension_specification.md
+++ b/specification/v0_9_1/docs/a2ui_extension_specification.md
@@ -30,8 +30,8 @@ Example AgentCard payload:
         "required": false,
         "params": {
           "supportedCatalogIds": [
-            "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json",
-            "https://my-company.com/a2ui/v0.9.1/my_custom_catalog.json"
+            "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+            "https://my-company.com/a2ui/v0.9/my_custom_catalog.json"
           ],
           "acceptsInlineCatalogs": true
         }
@@ -126,10 +126,10 @@ The client sends `sendMessageRequest.message["a2uiClientCapabilities"]` = [Clien
     ],
     "metadata": {
       "a2uiClientCapabilities": {
-        "v0.9": {
+        "v0.9.1": {
           "supportedCatalogIds": [
-            "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json",
-            "https://my-company.com/a2ui/v0.9.1/my_custom_catalog.json"
+            "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
+            "https://my-company.com/a2ui/v0.9/my_custom_catalog.json"
           ]
         }
       }
@@ -198,7 +198,7 @@ Example DataPart:
       "version": "v0.9.1",
       "createSurface": {
         "surfaceId": "example_surface",
-        "catalogId": "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
+        "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
       }
     },
     {

--- a/specification/v0_9_1/docs/a2ui_protocol.md
+++ b/specification/v0_9_1/docs/a2ui_protocol.md
@@ -3,7 +3,7 @@
 <!-- markdownlint-disable MD034 -->
 <div style="text-align: center;">
   <div class="centered-logo-text-group">
-    <img src="../../../assets/A2UI_dark.svg" alt="A2UI Protocol Logo" width="100">
+    <img src="../../../docs/public/assets/A2UI_dark.svg" alt="A2UI Protocol Logo" width="100">
     <h1>A2UI (Agent to UI) Protocol v0.9.1</h1>
   </div>
 </div>

--- a/specification/v1_0/docs/a2ui_protocol.md
+++ b/specification/v1_0/docs/a2ui_protocol.md
@@ -3,7 +3,7 @@
 <!-- markdownlint-disable MD034 -->
 <div style="text-align: center;">
   <div class="centered-logo-text-group">
-    <img src="../../../assets/A2UI_dark.svg" alt="A2UI Protocol Logo" width="100">
+    <img src="../../../docs/public/assets/A2UI_dark.svg" alt="A2UI Protocol Logo" width="100">
     <h1>A2UI (Agent to UI) Protocol v1.0</h1>
   </div>
 </div>

--- a/specification/v1_0/extensions/a2a/docs/a2ui_extension_specification.md
+++ b/specification/v1_0/extensions/a2a/docs/a2ui_extension_specification.md
@@ -1,150 +1,216 @@
-# A2UI (Agent-to-Agent UI) Extension spec v1.0
+# A2UI (Agent-to-Agent UI) Extension spec v0.9.1
 
 ## Overview
 
-This extension implements the A2UI (Agent-to-Agent UI) spec v1.0, a format for agents to send streaming, interactive user interfaces to clients.
+This document is intended for developers implementing the A2UI A2A extension. The extension adds A2UI v0.9.1 support to A2A, a format for agents to send streaming, interactive user interfaces to clients.
+
+Note that A2UI extension activation is optional as clients and agents can negotiate A2UI support using A2A `message.metadata["a2uiClientCapabilities"]` which is attached to every A2A message from the client and contains the supported protocol version and catalogs. Agents advertising A2UI support in their AgentCard is encouraged as clients may rely on it to determine if they should send `message.metadata["a2uiClientCapabilities"]`, however it is not explicitly required.
 
 ## Extension URI
 
-The URI of this extension is:
-`https://a2ui.org/a2a-extension/a2ui/v1.0`
+The URI of this extension is https://a2ui.org/a2a-extension/a2ui/v1.0
 
-This is the only URI accepted for this extension.
+This URI is the canonical way to communicate protocol versioning between clients and agents. The extension URI explicitly encodes the version (e.g., `v0.9.1`). A client requesting this specific URI indicates it supports the v0.9.1 schema format.
 
-## Core concepts
+## Agent Card
 
-The A2UI extension is built on the following main concepts:
+Agents are encouraged to advertise their A2UI capabilities in their AgentCard within the `AgentCapabilities.extensions` list. This advertisement is optional, but it informs the client whether to send `message.metadata["a2uiClientCapabilities"]`. The `params` object defines the agent's specific UI support and corresponds directly to the [Server Capabilities Schema](../../../json/server_capabilities.json).
 
-- **Surfaces**: A "Surface" is a distinct, controllable region of the client's UI. The spec uses a `surfaceId` to direct updates to specific surfaces (e.g., a main content area, a side panel, or a new chat bubble). This allows a single agent stream to manage multiple UI areas independently.
-- **Catalog Definition Document**: The A2UI extension is catalog-agnostic. All UI components (e.g., Text, Row, Button) and functions (e.g., required, email) are defined in a separate Catalog Definition Schema. This allows clients and servers to negotiate which catalog to use.
-- **Schemas**: The A2UI extension is defined by several primary JSON schemas:
-  - **Catalog Definition Schema**: A standard format for defining a library of components and functions ([catalog_definition.json](../../../json/catalog_definition.json)).
-  - **Server-to-Client Message List Schema**: The core wire format for messages sent from the agent to the client ([server_to_client_list.json](../../../json/server_to_client_list.json)).
-  - **Client-to-Server Message List Schema**: The core wire format for messages sent from the client to the agent ([client_to_server_list.json](../../../json/client_to_server_list.json)).
-  - **Server Capabilities Schema**: The schema for the `a2uiServerCapabilities` object, used by servers to declare their UI generation capabilities ([server_capabilities.json](../../../json/server_capabilities.json)).
-  - **Client Capabilities Schema**: The schema for the `a2uiClientCapabilities` object ([client_capabilities.json](../../../json/client_capabilities.json)).
-  - **Client Data Model Schema**: The schema for the `a2uiClientDataModel` object, used for two-way synchronization ([client_data_model.json](../../../json/client_data_model.json)).
-
----
-
-## Metadata and capabilities exchange
-
-In A2UI v1.0, capabilities and other session metadata are exchanged via **transport metadata** or initialization payloads rather than as first-class A2UI messages.
-
-### Server capabilities in Agent Cards
-
-Agents advertise their A2UI capabilities in their AgentCard within the `AgentCapabilities.extensions` list. The `params` object defines the agent's specific UI support and corresponds directly to the **Server Capabilities Schema** ([server_capabilities.json](../../../json/server_capabilities.json)).
-
-#### Example AgentExtension block
+Example AgentCard payload:
 
 ```json
 {
-  "uri": "https://a2ui.org/a2a-extension/a2ui/v1.0",
-  "description": "Ability to render A2UI v1.0",
-  "required": false,
-  "params": {
-    "supportedCatalogIds": [
-      "https://a2ui.org/specification/v1_0/catalogs/basic/catalog.json",
-      "https://my-company.com/a2ui/v0_1/my_custom_catalog.json"
-    ],
-    "acceptsInlineCatalogs": true
+  "name": "Dashboard Agent",
+  "description": "Agent capable of generating dynamic UI dashboards.",
+  "capabilities": {
+    "extensions": [
+      {
+        "uri": "https://a2ui.org/a2a-extension/a2ui/v1.0",
+        "description": "Ability to render A2UI v0.9.1",
+        "required": false,
+        "params": {
+          "supportedCatalogIds": [
+            "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json",
+            "https://my-company.com/a2ui/v0.9.1/my_custom_catalog.json"
+          ],
+          "acceptsInlineCatalogs": true
+        }
+      }
+    ]
   }
 }
 ```
 
-#### Parameter definitions
+The `params` object corresponds to the `v0.9.1` object in the `server_capabilities.json` schema:
 
-The `params` object corresponds to the `v1.0` object in the `server_capabilities.json` schema:
+- `params.supportedCatalogIds` (optional): An array of strings, where each string is an ID identifying a Catalog Definition Schema that the agent can generate. This is not necessarily a resolvable URI.
+- `params.acceptsInlineCatalogs` (optional): A boolean indicating if the agent can accept an `inlineCatalogs` array in the client's `a2uiClientCapabilities`. If omitted, this defaults to `false`.
 
-- `params.supportedCatalogIds` (array of strings, optional): An array of strings, where each string is an ID identifying a Catalog Definition Schema that the agent can generate. This is not necessarily a resolvable URI.
-- `params.acceptsInlineCatalogs` (boolean, optional): A boolean indicating if the agent can accept an `inlineCatalogs` array in the client's `a2uiClientCapabilities`. If omitted, this defaults to `false`.
+## A2A Extension activation
 
-### Client capabilities in message metadata
+Activating the A2UI extension is optional. Clients and agents can negotiate A2UI support using `message.metadata["a2uiClientCapabilities"]` A2A `DataPart.data.metadata["mimeType"] = "application/a2ui+json"`.
 
-The client sends its capabilities to the server in an `a2uiClientCapabilities` object. This object is included in the `metadata` field of every A2A `Message` sent from the client to the server, following the **Client Capabilities Schema** ([client_capabilities.json](../../../json/client_capabilities.json)).
+Specifically:
 
-#### Parameter definitions
+- If a client includes `message.metadata["a2uiClientCapabilities"]`, the agent can use this object to determine the supported A2UI protocol version and catalogs.
+- If an agent returns A2A A2A `DataPart.data.metadata["mimeType"] = "application/a2ui+json"`, the client knows the payload contains A2UI messages.
 
-The `a2uiClientCapabilities` object contains a `v1.0` object with the following properties:
+While explicit activation is not required, clients can still explicitly activate the extension using the transport-defined A2A extension activation mechanism. The [A2A Extensions Guide](https://a2a-protocol.org/latest/topics/extensions/) defines this process.
 
-- `v1.0.supportedCatalogIds` (array of strings, required): The string identifiers of supported component and function catalogs.
-- `v1.0.inlineCatalogs` (array, optional): An array of custom catalog definitions provided inline by the client. Functions defined within inline catalogs support declaring execution boundaries (`callableFrom: "clientOnly" | "remoteOnly" | "clientOrRemote"`) to statically specify remote invocation safety.
+Note: You should not use `accepted_output_modes: ['a2ui']` (which is not an A2UI standard) to trigger A2UI.
 
----
+### JSON-RPC and HTTP transports
 
-## Client-to-server data model synchronization
+To activate the A2UI A2A Extension, the `X-A2A-Extensions` HTTP header includes the extension URI.
 
-When `sendDataModel` is enabled for a surface (via the `createSurface` message), the client automatically appends the **entire data model** of that surface to the metadata of every message (such as an `action` or user query) sent to the server that created the surface.
+**Example HTTP `SendMessageRequest`:**
 
-In A2A transport, the data model is serialized to the `a2uiClientDataModel` format and placed in the `metadata` field of the A2A `Message` envelope, following the **Client Data Model Schema** ([client_data_model.json](../../../json/client_data_model.json)).
+```http
+POST /v1/messages HTTP/1.1
+Host: agent.example.com
+X-A2A-Extensions: https://a2ui.org/a2a-extension/a2ui/v1.0
+Content-Type: application/json
 
-### Parameter definitions
+{
+  "message": {
+    "parts": [
+      {
+        "text": "Hello, show me the dashboard"
+      }
+    ]
+  }
+}
+```
 
-The `a2uiClientDataModel` object contains:
+To see how the agent parses the extension URI, see [`extension.py`](../../../../../agent_sdks/python/a2ui_agent/src/a2ui/a2a/extension.py).
 
-- `version` (string, required): Must be the constant `"v1.0"`.
-- `surfaces` (object, required): A map of surface IDs to their current local data models.
+### GRPC transport
 
-### Synchronization rules
+To activate the A2UI A2A Extension, the client adds the extension URI to A2A `sendMessageParams.metadata["X-A2A-Extensions"]`.
 
-- **Targeted Delivery**: The data model is sent exclusively to the server that created the surface. Data cannot leak to other agents or servers.
-- **Trigger**: Data is sent only when a client-to-server message is triggered (e.g., by a user action like a button click). Passive data changes (like typing in a text field) do not trigger a network request on their own; they simply update the local state, which will be sent with the next action.
-- **Convergence**: The server treats the received data model as the current state of the client at the time of the action.
+**Example gRPC `SendMessageRequest`:**
 
----
+```json
+{
+  "metadata": {
+    "X-A2A-Extensions": "https://a2ui.org/a2a-extension/a2ui/v1.0"
+  },
+  "message": {
+    "parts": [
+      {
+        "text": "Hello, show me the dashboard"
+        }
+      ]
+    }
+  }
+}
+```
 
-## Extension activation
+## A2A Client to Server Metadata
 
-Clients indicate their desire to use the A2UI extension by specifying it via the transport-defined A2A extension activation mechanism.
+Clients attach `a2uiClientCapabilities` and `a2uiClientDataModel` to A2A messages to communicate their state and supported catalogs.
 
-- For **JSON-RPC and HTTP** transports, this is indicated via the `X-A2A-Extensions` HTTP header.
-- For **gRPC**, this is indicated via the `X-A2A-Extensions` metadata value.
+### `a2uiClientCapabilities`
 
-Activating this extension implies that the server can send A2UI-specific messages (like `updateComponents`) and the client is expected to send A2UI-specific events (like `action`).
+The client sends `sendMessageRequest.message["a2uiClientCapabilities"]` = [Client Capabilities Schema](../../../json/client_capabilities.json) to advertise which catalogs the renderer supports.
 
----
+**Example `SendMessageRequest` with Capabilities:**
+
+```json
+{
+  "message": {
+    "parts": [
+      {
+        "text": "Show me the dashboard."
+      }
+    ],
+    "metadata": {
+      "a2uiClientCapabilities": {
+        "v0.9": {
+          "supportedCatalogIds": [
+            "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json",
+            "https://my-company.com/a2ui/v0.9.1/my_custom_catalog.json"
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### `a2uiClientDataModel`
+
+When a surface enables Data Model Sync, the client sends `sendMessageRequest.message["a2uiClientDataModel"]` = [Client Data Model Schema](../json/client_data_model.json) on every message. This model provides the agent with the latest UI state. For more details, see the [Actions Guide](../../../../../docs/public/concepts/actions.md).
+
+**Example `SendMessageRequest` with Data Model:**
+
+```json
+{
+  "message": {
+    "parts": [
+      {
+        "text": "Submit the form."
+      }
+    ],
+    "metadata": {
+      "a2uiClientDataModel": {
+        "version": "v0.9.1",
+        "surfaces": {
+          "main_surface_id": {
+            "user_id": "12345",
+            "email": "user@example.com"
+          }
+        }
+      }
+    }
+  }
+}
+```
 
 ## Data encoding
 
-A2UI messages are encoded as an A2A `DataPart`. To identify a `DataPart` as containing A2UI data, it must have the following metadata:
+Agents and clients encode A2UI messages as an A2A `DataPart`.
 
-- `mimeType`: `application/a2ui+json`
+To identify a `DataPart` as containing A2UI data, it must have the following metadata:
 
-The `data` field of the `DataPart` contains a **list** of A2UI JSON messages (e.g., `createSurface`, `updateComponents`, `action`). It MUST be an array of messages.
+- `DataPart.data.metadata["mimeType"] = "application/a2ui+json"`
 
-### Processing rules
+The `data` field of the `DataPart` contains a list of A2UI JSON messages (e.g., `createSurface`, `updateComponents`, `action`). It MUST be an array of messages.
 
-The `data` field contains a list of messages. This list is **NOT** a transactional unit. Receivers (both Clients and Agents) MUST process messages in the list sequentially.
+### Processing Rules
+
+The `data` field contains a list of messages. This list is NOT a transactional unit. Receivers (both Clients and Agents) MUST process messages in the list sequentially.
 
 If a single message in the list fails to validate or apply (e.g., due to a schema violation or invalid reference), the receiver SHOULD report/log the error for that specific message and MUST continue processing the remaining messages in the list.
 
-Atomicity is guaranteed only at the **individual message** level. However, for a better user experience, a renderer SHOULD NOT repaint the UI until all messages in the list have been processed. This prevents intermediate states from flickering to the user.
+Atomicity is guaranteed only at the individual message level. However, for a better user experience, a renderer SHOULD NOT repaint the UI until all messages in the list have been processed. This prevents intermediate states from flickering to the user.
 
 ### Server-to-client messages
 
-When an agent sends a message to a client (or another agent acting as a client/renderer), the `data` payload must validate against the **Server-to-Client Message List Schema** ([server_to_client_list.json](../../../json/server_to_client_list.json)).
+When an agent sends a message to a client (or another agent acting as a client/renderer), the `data` payload must validate against the [Server-to-Client Message List Schema](../../../json/server_to_client_list.json).
 
-#### Example DataPart
+Example DataPart:
 
 ```json
 {
   "data": [
     {
-      "version": "v1.0",
+      "version": "v0.9.1",
       "createSurface": {
         "surfaceId": "example_surface",
-        "catalogId": "https://a2ui.org/specification/v1_0/catalogs/basic/catalog.json"
+        "catalogId": "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
       }
     },
     {
-      "version": "v1.0",
+      "version": "v0.9.1",
       "updateComponents": {
         "surfaceId": "example_surface",
         "components": [
           {
-            "component": "Text",
-            "id": "root",
-            "text": "Hello!"
+            "Text": {
+              "id": "root",
+              "text": "Hello!"
+            }
           }
         ]
       }
@@ -159,15 +225,15 @@ When an agent sends a message to a client (or another agent acting as a client/r
 
 ### Client-to-server events
 
-When a client (or an agent forwarding an event) sends a message to an agent, it also uses a `DataPart` with the same `application/a2ui+json` MIME type. However, the `data` payload must validate against the **Client-to-Server Message List Schema** ([client_to_server_list.json](../../../json/client_to_server_list.json)).
+When a client (or an agent forwarding an event) sends a message to an agent, it also uses a `DataPart` with the same `application/a2ui+json` MIME type. However, the `data` payload must validate against the [Client-to-Server Message List Schema](../../../json/client_to_server_list.json).
 
-#### Example `action` DataPart
+Example `action` DataPart:
 
 ```json
 {
   "data": [
     {
-      "version": "v1.0",
+      "version": "v0.9.1",
       "action": {
         "name": "submit_form",
         "surfaceId": "contact_form_1",

--- a/specification/v1_0/extensions/a2a/docs/a2ui_extension_specification.md
+++ b/specification/v1_0/extensions/a2a/docs/a2ui_extension_specification.md
@@ -140,7 +140,7 @@ The client sends `sendMessageRequest.message["a2uiClientCapabilities"]` = [Clien
 
 ### `a2uiClientDataModel`
 
-When a surface enables Data Model Sync, the client sends `sendMessageRequest.message["a2uiClientDataModel"]` = [Client Data Model Schema](../json/client_data_model.json) on every message. This model provides the agent with the latest UI state. For more details, see the [Actions Guide](../../../../../docs/public/concepts/actions.md).
+When a surface enables Data Model Sync, the client sends `sendMessageRequest.message["a2uiClientDataModel"]` = [Client Data Model Schema](../../../json/client_data_model.json) on every message. This model provides the agent with the latest UI state. For more details, see the [Actions Guide](../../../../../docs/public/concepts/actions.md).
 
 **Example `SendMessageRequest` with Data Model:**
 

--- a/specification/v1_0/extensions/a2a/docs/a2ui_extension_specification.md
+++ b/specification/v1_0/extensions/a2a/docs/a2ui_extension_specification.md
@@ -10,7 +10,7 @@ Note that A2UI extension activation is optional as clients and agents can negoti
 
 The URI of this extension is https://a2ui.org/a2a-extension/a2ui/v1.0
 
-This URI is the canonical way to communicate protocol versioning between clients and agents. The extension URI explicitly encodes the version (e.g., `v0.9.1`). A client requesting this specific URI indicates it supports the v0.9.1 schema format.
+This URI is the canonical way to communicate protocol versioning between clients and agents. The extension URI explicitly encodes the version (e.g., `v1.0`). A client requesting this specific URI indicates it supports the v1.0 schema format.
 
 ## Agent Card
 
@@ -26,12 +26,12 @@ Example AgentCard payload:
     "extensions": [
       {
         "uri": "https://a2ui.org/a2a-extension/a2ui/v1.0",
-        "description": "Ability to render A2UI v0.9.1",
+        "description": "Ability to render A2UI v1.0",
         "required": false,
         "params": {
           "supportedCatalogIds": [
-            "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json",
-            "https://my-company.com/a2ui/v0.9.1/my_custom_catalog.json"
+            "https://a2ui.org/specification/v1_0/catalogs/basic/catalog.json",
+            "https://my-company.com/a2ui/v1.0/my_custom_catalog.json"
           ],
           "acceptsInlineCatalogs": true
         }
@@ -130,8 +130,8 @@ Additionally, the client determines a function's execution boundary (e.g., `clie
       "a2uiClientCapabilities": {
         "v1.0": {
           "supportedCatalogIds": [
-            "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json",
-            "https://my-company.com/a2ui/v0.9.1/my_custom_catalog.json"
+            "https://a2ui.org/specification/v1_0/catalogs/basic/catalog.json",
+            "https://my-company.com/a2ui/v1.0/my_custom_catalog.json"
           ]
         }
       }
@@ -156,7 +156,7 @@ When a surface enables Data Model Sync, the client sends `sendMessageRequest.mes
     ],
     "metadata": {
       "a2uiClientDataModel": {
-        "version": "v0.9.1",
+        "version": "v1.0",
         "surfaces": {
           "main_surface_id": {
             "user_id": "12345",
@@ -197,14 +197,14 @@ Example DataPart:
 {
   "data": [
     {
-      "version": "v0.9.1",
+      "version": "v1.0",
       "createSurface": {
         "surfaceId": "example_surface",
-        "catalogId": "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
+        "catalogId": "https://a2ui.org/specification/v1_0/catalogs/basic/catalog.json"
       }
     },
     {
-      "version": "v0.9.1",
+      "version": "v1.0",
       "updateComponents": {
         "surfaceId": "example_surface",
         "components": [
@@ -235,7 +235,7 @@ Example `action` DataPart:
 {
   "data": [
     {
-      "version": "v0.9.1",
+      "version": "v1.0",
       "action": {
         "name": "submit_form",
         "surfaceId": "contact_form_1",

--- a/specification/v1_0/extensions/a2a/docs/a2ui_extension_specification.md
+++ b/specification/v1_0/extensions/a2a/docs/a2ui_extension_specification.md
@@ -209,10 +209,9 @@ Example DataPart:
         "surfaceId": "example_surface",
         "components": [
           {
-            "Text": {
-              "id": "root",
-              "text": "Hello!"
-            }
+            "id": "root",
+            "component": "Text",
+            "text": "Hello!"
           }
         ]
       }

--- a/specification/v1_0/extensions/a2a/docs/a2ui_extension_specification.md
+++ b/specification/v1_0/extensions/a2a/docs/a2ui_extension_specification.md
@@ -1,8 +1,8 @@
-# A2UI (Agent-to-Agent UI) Extension spec v0.9.1
+# A2UI (Agent-to-Agent UI) Extension spec v1.0
 
 ## Overview
 
-This document is intended for developers implementing the A2UI A2A extension. The extension adds A2UI v0.9.1 support to A2A, a format for agents to send streaming, interactive user interfaces to clients.
+This document is intended for developers implementing the A2UI A2A extension. The extension adds A2UI v1.0 support to A2A, a format for agents to send streaming, interactive user interfaces to clients.
 
 Note that A2UI extension activation is optional as clients and agents can negotiate A2UI support using A2A `message.metadata["a2uiClientCapabilities"]` which is attached to every A2A message from the client and contains the supported protocol version and catalogs. Agents advertising A2UI support in their AgentCard is encouraged as clients may rely on it to determine if they should send `message.metadata["a2uiClientCapabilities"]`, however it is not explicitly required.
 
@@ -41,7 +41,7 @@ Example AgentCard payload:
 }
 ```
 
-The `params` object corresponds to the `v0.9.1` object in the `server_capabilities.json` schema:
+The `params` object corresponds to the `v1.0` object in the `server_capabilities.json` schema:
 
 - `params.supportedCatalogIds` (optional): An array of strings, where each string is an ID identifying a Catalog Definition Schema that the agent can generate. This is not necessarily a resolvable URI.
 - `params.acceptsInlineCatalogs` (optional): A boolean indicating if the agent can accept an `inlineCatalogs` array in the client's `a2uiClientCapabilities`. If omitted, this defaults to `false`.
@@ -114,6 +114,8 @@ Clients attach `a2uiClientCapabilities` and `a2uiClientDataModel` to A2A message
 
 The client sends `sendMessageRequest.message["a2uiClientCapabilities"]` = [Client Capabilities Schema](../../../json/client_capabilities.json) to advertise which catalogs the renderer supports.
 
+Additionally, the client determines a function's execution boundary (e.g., `clientOnly` status) at runtime by reading its configuration from the active catalog definition.
+
 **Example `SendMessageRequest` with Capabilities:**
 
 ```json
@@ -126,7 +128,7 @@ The client sends `sendMessageRequest.message["a2uiClientCapabilities"]` = [Clien
     ],
     "metadata": {
       "a2uiClientCapabilities": {
-        "v0.9": {
+        "v1.0": {
           "supportedCatalogIds": [
             "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json",
             "https://my-company.com/a2ui/v0.9.1/my_custom_catalog.json"


### PR DESCRIPTION
This pull request reintroduces and refines changes to the A2UI extension specifications and their supporting infrastructure. The primary goal is to enhance the clarity and accuracy of the A2UI documentation by restructuring content, providing more detailed explanations of A2A integration points, and standardizing the MIME type. Additionally, it includes updates to internal tooling for improved handling of documentation links and validation.

### Highlights

* **Documentation Structure and Clarity**: The A2UI extension specification documents for versions v0.9, v0.9.1, and v1.0 were significantly restructured and expanded to improve clarity and detail regarding A2A integration.
* **Link Handling Improvements**: The `hooks.py` script was enhanced to correctly rewrite relative paths for JSON schemas, accommodating varying directory depths, and to convert external `docs/public/` links into internal relative links.
* **Link Validation Refinement**: The `lychee.toml` configuration was updated to modify link checking behavior, now excluding published documentation copies and validating original source files to prevent false positives caused by broken relative links in published versions.
* **Standardized MIME Type**: The A2UI MIME type was standardized from `application/json+a2ui` to `application/a2ui+json` across all relevant specification documents.
* **Detailed A2A Integration**: Comprehensive sections were added to the specification documents detailing Agent Card capabilities, A2A extension activation mechanisms (HTTP/JSON-RPC and gRPC), and client-to-server metadata exchange (`a2uiClientCapabilities` and `a2uiClientDataModel`).