### PR TITLE
feat: implement host-driven container dimension management via Resize…

### DIFF
--- a/samples/community/agent/adk/mcp_app_proxy/pong_app.html
+++ b/samples/community/agent/adk/mcp_app_proxy/pong_app.html
@@ -242,12 +242,27 @@
         window.parent.postMessage({jsonrpc: '2.0', method, params}, '*');
       }
 
+      function applyContainerDimensions(containerDimensions) {
+        if (!containerDimensions) return;
+        if (containerDimensions.width) {
+          document.documentElement.style.width = `${containerDimensions.width}px`;
+          document.body.style.width = `${containerDimensions.width}px`;
+        }
+        if (containerDimensions.height) {
+          document.documentElement.style.height = `${containerDimensions.height}px`;
+          document.body.style.height = `${containerDimensions.height}px`;
+        }
+        if (typeof resize === 'function') resize();
+      }
+
       window.addEventListener('message', event => {
         const data = event.data;
         if (data?.method === 'ping') {
           if (data.id) {
             window.parent.postMessage({jsonrpc: '2.0', id: data.id, result: {}}, '*');
           }
+        } else if (data?.method === 'ui/notifications/host-context-changed') {
+          applyContainerDimensions(data.params?.containerDimensions);
         } else if (data?.method === 'ui/notifications/data-model-update') {
           // TODO: Refactor message handlers to use `@modelcontextprotocol/ext-apps/app-bridge` App client.
           const params = data.params;
@@ -307,7 +322,13 @@
         .then(result => {
           console.log('Initialized with host:', result);
           sendNotification('ui/notifications/initialized', {});
-          sendNotification('ui/notifications/size-changed', {width: 728, height: 502});
+          
+          // The app is fully reactive to the host dimensions. 
+          // The host determines the container dimensions and passes them to the app.
+          applyContainerDimensions(result.hostContext?.containerDimensions);
+          
+          // Alternatively, if the app is to control the dimensions, uncomment and use:
+          // sendNotification('ui/notifications/size-changed', {width: 728, height: 502});
         })
         .catch(err => {
           console.error('Initialization failed:', err);

--- a/samples/community/agent/adk/mcp_app_proxy/pong_app.html
+++ b/samples/community/agent/adk/mcp_app_proxy/pong_app.html
@@ -322,11 +322,11 @@
         .then(result => {
           console.log('Initialized with host:', result);
           sendNotification('ui/notifications/initialized', {});
-          
-          // The app is fully reactive to the host dimensions. 
+
+          // The app is fully reactive to the host dimensions.
           // The host determines the container dimensions and passes them to the app.
           applyContainerDimensions(result.hostContext?.containerDimensions);
-          
+
           // Alternatively, if the app is to control the dimensions, uncomment and use:
           // sendNotification('ui/notifications/size-changed', {width: 728, height: 502});
         })

--- a/samples/community/agent/adk/mcp_app_proxy/pong_app.html
+++ b/samples/community/agent/adk/mcp_app_proxy/pong_app.html
@@ -244,11 +244,11 @@
 
       function applyContainerDimensions(containerDimensions) {
         if (!containerDimensions) return;
-        if (containerDimensions.width) {
+        if (typeof containerDimensions.width === 'number') {
           document.documentElement.style.width = `${containerDimensions.width}px`;
           document.body.style.width = `${containerDimensions.width}px`;
         }
-        if (containerDimensions.height) {
+        if (typeof containerDimensions.height === 'number') {
           document.documentElement.style.height = `${containerDimensions.height}px`;
           document.body.style.height = `${containerDimensions.height}px`;
         }
@@ -323,12 +323,13 @@
           console.log('Initialized with host:', result);
           sendNotification('ui/notifications/initialized', {});
 
-          // The app is fully reactive to the host dimensions.
-          // The host determines the container dimensions and passes them to the app.
-          applyContainerDimensions(result.hostContext?.containerDimensions);
-
-          // Alternatively, if the app is to control the dimensions, uncomment and use:
-          // sendNotification('ui/notifications/size-changed', {width: 728, height: 502});
+          // The app is reactive to host dimensions if provided; otherwise, it falls back
+          // to requesting default dimensions to maintain backward compatibility.
+          if (result.hostContext?.containerDimensions) {
+            applyContainerDimensions(result.hostContext.containerDimensions);
+          } else {
+            sendNotification('ui/notifications/size-changed', {width: 728, height: 502});
+          }
         })
         .catch(err => {
           console.error('Initialization failed:', err);

--- a/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/mcp-app.ts
+++ b/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/mcp-app.ts
@@ -416,7 +416,7 @@ export class McpApp extends CatalogComponent<any> implements OnDestroy, OnInit {
           containerDimensions: {
             width: entry.contentRect.width,
             height: entry.contentRect.height,
-          }
+          },
         });
       }
     });

--- a/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/mcp-app.ts
+++ b/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/mcp-app.ts
@@ -405,7 +405,16 @@ export class McpApp extends CatalogComponent<any> implements OnDestroy, OnInit {
       return {content: []};
     };
 
-    // Inform the app of its dimensions
+    // Set initial host context synchronously so it is available during the handshake
+    const rect = iframe.getBoundingClientRect();
+    bridge.setHostContext({
+      containerDimensions: {
+        width: rect.width,
+        height: rect.height,
+      },
+    });
+
+    // Inform the app of subsequent dimension changes
     if (this.hostResizeObserver) {
       this.hostResizeObserver.disconnect();
     }

--- a/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/mcp-app.ts
+++ b/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/mcp-app.ts
@@ -118,6 +118,7 @@ export class McpApp extends CatalogComponent<any> implements OnDestroy, OnInit {
   private lastHeight?: number;
   private lastBoundRootValue: string | null = null;
   private isProcessingAppWrite = false;
+  private hostResizeObserver: ResizeObserver | null = null;
 
   ngOnInit() {
     this.setupSandbox();
@@ -134,6 +135,10 @@ export class McpApp extends CatalogComponent<any> implements OnDestroy, OnInit {
     }
     if (this.messageHandler) {
       window.removeEventListener('message', this.messageHandler);
+    }
+    if (this.hostResizeObserver) {
+      this.hostResizeObserver.disconnect();
+      this.hostResizeObserver = null;
     }
     const bridge = this.appBridge();
     if (bridge) {
@@ -399,6 +404,23 @@ export class McpApp extends CatalogComponent<any> implements OnDestroy, OnInit {
       // Return empty result immediately (calculator UI can forget about it)
       return {content: []};
     };
+
+    // Inform the app of its dimensions
+    if (this.hostResizeObserver) {
+      this.hostResizeObserver.disconnect();
+    }
+    this.hostResizeObserver = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry && bridge) {
+        bridge.setHostContext({
+          containerDimensions: {
+            width: entry.contentRect.width,
+            height: entry.contentRect.height,
+          }
+        });
+      }
+    });
+    this.hostResizeObserver.observe(iframe);
 
     // Connect the bridge
     // We must pass the iframe's contentWindow as the target

--- a/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/mcp-apps-component_spec.md
+++ b/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/mcp-apps-component_spec.md
@@ -298,7 +298,30 @@ Sent as a response to a `ui/requests/function-call` request.
 **Embedded app action**  
 The embedded app processes the result or error based on its own logic.
 
-### C. Resource update (`ui/notifications/sandbox-resource-ready`)
+### C. Host context update (`ui/notifications/host-context-changed`)
+
+Sent when the host's context changes, such as when the container dimensions are resized or the theme is toggled. This aligns with the [Model Context Protocol Apps Specification: Host Context](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx).
+
+**Message schema**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "ui/notifications/host-context-changed",
+  "params": {
+    "theme": "string",
+    "containerDimensions": {
+      "width": "number",
+      "height": "number"
+    }
+  }
+}
+```
+
+**Embedded app action**  
+The embedded app SHOULD merge the received context fields with its current state. If `containerDimensions` are provided, the app SHOULD adapt its internal layout to fit within the newly specified fixed or flexible boundaries.
+
+### D. Resource update (`ui/notifications/sandbox-resource-ready`)
 
 Sent when the application HTML content is modified or updated by the A2UI agent.
 


### PR DESCRIPTION
…Observer and host-context-changed notification

# Description

Update MCP Apps spec to allow host-controlled resizing. I.e., the Host can inform the app what window size it has room for it to display so that the app can adjust it size based on the host context to fit snuggly. 

The protocol leverages the MCP's official protocol https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx


## Pre-launch Checklist

One time:

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have built and run at least one [sample].

For this PR:

- [ ] I have updated the relevant CHANGELOG.md file.
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
