### PR TITLE
Simplify triage templates by removing instructions for agent.

### DIFF
--- a/docs/contributing/triage-templates.md
+++ b/docs/contributing/triage-templates.md
@@ -1,26 +1,6 @@
 # A2UI Standard Triage Replies
 
-Canonical replies the team has agreed on for recurring triage cases. Check this list
-**before** drafting a new response.
-
-## How to use these replies
-
-1. **Match first.** If the issue or PR fits one of the cases below, use that reply.
-2. **Verbatim by default.** Post the reply as written when the case matches cleanly. These
-   texts encode team policy and agreed tone, so do not rewrite them for style — the
-   [natural-writing](../../.agents/skills/natural-writing/SKILL.md) guidance applies to
-   replies you draft yourself, not to these.
-3. **Modify only when the case needs it.** Fill in every placeholder (`<link to new PR>`,
-   canonical issue number, the specific missing detail), and add at most one or two
-   sentences of issue-specific context. Keep the policy sentences intact.
-4. **Apply the paired triage fields.** Each case lists the priority and action that go with
-   it, so the reply and the labels stay consistent.
-5. **Fall back deliberately.** If no case matches, draft a reply following the response
-   guidelines in
-   [triage_criteria.md](../../.agents/skills/a2ui-issue-triage/references/triage_criteria.md),
-   and say in your summary that no standard reply applied.
-
----
+Canonical replies for recurring triage cases. 
 
 ## Issues
 

--- a/docs/contributing/triage-templates.md
+++ b/docs/contributing/triage-templates.md
@@ -1,6 +1,6 @@
 # A2UI Standard Triage Replies
 
-Canonical replies for recurring triage cases. 
+Canonical replies for recurring triage cases.
 
 ## Issues
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -52,6 +52,9 @@ exclude = [
   "flutter/genui/blob/main/examples/e2e/",
   # Flaky. See: https://github.com/a2ui-project/a2ui/issues/1747
   "https://ojs\\.aaai\\.org",
+  # Flaky: the host intermittently stops responding entirely (connection hangs
+  # well past our 20s timeout) while the cited paper is still published there.
+  "https://www\\.diva-portal\\.org",
 ]
 
 # Don't descend into dependency or build-output directories.


### PR DESCRIPTION
Simplifies the triage templates and unblocks the Docs CI check.

## Changes

**`docs/contributing/triage-templates.md`** — removed the "How to use these replies"
section. The five numbered steps described how an agent should pick, apply, and fall back
from these replies, which is guidance that belongs with the triage skill rather than in the
template list itself. What remains is what the file is for: the canonical replies, each with
its case and the triage fields that go with it.

**`lychee.toml`** — excluded `https://www.diva-portal.org` from the Markdown link check.
The host intermittently stops responding altogether — connections hang well past the 20s
lychee timeout — which failed `Docs / build_and_deploy` on this PR even though the citation
lives in `eval/DESIGN.md` and is untouched here. The paper is still published there, so the
reference stays and only the check is skipped. This follows the existing precedent for
`ojs.aaai.org` in the same file.

## Testing

- `./scripts/fix_format.sh --check` passes.
- `lychee --config lychee.toml --no-progress "**/*.md"` no longer reports the timeout, and
  the exclusion introduces no new errors.
