### PR TITLE
fix(samples): remove workspace source override from gemini_enterprise samples

### DIFF
--- a/samples/community/agent/adk/gemini_enterprise/v0_8/agent_engine/pyproject.toml
+++ b/samples/community/agent/adk/gemini_enterprise/v0_8/agent_engine/pyproject.toml
@@ -23,6 +23,3 @@ dependencies = [
     "google-cloud-aiplatform[adk,agent-engines]>=1.128.0",
     "a2ui-agent-sdk>=0.1.2",
 ]
-
-[tool.uv.sources]
-a2ui-agent-sdk = { workspace = true }

--- a/samples/community/agent/adk/gemini_enterprise/v0_8/cloud_run/pyproject.toml
+++ b/samples/community/agent/adk/gemini_enterprise/v0_8/cloud_run/pyproject.toml
@@ -45,6 +45,3 @@ default = true
 
 [project.scripts]
 start = "main:serve"
-
-[tool.uv.sources]
-a2ui-agent-sdk = { workspace = true }


### PR DESCRIPTION
Remove `[tool.uv.sources]` specifying `a2ui-agent-sdk = { workspace = true }` from the Gemini Enterprise v0.8 sample packages.

- Prevents build and installation failures when deploying or running `agent_engine` and `cloud_run` samples as standalone packages outside the root workspace context.
- Allows `uv` and `pip` to resolve `a2ui-agent-sdk` directly from PyPI as declared in project dependencies.