### PR TITLE
chore(ci): fix docs build_and_deploy skip check on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,24 +36,39 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - ".github/workflows/docs.yml"
-      - "requirements-docs.txt"
-      - "pyproject.toml"
-      - "mkdocs.yml"
-      - "lychee.toml"
-      - "docs/**"
-      # Any Markdown change triggers the pre-submit link check below.
-      - "**.md"
 
 jobs:
+  changes:
+    if: github.repository == 'a2ui-project/a2ui'
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - name: Check for docs changes
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        id: filter
+        with:
+          filters: |
+            docs:
+              - ".github/workflows/docs.yml"
+              - "requirements-docs.txt"
+              - "pyproject.toml"
+              - "mkdocs.yml"
+              - "lychee.toml"
+              - "docs/**"
+              - "**.md"
+
   build_and_deploy:
+    needs: changes
+    if: github.repository == 'a2ui-project/a2ui' && (github.event_name == 'push' || needs.changes.outputs.docs == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: write
       actions: read
-
-    if: github.repository == 'a2ui-project/a2ui'
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Refactor docs.yml workflow to trigger on all pull requests and use dorny/paths-filter to conditionally execute the build_and_deploy job. This ensures the required status check gets reported as 'Skipped' on pull requests without documentation changes, rather than blocking the PR merge in a pending state.