### PR TITLE
fix(web_core): guard DataModel against prototype pollution and proper…

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -43,8 +43,9 @@ exclude = [
   "a2ui\\.org/a2a-extension",
   # Internal Google "go/" short links — only reachable by Googlers, by design.
   "^https?://go/",
-  # Valid Google vanity domain (Opal) that rejects/blocks automated checkers.
+  # Valid Google vanity domains / services that reject or block automated checkers.
   "opal\\.google",
+  "gemini\\.google\\.com",
   # Known-dead external references (verified 404, no published replacement).
   # Excluded to keep CI green; drop the referencing content if gone for good.
   "github\\.com/orgs/community/discussions/187776",

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- (v0_9) Add prototype pollution protection and safe property lookup to `DataModel` (non-breaking security fix).
 - (v0_8) Export `A2uiMessageSchema` in public API.
 
 ## 0.10.5

--- a/renderers/web_core/src/v0_9/state/data-model.test.ts
+++ b/renderers/web_core/src/v0_9/state/data-model.test.ts
@@ -445,4 +445,14 @@ describe('DataModel', () => {
     assert.strictEqual(model.get('/items/-1'), undefined);
     assert.strictEqual(model.get('/items/invalid'), undefined);
   });
+
+  it('rejects leading-zero array indices (RFC 6901)', () => {
+    assert.throws(() => {
+      model.set('/items/01', 'value');
+    }, /Cannot use non-numeric segment/);
+    assert.throws(() => {
+      model.set('/items/01/nested', 'value');
+    }, /Cannot use non-numeric segment/);
+    assert.strictEqual(model.get('/items/01'), undefined);
+  });
 });

--- a/renderers/web_core/src/v0_9/state/data-model.test.ts
+++ b/renderers/web_core/src/v0_9/state/data-model.test.ts
@@ -360,4 +360,89 @@ describe('DataModel', () => {
       assert.strictEqual(user['a~1b'], 'value');
     });
   });
+
+  // --- Security Tests: Prototype Pollution Protection ---
+
+  it('prevents prototype pollution via __proto__ in set, get, getSignal, subscribe', () => {
+    assert.throws(
+      () => model.set('/__proto__/polluted', 'hacked'),
+      /Forbidden path segment '__proto__'/,
+    );
+    assert.throws(() => model.get('/__proto__/polluted'), /Forbidden path segment '__proto__'/);
+    assert.throws(
+      () => model.getSignal('/__proto__/polluted'),
+      /Forbidden path segment '__proto__'/,
+    );
+    assert.throws(
+      () => model.subscribe('/__proto__/polluted', () => {}),
+      /Forbidden path segment '__proto__'/,
+    );
+    assert.strictEqual(({} as any).polluted, undefined);
+  });
+
+  it('prevents prototype pollution via constructor in set, get, getSignal, subscribe', () => {
+    assert.throws(
+      () => model.set('/constructor/prototype/polluted', 'hacked'),
+      /Forbidden path segment 'constructor'/,
+    );
+    assert.throws(
+      () => model.get('/constructor/prototype/polluted'),
+      /Forbidden path segment 'constructor'/,
+    );
+    assert.throws(
+      () => model.getSignal('/constructor/prototype/polluted'),
+      /Forbidden path segment 'constructor'/,
+    );
+    assert.throws(
+      () => model.subscribe('/constructor/prototype/polluted', () => {}),
+      /Forbidden path segment 'constructor'/,
+    );
+    assert.strictEqual(({} as any).polluted, undefined);
+  });
+
+  it('prevents prototype pollution via prototype in set, get, getSignal, subscribe', () => {
+    assert.throws(
+      () => model.set('/user/prototype/polluted', 'hacked'),
+      /Forbidden path segment 'prototype'/,
+    );
+    assert.throws(
+      () => model.get('/user/prototype/polluted'),
+      /Forbidden path segment 'prototype'/,
+    );
+    assert.throws(
+      () => model.getSignal('/user/prototype/polluted'),
+      /Forbidden path segment 'prototype'/,
+    );
+    assert.throws(
+      () => model.subscribe('/user/prototype/polluted', () => {}),
+      /Forbidden path segment 'prototype'/,
+    );
+    assert.strictEqual(({} as any).polluted, undefined);
+  });
+
+  it('does not leak Object.prototype inherited properties on get', () => {
+    assert.strictEqual(model.get('/toString'), undefined);
+    assert.strictEqual(model.get('/valueOf'), undefined);
+    assert.strictEqual(model.get('/hasOwnProperty'), undefined);
+  });
+
+  it('allows setting and reading own properties named after prototype methods', () => {
+    model.set('/toString', 'custom toString');
+    assert.strictEqual(model.get('/toString'), 'custom toString');
+
+    model.set('/valueOf/nested', 'custom valueOf');
+    assert.strictEqual(model.get('/valueOf/nested'), 'custom valueOf');
+  });
+
+  it('throws when trying to set nested property through a primitive in an array', () => {
+    assert.throws(() => {
+      model.set('/items/0/foo', 'bar');
+    }, /Cannot set path/);
+  });
+
+  it('returns undefined for out-of-bounds or non-numeric array index in get', () => {
+    assert.strictEqual(model.get('/items/99'), undefined);
+    assert.strictEqual(model.get('/items/-1'), undefined);
+    assert.strictEqual(model.get('/items/invalid'), undefined);
+  });
 });

--- a/renderers/web_core/src/v0_9/state/data-model.ts
+++ b/renderers/web_core/src/v0_9/state/data-model.ts
@@ -37,7 +37,7 @@ export interface DataSubscription<T> extends BaseSubscription {
 }
 
 function isNumeric(value: string): boolean {
-  return /^\d+$/.test(value);
+  return /^(0|[1-9]\d*)$/.test(value);
 }
 
 /**

--- a/renderers/web_core/src/v0_9/state/data-model.ts
+++ b/renderers/web_core/src/v0_9/state/data-model.ts
@@ -17,13 +17,13 @@
 import {Subscription as BaseSubscription} from '../common/events.js';
 import {A2uiDataError} from '../errors.js';
 import {
-  signal,
-  Signal,
   batchWrite,
   effect,
   getValue,
-  setValue,
   peekValue,
+  setValue,
+  signal,
+  Signal,
 } from '../reactivity/signals.js';
 
 /**
@@ -41,6 +41,13 @@ function isNumeric(value: string): boolean {
 }
 
 /**
+ * Keys forbidden in path resolution to prevent prototype pollution
+ * vulnerabilities. Accessing or mutating these keys via object paths can allow
+ * attackers to modify Object.prototype or Function.prototype.
+ */
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
  * A standalone, observable data store representing the client-side state.
  * It handles JSON Pointer path resolution and subscription management.
  */
@@ -52,7 +59,8 @@ export class DataModel {
   /**
    * Creates a new data model.
    *
-   * @param initialData The initial data for the model. Defaults to an empty object.
+   * @param initialData The initial data for the model. Defaults to an empty
+   *     object.
    */
   constructor(initialData: Record<string, unknown> = {}) {
     this.data = initialData;
@@ -61,11 +69,13 @@ export class DataModel {
   /**
    * Retrieves a Preact Signal for a specific data path.
    *
-   * This provides a reactive way to access a value. If the value at the path changes via `set()`,
-   * the signal will automatically be updated.
+   * This provides a reactive way to access a value. If the value at the path
+   * changes via `set()`, the signal will automatically be updated.
    *
    * @param path The JSON pointer path to create or retrieve a signal for.
    * @returns A Preact Signal representing the value at the specified path.
+   * @throws {A2uiDataError} If path is null, undefined, or contains forbidden
+   *     segments (`__proto__`, `constructor`, `prototype`).
    */
   getSignal<T>(path: string): Signal<T | undefined> {
     const normalizedPath = this.normalizePath(path);
@@ -80,8 +90,17 @@ export class DataModel {
    * If path is '/' or empty, replaces the entire root.
    *
    * Note on `undefined` values:
-   * - For objects: Setting a property to `undefined` removes the key from the object.
-   * - For arrays: Setting an index to `undefined` sets that index to `undefined` but preserves the array length (sparse array).
+   * - For objects: Setting a property to `undefined` removes the key from the
+   * object.
+   * - For arrays: Setting an index to `undefined` sets that index to
+   * `undefined` but preserves the array length (sparse array).
+   *
+   * @param path The JSON pointer path to set value for.
+   * @param value The value to set at the specified path.
+   * @returns This `DataModel` instance for chaining.
+   * @throws {A2uiDataError} If path is null, undefined, invalid for
+   *     arrays/primitives, or contains forbidden segments (`__proto__`,
+   *     `constructor`, `prototype`).
    */
   set(path: string, value: any): this {
     if (path === null || path === undefined) {
@@ -104,30 +123,54 @@ export class DataModel {
     for (let i = 0; i < segments.length; i++) {
       const segment = segments[i];
 
-      if (Array.isArray(current) && !isNumeric(segment)) {
-        throw new A2uiDataError(
-          `Cannot use non-numeric segment '${segment}' on an array in path '${path}'.`,
-          path,
-        );
+      if (Array.isArray(current)) {
+        if (!isNumeric(segment)) {
+          throw new A2uiDataError(
+            `Cannot use non-numeric segment '${segment}' on an array in path '${path}'.`,
+            path,
+          );
+        }
+
+        // If we encounter a primitive where a container is expected, we cannot
+        // proceed. We allow undefined/null to be overwritten by a new
+        // container.
+        const index = parseInt(segment, 10);
+        const val = current[index];
+        if (val !== undefined && val !== null && typeof val !== 'object') {
+          throw new A2uiDataError(
+            `Cannot set path '${path}': segment '${segment}' is a primitive value.`,
+            path,
+          );
+        }
+
+        if (val === undefined || val === null) {
+          const nextSegment = i < segments.length - 1 ? segments[i + 1] : lastSegment;
+          current[index] = isNumeric(nextSegment) ? [] : {};
+        }
+      } else {
+        // Ensure we only inspect own properties to prevent inherited
+        // Object.prototype properties (e.g., toString) from being treated as
+        // existing state.
+        const hasOwnProp = Object.prototype.hasOwnProperty.call(current, segment);
+        if (hasOwnProp) {
+          const propVal = current[segment];
+          // If we encounter a primitive where a container is expected, we
+          // cannot proceed. We allow undefined/null to be overwritten by a new
+          // container.
+          if (propVal !== undefined && propVal !== null && typeof propVal !== 'object') {
+            throw new A2uiDataError(
+              `Cannot set path '${path}': segment '${segment}' is a primitive value.`,
+              path,
+            );
+          }
+        }
+
+        if (!hasOwnProp || current[segment] === undefined || current[segment] === null) {
+          const nextSegment = i < segments.length - 1 ? segments[i + 1] : lastSegment;
+          current[segment] = isNumeric(nextSegment) ? [] : {};
+        }
       }
 
-      // If we encounter a primitive where a container is expected, we cannot proceed.
-      // We allow undefined/null to be overwritten by a new container.
-      if (
-        current[segment] !== undefined &&
-        current[segment] !== null &&
-        typeof current[segment] !== 'object'
-      ) {
-        throw new A2uiDataError(
-          `Cannot set path '${path}': segment '${segment}' is a primitive value.`,
-          path,
-        );
-      }
-
-      if (current[segment] === undefined || current[segment] === null) {
-        const nextSegment = i < segments.length - 1 ? segments[i + 1] : lastSegment;
-        current[segment] = isNumeric(nextSegment) ? [] : {};
-      }
       current = current[segment];
     }
 
@@ -157,6 +200,8 @@ export class DataModel {
    *
    * @param path The JSON pointer path to read from.
    * @returns The value at the specified path, or undefined if not found.
+   * @throws {A2uiDataError} If path is null, undefined, or contains forbidden
+   *     segments (`__proto__`, `constructor`, `prototype`).
    */
   get(path: string): any {
     if (path === null || path === undefined) {
@@ -169,10 +214,25 @@ export class DataModel {
     const segments = this.parsePath(path);
     let current: any = this.data;
     for (const segment of segments) {
-      if (current === undefined || current === null) {
+      if (current === undefined || current === null || typeof current !== 'object') {
         return undefined;
       }
-      current = current[segment];
+
+      if (Array.isArray(current)) {
+        if (!isNumeric(segment)) {
+          return undefined;
+        }
+        const index = parseInt(segment, 10);
+        if (index < 0 || index >= current.length) {
+          return undefined;
+        }
+        current = current[index];
+      } else {
+        if (!Object.prototype.hasOwnProperty.call(current, segment)) {
+          return undefined;
+        }
+        current = current[segment];
+      }
     }
     return current;
   }
@@ -180,13 +240,16 @@ export class DataModel {
   /**
    * Subscribes to changes at the specified data path.
    *
-   * This is a backwards-compatible layer using Preact Signals internally. It allows
-   * listeners to be notified whenever the value at the specified path (or any of its
-   * ancestors/descendants) changes.
+   * This is a backwards-compatible layer using Preact Signals internally. It
+   * allows listeners to be notified whenever the value at the specified path
+   * (or any of its ancestors/descendants) changes.
    *
    * @param path The JSON pointer path to observe.
    * @param onChange A callback fired whenever the value changes.
-   * @returns A `DataSubscription` containing the initial value and an `unsubscribe` method.
+   * @returns A `DataSubscription` containing the initial value and an
+   *     `unsubscribe` method.
+   * @throws {A2uiDataError} If path is null, undefined, or contains forbidden
+   *     segments (`__proto__`, `constructor`, `prototype`).
    */
   subscribe<T>(path: string, onChange: (value: T | undefined) => void): DataSubscription<T> {
     const sig = this.getSignal<T>(path);
@@ -237,7 +300,13 @@ export class DataModel {
     return path
       .split('/')
       .filter(p => p.length > 0)
-      .map(p => p.replace(/~([01])/g, (_, g) => (g === '1' ? '/' : '~')));
+      .map(rawSegment => {
+        const segment = rawSegment.replace(/~([01])/g, (_, g) => (g === '1' ? '/' : '~'));
+        if (FORBIDDEN_KEYS.has(segment)) {
+          throw new A2uiDataError(`Forbidden path segment '${segment}' in path '${path}'.`, path);
+        }
+        return segment;
+      });
   }
 
   private notifySignals(path: string): void {


### PR DESCRIPTION
fix(web_core): guard DataModel against prototype pollution and property leakage

- Prevent prototype pollution by validating path segments against forbidden keys ('__proto__', 'constructor', 'prototype') in DataModel.parsePath().
- Use Object.prototype.hasOwnProperty.call() during property traversal in set() and get() to prevent inherited Object.prototype properties from leaking or being misidentified as existing state.
- Update JSDoc method documentation across DataModel to detail @param, @returns, and @throws conditions for forbidden path segments.
- Add comprehensive security and edge-case unit tests in data-model.test.ts.