### PR TITLE
feat(ink): add terminal renderer for A2UI v0.9

### DIFF
--- a/renderers/README.md
+++ b/renderers/README.md
@@ -1,3 +1,13 @@
 # A2UI Renderer framework adapters
 
 This folder contains [framework adapters](../docs/public/concepts/glossary.md#fw-adapter) for A2UI renderer.
+
+| Package | Framework |
+|---------|-----------|
+| `web_core/` | Shared protocol/state (`@a2ui/web_core`) |
+| `react/` | React DOM |
+| `lit/` | Lit / Web Components |
+| `angular/` | Angular |
+| `ink/` | Ink (terminal / CLI) |
+| `markdown/` | Markdown helpers |
+| `flutter/` | Pointer to Flutter GenUI |

--- a/renderers/ink/.prettierignore
+++ b/renderers/ink/.prettierignore
@@ -1,0 +1,2 @@
+dist
+.wireit

--- a/renderers/ink/README.md
+++ b/renderers/ink/README.md
@@ -1,0 +1,101 @@
+# @a2ui/ink
+
+Ink (terminal) renderer for [A2UI](https://a2ui.org/) v0.9.x.
+
+Reuses `@a2ui/web_core` for protocol / state / binding. This package maps the
+**basic catalog** onto [Ink](https://github.com/vadimdemedes/ink) widgets.
+
+## Catalog coverage
+
+| Component                   | Terminal mapping                                                                                      |
+| --------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Text                        | Ink `Text`; variants via bold/underline/color; Markdown markers stripped (no MD renderer in terminal) |
+| Row / Column / List         | `Box` flex layouts; `justify`/`align` and child `weight` (flex-grow) honored                          |
+| Card / Divider              | bordered container / full-width rule                                                                  |
+| Button                      | focus + Enter/Space; `primary` green+bold, `borderless` underlined link style                         |
+| CheckBox / ChoicePicker     | focus + Enter/Space; `chips` displayStyle, filterable options, validation errors                      |
+| TextField / DateTimeInput   | focus + type; `number`/ISO input filtering, `obscured` masking, format hints, validation errors       |
+| Slider / Tabs               | focus + ←/→; slider honors `step`                                                                     |
+| Modal                       | focus trigger row, Enter/Space opens inline, Esc closes                                               |
+| Icon                        | glyph map covering the full catalog icon set                                                          |
+| Image / Video / AudioPlayer | framed placeholders sized by variant (no media in terminal)                                           |
+
+Interaction is **keyboard selection**, not pointer click (Tab focus → activate).
+
+## Setup
+
+```bash
+yarn install
+yarn workspace @a2ui/ink build
+```
+
+## Demo (all official examples)
+
+```bash
+cd renderers/ink
+yarn demo --list                 # list example ids
+yarn demo 00_simple-text
+yarn demo 19_software-purchase
+yarn demo 34_child-list-template
+yarn demo 36_modal
+```
+
+Partial names work (`yarn demo software-purchase`).
+
+## Explorer (gallery)
+
+Interactive terminal gallery — list / filter / preview all official examples,
+with a message stepper and data-model inspector (like React's `a2ui_explorer`):
+
+```bash
+cd renderers/ink
+yarn explorer
+yarn explorer 32_advanced-form
+```
+
+Keys: ↑/↓ Enter to open · `/` filter · in preview Ctrl+S step messages ·
+Ctrl+D data model · Ctrl+L back to list. See [explorer/README.md](explorer/README.md).
+
+## Live demo (same agent as React shell)
+
+Uses the [Restaurant Finder Agent](../../samples/agent/adk/restaurant_finder/)
+over A2A — the same backend as `samples/client/react/shell`.
+
+**Mock (no agent / no API key):**
+
+```bash
+cd renderers/ink
+yarn demo:live --mock --auto
+```
+
+**Live agent:**
+
+```bash
+# Terminal 1 — start the agent (needs GEMINI_API_KEY in .env)
+cd samples/agent/adk/restaurant_finder
+uv run .
+
+# Terminal 2 — Ink client
+cd renderers/ink
+yarn demo:live --auto
+# or: yarn demo:live --auto "Find sushi near me"
+```
+
+Keys: type a query + Enter to send; after the UI renders, Tab/Enter to interact;
+Ctrl+N for a new query (Esc cancels back to the UI); Ctrl+C to quit. Override
+agent URL with `--url` or `$A2A_AGENT_URL`.
+
+## Usage
+
+```tsx
+import {render} from 'ink';
+import {MessageProcessor} from '@a2ui/web_core/v0_9';
+import {A2uiSurface, basicCatalog} from '@a2ui/ink/v0_9';
+
+const processor = new MessageProcessor([basicCatalog], async action => {
+  console.log(action);
+});
+processor.processMessages(messages);
+const surface = [...processor.model.surfacesMap.values()][0]!;
+render(<A2uiSurface surface={surface} />);
+```

--- a/renderers/ink/demo/a2a-client.ts
+++ b/renderers/ink/demo/a2a-client.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {randomUUID} from 'node:crypto';
+import {A2AClient} from '@a2a-js/sdk/client';
+import type {MessageSendParams, Part} from '@a2a-js/sdk';
+import type {A2uiMessage, A2uiClientMessage} from '@a2ui/web_core/v0_9';
+
+const A2UI_MIME_TYPE = 'application/a2ui+json';
+const A2UI_EXTENSION = 'https://a2ui.org/a2a-extension/a2ui/v0.9';
+
+const fetchWithExtension: typeof fetch = async (url, init) => {
+  const headers = new Headers(init?.headers);
+  headers.set('X-A2A-Extensions', A2UI_EXTENSION);
+  return fetch(url, {...init, headers});
+};
+
+/**
+ * Node A2A client that talks to the same restaurant-finder agent the React
+ * shell uses (default http://localhost:10002). Mirrors the Vite middleware in
+ * samples/client/react/shell/middleware/a2a.ts without needing the browser proxy.
+ */
+export class InkA2AClient {
+  private client: A2AClient | null = null;
+
+  constructor(private readonly agentBaseUrl: string) {}
+
+  private async getClient(): Promise<A2AClient> {
+    if (!this.client) {
+      const cardUrl = `${this.agentBaseUrl.replace(/\/$/, '')}/.well-known/agent-card.json`;
+      this.client = await A2AClient.fromCardUrl(cardUrl, {fetchImpl: fetchWithExtension});
+    }
+    return this.client;
+  }
+
+  async send(
+    message: A2uiClientMessage | string,
+    onChunk?: (messages: A2uiMessage[]) => void,
+  ): Promise<A2uiMessage[]> {
+    const sendParams = this.toSendParams(message);
+    const client = await this.getClient();
+    const stream = client.sendMessageStream(sendParams);
+
+    const allMessages: A2uiMessage[] = [];
+    // A2A status-update events redeliver createSurface on every chunk.
+    const seenSurfaceIds = new Set<string>();
+
+    for await (const chunk of stream) {
+      let parts: Part[] | undefined;
+      if (chunk.kind === 'status-update' && chunk.status.message?.parts) {
+        parts = chunk.status.message.parts;
+      } else if (chunk.kind === 'message' && chunk.parts) {
+        parts = chunk.parts;
+      }
+      if (!parts) continue;
+
+      const chunkMessages: A2uiMessage[] = [];
+      for (const part of parts) {
+        if (part.kind === 'data' && part.data) {
+          const uiMessage = part.data as unknown as A2uiMessage;
+          const createSurface = (uiMessage as {createSurface?: {surfaceId: string}}).createSurface;
+          if (createSurface) {
+            if (seenSurfaceIds.has(createSurface.surfaceId)) continue;
+            seenSurfaceIds.add(createSurface.surfaceId);
+          }
+          chunkMessages.push(uiMessage);
+        }
+      }
+      if (chunkMessages.length > 0) {
+        allMessages.push(...chunkMessages);
+        onChunk?.(chunkMessages);
+      }
+    }
+
+    return allMessages;
+  }
+
+  private toSendParams(message: A2uiClientMessage | string): MessageSendParams {
+    if (typeof message === 'string') {
+      return {
+        message: {
+          messageId: randomUUID(),
+          role: 'user',
+          parts: [{kind: 'text', text: message}],
+          kind: 'message',
+        },
+      };
+    }
+    return {
+      message: {
+        messageId: randomUUID(),
+        role: 'user',
+        parts: [
+          {
+            kind: 'data',
+            data: message as unknown as Record<string, unknown>,
+            mimeType: A2UI_MIME_TYPE,
+          } as Part,
+        ],
+        kind: 'message',
+      },
+    };
+  }
+}

--- a/renderers/ink/demo/live.tsx
+++ b/renderers/ink/demo/live.tsx
@@ -1,0 +1,312 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {render, Box, Text, useInput, useApp} from 'ink';
+import {
+  MessageProcessor,
+  type A2uiClientMessage,
+  type A2uiMessage,
+  type SurfaceModel,
+} from '@a2ui/web_core/v0_9';
+import {A2uiSurface, basicCatalog, type InkComponentImplementation} from '../src/v0_9/index.js';
+import {InkA2AClient} from './a2a-client.js';
+import {
+  createRestaurantListMessages,
+  createBookingFormMessages,
+  createConfirmationMessages,
+} from '../../../samples/client/react/shell/src/mock/restaurantMessages.js';
+
+const DEFAULT_AGENT = process.env['A2A_AGENT_URL'] ?? 'http://localhost:10002';
+const DEFAULT_QUERY = 'Find Chinese restaurants in New York';
+
+function parseArgs(argv: string[]) {
+  const mock = argv.includes('--mock');
+  const auto = argv.includes('--auto');
+  const urlIdx = argv.indexOf('--url');
+  const url = urlIdx >= 0 ? argv[urlIdx + 1] : DEFAULT_AGENT;
+  const queryArg = argv.find((a, i) => !a.startsWith('--') && !(urlIdx >= 0 && i === urlIdx + 1));
+  return {mock, auto, url: url ?? DEFAULT_AGENT, initialQuery: queryArg};
+}
+
+function getMockResponse(message: A2uiClientMessage | string): A2uiMessage[] {
+  if (typeof message === 'object' && 'action' in message) {
+    const action = message.action;
+    const context = action.context || {};
+    if (action.name === 'book_restaurant') {
+      return createBookingFormMessages(
+        String(context.restaurantName || 'Restaurant'),
+        String(context.imageUrl || ''),
+        String(context.address || ''),
+      );
+    }
+    if (action.name === 'submit_booking') {
+      return createConfirmationMessages(
+        String(context.restaurantName || 'Restaurant'),
+        String(context.partySize || '2'),
+        String(context.reservationTime || ''),
+        String(context.dietary || ''),
+        String(context.imageUrl || ''),
+      );
+    }
+  }
+  return createRestaurantListMessages();
+}
+
+/** Minimal text prompt for the query line (active when not disabled). */
+function Prompt({
+  value,
+  onChange,
+  onSubmit,
+  disabled,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+  disabled: boolean;
+}) {
+  useInput(
+    (input, key) => {
+      if (key.return) {
+        onSubmit();
+        return;
+      }
+      if (key.backspace || key.delete) {
+        onChange(value.slice(0, -1));
+        return;
+      }
+      if (key.ctrl || key.meta || key.tab || key.upArrow || key.downArrow) return;
+      if (input) onChange(value + input);
+    },
+    {isActive: !disabled},
+  );
+
+  return (
+    <Box borderStyle="single" borderColor={disabled ? 'gray' : 'cyan'} paddingX={1}>
+      <Text color={disabled ? 'gray' : 'white'}>
+        {value}
+        {!disabled ? <Text color="cyan">█</Text> : null}
+      </Text>
+    </Box>
+  );
+}
+
+function LiveApp({
+  mock,
+  agentUrl,
+  initialQuery,
+  auto,
+}: {
+  mock: boolean;
+  agentUrl: string;
+  initialQuery?: string;
+  auto: boolean;
+}) {
+  const {exit} = useApp();
+  const [query, setQuery] = useState(initialQuery ?? DEFAULT_QUERY);
+  const [requesting, setRequesting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState(
+    mock ? 'mock mode — press Enter to send' : `agent ${agentUrl}`,
+  );
+  const [surfaces, setSurfaces] = useState<SurfaceModel<InkComponentImplementation>[]>([]);
+  const [actions, setActions] = useState<string[]>([]);
+  // When surfaces are showing, Tab focuses UI widgets; prompt is inactive
+  // until Ctrl+N opens a new query.
+  const [promptActive, setPromptActive] = useState(true);
+
+  const client = useMemo(() => (mock ? null : new InkA2AClient(agentUrl)), [mock, agentUrl]);
+  const sendRef = useRef<((message: A2uiClientMessage | string) => Promise<void>) | null>(null);
+
+  const processor = useMemo(
+    () =>
+      new MessageProcessor<InkComponentImplementation>([basicCatalog], action => {
+        const line = `${action.name} ← ${action.sourceComponentId}`;
+        setActions(prev => [...prev.slice(-2), line]);
+        void sendRef.current?.({version: 'v0.9', action});
+      }),
+    [],
+  );
+
+  useEffect(() => {
+    const created = processor.onSurfaceCreated(surface => {
+      setSurfaces(prev => [...prev.filter(s => s.id !== surface.id), surface]);
+    });
+    const deleted = processor.onSurfaceDeleted(id => {
+      setSurfaces(prev => prev.filter(s => s.id !== id));
+    });
+    return () => {
+      created.unsubscribe();
+      deleted.unsubscribe();
+    };
+  }, [processor]);
+
+  const sendAndProcess = useCallback(
+    async (message: A2uiClientMessage | string) => {
+      try {
+        setRequesting(true);
+        setError(null);
+        setStatus(
+          typeof message === 'string'
+            ? `sending: ${message}`
+            : 'action' in message
+              ? `action: ${message.action.name}`
+              : 'sending client message',
+        );
+        setPromptActive(false);
+
+        const clearSurfaces = () => {
+          for (const id of processor.model.surfacesMap.keys()) {
+            processor.model.deleteSurface(id);
+          }
+          setSurfaces([]);
+        };
+
+        if (mock) {
+          await new Promise(r => setTimeout(r, 300));
+          const response = getMockResponse(message);
+          // Clear + apply synchronously so React never paints an empty frame.
+          clearSurfaces();
+          processor.processMessages(structuredClone(response));
+          setStatus(
+            'mock response ready — Tab focus · Enter activate · Ctrl+N new query · Ctrl+C quit',
+          );
+        } else {
+          clearSurfaces();
+          await client!.send(message, chunk => {
+            processor.processMessages(chunk);
+            setStatus(`streaming… ${processor.model.surfacesMap.size} surface(s)`);
+          });
+          setStatus('ready — Tab focus · Enter activate · Ctrl+N new query · Ctrl+C quit');
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setError(msg);
+        setStatus('error — fix agent / try --mock · Ctrl+C quit');
+        setPromptActive(true);
+      } finally {
+        setRequesting(false);
+      }
+    },
+    [client, mock, processor],
+  );
+
+  useEffect(() => {
+    sendRef.current = sendAndProcess;
+  }, [sendAndProcess]);
+
+  // Global keys: quit, or Ctrl+N for a new query (bare "n" would steal
+  // keystrokes from TextField / DateTimeInput on the booking form).
+  useInput((input, key) => {
+    if (key.ctrl && input === 'c') {
+      exit();
+      return;
+    }
+    if (!promptActive && !requesting && key.ctrl && (input === 'n' || input === 'N')) {
+      setPromptActive(true);
+      setStatus('type a new query, then Enter · Esc cancels back to UI');
+    }
+    if (promptActive && !requesting && key.escape && surfaces.length > 0) {
+      setPromptActive(false);
+      setStatus('ready — Tab focus · Enter activate · Ctrl+N new query · Ctrl+C quit');
+    }
+  });
+
+  // Auto-send on launch when --auto or an explicit query arg is given.
+  const autoSent = useRef(false);
+  useEffect(() => {
+    if (autoSent.current) return;
+    if (!auto && initialQuery === undefined) return;
+    autoSent.current = true;
+    void sendAndProcess(initialQuery ?? DEFAULT_QUERY);
+  }, [auto, initialQuery, sendAndProcess]);
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="magenta">
+        A2UI Ink — Restaurant Finder {mock ? '(mock)' : '(live)'}
+      </Text>
+      <Text dimColor>{status}</Text>
+
+      {promptActive ? (
+        <Box flexDirection="column" marginY={1} gap={1}>
+          <Text dimColor>Query (Enter to send):</Text>
+          <Prompt
+            value={query}
+            onChange={setQuery}
+            disabled={requesting}
+            onSubmit={() => {
+              if (!query.trim() || requesting) return;
+              void sendAndProcess(query.trim());
+            }}
+          />
+        </Box>
+      ) : null}
+
+      {requesting ? <Text color="yellow">⏳ waiting for agent…</Text> : null}
+      {error ? <Text color="red">✗ {error}</Text> : null}
+
+      {!promptActive
+        ? surfaces.map(surface => (
+            <Box
+              key={surface.id}
+              marginTop={1}
+              borderStyle="round"
+              borderColor="gray"
+              padding={1}
+              flexDirection="column"
+            >
+              <A2uiSurface surface={surface} />
+            </Box>
+          ))
+        : null}
+
+      {actions.length > 0 ? (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold dimColor>
+            actions:
+          </Text>
+          {actions.map((line, i) => (
+            <Text key={`${i}-${line}`} color="yellow">
+              ⚡ {line}
+            </Text>
+          ))}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+const {mock, auto, url, initialQuery} = parseArgs(process.argv.slice(2));
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  console.log(`Usage: yarn demo:live [--mock] [--url http://localhost:10002] [--auto] [query]
+
+  --mock   Use React shell restaurant mock messages (no agent needed)
+  --url    Agent base URL (default: ${DEFAULT_AGENT} or $A2A_AGENT_URL)
+  --auto   Send the default/given query immediately
+  query    Optional initial query text
+
+Examples:
+  yarn demo:live --mock --auto
+  yarn demo:live --auto "Find sushi near me"
+  # Start agent first: cd samples/agent/adk/restaurant_finder && uv run .
+  yarn demo:live --auto
+`);
+  process.exit(0);
+}
+
+render(<LiveApp mock={mock} agentUrl={url} initialQuery={initialQuery} auto={auto} />);

--- a/renderers/ink/demo/run.tsx
+++ b/renderers/ink/demo/run.tsx
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {useMemo, useState} from 'react';
+import {render, Box, Text} from 'ink';
+import {readFileSync, readdirSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import {dirname, join, basename} from 'node:path';
+import {MessageProcessor} from '@a2ui/web_core/v0_9';
+import {A2uiSurface, basicCatalog, type InkComponentImplementation} from '../src/v0_9/index.js';
+
+type Messages = Parameters<MessageProcessor<InkComponentImplementation>['processMessages']>[0];
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const examplesDir = join(__dirname, '../../../specification/v0_9_1/catalogs/basic/examples');
+
+function listExamples(): string[] {
+  return readdirSync(examplesDir)
+    .filter(f => f.endsWith('.json'))
+    .map(f => basename(f, '.json'))
+    .sort();
+}
+
+function resolveExampleFile(name: string): string {
+  const files = readdirSync(examplesDir).filter(f => f.endsWith('.json'));
+  const exact = files.find(f => basename(f, '.json') === name);
+  if (exact) return exact;
+  const partial = files.find(f => basename(f, '.json').includes(name));
+  if (partial) return partial;
+  throw new Error(
+    `Unknown example "${name}".\nAvailable:\n${listExamples()
+      .map(e => `  - ${e}`)
+      .join('\n')}`,
+  );
+}
+
+function loadExample(name: string): {name: string; messages: Messages} {
+  const file = resolveExampleFile(name);
+  const raw = JSON.parse(readFileSync(join(examplesDir, file), 'utf8'));
+  return {name: (raw.name as string) ?? file, messages: raw.messages as Messages};
+}
+
+function App({exampleName}: {exampleName: string}) {
+  const [actions, setActions] = useState<string[]>([]);
+
+  const {name, surface} = useMemo(() => {
+    const example = loadExample(exampleName);
+    const processor = new MessageProcessor<InkComponentImplementation>(
+      [basicCatalog],
+      async action => {
+        const line = `${new Date().toLocaleTimeString()} ${action.name} ← ${action.sourceComponentId}`;
+        setActions(prev => [...prev.slice(-2), line]);
+      },
+    );
+    processor.processMessages(structuredClone(example.messages));
+    const surface = [...processor.model.surfacesMap.values()][0];
+    if (!surface) {
+      throw new Error('No surface created from example messages');
+    }
+    return {name: example.name, surface};
+  }, [exampleName]);
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="magenta">
+        A2UI Ink — {name}
+      </Text>
+      <Text dimColor>
+        Tab focus · Enter/Space activate · ←/→ tabs/slider · Esc modal · Ctrl+C quit
+      </Text>
+      <Box marginTop={1} borderStyle="round" borderColor="gray" padding={1} flexDirection="column">
+        <A2uiSurface surface={surface} />
+      </Box>
+      {actions.length > 0 ? (
+        <Box flexDirection="column">
+          <Text bold dimColor>
+            actions dispatched to agent:
+          </Text>
+          {actions.map(line => (
+            <Text key={line} color="yellow">
+              ⚡ {line}
+            </Text>
+          ))}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+const arg = process.argv[2];
+if (!arg || arg === '--list' || arg === 'list') {
+  console.log(listExamples().join('\n'));
+  process.exit(0);
+}
+
+render(<App exampleName={arg} />);

--- a/renderers/ink/eslint.config.mjs
+++ b/renderers/ink/eslint.config.mjs
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import preset from '../../eslint.preset.mjs';
+import reactHooks from 'eslint-plugin-react-hooks';
+
+export default [
+  ...preset,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    plugins: {'react-hooks': reactHooks},
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+    },
+  },
+];

--- a/renderers/ink/explorer/App.tsx
+++ b/renderers/ink/explorer/App.tsx
@@ -1,0 +1,376 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {Box, Text, useInput, useApp, useStdout} from 'ink';
+import {MessageProcessor, type A2uiClientAction, type SurfaceModel} from '@a2ui/web_core/v0_9';
+import {A2uiSurface, basicCatalog, type InkComponentImplementation} from '../src/v0_9/index.js';
+import {type ExampleItem, findExample, loadExamples} from './examples.js';
+
+type Mode = 'list' | 'preview';
+
+interface LogEntry {
+  time: string;
+  name: string;
+  source: string;
+}
+
+function DataModelPanel({surface}: {surface: SurfaceModel<InkComponentImplementation>}) {
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const sub = surface.dataModel.subscribe('/', () => setTick(t => t + 1));
+    return () => sub.unsubscribe();
+  }, [surface]);
+  void tick;
+  const json = JSON.stringify(surface.dataModel.get('/'), null, 2);
+  const lines = json.split('\n');
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="single"
+      borderColor="yellow"
+      paddingX={1}
+      marginTop={1}
+    >
+      <Text bold color="yellow">
+        data model — {surface.id}
+      </Text>
+      {lines.slice(0, 16).map((line, i) => (
+        <Text key={i} dimColor>
+          {line}
+        </Text>
+      ))}
+      {lines.length > 16 ? <Text dimColor>… ({lines.length - 16} more lines)</Text> : null}
+    </Box>
+  );
+}
+
+function createProcessor(
+  onAction: (action: A2uiClientAction) => void,
+): MessageProcessor<InkComponentImplementation> {
+  return new MessageProcessor<InkComponentImplementation>([basicCatalog], async action => {
+    onAction(action as A2uiClientAction);
+  });
+}
+
+export function ExplorerApp({initialId}: {initialId?: string}) {
+  const {exit} = useApp();
+  const {stdout} = useStdout();
+  const allExamples = useMemo(() => loadExamples(), []);
+
+  const initialIndex = useMemo(() => {
+    if (!initialId) return 0;
+    const hit = findExample(allExamples, initialId);
+    return hit ? allExamples.indexOf(hit) : 0;
+  }, [allExamples, initialId]);
+
+  const [mode, setMode] = useState<Mode>(initialId ? 'preview' : 'list');
+  const [filter, setFilter] = useState('');
+  const [filtering, setFiltering] = useState(false);
+  const [selected, setSelected] = useState(initialIndex);
+  const [showData, setShowData] = useState(false);
+  const [showActions, setShowActions] = useState(true);
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [messageIndex, setMessageIndex] = useState(-1);
+  const [surfaces, setSurfaces] = useState<SurfaceModel<InkComponentImplementation>[]>([]);
+
+  const processorRef = useRef<MessageProcessor<InkComponentImplementation> | null>(null);
+  const [, bump] = useState(0);
+  const forceRender = () => bump(n => n + 1);
+
+  const logAction = useCallback((action: A2uiClientAction) => {
+    setLogs(l => [
+      ...l.slice(-20),
+      {
+        time: new Date().toLocaleTimeString(),
+        name: action.name,
+        source: action.sourceComponentId,
+      },
+    ]);
+  }, []);
+
+  const syncSurfaces = useCallback(() => {
+    const p = processorRef.current;
+    setSurfaces(p ? [...p.model.surfacesMap.values()] : []);
+  }, []);
+
+  const disposeProcessor = useCallback(() => {
+    processorRef.current?.model.dispose();
+    processorRef.current = null;
+    setSurfaces([]);
+  }, []);
+
+  const filtered = useMemo(() => {
+    if (!filter) return allExamples;
+    const q = filter.toLowerCase();
+    return allExamples.filter(
+      e => e.id.toLowerCase().includes(q) || e.title.toLowerCase().includes(q),
+    );
+  }, [allExamples, filter]);
+
+  const safeSelected = Math.min(selected, Math.max(0, filtered.length - 1));
+  const currentExample: ExampleItem | undefined = filtered[safeSelected];
+
+  const loadExample = useCallback(
+    (example: ExampleItem, advanceToEnd: boolean) => {
+      disposeProcessor();
+      const p = createProcessor(logAction);
+      processorRef.current = p;
+      setLogs([]);
+      if (advanceToEnd) {
+        p.processMessages(structuredClone(example.messages));
+        setMessageIndex(example.messages.length - 1);
+      } else {
+        setMessageIndex(-1);
+      }
+      syncSurfaces();
+      forceRender();
+    },
+    [disposeProcessor, logAction, syncSurfaces],
+  );
+
+  // Keep surface list in sync for the active processor.
+  useEffect(() => {
+    const p = processorRef.current;
+    if (!p || mode !== 'preview') return;
+    syncSurfaces();
+    const c = p.onSurfaceCreated(() => syncSurfaces());
+    const d = p.onSurfaceDeleted(() => syncSurfaces());
+    return () => {
+      c.unsubscribe();
+      d.unsubscribe();
+    };
+  }, [mode, messageIndex, syncSurfaces]);
+
+  // Boot into preview when launched with an id
+  const booted = useRef(false);
+  useEffect(() => {
+    if (booted.current) return;
+    if (!initialId) return;
+    const hit = findExample(allExamples, initialId) ?? allExamples[initialIndex];
+    if (!hit) return;
+    booted.current = true;
+    loadExample(hit, true);
+    setMode('preview');
+  }, [allExamples, initialId, initialIndex, loadExample]);
+
+  useEffect(() => () => disposeProcessor(), [disposeProcessor]);
+
+  const stepMessage = useCallback(() => {
+    const example = currentExample;
+    const p = processorRef.current;
+    if (!example || !p) return;
+    const next = messageIndex + 1;
+    if (next >= example.messages.length) return;
+    p.processMessages(structuredClone([example.messages[next]!]));
+    setMessageIndex(next);
+    syncSurfaces();
+  }, [currentExample, messageIndex, syncSurfaces]);
+
+  useInput((input, key) => {
+    if (key.ctrl && input === 'c') {
+      exit();
+      return;
+    }
+
+    if (mode === 'list') {
+      if (filtering) {
+        if (key.escape) {
+          setFiltering(false);
+          setFilter('');
+          setSelected(0);
+          return;
+        }
+        if (key.return) {
+          setFiltering(false);
+          return;
+        }
+        if (key.backspace || key.delete) {
+          setFilter(f => f.slice(0, -1));
+          setSelected(0);
+          return;
+        }
+        if (key.upArrow) {
+          setSelected(i => Math.max(0, i - 1));
+          return;
+        }
+        if (key.downArrow) {
+          setSelected(i => Math.min(filtered.length - 1, i + 1));
+          return;
+        }
+        if (!key.ctrl && !key.meta && input) {
+          setFilter(f => f + input);
+          setSelected(0);
+        }
+        return;
+      }
+
+      if (input === '/') {
+        setFiltering(true);
+        return;
+      }
+      if (input === 'q' || input === 'Q') {
+        exit();
+        return;
+      }
+      if (key.upArrow) {
+        setSelected(i => Math.max(0, i - 1));
+        return;
+      }
+      if (key.downArrow) {
+        setSelected(i => Math.min(filtered.length - 1, i + 1));
+        return;
+      }
+      if (key.return && currentExample) {
+        loadExample(currentExample, true);
+        setMode('preview');
+      }
+      return;
+    }
+
+    // preview: Ctrl-only chords so TextField typing is never stolen
+    if (key.ctrl && (input === 'l' || input === 'L')) {
+      disposeProcessor();
+      setMessageIndex(-1);
+      setMode('list');
+      return;
+    }
+    if (key.ctrl && (input === 's' || input === 'S')) {
+      if (!processorRef.current && currentExample) {
+        loadExample(currentExample, false);
+      }
+      stepMessage();
+      return;
+    }
+    if (key.ctrl && (input === 'r' || input === 'R')) {
+      if (currentExample) loadExample(currentExample, true);
+      return;
+    }
+    if (key.ctrl && (input === 'x' || input === 'X')) {
+      if (currentExample) loadExample(currentExample, false);
+      return;
+    }
+    if (key.ctrl && (input === 'd' || input === 'D')) {
+      setShowData(v => !v);
+      return;
+    }
+    if (key.ctrl && (input === 'a' || input === 'A')) {
+      setShowActions(v => !v);
+    }
+  });
+
+  const listHeight = Math.max(8, (stdout?.rows ?? 24) - 10);
+  const start = Math.max(
+    0,
+    Math.min(safeSelected - Math.floor(listHeight / 2), filtered.length - listHeight),
+  );
+  const visible = filtered.slice(start, start + listHeight);
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="magenta">
+        A2UI Ink Explorer
+      </Text>
+
+      {mode === 'list' ? (
+        <Box flexDirection="column" marginTop={1}>
+          <Box borderStyle="single" borderColor={filtering ? 'cyan' : 'gray'} paddingX={1}>
+            <Text dimColor={!filtering}>filter: </Text>
+            <Text color={filtering ? 'white' : 'gray'}>
+              {filter || (filtering ? '' : '(press / to filter)')}
+              {filtering ? <Text color="cyan">█</Text> : null}
+            </Text>
+          </Box>
+          <Box flexDirection="column" marginTop={1}>
+            {visible.map((item, i) => {
+              const index = start + i;
+              const active = index === safeSelected;
+              return (
+                <Box key={item.id}>
+                  <Text inverse={active} color={active ? 'cyan' : undefined} bold={active}>
+                    {active ? '▸ ' : '  '}
+                    {item.id}
+                  </Text>
+                  <Text dimColor> {item.title}</Text>
+                </Box>
+              );
+            })}
+          </Box>
+          <Box marginTop={1}>
+            <Text dimColor>
+              {filtered.length}/{allExamples.length} · ↑/↓ · Enter open · / filter · q quit
+            </Text>
+          </Box>
+        </Box>
+      ) : currentExample ? (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold>{currentExample.title}</Text>
+          {currentExample.description ? <Text dimColor>{currentExample.description}</Text> : null}
+          <Text dimColor>
+            msg {messageIndex + 1}/{currentExample.messages.length} · Ctrl+S step · Ctrl+X reset ·
+            Ctrl+R apply-all · Ctrl+D data · Ctrl+A actions · Ctrl+L list
+          </Text>
+
+          <Box marginTop={1} flexDirection="column">
+            {surfaces.length === 0 ? (
+              <Text color="yellow">No surface yet — Ctrl+S to apply the next message</Text>
+            ) : (
+              surfaces.map(surface => (
+                <Box
+                  key={surface.id}
+                  flexDirection="column"
+                  borderStyle="round"
+                  borderColor="gray"
+                  padding={1}
+                  marginBottom={1}
+                >
+                  <A2uiSurface surface={surface} />
+                </Box>
+              ))
+            )}
+          </Box>
+
+          {showData ? surfaces.map(s => <DataModelPanel key={`data-${s.id}`} surface={s} />) : null}
+
+          {showActions ? (
+            <Box
+              flexDirection="column"
+              borderStyle="single"
+              borderColor="green"
+              paddingX={1}
+              marginTop={1}
+            >
+              <Text bold color="green">
+                actions
+              </Text>
+              {logs.length === 0 ? (
+                <Text dimColor>(none yet)</Text>
+              ) : (
+                logs.slice(-5).map((log, i) => (
+                  <Text key={`${i}-${log.time}-${log.name}`} color="yellow">
+                    ⚡ {log.time} {log.name} ← {log.source}
+                  </Text>
+                ))
+              )}
+            </Box>
+          ) : null}
+        </Box>
+      ) : (
+        <Text color="red">No example selected</Text>
+      )}
+    </Box>
+  );
+}

--- a/renderers/ink/explorer/README.md
+++ b/renderers/ink/explorer/README.md
@@ -1,0 +1,32 @@
+# A2UI Ink Explorer
+
+Terminal gallery for `@a2ui/ink` — the CLI counterpart of
+[`renderers/react/a2ui_explorer`](../../react/a2ui_explorer).
+
+Loads every official example under
+`specification/v0_9_1/catalogs/basic/examples/`.
+
+## Run
+
+```bash
+cd renderers/ink
+yarn explorer                 # browse list
+yarn explorer 32_advanced     # jump to a matching example
+yarn explorer --help
+```
+
+## Features
+
+| Feature              | How                                                      |
+| -------------------- | -------------------------------------------------------- |
+| Example browser      | ↑/↓ + Enter                                              |
+| Filter               | `/` then type                                            |
+| Live preview         | Renders with `A2uiSurface`                               |
+| Message stepper      | Ctrl+S applies the next JSON message (progressive build) |
+| Reset / apply-all    | Ctrl+X / Ctrl+R                                          |
+| Data model inspector | Ctrl+D                                                   |
+| Action log           | Ctrl+A (on by default)                                   |
+| Back to list         | Ctrl+L                                                   |
+
+Preview shortcuts are **Ctrl-chords only**, so they never steal keystrokes from
+TextField / DateTimeInput.

--- a/renderers/ink/explorer/examples.ts
+++ b/renderers/ink/explorer/examples.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {readFileSync, readdirSync} from 'node:fs';
+import {dirname, join, basename} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import type {A2uiMessage} from '@a2ui/web_core/v0_9';
+
+export interface ExampleItem {
+  id: string;
+  title: string;
+  description: string;
+  messages: A2uiMessage[];
+}
+
+const examplesDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../specification/v0_9_1/catalogs/basic/examples',
+);
+
+export function loadExamples(): ExampleItem[] {
+  return readdirSync(examplesDir)
+    .filter(f => f.endsWith('.json'))
+    .sort()
+    .map(file => {
+      const raw = JSON.parse(readFileSync(join(examplesDir, file), 'utf8')) as {
+        name?: string;
+        description?: string;
+        messages: A2uiMessage[];
+      };
+      const id = basename(file, '.json');
+      return {
+        id,
+        title: raw.name ?? id,
+        description: raw.description ?? '',
+        messages: raw.messages,
+      };
+    });
+}
+
+export function findExample(examples: ExampleItem[], query: string): ExampleItem | undefined {
+  const exact = examples.find(e => e.id === query);
+  if (exact) return exact;
+  return examples.find(
+    e => e.id.includes(query) || e.title.toLowerCase().includes(query.toLowerCase()),
+  );
+}

--- a/renderers/ink/explorer/run.tsx
+++ b/renderers/ink/explorer/run.tsx
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {render} from 'ink';
+import {ExplorerApp} from './App.js';
+
+const arg = process.argv[2];
+if (arg === '--help' || arg === '-h') {
+  console.log(`Usage: yarn explorer [example-id]
+
+Interactive gallery for the Ink renderer (terminal counterpart of
+renderers/react/a2ui_explorer).
+
+  yarn explorer                 # browse all official examples
+  yarn explorer 32_advanced     # open a matching example immediately
+
+Keys (list):   ↑/↓  Enter  / filter  q quit
+Keys (preview): Tab/Enter interact with UI
+               Ctrl+S step next message
+               Ctrl+X reset (no messages)
+               Ctrl+R apply all messages
+               Ctrl+D toggle data model
+               Ctrl+A toggle action log
+               Ctrl+L back to list
+`);
+  process.exit(0);
+}
+
+render(<ExplorerApp initialId={arg} />);

--- a/renderers/ink/package.json
+++ b/renderers/ink/package.json
@@ -1,0 +1,106 @@
+{
+  "name": "@a2ui/ink",
+  "version": "0.1.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "description": "Ink (CLI) renderer for A2UI (Agent-to-User Interface)",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./v0_9": {
+      "import": {
+        "types": "./dist/v0_9/index.d.ts",
+        "default": "./dist/v0_9/index.js"
+      },
+      "require": {
+        "types": "./dist/v0_9/index.d.cts",
+        "default": "./dist/v0_9/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "wireit",
+    "demo": "tsx demo/run.tsx",
+    "demo:list": "tsx demo/run.tsx --list",
+    "demo:live": "tsx demo/live.tsx",
+    "explorer": "tsx explorer/run.tsx",
+    "test": "wireit",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "clean": "wireit",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@a2ui/web_core": "workspace:*",
+    "zod": "^3.25.76"
+  },
+  "peerDependencies": {
+    "ink": "^6.0.0",
+    "react": "^19.2.7",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@a2a-js/sdk": "^0.3.13",
+    "@eslint/js": "^10.0.1",
+    "@types/node": "^25.9.3",
+    "@types/react": "^19.2.17",
+    "eslint": "^10.4.1",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "globals": "^17.6.0",
+    "ink": "^6.5.0",
+    "prettier": "^3.8.4",
+    "react": "^19.2.7",
+    "tsup": "^8.5.1",
+    "tsx": "^4.22.4",
+    "typescript": "5.9.3",
+    "typescript-eslint": "^8.61.0",
+    "wireit": "^0.15.0-pre.2"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "wireit": {
+    "build": {
+      "command": "tsup",
+      "dependencies": [
+        "../web_core:build"
+      ],
+      "files": [
+        "src/**/*",
+        "tsconfig.json",
+        "tsup.config.ts"
+      ],
+      "output": [
+        "dist/"
+      ]
+    },
+    "test": {
+      "command": "tsx --test src/v0_9/smoke.test.ts",
+      "dependencies": [
+        "build"
+      ]
+    },
+    "clean": {
+      "command": "rm -rf dist .tsbuildinfo .wireit"
+    }
+  }
+}

--- a/renderers/ink/src/index.ts
+++ b/renderers/ink/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './v0_9/index.js';

--- a/renderers/ink/src/v0_9/A2uiSurface.tsx
+++ b/renderers/ink/src/v0_9/A2uiSurface.tsx
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {useSyncExternalStore, memo, useMemo, useCallback} from 'react';
+import {Text} from 'ink';
+import {type SurfaceModel, ComponentContext, type ComponentModel} from '@a2ui/web_core/v0_9';
+import type {InkComponentImplementation} from './adapter.js';
+
+const ResolvedChild = memo(
+  ({
+    surface,
+    id,
+    basePath,
+    compImpl,
+    componentModel,
+  }: {
+    surface: SurfaceModel<InkComponentImplementation>;
+    id: string;
+    basePath: string;
+    componentModel: ComponentModel;
+    compImpl: InkComponentImplementation;
+  }) => {
+    const ComponentToRender = compImpl.render;
+
+    const context = useMemo(
+      () => new ComponentContext(surface, id, basePath),
+      // componentModel triggers recreation when the model instance is replaced
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [surface, id, basePath, componentModel],
+    );
+
+    const buildChild = useCallback(
+      (childId: string, specificPath?: string) => {
+        const path = specificPath || context.dataContext.path;
+        return (
+          <DeferredChild
+            key={`${childId}-${path}`}
+            surface={surface}
+            id={childId}
+            basePath={path}
+          />
+        );
+      },
+      [surface, context.dataContext.path],
+    );
+
+    return <ComponentToRender context={context} buildChild={buildChild} />;
+  },
+);
+ResolvedChild.displayName = 'ResolvedChild';
+
+export const DeferredChild: React.FC<{
+  surface: SurfaceModel<InkComponentImplementation>;
+  id: string;
+  basePath: string;
+}> = memo(({surface, id, basePath}) => {
+  const store = useMemo(() => {
+    let version = 0;
+    return {
+      subscribe: (cb: () => void) => {
+        const unsub1 = surface.componentsModel.onCreated.subscribe(comp => {
+          if (comp.id === id) {
+            version++;
+            cb();
+          }
+        });
+        const unsub2 = surface.componentsModel.onDeleted.subscribe(delId => {
+          if (delId === id) {
+            version++;
+            cb();
+          }
+        });
+        return () => {
+          unsub1.unsubscribe();
+          unsub2.unsubscribe();
+        };
+      },
+      getSnapshot: () => {
+        const comp = surface.componentsModel.get(id);
+        return comp ? `${comp.type}-${version}` : `missing-${version}`;
+      },
+    };
+  }, [surface, id]);
+
+  useSyncExternalStore(store.subscribe, store.getSnapshot);
+
+  const componentModel = surface.componentsModel.get(id);
+
+  if (!componentModel) {
+    return <Text dimColor>[Loading {id}...]</Text>;
+  }
+
+  const compImpl = surface.catalog.components.get(componentModel.type);
+
+  if (!compImpl) {
+    return <Text color="red">Unknown component: {componentModel.type}</Text>;
+  }
+
+  return (
+    <ResolvedChild
+      surface={surface}
+      id={id}
+      basePath={basePath}
+      componentModel={componentModel}
+      compImpl={compImpl}
+    />
+  );
+});
+DeferredChild.displayName = 'DeferredChild';
+
+/** Root host: renders the surface starting at component id `root`. */
+export const A2uiSurface: React.FC<{surface: SurfaceModel<InkComponentImplementation>}> = ({
+  surface,
+}) => {
+  return <DeferredChild surface={surface} id="root" basePath="/" />;
+};

--- a/renderers/ink/src/v0_9/adapter.tsx
+++ b/renderers/ink/src/v0_9/adapter.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, {useRef, useSyncExternalStore, useCallback, memo, useEffect} from 'react';
+import React, {useMemo, useSyncExternalStore, useCallback, memo, useEffect} from 'react';
 import {type ComponentContext, GenericBinder} from '@a2ui/web_core/v0_9';
 import type {
   ComponentApi,
@@ -58,15 +58,10 @@ export function createComponentImplementation<Api extends ComponentApi>(
     context: ComponentContext;
     buildChild: (id: string, basePath?: string) => React.ReactNode;
   }> = ({context, buildChild}) => {
-    const bindingRef = useRef<GenericBinder<Props> | null>(null);
-
-    if (!bindingRef.current) {
-      bindingRef.current = new GenericBinder<Props>(context, api.schema);
-    } else if ((bindingRef.current as unknown as {context: ComponentContext}).context !== context) {
-      bindingRef.current.dispose();
-      bindingRef.current = new GenericBinder<Props>(context, api.schema);
-    }
-    const binding = bindingRef.current;
+    // DeferredChild memoizes `context`, so reference changes correspond to
+    // ComponentModel updates or base-path adjustments. Cleanup disposes the
+    // previous binder when this instance changes (or on unmount).
+    const binding = useMemo(() => new GenericBinder<Props>(context, api.schema), [context]);
 
     const subscribe = useCallback(
       (callback: () => void) => {

--- a/renderers/ink/src/v0_9/adapter.tsx
+++ b/renderers/ink/src/v0_9/adapter.tsx
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {useRef, useSyncExternalStore, useCallback, memo, useEffect} from 'react';
+import {type ComponentContext, GenericBinder} from '@a2ui/web_core/v0_9';
+import type {
+  ComponentApi,
+  InferredComponentApiSchemaType,
+  ResolveA2uiProps,
+} from '@a2ui/web_core/v0_9';
+
+export interface InkComponentImplementation extends ComponentApi {
+  /** The framework-specific rendering wrapper. */
+  render: React.FC<{
+    context: ComponentContext;
+    buildChild: (id: string, basePath?: string) => React.ReactNode;
+  }>;
+}
+
+export type InkA2uiComponentProps<T> = {
+  props: T;
+  buildChild: (id: string, basePath?: string) => React.ReactNode;
+  context: ComponentContext;
+};
+
+/**
+ * Creates an Ink component implementation using the deep generic binder.
+ */
+export function createComponentImplementation<Api extends ComponentApi>(
+  api: Api,
+  RenderComponent: React.FC<
+    InkA2uiComponentProps<ResolveA2uiProps<InferredComponentApiSchemaType<Api>>>
+  >,
+): InkComponentImplementation {
+  type Props = ResolveA2uiProps<InferredComponentApiSchemaType<Api>>;
+
+  const MemoizedRender = memo(RenderComponent, (prev, next) => {
+    if (prev.props !== next.props) return false;
+    if (prev.context.componentModel.id !== next.context.componentModel.id) return false;
+    if (prev.context.dataContext.path !== next.context.dataContext.path) return false;
+    return true;
+  });
+
+  const InkWrapper: React.FC<{
+    context: ComponentContext;
+    buildChild: (id: string, basePath?: string) => React.ReactNode;
+  }> = ({context, buildChild}) => {
+    const bindingRef = useRef<GenericBinder<Props> | null>(null);
+
+    if (!bindingRef.current) {
+      bindingRef.current = new GenericBinder<Props>(context, api.schema);
+    } else if ((bindingRef.current as unknown as {context: ComponentContext}).context !== context) {
+      bindingRef.current.dispose();
+      bindingRef.current = new GenericBinder<Props>(context, api.schema);
+    }
+    const binding = bindingRef.current;
+
+    const subscribe = useCallback(
+      (callback: () => void) => {
+        const sub = binding.subscribe(callback);
+        return () => sub.unsubscribe();
+      },
+      [binding],
+    );
+
+    const getSnapshot = useCallback(() => binding.snapshot, [binding]);
+    const props = useSyncExternalStore(subscribe, getSnapshot);
+
+    useEffect(() => {
+      return () => binding.dispose();
+    }, [binding]);
+
+    return (
+      <MemoizedRender props={props || ({} as Props)} buildChild={buildChild} context={context} />
+    );
+  };
+
+  return {
+    name: api.name,
+    schema: api.schema,
+    render: InkWrapper,
+  };
+}

--- a/renderers/ink/src/v0_9/catalog/basic/components/AudioPlayer.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/AudioPlayer.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Box, Text} from 'ink';
+import {createComponentImplementation} from '../../../adapter.js';
+import {AudioPlayerApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {weightProps} from '../utils.js';
+
+/** Audio playback is unavailable in a terminal; shows the description or URL as a placeholder. */
+export const AudioPlayer = createComponentImplementation(AudioPlayerApi, ({props}) => {
+  const desc =
+    typeof props.description === 'string' && props.description
+      ? props.description
+      : typeof props.url === 'string'
+        ? props.url
+        : '(no url)';
+  return (
+    <Box borderStyle="single" borderColor="gray" paddingX={1} {...weightProps(props.weight)}>
+      <Text dimColor wrap="truncate-end">
+        ♪ audio: {desc}
+      </Text>
+    </Box>
+  );
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/Button.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/Button.tsx
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Box, Text, useFocus, useInput} from 'ink';
+import {createComponentImplementation} from '../../../adapter.js';
+import {ButtonApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {weightProps} from '../utils.js';
+import {useInModalTrigger} from '../modal-trigger-context.js';
+
+/**
+ * Terminal button. Activate with Enter or Space while focused (Tab cycles
+ * focus). Variants:
+ * - default:    [ label ] in cyan
+ * - primary:    [ label ] in green (main call-to-action)
+ * - borderless: underline chrome, no brackets (link-like)
+ *
+ * When rendered as a Modal trigger, focus is owned by the Modal — this button
+ * stays visual-only so Tab doesn't register two stops.
+ *
+ * Note: `label` from buildChild is a component tree and must NOT be nested
+ * inside Ink <Text> (Text only allows strings / nested Text).
+ */
+export const Button = createComponentImplementation(ButtonApi, ({props, buildChild}) => {
+  const disabled = props.isValid === false;
+  const inModalTrigger = useInModalTrigger();
+  const borderless = props.variant === 'borderless';
+  const {isFocused} = useFocus({isActive: !disabled && !inModalTrigger});
+  const color = disabled ? 'gray' : props.variant === 'primary' ? 'green' : 'cyan';
+
+  useInput(
+    (input, key) => {
+      // Defense in depth: never fire while checks fail, even if focus leaked.
+      if (disabled) return;
+      if (key.return || input === ' ') {
+        props.action?.();
+      }
+    },
+    {isActive: isFocused && !disabled && !inModalTrigger},
+  );
+
+  const label = props.child ? buildChild(props.child) : <Text color={color}>Button</Text>;
+
+  return (
+    <Box {...weightProps(props.weight)}>
+      {borderless ? (
+        <Text inverse={isFocused} underline color={color} dimColor={disabled}>
+          {' '}
+        </Text>
+      ) : (
+        <Text
+          inverse={isFocused}
+          color={color}
+          dimColor={disabled}
+          bold={props.variant === 'primary'}
+        >
+          [{' '}
+        </Text>
+      )}
+      {label}
+      {borderless ? (
+        <Text inverse={isFocused} underline color={color} dimColor={disabled}>
+          {' '}
+        </Text>
+      ) : (
+        <Text
+          inverse={isFocused}
+          color={color}
+          dimColor={disabled}
+          bold={props.variant === 'primary'}
+        >
+          {' '}
+          ]
+        </Text>
+      )}
+    </Box>
+  );
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/Card.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/Card.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Box} from 'ink';
+import {createComponentImplementation} from '../../../adapter.js';
+import {CardApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {weightProps} from '../utils.js';
+
+export const Card = createComponentImplementation(CardApi, ({props, buildChild}) => {
+  return (
+    <Box
+      borderStyle="round"
+      borderColor="cyan"
+      paddingX={1}
+      paddingY={0}
+      flexDirection="column"
+      {...weightProps(props.weight)}
+    >
+      {props.child ? buildChild(props.child) : null}
+    </Box>
+  );
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/CheckBox.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/CheckBox.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Box, Text, useFocus, useInput} from 'ink';
+import {createComponentImplementation} from '../../../adapter.js';
+import {CheckBoxApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {weightProps} from '../utils.js';
+
+/** Terminal checkbox. Toggle with Enter or Space while focused. */
+export const CheckBox = createComponentImplementation(CheckBoxApi, ({props}) => {
+  const checked = !!props.value;
+  const {isFocused} = useFocus();
+  const errors = props.validationErrors ?? [];
+  const label = typeof props.label === 'string' ? props.label : String(props.label ?? '');
+
+  useInput(
+    (input, key) => {
+      if (key.return || input === ' ') {
+        props.setValue?.(!checked);
+      }
+    },
+    {isActive: isFocused},
+  );
+
+  return (
+    <Box flexDirection="column" {...weightProps(props.weight)}>
+      <Text inverse={isFocused} color={errors.length > 0 ? 'red' : checked ? 'green' : undefined}>
+        [{checked ? '✓' : ' '}] {label}
+      </Text>
+      {errors.map(error => (
+        <Text key={error} color="red">
+          ✗ {error}
+        </Text>
+      ))}
+    </Box>
+  );
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/ChildList.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/ChildList.tsx
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {type ComponentContext, type ComponentId} from '@a2ui/web_core/v0_9';
+
+type ResolvedChildRef =
+  | ComponentId
+  | {
+      id: ComponentId;
+      basePath: string;
+    };
+
+type ResolvedChildList = ResolvedChildRef[];
+
+export const ChildList: React.FC<{
+  childList: ResolvedChildList;
+  context: ComponentContext;
+  buildChild: (id: ComponentId, basePath?: string) => React.ReactNode;
+}> = ({childList, buildChild}) => {
+  if (!Array.isArray(childList)) return null;
+
+  return (
+    <>
+      {childList.map((childRef, index) => {
+        if (typeof childRef === 'string') {
+          return (
+            <React.Fragment key={`${childRef}-${index}`}>{buildChild(childRef)}</React.Fragment>
+          );
+        }
+
+        return (
+          <React.Fragment key={`${childRef.id}-${childRef.basePath}`}>
+            {buildChild(childRef.id, childRef.basePath)}
+          </React.Fragment>
+        );
+      })}
+    </>
+  );
+};

--- a/renderers/ink/src/v0_9/catalog/basic/components/ChildList.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/ChildList.tsx
@@ -36,6 +36,7 @@ export const ChildList: React.FC<{
   return (
     <>
       {childList.map((childRef, index) => {
+        if (!childRef) return null;
         if (typeof childRef === 'string') {
           return (
             <React.Fragment key={`${childRef}-${index}`}>{buildChild(childRef)}</React.Fragment>

--- a/renderers/ink/src/v0_9/catalog/basic/components/ChoicePicker.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/ChoicePicker.tsx
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {useState} from 'react';
+import {Box, Text, useFocus, useInput} from 'ink';
+import {createComponentImplementation} from '../../../adapter.js';
+import {ChoicePickerApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {weightProps} from '../utils.js';
+
+interface ResolvedOption {
+  label: unknown;
+  value: string;
+}
+
+function ChoiceOption({
+  label,
+  selected,
+  exclusive,
+  chips,
+  onToggle,
+}: {
+  label: string;
+  selected: boolean;
+  exclusive: boolean;
+  chips: boolean;
+  onToggle: () => void;
+}) {
+  const {isFocused} = useFocus();
+  useInput(
+    (input, key) => {
+      if (key.return || input === ' ') onToggle();
+    },
+    {isActive: isFocused},
+  );
+  if (chips) {
+    return (
+      <Text inverse={isFocused || selected} color={selected ? 'green' : 'cyan'}>
+        {' '}
+        {label}{' '}
+      </Text>
+    );
+  }
+  const mark = exclusive ? (selected ? '(•)' : '( )') : selected ? '[✓]' : '[ ]';
+  return (
+    <Text inverse={isFocused} color={selected ? 'green' : undefined}>
+      {mark} {label}
+    </Text>
+  );
+}
+
+/**
+ * Terminal choice picker. Tab moves between options; Enter or Space toggles
+ * the focused option. 'chips' displayStyle lays options out horizontally.
+ */
+export const ChoicePicker = createComponentImplementation(ChoicePickerApi, ({props}) => {
+  const [filter, setFilter] = useState('');
+  const {isFocused: filterFocused} = useFocus({isActive: props.filterable === true});
+  const values = Array.isArray(props.value) ? props.value : [];
+  const isMutuallyExclusive = props.variant !== 'multipleSelection';
+  const chips = props.displayStyle === 'chips';
+  const groupLabel =
+    typeof props.label === 'string' ? props.label : props.label ? String(props.label) : '';
+  const errors = props.validationErrors ?? [];
+
+  const onToggle = (val: string) => {
+    if (isMutuallyExclusive) {
+      props.setValue?.([val]);
+    } else {
+      const next = values.includes(val)
+        ? values.filter((v: string) => v !== val)
+        : [...values, val];
+      props.setValue?.(next);
+    }
+  };
+
+  useInput(
+    (input, key) => {
+      if (key.backspace || key.delete) {
+        setFilter(f => f.slice(0, -1));
+        return;
+      }
+      if (key.return || key.escape || key.tab || key.upArrow || key.downArrow) return;
+      if (input && !key.ctrl && !key.meta) setFilter(f => f + input);
+    },
+    {isActive: filterFocused && props.filterable === true},
+  );
+
+  const allOptions: ResolvedOption[] = Array.isArray(props.options) ? props.options : [];
+  const options = allOptions.filter(
+    opt =>
+      !props.filterable ||
+      filter === '' ||
+      String(opt.label).toLowerCase().includes(filter.toLowerCase()),
+  );
+
+  return (
+    <Box flexDirection="column" gap={chips ? 0 : 1} {...weightProps(props.weight)}>
+      {groupLabel ? <Text bold>{groupLabel}</Text> : null}
+      {props.filterable ? (
+        <Text inverse={filterFocused} dimColor={!filterFocused}>
+          ⌕ {filter || 'type to filter'}
+        </Text>
+      ) : null}
+      <Box flexDirection={chips ? 'row' : 'column'} gap={1} flexWrap={chips ? 'wrap' : undefined}>
+        {options.map(opt => (
+          <ChoiceOption
+            key={opt.value}
+            label={String(opt.label)}
+            selected={values.includes(opt.value)}
+            exclusive={isMutuallyExclusive}
+            chips={chips}
+            onToggle={() => onToggle(opt.value)}
+          />
+        ))}
+      </Box>
+      {errors.map(error => (
+        <Text key={error} color="red">
+          ✗ {error}
+        </Text>
+      ))}
+    </Box>
+  );
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/Column.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/Column.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Box} from 'ink';
+import {createComponentImplementation} from '../../../adapter.js';
+import {ColumnApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {ChildList} from './ChildList.js';
+import {mapJustify, mapAlign, weightProps} from '../utils.js';
+
+export const Column = createComponentImplementation(ColumnApi, ({props, buildChild, context}) => {
+  return (
+    <Box
+      flexDirection="column"
+      justifyContent={mapJustify(props.justify)}
+      alignItems={mapAlign(props.align)}
+      gap={1}
+      {...weightProps(props.weight)}
+    >
+      <ChildList childList={props.children} buildChild={buildChild} context={context} />
+    </Box>
+  );
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/DateTimeInput.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/DateTimeInput.tsx
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Box, Text, useFocus, useInput} from 'ink';
+import {createComponentImplementation} from '../../../adapter.js';
+import {DateTimeInputApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {weightProps} from '../utils.js';
+
+const ISO_CHARS = /^[0-9T:\-+.Z ]$/i;
+
+/**
+ * Terminal date/time input. There is no native picker, so the ISO 8601 value
+ * is edited as text with a format hint (e.g. 2026-07-16 or 14:30).
+ */
+export const DateTimeInput = createComponentImplementation(DateTimeInputApi, ({props}) => {
+  const {isFocused} = useFocus();
+  const value = typeof props.value === 'string' ? props.value : String(props.value ?? '');
+  const label =
+    typeof props.label === 'string' ? props.label : props.label ? String(props.label) : '';
+  const errors = props.validationErrors ?? [];
+
+  const formatHint = [props.enableDate ? 'YYYY-MM-DD' : null, props.enableTime ? 'HH:MM' : null]
+    .filter(Boolean)
+    .join('T');
+
+  useInput(
+    (input, key) => {
+      if (key.backspace || key.delete) {
+        props.setValue?.(value.slice(0, -1));
+        return;
+      }
+      if (key.return || key.escape || key.tab || key.upArrow || key.downArrow) return;
+      if (!input || key.ctrl || key.meta) return;
+      if (![...input].every(ch => ISO_CHARS.test(ch))) return;
+      props.setValue?.(value + input);
+    },
+    {isActive: isFocused},
+  );
+
+  // The spec requires at least one of enableDate/enableTime; render nothing
+  // (after hooks) if the agent enabled neither.
+  if (!(props.enableDate || props.enableTime)) return null;
+
+  return (
+    <Box flexDirection="column" {...weightProps(props.weight)}>
+      {label ? (
+        <Text dimColor={!isFocused} color={isFocused ? 'cyan' : undefined}>
+          {label}
+        </Text>
+      ) : null}
+      <Box
+        borderStyle="single"
+        borderColor={errors.length > 0 ? 'red' : isFocused ? 'cyan' : 'gray'}
+        paddingX={1}
+      >
+        <Text>
+          {value || <Text dimColor>{formatHint}</Text>}
+          {isFocused ? <Text color="cyan">█</Text> : null}
+        </Text>
+      </Box>
+      {errors.map(error => (
+        <Text key={error} color="red">
+          ✗ {error}
+        </Text>
+      ))}
+    </Box>
+  );
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/Divider.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/Divider.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Box, Text} from 'ink';
+import {createComponentImplementation} from '../../../adapter.js';
+import {DividerApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {weightProps} from '../utils.js';
+
+export const Divider = createComponentImplementation(DividerApi, ({props}) => {
+  if (props.axis === 'vertical') {
+    return <Text dimColor>│</Text>;
+  }
+  // Do not use flexGrow here: in a Column, grow expands on the vertical axis
+  // and leaves a tall empty gap. Fill horizontally via truncate instead.
+  return (
+    <Box width="100%" {...weightProps(props.weight)}>
+      <Text dimColor wrap="truncate">
+        {'─'.repeat(120)}
+      </Text>
+    </Box>
+  );
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/Icon.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/Icon.tsx
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Text} from 'ink';
+import {createComponentImplementation} from '../../../adapter.js';
+import {IconApi} from '@a2ui/web_core/v0_9/basic_catalog';
+
+/**
+ * Single-cell glyphs for every icon name in the v0.9 basic catalog.
+ * Prefers widely supported Unicode symbols over emoji to keep column
+ * alignment stable across terminals.
+ */
+const ICON_GLYPHS: Record<string, string> = {
+  accountCircle: '◉',
+  add: '+',
+  arrowBack: '←',
+  arrowForward: '→',
+  attachFile: '📎',
+  calendarToday: '▦',
+  call: '☎',
+  camera: '📷',
+  check: '✓',
+  close: '✕',
+  delete: '⌫',
+  download: '⇩',
+  edit: '✎',
+  event: '▦',
+  error: '⊗',
+  fastForward: '⏩',
+  favorite: '♥',
+  favoriteOff: '♡',
+  folder: '🗀',
+  help: '?',
+  home: '⌂',
+  info: 'ℹ',
+  locationOn: '⌖',
+  lock: '🔒',
+  lockOpen: '🔓',
+  mail: '✉',
+  menu: '≡',
+  moreVert: '⋮',
+  moreHoriz: '…',
+  notificationsOff: '🔕',
+  notifications: '🔔',
+  pause: '⏸',
+  payment: '💳',
+  person: '☺',
+  phone: '☎',
+  photo: '🖼',
+  play: '▶',
+  print: '⎙',
+  refresh: '↻',
+  rewind: '⏪',
+  search: '⌕',
+  send: '➤',
+  settings: '⚙',
+  share: '⤴',
+  shoppingCart: '🛒',
+  skipNext: '⏭',
+  skipPrevious: '⏮',
+  star: '★',
+  starHalf: '⯪',
+  starOff: '☆',
+  stop: '■',
+  upload: '⇧',
+  visibility: '👁',
+  visibilityOff: '⌀',
+  volumeDown: '🔉',
+  volumeMute: '🔈',
+  volumeOff: '🔇',
+  volumeUp: '🔊',
+  warning: '⚠',
+};
+
+export const Icon = createComponentImplementation(IconApi, ({props}) => {
+  const name = props.name;
+  if (typeof name === 'object' && name !== null) {
+    // Custom SVG paths cannot be rasterized in a terminal.
+    return <Text dimColor>[svg]</Text>;
+  }
+  const key = typeof name === 'string' ? name : '';
+  const glyph = ICON_GLYPHS[key];
+  if (!glyph) {
+    return <Text dimColor>:{key || 'icon'}:</Text>;
+  }
+  return <Text color="yellow">{glyph}</Text>;
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/Image.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/Image.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Box, Text} from 'ink';
+import {createComponentImplementation} from '../../../adapter.js';
+import {ImageApi} from '@a2ui/web_core/v0_9/basic_catalog';
+
+/** Rough terminal footprint per image variant (columns x rows). */
+const VARIANT_SIZE: Record<string, {width: number; height: number}> = {
+  icon: {width: 6, height: 1},
+  avatar: {width: 10, height: 3},
+  smallFeature: {width: 16, height: 3},
+  mediumFeature: {width: 24, height: 5},
+  largeFeature: {width: 32, height: 7},
+  header: {width: 40, height: 5},
+};
+
+/**
+ * Images cannot be rasterized portably in a terminal, so this renders a
+ * framed placeholder sized by variant, labeled with the accessibility
+ * description (preferred) or the URL host/path.
+ */
+export const Image = createComponentImplementation(ImageApi, ({props}) => {
+  const desc =
+    typeof props.description === 'string' && props.description
+      ? props.description
+      : typeof props.url === 'string'
+        ? props.url.replace(/^https?:\/\//, '')
+        : 'image';
+  const size = VARIANT_SIZE[props.variant ?? 'mediumFeature'] ?? VARIANT_SIZE['mediumFeature']!;
+
+  if (props.variant === 'icon') {
+    return <Text dimColor>[{desc.slice(0, 12)}]</Text>;
+  }
+
+  // Prefer intrinsic size over flex weight for terminal placeholders — a fixed
+  // width + flexBasis:0 was collapsing sibling text columns to 1 character.
+  return (
+    <Box
+      borderStyle="single"
+      borderColor="gray"
+      width={size.width}
+      height={size.height}
+      justifyContent="center"
+      alignItems="center"
+      flexShrink={0}
+    >
+      <Text dimColor wrap="truncate-end">
+        🖼 {desc}
+      </Text>
+    </Box>
+  );
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/List.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/List.tsx
@@ -35,6 +35,7 @@ export const List = createComponentImplementation(ListApi, ({props, buildChild})
       {...weightProps(props.weight)}
     >
       {children.map((childRef, index) => {
+        if (!childRef) return null;
         const isRef = typeof childRef !== 'string';
         const marker = style === 'ordered' ? `${index + 1}. ` : style === 'unordered' ? '• ' : '';
         const key = isRef ? `${childRef.id}-${childRef.basePath}` : `${childRef}-${index}`;

--- a/renderers/ink/src/v0_9/catalog/basic/components/List.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/List.tsx
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Box, Text} from 'ink';
+import {type ComponentId} from '@a2ui/web_core/v0_9';
+import {createComponentImplementation} from '../../../adapter.js';
+import {ListApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {mapAlign, weightProps} from '../utils.js';
+
+type ResolvedChildRef = ComponentId | {id: ComponentId; basePath: string};
+
+export const List = createComponentImplementation(ListApi, ({props, buildChild}) => {
+  const isHorizontal = props.direction === 'horizontal';
+  const style = props.listStyle;
+  const children: ResolvedChildRef[] = Array.isArray(props.children) ? props.children : [];
+
+  return (
+    <Box
+      flexDirection={isHorizontal ? 'row' : 'column'}
+      alignItems={mapAlign(props.align)}
+      gap={1}
+      {...weightProps(props.weight)}
+    >
+      {children.map((childRef, index) => {
+        const isRef = typeof childRef !== 'string';
+        const marker = style === 'ordered' ? `${index + 1}. ` : style === 'unordered' ? '• ' : '';
+        const key = isRef ? `${childRef.id}-${childRef.basePath}` : `${childRef}-${index}`;
+        const node = isRef ? buildChild(childRef.id, childRef.basePath) : buildChild(childRef);
+        return (
+          <Box key={key} flexDirection="row">
+            {marker ? <Text dimColor>{marker}</Text> : null}
+            {node}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/Modal.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/Modal.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {useState} from 'react';
+import {Box, Text, useFocus, useInput} from 'ink';
+import {createComponentImplementation} from '../../../adapter.js';
+import {ModalApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {ModalTriggerContext} from '../modal-trigger-context.js';
+
+/**
+ * Terminal modal. One focus target on the trigger row (▸): Enter/Space opens,
+ * Esc closes. Nested Button triggers are not separately focusable (see
+ * ModalTriggerContext) so Tab doesn't hit both the chevron and the button.
+ * Content expands inline — terminals have no overlay layer.
+ */
+export const Modal = createComponentImplementation(ModalApi, ({props, buildChild}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const {isFocused} = useFocus();
+
+  useInput(
+    (input, key) => {
+      if (key.escape && isOpen) {
+        setIsOpen(false);
+        return;
+      }
+      if (!isFocused) return;
+      if (key.return || input === ' ') {
+        setIsOpen(open => !open);
+      }
+    },
+    {isActive: isFocused || isOpen},
+  );
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Box flexDirection="row" gap={1}>
+        <Text inverse={isFocused} color="magenta">
+          {isOpen ? '▾' : '▸'}
+        </Text>
+        <ModalTriggerContext.Provider value={true}>
+          {props.trigger ? buildChild(props.trigger) : null}
+        </ModalTriggerContext.Provider>
+      </Box>
+      {isOpen ? (
+        <Box borderStyle="double" borderColor="magenta" paddingX={1} flexDirection="column">
+          {props.content ? buildChild(props.content) : null}
+          <Text dimColor italic>
+            Esc to dismiss
+          </Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/Row.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/Row.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Box} from 'ink';
+import {createComponentImplementation} from '../../../adapter.js';
+import {RowApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {ChildList} from './ChildList.js';
+import {mapJustify, mapAlign, weightProps} from '../utils.js';
+
+export const Row = createComponentImplementation(RowApi, ({props, buildChild, context}) => {
+  return (
+    <Box
+      flexDirection="row"
+      justifyContent={mapJustify(props.justify)}
+      alignItems={mapAlign(props.align)}
+      gap={1}
+      {...weightProps(props.weight)}
+    >
+      <ChildList childList={props.children} buildChild={buildChild} context={context} />
+    </Box>
+  );
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/Slider.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/Slider.tsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Box, Text, useFocus, useInput} from 'ink';
+import {createComponentImplementation} from '../../../adapter.js';
+import {SliderApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {weightProps} from '../utils.js';
+
+const BAR_WIDTH = 20;
+
+/**
+ * Terminal slider. While focused, ←/→ adjust by one step. The step defaults
+ * to 1/20 of the range (one bar cell) when not specified by the agent.
+ */
+export const Slider = createComponentImplementation(SliderApi, ({props}) => {
+  const min = typeof props.min === 'number' ? props.min : 0;
+  const max = typeof props.max === 'number' ? props.max : 100;
+  const span = Math.max(Number.EPSILON, max - min);
+  const step = typeof props.step === 'number' && props.step > 0 ? props.step : span / BAR_WIDTH;
+  const value = typeof props.value === 'number' ? props.value : min;
+  const {isFocused} = useFocus();
+  const label =
+    typeof props.label === 'string' ? props.label : props.label ? String(props.label) : '';
+
+  useInput(
+    (_input, key) => {
+      // Round to the step grid to avoid floating point drift.
+      const snap = (v: number) => Math.round(v / step) * step;
+      if (key.leftArrow) {
+        props.setValue?.(Math.max(min, snap(value - step)));
+      } else if (key.rightArrow) {
+        props.setValue?.(Math.min(max, snap(value + step)));
+      }
+    },
+    {isActive: isFocused},
+  );
+
+  const filled = Math.max(0, Math.min(BAR_WIDTH, Math.round(((value - min) / span) * BAR_WIDTH)));
+  const bar = '█'.repeat(filled) + '░'.repeat(BAR_WIDTH - filled);
+
+  return (
+    <Box flexDirection="column" {...weightProps(props.weight)}>
+      <Text>
+        {label ? `${label} ` : ''}
+        <Text dimColor>
+          {min} ≤ {Number.isInteger(value) ? value : value.toFixed(2)} ≤ {max}
+        </Text>
+      </Text>
+      <Text inverse={isFocused} color="cyan">
+        [{bar}]
+      </Text>
+      {isFocused ? <Text dimColor>←/→ to adjust</Text> : null}
+    </Box>
+  );
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/Tabs.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/Tabs.tsx
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {useState} from 'react';
+import {Box, Text, useFocus, useInput} from 'ink';
+import {type ComponentId} from '@a2ui/web_core/v0_9';
+import {createComponentImplementation} from '../../../adapter.js';
+import {TabsApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {weightProps} from '../utils.js';
+
+interface ResolvedTab {
+  title: unknown;
+  child: ComponentId;
+}
+
+/** Terminal tabs. Focus the tab bar with Tab, then switch tabs with ←/→. */
+export const Tabs = createComponentImplementation(TabsApi, ({props, buildChild}) => {
+  const tabs: ResolvedTab[] = Array.isArray(props.tabs) ? props.tabs : [];
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const {isFocused} = useFocus();
+  const activeTab = tabs[Math.min(selectedIndex, tabs.length - 1)];
+
+  useInput(
+    (_input, key) => {
+      if (tabs.length === 0) return;
+      if (key.leftArrow) {
+        setSelectedIndex(i => (i - 1 + tabs.length) % tabs.length);
+      } else if (key.rightArrow) {
+        setSelectedIndex(i => (i + 1) % tabs.length);
+      }
+    },
+    {isActive: isFocused},
+  );
+
+  return (
+    <Box flexDirection="column" {...weightProps(props.weight)}>
+      <Box flexDirection="row" gap={1}>
+        {isFocused ? <Text color="cyan">‹</Text> : null}
+        {tabs.map((tab, i) => (
+          <Text
+            key={i}
+            inverse={i === selectedIndex}
+            color={i === selectedIndex ? 'cyan' : undefined}
+            dimColor={i !== selectedIndex}
+            bold={i === selectedIndex}
+          >
+            {` ${String(tab.title ?? `Tab ${i + 1}`)} `}
+          </Text>
+        ))}
+        {isFocused ? <Text color="cyan">›</Text> : null}
+      </Box>
+      <Box borderStyle="single" borderColor={isFocused ? 'cyan' : 'gray'} paddingX={1}>
+        {activeTab ? buildChild(activeTab.child) : null}
+      </Box>
+    </Box>
+  );
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/Tabs.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/Tabs.tsx
@@ -31,7 +31,7 @@ export const Tabs = createComponentImplementation(TabsApi, ({props, buildChild})
   const tabs: ResolvedTab[] = Array.isArray(props.tabs) ? props.tabs : [];
   const [selectedIndex, setSelectedIndex] = useState(0);
   const {isFocused} = useFocus();
-  const activeTab = tabs[Math.min(selectedIndex, tabs.length - 1)];
+  const activeTab = tabs[Math.min(selectedIndex, Math.max(tabs.length - 1, 0))];
 
   useInput(
     (_input, key) => {
@@ -49,21 +49,24 @@ export const Tabs = createComponentImplementation(TabsApi, ({props, buildChild})
     <Box flexDirection="column" {...weightProps(props.weight)}>
       <Box flexDirection="row" gap={1}>
         {isFocused ? <Text color="cyan">‹</Text> : null}
-        {tabs.map((tab, i) => (
-          <Text
-            key={i}
-            inverse={i === selectedIndex}
-            color={i === selectedIndex ? 'cyan' : undefined}
-            dimColor={i !== selectedIndex}
-            bold={i === selectedIndex}
-          >
-            {` ${String(tab.title ?? `Tab ${i + 1}`)} `}
-          </Text>
-        ))}
+        {tabs.map((tab, i) => {
+          if (!tab) return null;
+          return (
+            <Text
+              key={i}
+              inverse={i === selectedIndex}
+              color={i === selectedIndex ? 'cyan' : undefined}
+              dimColor={i !== selectedIndex}
+              bold={i === selectedIndex}
+            >
+              {` ${String(tab.title ?? `Tab ${i + 1}`)} `}
+            </Text>
+          );
+        })}
         {isFocused ? <Text color="cyan">›</Text> : null}
       </Box>
       <Box borderStyle="single" borderColor={isFocused ? 'cyan' : 'gray'} paddingX={1}>
-        {activeTab ? buildChild(activeTab.child) : null}
+        {activeTab?.child ? buildChild(activeTab.child) : null}
       </Box>
     </Box>
   );

--- a/renderers/ink/src/v0_9/catalog/basic/components/Text.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/Text.tsx
@@ -24,11 +24,7 @@ export const Text = createComponentImplementation(TextApi, ({props}) => {
   const text = stripMarkdown(raw);
   const style = textVariantStyle(props.variant);
 
-  const node = (
-    <InkText wrap="truncate-end" {...style}>
-      {text}
-    </InkText>
-  );
+  const node = <InkText {...style}>{text}</InkText>;
 
   // Only introduce a Box when weight participates in flex layout, so that
   // Text stays inline inside e.g. Button labels.

--- a/renderers/ink/src/v0_9/catalog/basic/components/Text.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/Text.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Box, Text as InkText} from 'ink';
+import {createComponentImplementation} from '../../../adapter.js';
+import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {textVariantStyle, stripMarkdown, weightProps} from '../utils.js';
+
+export const Text = createComponentImplementation(TextApi, ({props}) => {
+  const raw = typeof props.text === 'string' ? props.text : String(props.text ?? '');
+  const text = stripMarkdown(raw);
+  const style = textVariantStyle(props.variant);
+
+  const node = (
+    <InkText wrap="truncate-end" {...style}>
+      {text}
+    </InkText>
+  );
+
+  // Only introduce a Box when weight participates in flex layout, so that
+  // Text stays inline inside e.g. Button labels.
+  if (typeof props.weight === 'number') {
+    return <Box {...weightProps(props.weight)}>{node}</Box>;
+  }
+  return node;
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/TextField.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/TextField.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Box, Text, useFocus, useInput} from 'ink';
+import {createComponentImplementation} from '../../../adapter.js';
+import {TextFieldApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {weightProps} from '../utils.js';
+
+const NUMBER_CHARS = /^[0-9.,\-+]$/;
+
+/**
+ * Terminal text field. Focus with Tab, then type to edit; Backspace deletes.
+ * Variant handling:
+ * - obscured: masks the value with '*'
+ * - number:   only accepts numeric characters
+ * - longText: same single-line editor (terminal limitation), but wraps
+ */
+export const TextField = createComponentImplementation(TextFieldApi, ({props}) => {
+  const {isFocused} = useFocus();
+  const value = typeof props.value === 'string' ? props.value : String(props.value ?? '');
+  const errors = props.validationErrors ?? [];
+  const hasError = errors.length > 0;
+  const display = props.variant === 'obscured' ? '*'.repeat([...value].length) : value;
+
+  useInput(
+    (input, key) => {
+      if (key.backspace || key.delete) {
+        props.setValue?.(value.slice(0, -1));
+        return;
+      }
+      // Leave navigation keys to Ink's focus manager / parent handlers.
+      if (key.return || key.escape || key.tab || key.upArrow || key.downArrow) {
+        return;
+      }
+      if (!input || key.ctrl || key.meta) return;
+      if (props.variant === 'number' && ![...input].every(ch => NUMBER_CHARS.test(ch))) {
+        return;
+      }
+      props.setValue?.(value + input);
+    },
+    {isActive: isFocused},
+  );
+
+  return (
+    <Box flexDirection="column" {...weightProps(props.weight)}>
+      {props.label ? (
+        <Text dimColor={!isFocused} color={isFocused ? 'cyan' : undefined}>
+          {typeof props.label === 'string' ? props.label : String(props.label)}
+        </Text>
+      ) : null}
+      <Box
+        borderStyle="single"
+        borderColor={hasError ? 'red' : isFocused ? 'cyan' : 'gray'}
+        paddingX={1}
+      >
+        <Text
+          color={isFocused ? 'white' : 'gray'}
+          wrap={props.variant === 'longText' ? 'wrap' : 'truncate-start'}
+        >
+          {display}
+          {isFocused ? <Text color="cyan">█</Text> : display ? '' : ' '}
+        </Text>
+      </Box>
+      {errors.map(error => (
+        <Text key={error} color="red">
+          ✗ {error}
+        </Text>
+      ))}
+    </Box>
+  );
+});

--- a/renderers/ink/src/v0_9/catalog/basic/components/Video.tsx
+++ b/renderers/ink/src/v0_9/catalog/basic/components/Video.tsx
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Box, Text} from 'ink';
+import {createComponentImplementation} from '../../../adapter.js';
+import {VideoApi} from '@a2ui/web_core/v0_9/basic_catalog';
+import {weightProps} from '../utils.js';
+
+/** Video playback is unavailable in a terminal; shows the URL as a framed placeholder. */
+export const Video = createComponentImplementation(VideoApi, ({props}) => {
+  const url = typeof props.url === 'string' ? props.url : '';
+  return (
+    <Box borderStyle="single" borderColor="gray" paddingX={1} {...weightProps(props.weight)}>
+      <Text dimColor wrap="truncate-end">
+        ▶ video: {url || '(no url)'}
+      </Text>
+    </Box>
+  );
+});

--- a/renderers/ink/src/v0_9/catalog/basic/index.ts
+++ b/renderers/ink/src/v0_9/catalog/basic/index.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Catalog} from '@a2ui/web_core/v0_9';
+import {BASIC_FUNCTIONS} from '@a2ui/web_core/v0_9/basic_catalog';
+import type {InkComponentImplementation} from '../../adapter.js';
+
+import {Text} from './components/Text.js';
+import {Image} from './components/Image.js';
+import {Icon} from './components/Icon.js';
+import {Video} from './components/Video.js';
+import {AudioPlayer} from './components/AudioPlayer.js';
+import {Row} from './components/Row.js';
+import {Column} from './components/Column.js';
+import {List} from './components/List.js';
+import {Card} from './components/Card.js';
+import {Tabs} from './components/Tabs.js';
+import {Divider} from './components/Divider.js';
+import {Modal} from './components/Modal.js';
+import {Button} from './components/Button.js';
+import {TextField} from './components/TextField.js';
+import {CheckBox} from './components/CheckBox.js';
+import {ChoicePicker} from './components/ChoicePicker.js';
+import {Slider} from './components/Slider.js';
+import {DateTimeInput} from './components/DateTimeInput.js';
+
+const basicComponents: InkComponentImplementation[] = [
+  Text,
+  Image,
+  Icon,
+  Video,
+  AudioPlayer,
+  Row,
+  Column,
+  List,
+  Card,
+  Tabs,
+  Divider,
+  Modal,
+  Button,
+  TextField,
+  CheckBox,
+  ChoicePicker,
+  Slider,
+  DateTimeInput,
+];
+
+/** Full basic catalog mapped to Ink terminal widgets. */
+export const basicCatalog = new Catalog<InkComponentImplementation>(
+  'https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json',
+  basicComponents,
+  BASIC_FUNCTIONS,
+);
+
+export {
+  Text,
+  Image,
+  Icon,
+  Video,
+  AudioPlayer,
+  Row,
+  Column,
+  List,
+  Card,
+  Tabs,
+  Divider,
+  Modal,
+  Button,
+  TextField,
+  CheckBox,
+  ChoicePicker,
+  Slider,
+  DateTimeInput,
+};

--- a/renderers/ink/src/v0_9/catalog/basic/modal-trigger-context.ts
+++ b/renderers/ink/src/v0_9/catalog/basic/modal-trigger-context.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createContext, useContext} from 'react';
+
+/**
+ * When true, the component is rendered as a Modal trigger. Interactive
+ * children (e.g. Button) should not register their own focus — the Modal
+ * owns the single focus target and opens on Enter/Space.
+ */
+export const ModalTriggerContext = createContext(false);
+
+export function useInModalTrigger(): boolean {
+  return useContext(ModalTriggerContext);
+}

--- a/renderers/ink/src/v0_9/catalog/basic/utils.ts
+++ b/renderers/ink/src/v0_9/catalog/basic/utils.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {BoxProps, TextProps} from 'ink';
+
+export const mapJustify = (j?: string): BoxProps['justifyContent'] => {
+  switch (j) {
+    case 'center':
+      return 'center';
+    case 'end':
+      return 'flex-end';
+    case 'spaceAround':
+      return 'space-around';
+    case 'spaceBetween':
+      return 'space-between';
+    case 'spaceEvenly':
+      return 'space-evenly';
+    case 'start':
+    case 'stretch':
+    default:
+      return 'flex-start';
+  }
+};
+
+export const mapAlign = (a?: string): BoxProps['alignItems'] => {
+  switch (a) {
+    case 'start':
+      return 'flex-start';
+    case 'center':
+      return 'center';
+    case 'end':
+      return 'flex-end';
+    case 'stretch':
+    default:
+      return 'stretch';
+  }
+};
+
+/**
+ * Maps the A2UI `weight` property (flex-grow semantics) to Ink Box flex props.
+ * Per the basic catalog guide, weight is only meaningful on direct children of
+ * Row/Column; components apply it to their own root container.
+ *
+ * IMPORTANT: Do NOT set `flexBasis: 0` here. In Ink/Yoga, a zero basis inside a
+ * parent with an indefinite width (nested Card/List/Row is common) collapses
+ * the child to ~1 column; Text with wrap then stacks one character per line.
+ */
+export const weightProps = (weight?: number): Pick<BoxProps, 'flexGrow'> => {
+  if (typeof weight !== 'number') return {};
+  return {flexGrow: weight};
+};
+
+/**
+ * Terminal fallback for Markdown per the basic catalog implementation guide:
+ * no Markdown renderer is available, so strip common markers to keep the text
+ * legible instead of showing raw `**`/`#`/link syntax.
+ */
+export const stripMarkdown = (text: string): string => {
+  return (
+    text
+      // links: [label](url) -> label
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+      // bold / italic markers
+      .replace(/\*\*([^*]+)\*\*/g, '$1')
+      .replace(/__([^_]+)__/g, '$1')
+      .replace(/\*([^*\n]+)\*/g, '$1')
+      // inline code
+      .replace(/`([^`]+)`/g, '$1')
+      // heading markers at line start
+      .replace(/^#{1,6}\s+/gm, '')
+  );
+};
+
+/**
+ * Typographic mapping for Text variants. Terminals have a single font size,
+ * so heading levels are expressed with weight/underline/color instead.
+ */
+export const textVariantStyle = (variant?: string): Partial<TextProps> => {
+  switch (variant) {
+    case 'h1':
+      return {bold: true, underline: true, color: 'cyan'};
+    case 'h2':
+      return {bold: true, color: 'cyan'};
+    case 'h3':
+      return {bold: true, color: 'cyanBright'};
+    case 'h4':
+    case 'h5':
+      return {bold: true};
+    case 'caption':
+      return {dimColor: true, italic: true};
+    default:
+      return {};
+  }
+};

--- a/renderers/ink/src/v0_9/index.ts
+++ b/renderers/ink/src/v0_9/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './A2uiSurface.js';
+export * from './adapter.js';
+export * from './catalog/basic/index.js';

--- a/renderers/ink/src/v0_9/smoke.test.ts
+++ b/renderers/ink/src/v0_9/smoke.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import {readFileSync, readdirSync} from 'node:fs';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {MessageProcessor} from '@a2ui/web_core/v0_9';
+import {basicCatalog} from './catalog/basic/index.js';
+import type {InkComponentImplementation} from './adapter.js';
+import {stripMarkdown, weightProps, mapJustify, mapAlign} from './catalog/basic/utils.js';
+
+type Messages = Parameters<MessageProcessor<InkComponentImplementation>['processMessages']>[0];
+
+const examplesDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../../specification/v0_9_1/catalogs/basic/examples',
+);
+
+describe('@a2ui/ink examples', () => {
+  const files = readdirSync(examplesDir)
+    .filter(f => f.endsWith('.json'))
+    .sort();
+
+  assert.ok(files.length > 0, 'expected example JSON files');
+
+  for (const file of files) {
+    it(`processes ${file}`, () => {
+      const raw = JSON.parse(readFileSync(join(examplesDir, file), 'utf8'));
+      const processor = new MessageProcessor<InkComponentImplementation>([basicCatalog]);
+      processor.processMessages(structuredClone(raw.messages) as Messages);
+      assert.ok(processor.model.surfacesMap.size >= 1, 'expected at least one surface');
+      for (const surface of processor.model.surfacesMap.values()) {
+        const root = surface.componentsModel.get('root');
+        assert.ok(root, `${file}: missing root component`);
+        assert.ok(
+          surface.catalog.components.has(root.type),
+          `${file}: catalog missing type ${root.type}`,
+        );
+      }
+    });
+  }
+
+  it('registers full basic catalog component set', () => {
+    const expected = [
+      'Text',
+      'Image',
+      'Icon',
+      'Video',
+      'AudioPlayer',
+      'Row',
+      'Column',
+      'List',
+      'Card',
+      'Tabs',
+      'Divider',
+      'Modal',
+      'Button',
+      'TextField',
+      'CheckBox',
+      'ChoicePicker',
+      'Slider',
+      'DateTimeInput',
+    ];
+    for (const name of expected) {
+      assert.ok(basicCatalog.components.has(name), `missing ${name}`);
+    }
+  });
+});
+
+describe('@a2ui/ink terminal mapping utils', () => {
+  it('strips common markdown markers for terminal fallback', () => {
+    assert.equal(stripMarkdown('**bold** and *italic*'), 'bold and italic');
+    assert.equal(stripMarkdown('`code` sample'), 'code sample');
+    assert.equal(stripMarkdown('# Heading\nbody'), 'Heading\nbody');
+    assert.equal(stripMarkdown('[link](https://example.com)'), 'link');
+    assert.equal(stripMarkdown('plain text'), 'plain text');
+  });
+
+  it('maps weight to flex-grow semantics', () => {
+    assert.deepEqual(weightProps(2), {flexGrow: 2});
+    assert.deepEqual(weightProps(undefined), {});
+  });
+
+  it('maps justify/align enums to yoga values', () => {
+    assert.equal(mapJustify('spaceBetween'), 'space-between');
+    assert.equal(mapJustify(undefined), 'flex-start');
+    assert.equal(mapAlign('center'), 'center');
+    assert.equal(mapAlign(undefined), 'stretch');
+  });
+});

--- a/renderers/ink/tsconfig.json
+++ b/renderers/ink/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "demo/**/*", "explorer/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/renderers/ink/tsup.config.ts
+++ b/renderers/ink/tsup.config.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2026 kokoro-ele
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {defineConfig} from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    'v0_9/index': 'src/v0_9/index.ts',
+  },
+  format: ['esm', 'cjs'],
+  dts: true,
+  splitting: true,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  external: ['react', 'ink'],
+  esbuildOptions(options) {
+    options.jsx = 'automatic';
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -146,6 +146,36 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@a2ui/ink@workspace:renderers/ink":
+  version: 0.0.0-use.local
+  resolution: "@a2ui/ink@workspace:renderers/ink"
+  dependencies:
+    "@a2a-js/sdk": "npm:^0.3.13"
+    "@a2ui/web_core": "workspace:*"
+    "@eslint/js": "npm:^10.0.1"
+    "@types/node": "npm:^25.9.3"
+    "@types/react": "npm:^19.2.17"
+    eslint: "npm:^10.4.1"
+    eslint-config-prettier: "npm:^10.1.8"
+    eslint-plugin-react: "npm:^7.37.5"
+    eslint-plugin-react-hooks: "npm:^7.1.1"
+    globals: "npm:^17.6.0"
+    ink: "npm:^6.5.0"
+    prettier: "npm:^3.8.4"
+    react: "npm:^19.2.7"
+    tsup: "npm:^8.5.1"
+    tsx: "npm:^4.22.4"
+    typescript: "npm:5.9.3"
+    typescript-eslint: "npm:^8.61.0"
+    wireit: "npm:^0.15.0-pre.2"
+    zod: "npm:^3.25.76"
+  peerDependencies:
+    ink: ^6.0.0
+    react: ^19.2.7
+    zod: ^3.25.76
+  languageName: unknown
+  linkType: soft
+
 "@a2ui/inspector@workspace:tools/inspector":
   version: 0.0.0-use.local
   resolution: "@a2ui/inspector@workspace:tools/inspector"
@@ -792,6 +822,16 @@ __metadata:
   dependencies:
     json-schema: "npm:^0.4.0"
   checksum: 10c0/c68637c0139a6ce8af17bac1d7d539f531860026237c5c971dcecda2daa8b1e42d8c05e1e664ece60c15edb325c0253fd5b091ee54d32f870a750a493acbb0b7
+  languageName: node
+  linkType: hard
+
+"@alcalzone/ansi-tokenize@npm:^0.2.4":
+  version: 0.2.5
+  resolution: "@alcalzone/ansi-tokenize@npm:0.2.5"
+  dependencies:
+    ansi-styles: "npm:^6.2.1"
+    is-fullwidth-code-point: "npm:^5.0.0"
+  checksum: 10c0/dd8622288426b5b7dbf8b68d51d4b930cea591d0e3b9dbc3f523131464d78ac922c165fcb7ba5307f133d35dbcaa0e6648a1c3fb6a0dc2725546d6f867b70af4
   languageName: node
   linkType: hard
 
@@ -12249,7 +12289,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-escapes@npm:^7.0.0":
+"ansi-escapes@npm:^7.0.0, ansi-escapes@npm:^7.3.0":
   version: 7.3.0
   resolution: "ansi-escapes@npm:7.3.0"
   dependencies:
@@ -12567,6 +12607,13 @@ __metadata:
   version: 1.0.0
   resolution: "atomic-sleep@npm:1.0.0"
   checksum: 10c0/e329a6665512736a9bbb073e1761b4ec102f7926cce35037753146a9db9c8104f5044c1662e4a863576ce544fb8be27cd2be6bc8c1a40147d03f31eb1cfb6e8a
+  languageName: node
+  linkType: hard
+
+"auto-bind@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "auto-bind@npm:5.0.1"
+  checksum: 10c0/a703375350ea7b6e92405d8e6bcc6dbfb84b0d7c7172b33e5788a7593929a18227999ff9aa9c32436741d06d021e6672457b1cec73287efe3fab95cff6627eaf
   languageName: node
   linkType: hard
 
@@ -13087,7 +13134,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:5.6.2, chalk@npm:^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 <5.6.1 || ^5.6.2 >5.6.1, chalk@npm:^5.2.0, chalk@npm:^5.3.0, chalk@npm:^5.4.1, chalk@npm:^5.6.2":
+"chalk@npm:5.6.2, chalk@npm:^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 <5.6.1 || ^5.6.2 >5.6.1, chalk@npm:^5.2.0, chalk@npm:^5.3.0, chalk@npm:^5.4.1, chalk@npm:^5.6.0, chalk@npm:^5.6.2":
   version: 5.6.2
   resolution: "chalk@npm:5.6.2"
   checksum: 10c0/99a4b0f0e7991796b1e7e3f52dceb9137cae2a9dfc8fc0784a550dc4c558e15ab32ed70b14b21b52beb2679b4892b41a0aa44249bcb996f01e125d58477c6976
@@ -13286,12 +13333,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-boxes@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "cli-boxes@npm:3.0.0"
+  checksum: 10c0/4db3e8fbfaf1aac4fb3a6cbe5a2d3fa048bee741a45371b906439b9ffc821c6e626b0f108bdcd3ddf126a4a319409aedcf39a0730573ff050fdd7b6731e99fb9
+  languageName: node
+  linkType: hard
+
 "cli-cursor@npm:^3.1.0":
   version: 3.1.0
   resolution: "cli-cursor@npm:3.1.0"
   dependencies:
     restore-cursor: "npm:^3.1.0"
   checksum: 10c0/92a2f98ff9037d09be3dfe1f0d749664797fb674bf388375a2207a1203b69d41847abf16434203e0089212479e47a358b13a0222ab9fccfe8e2644a7ccebd111
+  languageName: node
+  linkType: hard
+
+"cli-cursor@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "cli-cursor@npm:4.0.0"
+  dependencies:
+    restore-cursor: "npm:^4.0.0"
+  checksum: 10c0/e776e8c3c6727300d0539b0d25160b2bb56aed1a63942753ba1826b012f337a6f4b7ace3548402e4f2f13b5e16bfd751be672c44b203205e7eca8be94afec42c
   languageName: node
   linkType: hard
 
@@ -13331,7 +13394,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-truncate@npm:^5.0.0":
+"cli-truncate@npm:^5.0.0, cli-truncate@npm:^5.1.1":
   version: 5.2.0
   resolution: "cli-truncate@npm:5.2.0"
   dependencies:
@@ -13421,6 +13484,15 @@ __metadata:
   version: 2.1.1
   resolution: "clsx@npm:2.1.1"
   checksum: 10c0/c4c8eb865f8c82baab07e71bfa8897c73454881c4f99d6bc81585aecd7c441746c1399d08363dc096c550cceaf97bd4ce1e8854e1771e9998d9f94c4fe075839
+  languageName: node
+  linkType: hard
+
+"code-excerpt@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "code-excerpt@npm:4.0.0"
+  dependencies:
+    convert-to-spaces: "npm:^2.0.1"
+  checksum: 10c0/b6c5a06e039cecd2ab6a0e10ee0831de8362107d1f298ca3558b5f9004cb8e0260b02dd6c07f57b9a0e346c76864d2873311ee1989809fdeb05bd5fbbadde773
   languageName: node
   linkType: hard
 
@@ -13683,6 +13755,13 @@ __metadata:
   version: 2.0.0
   resolution: "convert-source-map@npm:2.0.0"
   checksum: 10c0/8f2f7a27a1a011cc6cc88cc4da2d7d0cfa5ee0369508baae3d98c260bb3ac520691464e5bbe4ae7cdf09860c1d69ecc6f70c63c6e7c7f7e3f18ec08484dc7d9b
+  languageName: node
+  linkType: hard
+
+"convert-to-spaces@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "convert-to-spaces@npm:2.0.1"
+  checksum: 10c0/d90aa0e3b6a27f9d5265a8d32def3c5c855b3e823a9db1f26d772f8146d6b91020a2fdfd905ce8048a73fad3aaf836fef8188c67602c374405e2ae8396c4ac46
   languageName: node
   linkType: hard
 
@@ -15158,6 +15237,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-toolkit@npm:^1.39.10":
+  version: 1.49.0
+  resolution: "es-toolkit@npm:1.49.0"
+  dependenciesMeta:
+    "@trivago/prettier-plugin-sort-imports@4.3.0":
+      unplugged: true
+    prettier-plugin-sort-re-exports@0.0.1:
+      unplugged: true
+    vitepress-plugin-sandpack@1.1.4:
+      unplugged: true
+  checksum: 10c0/ab0864bb0c5c494ed09043d53a74b58a0ab9df1b89b9b54bce72a63de2869152d7d65e489dc89ab671f0fea243728922c8a8f8c873f1b2a53350a23360b3e2df
+  languageName: node
+  linkType: hard
+
 "es-toolkit@npm:^1.39.7":
   version: 1.47.0
   resolution: "es-toolkit@npm:1.47.0"
@@ -15293,6 +15386,13 @@ __metadata:
   version: 1.0.5
   resolution: "escape-string-regexp@npm:1.0.5"
   checksum: 10c0/a968ad453dd0c2724e14a4f20e177aaf32bb384ab41b674a8454afe9a41c5e6fe8903323e0a1052f56289d04bd600f81278edf140b0fcc02f5cac98d0f5b5371
+  languageName: node
+  linkType: hard
+
+"escape-string-regexp@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "escape-string-regexp@npm:2.0.0"
+  checksum: 10c0/2530479fe8db57eace5e8646c9c2a9c80fa279614986d16dcc6bcaceb63ae77f05a851ba6c43756d816c61d7f4534baf56e3c705e3e0d884818a46808811c507
   languageName: node
   linkType: hard
 
@@ -17912,6 +18012,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"indent-string@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "indent-string@npm:5.0.0"
+  checksum: 10c0/8ee77b57d92e71745e133f6f444d6fa3ed503ad0e1bcd7e80c8da08b42375c07117128d670589725ed07b1978065803fa86318c309ba45415b7fe13e7f170220
+  languageName: node
+  linkType: hard
+
 "inflight@npm:^1.0.4":
   version: 1.0.6
   resolution: "inflight@npm:1.0.6"
@@ -17949,6 +18056,48 @@ __metadata:
   dependencies:
     tslib: "npm:^2.0.0"
   checksum: 10c0/8947b3382c5e9e9aab2e80a010ae339cdfda1fd5d8116138bb3098a1e99316f5bc09d057ea57627707b56527e24119d3e8c5afdb01a82911d80025a4fe4c3b92
+  languageName: node
+  linkType: hard
+
+"ink@npm:^6.5.0":
+  version: 6.8.0
+  resolution: "ink@npm:6.8.0"
+  dependencies:
+    "@alcalzone/ansi-tokenize": "npm:^0.2.4"
+    ansi-escapes: "npm:^7.3.0"
+    ansi-styles: "npm:^6.2.1"
+    auto-bind: "npm:^5.0.1"
+    chalk: "npm:^5.6.0"
+    cli-boxes: "npm:^3.0.0"
+    cli-cursor: "npm:^4.0.0"
+    cli-truncate: "npm:^5.1.1"
+    code-excerpt: "npm:^4.0.0"
+    es-toolkit: "npm:^1.39.10"
+    indent-string: "npm:^5.0.0"
+    is-in-ci: "npm:^2.0.0"
+    patch-console: "npm:^2.0.0"
+    react-reconciler: "npm:^0.33.0"
+    scheduler: "npm:^0.27.0"
+    signal-exit: "npm:^3.0.7"
+    slice-ansi: "npm:^8.0.0"
+    stack-utils: "npm:^2.0.6"
+    string-width: "npm:^8.1.1"
+    terminal-size: "npm:^4.0.1"
+    type-fest: "npm:^5.4.1"
+    widest-line: "npm:^6.0.0"
+    wrap-ansi: "npm:^9.0.0"
+    ws: "npm:^8.18.0"
+    yoga-layout: "npm:~3.2.1"
+  peerDependencies:
+    "@types/react": ">=19.0.0"
+    react: ">=19.0.0"
+    react-devtools-core: ">=6.1.2"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react-devtools-core:
+      optional: true
+  checksum: 10c0/50500e547fdf6a1f1d836d6befbd4770e3ab649ef0be1884500a6da411fb68a90e22dd7dcc9c404911d30e9f87506b3b9d8e997c6c6ceac85ee054b4dadefaff
   languageName: node
   linkType: hard
 
@@ -18242,6 +18391,15 @@ __metadata:
   version: 2.0.1
   resolution: "is-hexadecimal@npm:2.0.1"
   checksum: 10c0/3eb60fe2f1e2bbc760b927dcad4d51eaa0c60138cf7fc671803f66353ad90c301605b502c7ea4c6bb0548e1c7e79dfd37b73b632652e3b76030bba603a7e9626
+  languageName: node
+  linkType: hard
+
+"is-in-ci@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "is-in-ci@npm:2.0.0"
+  bin:
+    is-in-ci: cli.js
+  checksum: 10c0/1e1d1056939a681e8206035de5ad84e0404556eaa7622bb55f0f1868b9788bff3df427bc0b1ed5a172623154a90fcb1e759a230817cd73d09435543ae3c71feb
   languageName: node
   linkType: hard
 
@@ -22422,6 +22580,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"patch-console@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "patch-console@npm:2.0.0"
+  checksum: 10c0/486602591a0af7af8d4c76d8eea42cad32b6de7200488819c6383c75e43733ca7bdc80e30f2e68ce05f06a1607cce1683a1706c6672ca27dada1921b366e8f1c
+  languageName: node
+  linkType: hard
+
 "path-data-parser@npm:0.1.0, path-data-parser@npm:^0.1.0":
   version: 0.1.0
   resolution: "path-data-parser@npm:0.1.0"
@@ -23331,6 +23496,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-reconciler@npm:^0.33.0":
+  version: 0.33.0
+  resolution: "react-reconciler@npm:0.33.0"
+  dependencies:
+    scheduler: "npm:^0.27.0"
+  peerDependencies:
+    react: ^19.2.0
+  checksum: 10c0/3f7b27ea8d0ff4c8bf0e402a285e1af9b7d0e6f4c1a70a28f4384938bc1130bc82a90a31df0b79ef5e380e2e55e2598bd90b4dbf802b1203d735ba0355817d3a
+  languageName: node
+  linkType: hard
+
 "react-remove-scroll-bar@npm:^2.3.7":
   version: 2.3.8
   resolution: "react-remove-scroll-bar@npm:2.3.8"
@@ -23903,6 +24079,16 @@ __metadata:
     onetime: "npm:^5.1.0"
     signal-exit: "npm:^3.0.2"
   checksum: 10c0/8051a371d6aa67ff21625fa94e2357bd81ffdc96267f3fb0fc4aaf4534028343836548ef34c240ffa8c25b280ca35eb36be00b3cb2133fa4f51896d7e73c6b4f
+  languageName: node
+  linkType: hard
+
+"restore-cursor@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "restore-cursor@npm:4.0.0"
+  dependencies:
+    onetime: "npm:^5.1.0"
+    signal-exit: "npm:^3.0.2"
+  checksum: 10c0/6f7da8c5e422ac26aa38354870b1afac09963572cf2879443540449068cb43476e9cbccf6f8de3e0171e0d6f7f533c2bc1a0a008003c9a525bbc098e89041318
   languageName: node
   linkType: hard
 
@@ -24778,7 +24964,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3":
+"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: 10c0/25d272fa73e146048565e08f3309d5b942c1979a6f4a58a8c59d5fa299728e9c2fcd1a759ec870863b1fd38653670240cd420dad2ad9330c71f36608a6a1c912
@@ -25086,6 +25272,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stack-utils@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "stack-utils@npm:2.0.6"
+  dependencies:
+    escape-string-regexp: "npm:^2.0.0"
+  checksum: 10c0/651c9f87667e077584bbe848acaecc6049bc71979f1e9a46c7b920cad4431c388df0f51b8ad7cfd6eed3db97a2878d0fc8b3122979439ea8bac29c61c95eec8a
+  languageName: node
+  linkType: hard
+
 "stackback@npm:0.0.2":
   version: 0.0.2
   resolution: "stackback@npm:0.0.2"
@@ -25256,6 +25451,16 @@ __metadata:
     get-east-asian-width: "npm:^1.5.0"
     strip-ansi: "npm:^7.1.2"
   checksum: 10c0/d8915428b43519b0f494da6590dbe4491857d8a12e40250e50fc01fbb616ffd8400a436bbe25712255ee129511fe0414c49d3b6b9627e2bc3a33dcec1d2eda02
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^8.1.1":
+  version: 8.2.2
+  resolution: "string-width@npm:8.2.2"
+  dependencies:
+    get-east-asian-width: "npm:^1.5.0"
+    strip-ansi: "npm:^7.1.2"
+  checksum: 10c0/895624534e4e2f229e880bbc30aa77bdeb758e1a0edce203e0a17b8b4f08b8d3c1156516efc50a35e3efd0052d938a73797692111250ac9f52ee384710a01714
   languageName: node
   linkType: hard
 
@@ -25580,6 +25785,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tagged-tag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "tagged-tag@npm:1.0.0"
+  checksum: 10c0/91d25c9ffb86a91f20522cefb2cbec9b64caa1febe27ad0df52f08993ff60888022d771e868e6416cf2e72dab68449d2139e8709ba009b74c6c7ecd4000048d1
+  languageName: node
+  linkType: hard
+
 "tailwind-merge@npm:^3.3.1":
   version: 3.5.0
   resolution: "tailwind-merge@npm:3.5.0"
@@ -25659,6 +25871,13 @@ __metadata:
   dependencies:
     streamx: "npm:^2.12.5"
   checksum: 10c0/8df9166c037ba694b49d32a49858e314c60e513d55ac5e084dbf1ddbb827c5fa43cc389a81e87684419c21283308e9d68bb068798189c767ec4c252f890b8a77
+  languageName: node
+  linkType: hard
+
+"terminal-size@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "terminal-size@npm:4.0.1"
+  checksum: 10c0/89afd9d816dd9dbfe4499da9aeea70491bbde4ff4592226a9c8ac71074a7580afead6a78e95ecc35f6d42e09087b55ffcb1019302cd55e0cc957b6ce5c4847e8
   languageName: node
   linkType: hard
 
@@ -26139,6 +26358,15 @@ __metadata:
   version: 0.8.1
   resolution: "type-fest@npm:0.8.1"
   checksum: 10c0/dffbb99329da2aa840f506d376c863bd55f5636f4741ad6e65e82f5ce47e6914108f44f340a0b74009b0cb5d09d6752ae83203e53e98b1192cf80ecee5651636
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^5.4.1":
+  version: 5.8.0
+  resolution: "type-fest@npm:5.8.0"
+  dependencies:
+    tagged-tag: "npm:^1.0.0"
+  checksum: 10c0/c8aae118a763d550a9552a511dff6b71840a23dab4edf693cf1c4df22596942794e6f6723389bd9036a90182249d915158bacf0815a1ae87f05f901b1d5f574e
   languageName: node
   linkType: hard
 
@@ -27316,6 +27544,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"widest-line@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "widest-line@npm:6.0.0"
+  dependencies:
+    string-width: "npm:^8.1.0"
+  checksum: 10c0/735f1fdcd97fe765a07bb8b5e73c020bed8e53ab34e83ce0ef01693ba3c914d9e7977fe5f5facf0d0b670297a82dd5e376d3efa0896860dfcdaf7cd6924c0fb7
+  languageName: node
+  linkType: hard
+
 "widget-builder@workspace:tools/composer":
   version: 0.0.0-use.local
   resolution: "widget-builder@workspace:tools/composer"
@@ -27791,6 +28028,13 @@ __metadata:
   version: 2.1.2
   resolution: "yoctocolors@npm:2.1.2"
   checksum: 10c0/b220f30f53ebc2167330c3adc86a3c7f158bcba0236f6c67e25644c3188e2571a6014ffc1321943bb619460259d3d27eb4c9cc58c2d884c1b195805883ec7066
+  languageName: node
+  linkType: hard
+
+"yoga-layout@npm:~3.2.1":
+  version: 3.2.1
+  resolution: "yoga-layout@npm:3.2.1"
+  checksum: 10c0/9001e51be993c85e03757e5a04a2b61b8b30c9e5a7865d0156ca87a6431a3b717d51eb4990bfe588189fcfeac688dd9c3de707bbd50d1c344a84e63974cc54a8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add an Ink adapter and keyboard-first implementations for the full v0.9 basic catalog
- add official-example replay, live A2A/mock demos, and a terminal example explorer
- add workspace build, lint, format, type-check, and smoke-test configuration

## Test plan
- [x] `cd renderers/ink && yarn test` (47 tests)
- [x] `cd renderers/ink && yarn lint`
- [x] `cd renderers/ink && yarn format:check`
- [x] `cd renderers/ink && yarn typecheck`

Closes #1998

Made with [Cursor](https://cursor.com)