### PR TITLE
feat(v1.0): add rootOnly component metadata to enforce root-level rendering

### DIFF
--- a/specification/v1_0/docs/a2ui_protocol.md
+++ b/specification/v1_0/docs/a2ui_protocol.md
@@ -519,7 +519,7 @@ To ensure catalog schemas can be translated reliably into alternative, LLM-frien
      - Mandatory metadata fields outside the strict JSON validation properties to advertise interface details:
        - **`returnType`**: Must be a string enum indicating the return type (`string`, `number`, `boolean`, `array`, `object`, `any`, or `void`).
        - **`callableFrom`**: Must be a string enum indicating the execution boundary (`rendererOnly`, `agentOnly`, or `rendererOrAgent`). If omitted, it defaults to `rendererOnly`.
-7. **Component Structural Metadata:**
+7. **rootOnly components:**
    - Component schemas may include an optional `rootOnly` boolean property. If `"rootOnly": true`, the renderer MUST enforce that instances of this component are only rendered at the root of a surface and MUST reject payloads that nest this component within another.
 8. **Strict Top-Level Schema Keys:**
    - To keep catalog schemas predictable and prevent custom extensions from polluting the global file space, a `catalog.json` file is restricted to the following root-level keys:
@@ -550,8 +550,10 @@ Below is an annotated, fully compliant `catalog.json` schema template (written i
 
   // Rule 1: Top-level components declared under top-level "components" map.
   "components": {
-    "Text": {
+    "ToastMessage": {
       "type": "object",
+      // Rule 7: rootOnly components like this "Toast" can't be nested inside other components
+      "rootOnly": true,
       // Rule 5: Components must combine ComponentCommon and local properties using "allOf".
       "allOf": [
         {

--- a/specification/v1_0/docs/a2ui_protocol.md
+++ b/specification/v1_0/docs/a2ui_protocol.md
@@ -519,7 +519,9 @@ To ensure catalog schemas can be translated reliably into alternative, LLM-frien
      - Mandatory metadata fields outside the strict JSON validation properties to advertise interface details:
        - **`returnType`**: Must be a string enum indicating the return type (`string`, `number`, `boolean`, `array`, `object`, `any`, or `void`).
        - **`callableFrom`**: Must be a string enum indicating the execution boundary (`rendererOnly`, `agentOnly`, or `rendererOrAgent`). If omitted, it defaults to `rendererOnly`.
-7. **Strict Top-Level Schema Keys:**
+7. **Component Structural Metadata:**
+   - Component schemas may include an optional `rootOnly` boolean property outside the strict JSON validation properties block. If `"rootOnly": true`, the renderer MUST enforce that instances of this component are only rendered at the root of a surface and MUST reject payloads that nest this component within another.
+8. **Strict Top-Level Schema Keys:**
    - To keep catalog schemas predictable and prevent custom extensions from polluting the global file space, a `catalog.json` file is restricted to the following root-level keys:
      - `$schema`
      - `$id`
@@ -538,7 +540,7 @@ Below is an annotated, fully compliant `catalog.json` schema template (written i
 
 ```jsonc
 {
-  // Rule 7: Strict Top-Level Schema Keys
+  // Rule 8: Strict Top-Level Schema Keys
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://a2ui.org/specification/v1_0/catalogs/basic/catalog.json",
   "title": "A2UI Basic Catalog Template",

--- a/specification/v1_0/docs/a2ui_protocol.md
+++ b/specification/v1_0/docs/a2ui_protocol.md
@@ -520,7 +520,7 @@ To ensure catalog schemas can be translated reliably into alternative, LLM-frien
        - **`returnType`**: Must be a string enum indicating the return type (`string`, `number`, `boolean`, `array`, `object`, `any`, or `void`).
        - **`callableFrom`**: Must be a string enum indicating the execution boundary (`rendererOnly`, `agentOnly`, or `rendererOrAgent`). If omitted, it defaults to `rendererOnly`.
 7. **Component Structural Metadata:**
-   - Component schemas may include an optional `rootOnly` boolean property outside the strict JSON validation properties block. If `"rootOnly": true`, the renderer MUST enforce that instances of this component are only rendered at the root of a surface and MUST reject payloads that nest this component within another.
+   - Component schemas may include an optional `rootOnly` boolean property. If `"rootOnly": true`, the renderer MUST enforce that instances of this component are only rendered at the root of a surface and MUST reject payloads that nest this component within another.
 8. **Strict Top-Level Schema Keys:**
    - To keep catalog schemas predictable and prevent custom extensions from polluting the global file space, a `catalog.json` file is restricted to the following root-level keys:
      - `$schema`

--- a/specification/v1_0/docs/a2ui_protocol.md
+++ b/specification/v1_0/docs/a2ui_protocol.md
@@ -519,8 +519,8 @@ To ensure catalog schemas can be translated reliably into alternative, LLM-frien
      - Mandatory metadata fields outside the strict JSON validation properties to advertise interface details:
        - **`returnType`**: Must be a string enum indicating the return type (`string`, `number`, `boolean`, `array`, `object`, `any`, or `void`).
        - **`callableFrom`**: Must be a string enum indicating the execution boundary (`rendererOnly`, `agentOnly`, or `rendererOrAgent`). If omitted, it defaults to `rendererOnly`.
-7. **rootOnly components:**
-   - Component schemas may include an optional `rootOnly` boolean property. If `"rootOnly": true`, the renderer MUST enforce that instances of this component are only rendered at the root of a surface and MUST reject payloads that nest this component within another.
+7. **Root-Only Components (`rootOnly` Property):**
+   - Component schemas may include an optional `rootOnly` boolean property. If `"rootOnly": true`, the renderer MUST enforce that instances of this component appear only at the root of a surface, rejecting any payloads that nest the component within another component.
 8. **Strict Top-Level Schema Keys:**
    - To keep catalog schemas predictable and prevent custom extensions from polluting the global file space, a `catalog.json` file is restricted to the following root-level keys:
      - `$schema`
@@ -552,7 +552,7 @@ Below is an annotated, fully compliant `catalog.json` schema template (written i
   "components": {
     "ToastMessage": {
       "type": "object",
-      // Rule 7: rootOnly components like this "Toast" can't be nested inside other components
+      // Rule 7: Root-only components like "ToastMessage" cannot be nested inside other components.
       "rootOnly": true,
       // Rule 5: Components must combine ComponentCommon and local properties using "allOf".
       "allOf": [
@@ -565,7 +565,7 @@ Below is an annotated, fully compliant `catalog.json` schema template (written i
           "properties": {
             // Rule 4: Required "component" property must be a constant matching the component key.
             "component": {
-              "const": "Text",
+              "const": "ToastMessage",
             },
             // Leaf properties can be standard JSON primitives or Dynamic wrappers
             "text": {

--- a/specification/v1_0/docs/a2ui_protocol.md
+++ b/specification/v1_0/docs/a2ui_protocol.md
@@ -519,7 +519,7 @@ To ensure catalog schemas can be translated reliably into alternative, LLM-frien
      - Mandatory metadata fields outside the strict JSON validation properties to advertise interface details:
        - **`returnType`**: Must be a string enum indicating the return type (`string`, `number`, `boolean`, `array`, `object`, `any`, or `void`).
        - **`callableFrom`**: Must be a string enum indicating the execution boundary (`rendererOnly`, `agentOnly`, or `rendererOrAgent`). If omitted, it defaults to `rendererOnly`.
-7. **Root-Only Components (`rootOnly` Property):**
+7. **Root-Only Components:**
    - Component schemas may include an optional `rootOnly` boolean property. If `"rootOnly": true`, the renderer MUST enforce that instances of this component appear only at the root of a surface, rejecting any payloads that nest the component within another component.
 8. **Strict Top-Level Schema Keys:**
    - To keep catalog schemas predictable and prevent custom extensions from polluting the global file space, a `catalog.json` file is restricted to the following root-level keys:

--- a/specification/v1_0/docs/evolution_guide.md
+++ b/specification/v1_0/docs/evolution_guide.md
@@ -12,7 +12,7 @@ Version 1.0 differs from 0.9 in the following ways:
 - Components and initial data model states can be defined directly within the `createSurface` parameters. This allows for the creation of entire UIs in a single message, rather than a create followed by separate updates.
 - The `functions` field in a Catalog is now defined as a map of function name to its definition, instead of a list.
 - Standard JSON Schema metadata fields (`$schema`, `$id`, `title`, and `description`) are supported in catalogs, preventing validation failures on inline catalogs with strict property checks.
-- A new `rootOnly` structural validation property on component schemas prevents standalone widgets from being nested inside containers.
+- A new `rootOnly` structural validation property on component schemas prevents standalone widgets or containers that only belong at the root from being nested inside other components.
 - Identifier naming rules across all catalog entities (component names, function names, and argument keys) must conform to Unicode Standard Annex #31 (UAX #31).
 - The `@index` built-in function dynamically retrieves iteration indices during list template rendering. The `@` prefix is reserved for core system context evaluations.
 - Standardized the names of core architectural components, renaming "client" to _renderer_ and "server" to _agent_ (e.g., `server_to_client` schemas are renamed to `agent_to_renderer`), because A2UI is sometimes generated on clients, and rendering sometimes happens on servers, making those terms ambiguous.
@@ -24,7 +24,7 @@ Version 1.0 differs from 0.9 in the following ways:
 - Renamed the `$defs/theme` schema to `$defs/surfaceProperties` in the Catalog schema, and removed the `primaryColor` property.
 - Changed the `functions` property in the Catalog schema from a list to a map object, keyed by function name.
 - Added `callableFrom` (enum: `rendererOnly`, `agentOnly`, `rendererOrAgent`) to `FunctionDefinition` to restrict where a function can be invoked.
-- Added `rootOnly` (boolean) to `ComponentDefinition` to enforce structural validation, preventing standalone components from being nested inside others.
+- Added `rootOnly` (boolean) to `ComponentDefinition` to enforce structural validation, preventing standalone widgets or containers that only belong at root from being nested inside others.
 - Added an optional `instructions` field to the `Catalog` schema to embed design guidelines and component usage rules directly in the catalog, replacing the external `rules.txt` file.
 - Supported standard JSON Schema metadata fields (`$schema`, `$id`, `title`, and `description`) in the Catalog object definition. Since the Catalog schema restricts properties with `additionalProperties: false`, this ensures inline catalogs containing standard schema metadata do not fail schema validation.
 - Enforced Unicode Standard Annex #31 (UAX #31) identifier naming constraints (`XID_Start`, `XID_Continue`) across component names, function names, and argument keys.

--- a/specification/v1_0/docs/evolution_guide.md
+++ b/specification/v1_0/docs/evolution_guide.md
@@ -12,7 +12,7 @@ Version 1.0 differs from 0.9 in the following ways:
 - Components and initial data model states can be defined directly within the `createSurface` parameters. This allows for the creation of entire UIs in a single message, rather than a create followed by separate updates.
 - The `functions` field in a Catalog is now defined as a map of function name to its definition, instead of a list.
 - Standard JSON Schema metadata fields (`$schema`, `$id`, `title`, and `description`) are supported in catalogs, preventing validation failures on inline catalogs with strict property checks.
-- A new `rootOnly` structural validation property on component schemas prevents standalone widgets or containers that only belong at the root from being nested inside other components.
+- A new `rootOnly` boolean property on component schemas prevents standalone root-level widgets or containers from being nested inside other components.
 - Identifier naming rules across all catalog entities (component names, function names, and argument keys) must conform to Unicode Standard Annex #31 (UAX #31).
 - The `@index` built-in function dynamically retrieves iteration indices during list template rendering. The `@` prefix is reserved for core system context evaluations.
 - Standardized the names of core architectural components, renaming "client" to _renderer_ and "server" to _agent_ (e.g., `server_to_client` schemas are renamed to `agent_to_renderer`), because A2UI is sometimes generated on clients, and rendering sometimes happens on servers, making those terms ambiguous.
@@ -24,7 +24,7 @@ Version 1.0 differs from 0.9 in the following ways:
 - Renamed the `$defs/theme` schema to `$defs/surfaceProperties` in the Catalog schema, and removed the `primaryColor` property.
 - Changed the `functions` property in the Catalog schema from a list to a map object, keyed by function name.
 - Added `callableFrom` (enum: `rendererOnly`, `agentOnly`, `rendererOrAgent`) to `FunctionDefinition` to restrict where a function can be invoked.
-- Added `rootOnly` (boolean) to `ComponentDefinition` to enforce structural validation, preventing standalone widgets or containers that only belong at root from being nested inside others.
+- Added `rootOnly` (boolean) to `ComponentDefinition` to prevent standalone root-level components from being nested inside other components.
 - Added an optional `instructions` field to the `Catalog` schema to embed design guidelines and component usage rules directly in the catalog, replacing the external `rules.txt` file.
 - Supported standard JSON Schema metadata fields (`$schema`, `$id`, `title`, and `description`) in the Catalog object definition. Since the Catalog schema restricts properties with `additionalProperties: false`, this ensures inline catalogs containing standard schema metadata do not fail schema validation.
 - Enforced Unicode Standard Annex #31 (UAX #31) identifier naming constraints (`XID_Start`, `XID_Continue`) across component names, function names, and argument keys.
@@ -56,7 +56,7 @@ Version 1.0 differs from 0.9 in the following ways:
 - Added an optional `instructions` field to the `Catalog` object definition (`catalog_definition.json`) as a plain Markdown string to embed design guidelines directly.
 - Renamed `theme` capability block to `surfaceProperties` within the Catalog definition in `catalog_definition.json`.
 - Added static `callableFrom` and `returnType` metadata properties to `FunctionDefinition` inside `catalog_definition.json` to advertise execution boundaries and return types to the agent.
-- Added `rootOnly` metadata property to `ComponentDefinition` inside `catalog_definition.json` to enforce structural validation at runtime.
+- Added a static `rootOnly` boolean property to `ComponentDefinition` inside `catalog_definition.json` to enforce that certain components can only be rendered at the root of a surface and not nested within other components.
 
 ### 2.6. Agent card and transport metadata
 

--- a/specification/v1_0/docs/evolution_guide.md
+++ b/specification/v1_0/docs/evolution_guide.md
@@ -12,6 +12,7 @@ Version 1.0 differs from 0.9 in the following ways:
 - Components and initial data model states can be defined directly within the `createSurface` parameters. This allows for the creation of entire UIs in a single message, rather than a create followed by separate updates.
 - The `functions` field in a Catalog is now defined as a map of function name to its definition, instead of a list.
 - Standard JSON Schema metadata fields (`$schema`, `$id`, `title`, and `description`) are supported in catalogs, preventing validation failures on inline catalogs with strict property checks.
+- A new `rootOnly` structural validation property on component schemas prevents standalone widgets from being nested inside containers.
 - Identifier naming rules across all catalog entities (component names, function names, and argument keys) must conform to Unicode Standard Annex #31 (UAX #31).
 - The `@index` built-in function dynamically retrieves iteration indices during list template rendering. The `@` prefix is reserved for core system context evaluations.
 - Standardized the names of core architectural components, renaming "client" to _renderer_ and "server" to _agent_ (e.g., `server_to_client` schemas are renamed to `agent_to_renderer`), because A2UI is sometimes generated on clients, and rendering sometimes happens on servers, making those terms ambiguous.
@@ -23,6 +24,7 @@ Version 1.0 differs from 0.9 in the following ways:
 - Renamed the `$defs/theme` schema to `$defs/surfaceProperties` in the Catalog schema, and removed the `primaryColor` property.
 - Changed the `functions` property in the Catalog schema from a list to a map object, keyed by function name.
 - Added `callableFrom` (enum: `rendererOnly`, `agentOnly`, `rendererOrAgent`) to `FunctionDefinition` to restrict where a function can be invoked.
+- Added `rootOnly` (boolean) to `ComponentDefinition` to enforce structural validation, preventing standalone components from being nested inside others.
 - Added an optional `instructions` field to the `Catalog` schema to embed design guidelines and component usage rules directly in the catalog, replacing the external `rules.txt` file.
 - Supported standard JSON Schema metadata fields (`$schema`, `$id`, `title`, and `description`) in the Catalog object definition. Since the Catalog schema restricts properties with `additionalProperties: false`, this ensures inline catalogs containing standard schema metadata do not fail schema validation.
 - Enforced Unicode Standard Annex #31 (UAX #31) identifier naming constraints (`XID_Start`, `XID_Continue`) across component names, function names, and argument keys.
@@ -54,6 +56,7 @@ Version 1.0 differs from 0.9 in the following ways:
 - Added an optional `instructions` field to the `Catalog` object definition (`catalog_definition.json`) as a plain Markdown string to embed design guidelines directly.
 - Renamed `theme` capability block to `surfaceProperties` within the Catalog definition in `catalog_definition.json`.
 - Added static `callableFrom` and `returnType` metadata properties to `FunctionDefinition` inside `catalog_definition.json` to advertise execution boundaries and return types to the agent.
+- Added `rootOnly` metadata property to `ComponentDefinition` inside `catalog_definition.json` to enforce structural validation at runtime.
 
 ### 2.6. Agent card and transport metadata
 

--- a/specification/v1_0/json/catalog_definition.json
+++ b/specification/v1_0/json/catalog_definition.json
@@ -136,14 +136,21 @@
     },
     "ComponentDefinition": {
       "description": "Describes a component's validation schema and structural metadata.",
-      "$ref": "https://json-schema.org/draft/2020-12/schema",
-      "properties": {
-        "rootOnly": {
-          "type": "boolean",
-          "default": false,
-          "description": "If true, this component must only be instantiated at the root of a surface."
+      "allOf": [
+        {
+          "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "rootOnly": {
+              "type": "boolean",
+              "default": false,
+              "description": "If true, this component must only be instantiated at the root of a surface."
+            }
+          }
         }
-      }
+      ]
     }
   }
 }

--- a/specification/v1_0/json/catalog_definition.json
+++ b/specification/v1_0/json/catalog_definition.json
@@ -50,7 +50,7 @@
       "type": "object",
       "description": "Definitions for UI components supported by this catalog.",
       "additionalProperties": {
-        "$ref": "https://json-schema.org/draft/2020-12/schema"
+        "$ref": "#/$defs/ComponentDefinition"
       }
     },
     "functions": {
@@ -133,6 +133,21 @@
         }
       ],
       "unevaluatedProperties": false
+    },
+    "ComponentDefinition": {
+      "type": "object",
+      "description": "Describes a component's validation schema and structural metadata.",
+      "allOf": [
+        {
+          "$ref": "https://json-schema.org/draft/2020-12/schema"
+        }
+      ],
+      "properties": {
+        "rootOnly": {
+          "type": "boolean",
+          "description": "If true, this component must only be instantiated at the root of a surface."
+        }
+      }
     }
   }
 }

--- a/specification/v1_0/json/catalog_definition.json
+++ b/specification/v1_0/json/catalog_definition.json
@@ -135,13 +135,8 @@
       "unevaluatedProperties": false
     },
     "ComponentDefinition": {
-      "type": "object",
       "description": "Describes a component's validation schema and structural metadata.",
-      "allOf": [
-        {
-          "$ref": "https://json-schema.org/draft/2020-12/schema"
-        }
-      ],
+      "$ref": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "rootOnly": {
           "type": "boolean",

--- a/specification/v1_0/json/catalog_definition.json
+++ b/specification/v1_0/json/catalog_definition.json
@@ -146,7 +146,7 @@
             "rootOnly": {
               "type": "boolean",
               "default": false,
-              "description": "If true, this component must only be instantiated at the root of a surface."
+              "description": "If true, this component must only be rendered at the root of a surface and cannot be nested within other components."
             }
           }
         }

--- a/specification/v1_0/json/catalog_definition.json
+++ b/specification/v1_0/json/catalog_definition.json
@@ -140,6 +140,7 @@
       "properties": {
         "rootOnly": {
           "type": "boolean",
+          "default": false,
           "description": "If true, this component must only be instantiated at the root of a surface."
         }
       }

--- a/specification/v1_0/test/cases/catalog_root_only_checks.json
+++ b/specification/v1_0/test/cases/catalog_root_only_checks.json
@@ -1,0 +1,71 @@
+{
+  "schema": "catalog_definition.json",
+  "tests": [
+    {
+      "description": "Component defining rootOnly: true is valid",
+      "valid": true,
+      "data": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://a2ui.org/specification/v1_0/testing_catalog_valid.json",
+        "title": "A2UI Testing Catalog",
+        "description": "Catalog for testing purposes.",
+        "catalogId": "https://a2ui.org/specification/v1_0/testing_catalog.json",
+        "components": {
+          "MyRootOnlyWidget": {
+            "rootOnly": true,
+            "type": "object",
+            "properties": {
+              "component": {"const": "MyRootOnlyWidget"}
+            },
+            "required": ["component"]
+          }
+        },
+        "functions": {},
+        "$defs": {
+          "anyComponent": {
+            "oneOf": [{"$ref": "#/components/MyRootOnlyWidget"}],
+            "discriminator": {
+              "propertyName": "component"
+            }
+          },
+          "anyFunction": {
+            "not": {}
+          }
+        }
+      }
+    },
+    {
+      "description": "Component defining rootOnly with incorrect type (string) is invalid",
+      "valid": false,
+      "data": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://a2ui.org/specification/v1_0/testing_catalog_invalid.json",
+        "title": "A2UI Testing Catalog",
+        "description": "Catalog for testing purposes.",
+        "catalogId": "https://a2ui.org/specification/v1_0/testing_catalog.json",
+        "components": {
+          "MyRootOnlyWidget": {
+            "rootOnly": "true",
+            "type": "object",
+            "properties": {
+              "component": {"const": "MyRootOnlyWidget"}
+            },
+            "required": ["component"]
+          }
+        },
+        "functions": {},
+        "$defs": {
+          "anyComponent": {
+            "oneOf": [{"$ref": "#/components/MyRootOnlyWidget"}],
+            "discriminator": {
+              "propertyName": "component"
+            }
+          },
+          "anyFunction": {
+            "not": {}
+          }
+        }
+      }
+    }
+  ]
+}

--- a/specification/v1_0/test/run_tests.py
+++ b/specification/v1_0/test/run_tests.py
@@ -35,6 +35,7 @@ SCHEMAS = {
     "common_types.json": os.path.join(SCHEMA_DIR, "common_types.json"),
     "catalog.json": TEMP_CATALOG_FILE,
     "renderer_to_agent.json": os.path.join(SCHEMA_DIR, "renderer_to_agent.json"),
+    "catalog_definition.json": os.path.join(SCHEMA_DIR, "catalog_definition.json"),
 }
 
 


### PR DESCRIPTION
## What changed
Introduces an optional `rootOnly` boolean metadata property to component definitions in the A2UI v1.0 Catalog schema (`catalog_definition.json`). 
When `"rootOnly": true`, renderers must enforce that instances of the component appear only at the root of a surface and reject payloads that nest the component within another component.
## Why this is needed
A2UI v1.0 added support for mixing catalogs, so standalone components (`SuggestionBox`, `Canvas`, full-page iframe, `ToastMessage`) are now mixable with composable widget catalogs (`Button`, `Table`, `TextBox`). A mechanism is needed for catalog components to explicitly opt out of nesting. Since this involves interaction between catalogs using the ChildList in common_types, this can't be solved by individual catalogs themselves and we need a framework wide mechanism. Additionally, since A2UI represents component trees as a flat adjacency list on the wire, standard JSON Schema validation cannot detect when a standalone component is invalidly nested inside another component. 
## Why this approach
- **Zero wire overhead:** Defining `rootOnly` as static catalog metadata (parallel to `callableFrom` and `returnType` for functions) avoids adding validation properties to wire payloads in `common_types.json`.
- **Targeted scope:** A top-level `rootOnly` boolean cleanly solves the most common structural issue when mixing catalogs. More complex parent-child constraints (eg, MenuItem is the only child of Menu) remain the responsibility of individual component schemas.
## Testing
- Updated `specification/v1_0/json/catalog_definition.json`, `a2ui_protocol.md`, and `evolution_guide.md`.
- Added schema validation test cases in `catalog_root_only_checks.json` and updated `run_tests.py`.
