### PR TITLE
fix(web_core): fix v0.9 TS compilation issues, prototype restoration, and schema path resolution

### DIFF
--- a/renderers/web_core/src/v0_9/catalog/types.test.ts
+++ b/renderers/web_core/src/v0_9/catalog/types.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'node:assert';
 import {describe, it} from 'node:test';
 import {
   Catalog,

--- a/renderers/web_core/src/v0_9/common/events.test.ts
+++ b/renderers/web_core/src/v0_9/common/events.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'node:assert';
 import {describe, it} from 'node:test';
 import {EventEmitter} from './events.js';
 

--- a/renderers/web_core/src/v0_9/processing/message-processor.test.ts
+++ b/renderers/web_core/src/v0_9/processing/message-processor.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'node:assert';
 import {describe, it, beforeEach} from 'node:test';
 import {MessageProcessor} from './message-processor.js';
 import {Catalog, ComponentApi} from '../catalog/types.js';

--- a/renderers/web_core/src/v0_9/reactivity/signals.test.ts
+++ b/renderers/web_core/src/v0_9/reactivity/signals.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'node:assert';
 import {after, describe, it} from 'node:test';
 import {
   signal as aSignal,

--- a/renderers/web_core/src/v0_9/rendering/data-context.test.ts
+++ b/renderers/web_core/src/v0_9/rendering/data-context.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'node:assert';
 import {describe, it, beforeEach} from 'node:test';
 import {signal, computed, peekValue, getValue, setValue} from '../reactivity/signals.js';
 import {z} from 'zod';

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'node:assert';
 import {describe, it} from 'node:test';
 import {z} from 'zod';
 import {GenericBinder} from './generic-binder.js';

--- a/renderers/web_core/src/v0_9/schema/verify-schema.test.ts
+++ b/renderers/web_core/src/v0_9/schema/verify-schema.test.ts
@@ -17,9 +17,8 @@
 import {describe, it} from 'node:test';
 import * as assert from 'node:assert';
 import {zodToJsonSchema} from 'zod-to-json-schema';
-import {readFileSync} from 'fs';
-import {resolve, join, dirname} from 'path';
-import {fileURLToPath} from 'url';
+import {readFileSync, existsSync} from 'fs';
+import {resolve, join} from 'path';
 import {
   A2uiMessageSchema,
   CreateSurfaceMessageSchema,
@@ -28,11 +27,10 @@ import {
   DeleteSurfaceMessageSchema,
 } from './server-to-client.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-// `__dirname` will be `dist/src/v0_9/schema` when run via `node --test dist/**/*.test.js`
-const SPEC_DIR_V0_9 = resolve(__dirname, '../../../../../../specification/v0_9/json');
+const currentDir = typeof __dirname !== 'undefined' ? __dirname : resolve('src/v0_9/schema');
+const specPathCandidate1 = resolve(currentDir, '../../../../../specification/v0_9/json');
+const specPathCandidate2 = resolve(currentDir, '../../../../../../specification/v0_9/json');
+const SPEC_DIR_V0_9 = existsSync(specPathCandidate1) ? specPathCandidate1 : specPathCandidate2;
 
 // Parse both so we can do structural comparison rather than formatting
 // Compare definitions specifically, ignoring descriptions

--- a/renderers/web_core/src/v0_9/state/component-model.test.ts
+++ b/renderers/web_core/src/v0_9/state/component-model.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'node:assert';
 import {describe, it, beforeEach} from 'node:test';
 import {ComponentModel} from './component-model.js';
 

--- a/renderers/web_core/src/v0_9/state/data-model.test.ts
+++ b/renderers/web_core/src/v0_9/state/data-model.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'node:assert';
 import {describe, it, beforeEach} from 'node:test';
 import {DataModel} from './data-model.js';
 

--- a/renderers/web_core/src/v0_9/state/surface-components-model.test.ts
+++ b/renderers/web_core/src/v0_9/state/surface-components-model.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'node:assert';
 import {describe, it, beforeEach} from 'node:test';
 import {SurfaceComponentsModel} from './surface-components-model.js';
 import {ComponentModel} from './component-model.js';

--- a/renderers/web_core/src/v0_9/state/surface-group-model.test.ts
+++ b/renderers/web_core/src/v0_9/state/surface-group-model.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'node:assert';
 import {describe, it, beforeEach} from 'node:test';
 import {SurfaceGroupModel} from './surface-group-model.js';
 import {Catalog, ComponentApi} from '../catalog/types.js';

--- a/renderers/web_core/src/v0_9/state/surface-model.test.ts
+++ b/renderers/web_core/src/v0_9/state/surface-model.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import assert from 'node:assert';
+import * as assert from 'node:assert';
 import {describe, it, beforeEach} from 'node:test';
 import {SurfaceModel} from './surface-model.js';
 import {Catalog, ComponentApi} from '../catalog/types.js';


### PR DESCRIPTION
## What
Fixes TypeScript compilation issues, error prototype restoration, and schema path resolution in `web_core` v0.9:
- Add `Object.setPrototypeOf(this, new.target.prototype)` to `A2uiError` and all subclasses to ensure proper prototype restoration when compiled to ES5/CommonJS.
- Replace default `assert` imports with namespace import (`import * as assert from 'node:assert'`) across all v0.9 test files.
- Update `verify-schema.test.ts` path resolution for `currentDir` using `__dirname` when available and `resolve('src/v0_9/schema')` fallback.

## Testing
- Ran `npm test` under `renderers/web_core` — 279/279 tests pass.
