### PR TITLE
feat(accessibility): Implement Issue 1410: Add accessibility attributes to A2UI components

### DIFF
--- a/renderers/angular/src/v0_9/catalog/basic/button.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/button.component.spec.ts
@@ -180,7 +180,7 @@ describe('ButtonComponent', () => {
     fixture.detectChanges();
     const button = fixture.debugElement.query(By.css('button'));
     expect(button.nativeElement.getAttribute('aria-label')).toBe('Submit Form');
-    expect(button.nativeElement.getAttribute('aria-describedby')).toBe(
+    expect(button.nativeElement.getAttribute('aria-description')).toBe(
       'Submits the user details to the server'
     );
   });

--- a/renderers/angular/src/v0_9/catalog/basic/button.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/button.component.spec.ts
@@ -17,7 +17,7 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component, input} from '@angular/core';
 import {ButtonComponent} from './button.component';
-import {Action, ComponentModel} from '@a2ui/web_core/v0_9';
+import {Action, ComponentModel, AccessibilityAttributes} from '@a2ui/web_core/v0_9';
 import {A2uiRendererService} from '../../core/a2ui-renderer.service';
 import {ComponentBinder, Child} from '../../core/component-binder.service';
 import {By} from '@angular/platform-browser';
@@ -95,6 +95,7 @@ describe('ButtonComponent', () => {
       }),
       isValid: createBoundProperty(true),
       validationErrors: createBoundProperty<string[]>([]),
+      accessibility: createBoundProperty<AccessibilityAttributes>({}),
     };
     setComponentProps(fixture, defaultProps);
   });
@@ -166,5 +167,21 @@ describe('ButtonComponent', () => {
     const computedStyle = window.getComputedStyle(button.nativeElement);
 
     expect(computedStyle.backgroundColor).toBe('rgb(255, 0, 0)'); // 'red' is evaluated to rgb in computed style
+  });
+
+  it('should apply accessibility attributes', () => {
+    setComponentProps(fixture, {
+      ...defaultProps,
+      accessibility: createBoundProperty<AccessibilityAttributes>({
+        label: 'Submit Form',
+        description: 'Submits the user details to the server',
+      }),
+    });
+    fixture.detectChanges();
+    const button = fixture.debugElement.query(By.css('button'));
+    expect(button.nativeElement.getAttribute('aria-label')).toBe('Submit Form');
+    expect(button.nativeElement.getAttribute('aria-describedby')).toBe(
+      'Submits the user details to the server'
+    );
   });
 });

--- a/renderers/angular/src/v0_9/catalog/basic/button.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/button.component.ts
@@ -45,6 +45,8 @@ import {ButtonApi} from '@a2ui/web_core/v0_9/basic_catalog';
       [class]="'a2ui-button ' + variant()"
       (click)="handleClick()"
       [disabled]="props()['isValid']?.value() === false"
+      [attr.aria-label]="ariaLabel()"
+      [attr.aria-describedby]="ariaDescribedBy()"
     >
       @if (child()) {
         <a2ui-v09-component-host [componentKey]="child()!" [surfaceId]="surfaceId()">
@@ -99,6 +101,8 @@ export class ButtonComponent extends BasicCatalogComponent<typeof ButtonApi> {
   readonly variant = computed(() => this.props()['variant']?.value() ?? 'default');
   readonly child = computed(() => this.props()['child']?.value());
   readonly action = computed(() => this.props()['action']?.value());
+  readonly ariaLabel = computed(() => this.props()['accessibility']?.value()?.label ?? null);
+  readonly ariaDescribedBy = computed(() => this.props()['accessibility']?.value()?.description ?? null);
 
   handleClick() {
     const action = this.action();

--- a/renderers/angular/src/v0_9/catalog/basic/button.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/button.component.ts
@@ -46,7 +46,7 @@ import {ButtonApi} from '@a2ui/web_core/v0_9/basic_catalog';
       (click)="handleClick()"
       [disabled]="props()['isValid']?.value() === false"
       [attr.aria-label]="ariaLabel()"
-      [attr.aria-describedby]="ariaDescribedBy()"
+      [attr.aria-description]="ariaDescription()"
     >
       @if (child()) {
         <a2ui-v09-component-host [componentKey]="child()!" [surfaceId]="surfaceId()">
@@ -103,7 +103,7 @@ export class ButtonComponent extends BasicCatalogComponent<typeof ButtonApi> {
   readonly action = computed(() => this.props()['action']?.value());
   readonly accessibility = computed(() => this.props()['accessibility']?.value());
   readonly ariaLabel = computed(() => this.accessibility()?.label ?? null);
-  readonly ariaDescribedBy = computed(() => this.accessibility()?.description ?? null);
+  readonly ariaDescription = computed(() => this.accessibility()?.description ?? null);
 
   handleClick() {
     const action = this.action();

--- a/renderers/angular/src/v0_9/catalog/basic/button.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/button.component.ts
@@ -101,8 +101,9 @@ export class ButtonComponent extends BasicCatalogComponent<typeof ButtonApi> {
   readonly variant = computed(() => this.props()['variant']?.value() ?? 'default');
   readonly child = computed(() => this.props()['child']?.value());
   readonly action = computed(() => this.props()['action']?.value());
-  readonly ariaLabel = computed(() => this.props()['accessibility']?.value()?.label ?? null);
-  readonly ariaDescribedBy = computed(() => this.props()['accessibility']?.value()?.description ?? null);
+  readonly accessibility = computed(() => this.props()['accessibility']?.value());
+  readonly ariaLabel = computed(() => this.accessibility()?.label ?? null);
+  readonly ariaDescribedBy = computed(() => this.accessibility()?.description ?? null);
 
   handleClick() {
     const action = this.action();

--- a/renderers/angular/src/v0_9/catalog/basic/card.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/card.component.spec.ts
@@ -22,6 +22,7 @@ import {ComponentModel} from '@a2ui/web_core/v0_9';
 import {A2uiRendererService} from '../../core/a2ui-renderer.service';
 import {ComponentBinder} from '../../core/component-binder.service';
 import {setComponentProps, createBoundProperty, ComponentToProps} from '@a2ui/angular/testing';
+import {AccessibilityAttributes} from '@a2ui/web_core/v0_9';
 
 @Component({
   selector: 'dummy-text-for-card',
@@ -74,6 +75,7 @@ describe('CardComponent', () => {
 
     defaultProps = {
       child: createBoundProperty({id: 'child-1', basePath: '/'}),
+      accessibility: createBoundProperty<AccessibilityAttributes>({}),
     };
     setComponentProps(fixture, defaultProps);
   });
@@ -88,5 +90,21 @@ describe('CardComponent', () => {
     const host = fixture.debugElement.query(By.css('a2ui-v09-component-host'));
     expect(host).toBeTruthy();
     expect(host.componentInstance.componentKey()).toEqual({id: 'child-1', basePath: '/'});
+  });
+
+  it('should apply accessibility attributes to host element', () => {
+    setComponentProps(fixture, {
+      ...defaultProps,
+      accessibility: createBoundProperty<AccessibilityAttributes>({
+        role: 'region',
+        label: 'Important Card',
+        description: 'Contains critical info',
+      }),
+    });
+    fixture.detectChanges();
+    const hostElement = fixture.nativeElement;
+    expect(hostElement.getAttribute('role')).toBe('region');
+    expect(hostElement.getAttribute('aria-label')).toBe('Important Card');
+    expect(hostElement.getAttribute('aria-describedby')).toBe('Contains critical info');
   });
 });

--- a/renderers/angular/src/v0_9/catalog/basic/card.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/card.component.spec.ts
@@ -105,6 +105,6 @@ describe('CardComponent', () => {
     const hostElement = fixture.nativeElement;
     expect(hostElement.getAttribute('role')).toBe('region');
     expect(hostElement.getAttribute('aria-label')).toBe('Important Card');
-    expect(hostElement.getAttribute('aria-describedby')).toBe('Contains critical info');
+    expect(hostElement.getAttribute('aria-description')).toBe('Contains critical info');
   });
 });

--- a/renderers/angular/src/v0_9/catalog/basic/card.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/card.component.ts
@@ -36,6 +36,11 @@ import {CardApi} from '@a2ui/web_core/v0_9/basic_catalog';
   selector: 'a2ui-v09-card',
   standalone: true,
   imports: [ComponentHostComponent],
+  host: {
+    '[attr.role]': 'role()',
+    '[attr.aria-label]': 'ariaLabel()',
+    '[attr.aria-describedby]': 'ariaDescribedBy()',
+  },
   template: `
     <div class="a2ui-card">
       @if (child()) {
@@ -63,4 +68,8 @@ import {CardApi} from '@a2ui/web_core/v0_9/basic_catalog';
 })
 export class CardComponent extends BasicCatalogComponent<typeof CardApi> {
   readonly child = computed(() => this.props()['child']?.value());
+  readonly accessibility = computed(() => this.props()['accessibility']?.value());
+  readonly role = computed(() => this.accessibility()?.role ?? null);
+  readonly ariaLabel = computed(() => this.accessibility()?.label ?? null);
+  readonly ariaDescribedBy = computed(() => this.accessibility()?.description ?? null);
 }

--- a/renderers/angular/src/v0_9/catalog/basic/card.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/card.component.ts
@@ -39,7 +39,7 @@ import {CardApi} from '@a2ui/web_core/v0_9/basic_catalog';
   host: {
     '[attr.role]': 'role()',
     '[attr.aria-label]': 'ariaLabel()',
-    '[attr.aria-describedby]': 'ariaDescribedBy()',
+    '[attr.aria-description]': 'ariaDescription()',
   },
   template: `
     <div class="a2ui-card">
@@ -71,5 +71,5 @@ export class CardComponent extends BasicCatalogComponent<typeof CardApi> {
   readonly accessibility = computed(() => this.props()['accessibility']?.value());
   readonly role = computed(() => this.accessibility()?.role ?? null);
   readonly ariaLabel = computed(() => this.accessibility()?.label ?? null);
-  readonly ariaDescribedBy = computed(() => this.accessibility()?.description ?? null);
+  readonly ariaDescription = computed(() => this.accessibility()?.description ?? null);
 }

--- a/renderers/angular/src/v0_9/catalog/basic/image.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/image.component.spec.ts
@@ -19,6 +19,7 @@ import {ImageComponent} from './image.component';
 import {A2uiRendererService} from '../../core/a2ui-renderer.service';
 import {ComponentBinder} from '../../core/component-binder.service';
 import {setComponentProps, createBoundProperty, ComponentToProps} from '@a2ui/angular/testing';
+import {AccessibilityAttributes} from '@a2ui/web_core/v0_9';
 
 describe('ImageComponent', () => {
   let component: ImageComponent;
@@ -58,6 +59,7 @@ describe('ImageComponent', () => {
       url: createBoundProperty('https://example.com/image.png'),
       fit: createBoundProperty('cover' as const),
       variant: createBoundProperty('avatar' as const),
+      accessibility: createBoundProperty<AccessibilityAttributes>({}),
     };
     setComponentProps(fixture, defaultProps);
   });
@@ -85,6 +87,32 @@ describe('ImageComponent', () => {
     expect(img.alt).toBe('A cute cat');
   });
 
+  it('should render image with accessibility label', () => {
+    setComponentProps(fixture, {
+      ...defaultProps,
+      description: createBoundProperty('A cute cat'),
+      accessibility: createBoundProperty<AccessibilityAttributes>({
+        label: 'A cute cat wearing a hat',
+      }),
+    });
+    fixture.detectChanges();
+    const img = fixture.nativeElement.querySelector('img') as HTMLImageElement;
+    expect(img.alt).toBe('A cute cat wearing a hat');
+  });
+
+  it('should render image with accessibility description when label is not set', () => {
+    setComponentProps(fixture, {
+      ...defaultProps,
+      description: createBoundProperty('A cute cat'),
+      accessibility: createBoundProperty<AccessibilityAttributes>({
+        description: 'A cute cat playing with a ball of yarn',
+      }),
+    });
+    fixture.detectChanges();
+    const img = fixture.nativeElement.querySelector('img') as HTMLImageElement;
+    expect(img.alt).toBe('A cute cat playing with a ball of yarn');
+  });
+ 
   it('should support all specified variants', () => {
     const variants = [
       'icon',

--- a/renderers/angular/src/v0_9/catalog/basic/image.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/image.component.ts
@@ -38,7 +38,7 @@ import {ImageApi} from '@a2ui/web_core/v0_9/basic_catalog';
   template: `
     <img
       [src]="url()"
-      [alt]="description()"
+      [alt]="altText()"
       [style.object-fit]="fit()"
       [class]="'a2ui-image ' + variant()"
     />
@@ -78,4 +78,6 @@ export class ImageComponent extends BasicCatalogComponent<typeof ImageApi> {
   readonly description = computed(() => this.props()['description']?.value() || '');
   readonly fit = computed(() => this.props()['fit']?.value() || 'cover');
   readonly variant = computed(() => this.props()['variant']?.value() || 'default');
+  readonly accessibility = computed(() => this.props()['accessibility']?.value());
+  readonly altText = computed(() => this.accessibility()?.label || this.accessibility()?.description || this.description());
 }

--- a/renderers/angular/src/v0_9/catalog/basic/image.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/image.component.ts
@@ -79,5 +79,5 @@ export class ImageComponent extends BasicCatalogComponent<typeof ImageApi> {
   readonly fit = computed(() => this.props()['fit']?.value() || 'cover');
   readonly variant = computed(() => this.props()['variant']?.value() || 'default');
   readonly accessibility = computed(() => this.props()['accessibility']?.value());
-  readonly altText = computed(() => this.accessibility()?.label || this.accessibility()?.description || this.description());
+  readonly altText = computed(() => this.accessibility()?.label ?? this.accessibility()?.description ?? this.description());
 }

--- a/renderers/angular/src/v0_9/catalog/basic/text-field.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text-field.component.spec.ts
@@ -147,6 +147,6 @@ describe('TextFieldComponent', () => {
     fixture.detectChanges();
     const input = fixture.debugElement.query(By.css('input'));
     expect(input.nativeElement.getAttribute('aria-label')).toBe('Enter Username');
-    expect(input.nativeElement.getAttribute('aria-describedby')).toBe('Your unique identifier');
+    expect(input.nativeElement.getAttribute('aria-description')).toBe('Your unique identifier');
   });
 });

--- a/renderers/angular/src/v0_9/catalog/basic/text-field.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text-field.component.spec.ts
@@ -18,6 +18,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {TextFieldComponent} from './text-field.component';
 import {A2uiRendererService, A2UI_RENDERER_CONFIG} from '../../core/a2ui-renderer.service';
 import {setComponentProps, createBoundProperty, ComponentToProps} from '@a2ui/angular/testing';
+import {AccessibilityAttributes} from '@a2ui/web_core/v0_9';
 import {By} from '@angular/platform-browser';
 
 describe('TextFieldComponent', () => {
@@ -40,6 +41,7 @@ describe('TextFieldComponent', () => {
       variant: createBoundProperty('shortText' as const),
       isValid: createBoundProperty(true),
       validationErrors: createBoundProperty<string[]>([]),
+      accessibility: createBoundProperty<AccessibilityAttributes>({}),
     };
     setComponentProps(fixture, defaultProps);
   });
@@ -132,5 +134,19 @@ describe('TextFieldComponent', () => {
     expect(errorMsgs.length).toBe(2);
     expect(errorMsgs[0].nativeElement.textContent).toContain('Error 1');
     expect(errorMsgs[1].nativeElement.textContent).toContain('Error 2');
+  });
+
+  it('should apply accessibility attributes to input', () => {
+    setComponentProps(fixture, {
+      ...defaultProps,
+      accessibility: createBoundProperty<AccessibilityAttributes>({
+        label: 'Enter Username',
+        description: 'Your unique identifier',
+      }),
+    });
+    fixture.detectChanges();
+    const input = fixture.debugElement.query(By.css('input'));
+    expect(input.nativeElement.getAttribute('aria-label')).toBe('Enter Username');
+    expect(input.nativeElement.getAttribute('aria-describedby')).toBe('Your unique identifier');
   });
 });

--- a/renderers/angular/src/v0_9/catalog/basic/text-field.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text-field.component.ts
@@ -50,7 +50,7 @@ import {TextFieldApi} from '@a2ui/web_core/v0_9/basic_catalog';
         (input)="handleInput($event)"
         [class.invalid]="props()['isValid']?.value() === false"
         [attr.aria-label]="ariaLabel()"
-        [attr.aria-describedby]="ariaDescribedBy()"
+        [attr.aria-description]="ariaDescription()"
       />
       @for (message of props()['validationErrors']?.value(); track message) {
         <div class="a2ui-error-message">{{ message }}</div>
@@ -101,7 +101,7 @@ export class TextFieldComponent extends BasicCatalogComponent<typeof TextFieldAp
   readonly variant = computed(() => this.props()['variant']?.value());
   readonly accessibility = computed(() => this.props()['accessibility']?.value());
   readonly ariaLabel = computed(() => this.accessibility()?.label ?? null);
-  readonly ariaDescribedBy = computed(() => this.accessibility()?.description ?? null);
+  readonly ariaDescription = computed(() => this.accessibility()?.description ?? null);
 
   readonly inputType = computed(() => {
     switch (this.variant()) {

--- a/renderers/angular/src/v0_9/catalog/basic/text-field.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text-field.component.ts
@@ -49,6 +49,8 @@ import {TextFieldApi} from '@a2ui/web_core/v0_9/basic_catalog';
         [value]="value()"
         (input)="handleInput($event)"
         [class.invalid]="props()['isValid']?.value() === false"
+        [attr.aria-label]="ariaLabel()"
+        [attr.aria-describedby]="ariaDescribedBy()"
       />
       @for (message of props()['validationErrors']?.value(); track message) {
         <div class="a2ui-error-message">{{ message }}</div>
@@ -97,6 +99,8 @@ export class TextFieldComponent extends BasicCatalogComponent<typeof TextFieldAp
   readonly label = computed(() => this.props()['label']?.value());
   readonly value = computed(() => this.props()['value']?.value() || '');
   readonly variant = computed(() => this.props()['variant']?.value());
+  readonly ariaLabel = computed(() => this.props()['accessibility']?.value()?.label ?? null);
+  readonly ariaDescribedBy = computed(() => this.props()['accessibility']?.value()?.description ?? null);
 
   readonly inputType = computed(() => {
     switch (this.variant()) {

--- a/renderers/angular/src/v0_9/catalog/basic/text-field.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text-field.component.ts
@@ -99,8 +99,9 @@ export class TextFieldComponent extends BasicCatalogComponent<typeof TextFieldAp
   readonly label = computed(() => this.props()['label']?.value());
   readonly value = computed(() => this.props()['value']?.value() || '');
   readonly variant = computed(() => this.props()['variant']?.value());
-  readonly ariaLabel = computed(() => this.props()['accessibility']?.value()?.label ?? null);
-  readonly ariaDescribedBy = computed(() => this.props()['accessibility']?.value()?.description ?? null);
+  readonly accessibility = computed(() => this.props()['accessibility']?.value());
+  readonly ariaLabel = computed(() => this.accessibility()?.label ?? null);
+  readonly ariaDescribedBy = computed(() => this.accessibility()?.description ?? null);
 
   readonly inputType = computed(() => {
     switch (this.variant()) {

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
@@ -192,6 +192,6 @@ describe('TextComponent', () => {
     fixture.detectChanges();
     const hostElement = fixture.nativeElement;
     expect(hostElement.getAttribute('aria-label')).toBe('A text block');
-    expect(hostElement.getAttribute('aria-describedby')).toBe('Contains static text');
+    expect(hostElement.getAttribute('aria-description')).toBe('Contains static text');
   });
 });

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.spec.ts
@@ -19,6 +19,7 @@ import {TextComponent} from './text.component';
 import {By} from '@angular/platform-browser';
 import {MarkdownRenderer} from '../../core/markdown';
 import {setComponentProps, createBoundProperty, ComponentToProps} from '@a2ui/angular/testing';
+import {AccessibilityAttributes} from '@a2ui/web_core/v0_9';
 import {A2uiRendererService, A2UI_RENDERER_CONFIG} from '../../core/a2ui-renderer.service';
 
 describe('TextComponent', () => {
@@ -46,6 +47,7 @@ describe('TextComponent', () => {
 
     defaultProps = {
       text: createBoundProperty('Hello World'),
+      accessibility: createBoundProperty<AccessibilityAttributes>({}),
     };
     setComponentProps(fixture, defaultProps);
   });
@@ -177,5 +179,19 @@ describe('TextComponent', () => {
     fixture.detectChanges();
 
     expect(mockMarkdownRenderer.render).toHaveBeenCalledWith('');
+  });
+
+  it('should apply accessibility attributes to host element', () => {
+    setComponentProps(fixture, {
+      ...defaultProps,
+      accessibility: createBoundProperty<AccessibilityAttributes>({
+        label: 'A text block',
+        description: 'Contains static text',
+      }),
+    });
+    fixture.detectChanges();
+    const hostElement = fixture.nativeElement;
+    expect(hostElement.getAttribute('aria-label')).toBe('A text block');
+    expect(hostElement.getAttribute('aria-describedby')).toBe('Contains static text');
   });
 });

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.ts
@@ -40,7 +40,7 @@ import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
   standalone: true,
   host: {
     '[attr.aria-label]': 'ariaLabel()',
-    '[attr.aria-describedby]': 'ariaDescribedBy()',
+    '[attr.aria-description]': 'ariaDescription()',
   },
   template: `
     @if (isNonMarkdownVariant()) {
@@ -152,7 +152,7 @@ export class TextComponent extends BasicCatalogComponent<typeof TextApi> {
   readonly text = computed(() => this.props()['text']?.value() || '');
   readonly accessibility = computed(() => this.props()['accessibility']?.value());
   readonly ariaLabel = computed(() => this.accessibility()?.label ?? null);
-  readonly ariaDescribedBy = computed(() => this.accessibility()?.description ?? null);
+  readonly ariaDescription = computed(() => this.accessibility()?.description ?? null);
 
   readonly isNonMarkdownVariant = computed(() => {
     return TextComponent.NON_MARKDOWN_VARIANTS.has(this.variant());

--- a/renderers/angular/src/v0_9/catalog/basic/text.component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/text.component.ts
@@ -38,6 +38,10 @@ import {TextApi} from '@a2ui/web_core/v0_9/basic_catalog';
 @Component({
   selector: 'a2ui-v09-text',
   standalone: true,
+  host: {
+    '[attr.aria-label]': 'ariaLabel()',
+    '[attr.aria-describedby]': 'ariaDescribedBy()',
+  },
   template: `
     @if (isNonMarkdownVariant()) {
       <span [class]="'a2ui-text ' + variant()">
@@ -146,6 +150,9 @@ export class TextComponent extends BasicCatalogComponent<typeof TextApi> {
 
   readonly variant = computed(() => this.props()['variant']?.value() || 'body');
   readonly text = computed(() => this.props()['text']?.value() || '');
+  readonly accessibility = computed(() => this.props()['accessibility']?.value());
+  readonly ariaLabel = computed(() => this.accessibility()?.label ?? null);
+  readonly ariaDescribedBy = computed(() => this.accessibility()?.description ?? null);
 
   readonly isNonMarkdownVariant = computed(() => {
     return TextComponent.NON_MARKDOWN_VARIANTS.has(this.variant());

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Button.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Button.ts
@@ -108,12 +108,12 @@ export class A2uiBasicButtonElement extends BasicCatalogA2uiLitElement<typeof Bu
     };
 
     const ariaLabel = props.accessibility?.label;
-    const ariaDescribedBy = props.accessibility?.description;
+    const ariaDescription = props.accessibility?.description;
 
     return html`
       <button
         aria-label=${ifDefined(ariaLabel)}
-        aria-describedby=${ifDefined(ariaDescribedBy)}
+        aria-description=${ifDefined(ariaDescription)}
         class=${classMap(classes)}
         @click=${() => !isDisabled && props.action && props.action()}
         ?disabled=${isDisabled}

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Button.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Button.ts
@@ -17,6 +17,7 @@
 import {html, nothing, css} from 'lit';
 import {customElement} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
+import {ifDefined} from 'lit/directives/if-defined.js';
 import {ButtonApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {BasicCatalogA2uiLitElement} from '../basic-catalog-a2ui-lit-element.js';
 import {A2uiController} from '../../../a2ui-controller.js';
@@ -106,8 +107,13 @@ export class A2uiBasicButtonElement extends BasicCatalogA2uiLitElement<typeof Bu
       ['a2ui-button-' + (props.variant || 'default')]: true,
     };
 
+    const ariaLabel = props.accessibility?.label;
+    const ariaDescribedBy = props.accessibility?.description;
+
     return html`
       <button
+        aria-label=${ifDefined(ariaLabel)}
+        aria-describedby=${ifDefined(ariaDescribedBy)}
         class=${classMap(classes)}
         @click=${() => !isDisabled && props.action && props.action()}
         ?disabled=${isDisabled}

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Card.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Card.ts
@@ -70,9 +70,9 @@ export class A2uiCardElement extends BasicCatalogA2uiLitElement<typeof CardApi> 
       }
       const description = props.accessibility?.description;
       if (description) {
-        this.setAttribute('aria-describedby', description as string);
+        this.setAttribute('aria-description', description as string);
       } else {
-        this.removeAttribute('aria-describedby');
+        this.removeAttribute('aria-description');
       }
     }
   }

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Card.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Card.ts
@@ -52,6 +52,31 @@ export class A2uiCardElement extends BasicCatalogA2uiLitElement<typeof CardApi> 
     return new A2uiController(this, CardApi);
   }
 
+  override updated(changedProperties: Map<string, any>) {
+    super.updated(changedProperties);
+    const props = this.controller.props;
+    if (props) {
+      const role = props.accessibility?.role;
+      if (role) {
+        this.setAttribute('role', role as string);
+      } else {
+        this.removeAttribute('role');
+      }
+      const label = props.accessibility?.label;
+      if (label) {
+        this.setAttribute('aria-label', label as string);
+      } else {
+        this.removeAttribute('aria-label');
+      }
+      const description = props.accessibility?.description;
+      if (description) {
+        this.setAttribute('aria-describedby', description as string);
+      } else {
+        this.removeAttribute('aria-describedby');
+      }
+    }
+  }
+
   override render() {
     const props = this.controller.props;
     if (!props) return nothing;

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Image.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Image.ts
@@ -84,9 +84,15 @@ export class A2uiImageElement extends BasicCatalogA2uiLitElement<typeof ImageApi
       objectFit: props.fit || 'fill',
     };
 
+    const altText =
+      props.accessibility?.label ||
+      props.accessibility?.description ||
+      props.description ||
+      '';
+
     return html`<img
       src=${props.url}
-      alt=${props.description || ''}
+      alt=${altText}
       class=${classMap(classes)}
       style=${styleMap(styles)}
     />`;

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Image.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Image.ts
@@ -85,9 +85,9 @@ export class A2uiImageElement extends BasicCatalogA2uiLitElement<typeof ImageApi
     };
 
     const altText =
-      props.accessibility?.label ||
-      props.accessibility?.description ||
-      props.description ||
+      props.accessibility?.label ??
+      props.accessibility?.description ??
+      props.description ??
       '';
 
     return html`<img

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Text.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Text.ts
@@ -107,6 +107,25 @@ export class A2uiBasicTextElement extends BasicCatalogA2uiLitElement<typeof Text
     return new A2uiController(this, TextApi);
   }
 
+  override updated(changedProperties: Map<string, any>) {
+    super.updated(changedProperties);
+    const props = this.controller.props;
+    if (props) {
+      const label = props.accessibility?.label;
+      if (label) {
+        this.setAttribute('aria-label', label as string);
+      } else {
+        this.removeAttribute('aria-label');
+      }
+      const description = props.accessibility?.description;
+      if (description) {
+        this.setAttribute('aria-describedby', description as string);
+      } else {
+        this.removeAttribute('aria-describedby');
+      }
+    }
+  }
+
   override render() {
     const props = this.controller.props;
     if (!props) return nothing;

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Text.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Text.ts
@@ -119,9 +119,9 @@ export class A2uiBasicTextElement extends BasicCatalogA2uiLitElement<typeof Text
       }
       const description = props.accessibility?.description;
       if (description) {
-        this.setAttribute('aria-describedby', description as string);
+        this.setAttribute('aria-description', description as string);
       } else {
-        this.removeAttribute('aria-describedby');
+        this.removeAttribute('aria-description');
       }
     }
   }

--- a/renderers/lit/src/v0_9/catalogs/basic/components/TextField.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/TextField.ts
@@ -17,6 +17,7 @@
 import {html, nothing, css} from 'lit';
 import {customElement} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
+import {ifDefined} from 'lit/directives/if-defined.js';
 import {TextFieldApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {BasicCatalogA2uiLitElement} from '../basic-catalog-a2ui-lit-element.js';
 import {A2uiController} from '../../../a2ui-controller.js';
@@ -88,17 +89,23 @@ export class A2uiBasicTextFieldElement extends BasicCatalogA2uiLitElement<typeof
     if (props.variant === 'obscured') type = 'password';
 
     const classes = {'a2ui-textfield': true, invalid: isInvalid};
+    const ariaLabel = props.accessibility?.label;
+    const ariaDescribedBy = props.accessibility?.description;
 
     return html`
       ${props.label ? html`<label>${props.label}</label>` : nothing}
       ${props.variant === 'longText'
         ? html`<textarea
+            aria-label=${ifDefined(ariaLabel)}
+            aria-describedby=${ifDefined(ariaDescribedBy)}
             class=${classMap(classes)}
             .value=${props.value || ''}
             @input=${onInput}
           ></textarea>`
         : html`<input
             type=${type}
+            aria-label=${ifDefined(ariaLabel)}
+            aria-describedby=${ifDefined(ariaDescribedBy)}
             class=${classMap(classes)}
             .value=${props.value || ''}
             @input=${onInput}

--- a/renderers/lit/src/v0_9/catalogs/basic/components/TextField.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/TextField.ts
@@ -90,14 +90,14 @@ export class A2uiBasicTextFieldElement extends BasicCatalogA2uiLitElement<typeof
 
     const classes = {'a2ui-textfield': true, invalid: isInvalid};
     const ariaLabel = props.accessibility?.label;
-    const ariaDescribedBy = props.accessibility?.description;
+    const ariaDescription = props.accessibility?.description;
 
     return html`
       ${props.label ? html`<label>${props.label}</label>` : nothing}
       ${props.variant === 'longText'
         ? html`<textarea
             aria-label=${ifDefined(ariaLabel)}
-            aria-describedby=${ifDefined(ariaDescribedBy)}
+            aria-description=${ifDefined(ariaDescription)}
             class=${classMap(classes)}
             .value=${props.value || ''}
             @input=${onInput}
@@ -105,7 +105,7 @@ export class A2uiBasicTextFieldElement extends BasicCatalogA2uiLitElement<typeof
         : html`<input
             type=${type}
             aria-label=${ifDefined(ariaLabel)}
-            aria-describedby=${ifDefined(ariaDescribedBy)}
+            aria-description=${ifDefined(ariaDescription)}
             class=${classMap(classes)}
             .value=${props.value || ''}
             @input=${onInput}

--- a/renderers/lit/src/v0_9/tests/components/Button.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/Button.test.ts
@@ -78,6 +78,16 @@ describe('Button Component', () => {
               action: {event: {name: 'ignored'}},
             },
             {
+              id: 'btn_a11y',
+              component: 'Button',
+              child: 'txt1',
+              accessibility: {
+                label: 'Book Mott 32 Now',
+                description: 'Restaurant booking details',
+              },
+              action: {event: {name: 'a11y_click'}},
+            },
+            {
               id: 'txt1',
               component: 'Text',
               text: 'Click Me',
@@ -144,5 +154,21 @@ describe('Button Component', () => {
 
     button.click();
     assert.strictEqual(dispatchedAction, false);
+  });
+
+  it('should render accessibility attributes when provided', async () => {
+    const el = document.createElement('a2ui-basic-button') as A2uiBasicButtonElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'btn_a11y');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const button = el.shadowRoot?.querySelector('button');
+    assert.ok(button);
+    assert.strictEqual(button.getAttribute('aria-label'), 'Book Mott 32 Now');
+    assert.strictEqual(button.getAttribute('aria-describedby'), 'Restaurant booking details');
   });
 });

--- a/renderers/lit/src/v0_9/tests/components/Button.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/Button.test.ts
@@ -169,6 +169,6 @@ describe('Button Component', () => {
     const button = el.shadowRoot?.querySelector('button');
     assert.ok(button);
     assert.strictEqual(button.getAttribute('aria-label'), 'Book Mott 32 Now');
-    assert.strictEqual(button.getAttribute('aria-describedby'), 'Restaurant booking details');
+    assert.strictEqual(button.getAttribute('aria-description'), 'Restaurant booking details');
   });
 });

--- a/renderers/lit/src/v0_9/tests/components/Card.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/Card.test.ts
@@ -118,6 +118,6 @@ describe('Card Component', () => {
 
     assert.strictEqual(el.getAttribute('role'), 'region');
     assert.strictEqual(el.getAttribute('aria-label'), 'Featured product info');
-    assert.strictEqual(el.getAttribute('aria-describedby'), 'Detailed specifications and price');
+    assert.strictEqual(el.getAttribute('aria-description'), 'Detailed specifications and price');
   });
 });

--- a/renderers/lit/src/v0_9/tests/components/Card.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/Card.test.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../dom-setup.js';
+import assert from 'node:assert';
+import {describe, it, beforeEach, afterEach, after, before} from 'node:test';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+} from '@a2ui/web_core/v0_9';
+import type {A2uiCardElement} from '../../catalogs/basic/components/Card.js';
+
+describe('Card Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../../catalogs/basic/index.js')).basicCatalog;
+    await import('../../catalogs/basic/components/Card.js');
+    await import('../../catalogs/basic/components/Text.js'); // For children rendering test
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiCardElement | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'card_normal',
+              component: 'Card',
+              child: 'txt1',
+            },
+            {
+              id: 'card_a11y',
+              component: 'Card',
+              child: 'txt1',
+              accessibility: {
+                role: 'region',
+                label: 'Featured product info',
+                description: 'Detailed specifications and price',
+              },
+            },
+            {
+              id: 'txt1',
+              component: 'Text',
+              text: 'Card Content',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render card with child content', async () => {
+    const el = document.createElement('a2ui-card') as A2uiCardElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'card_normal');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    assert.ok(el.shadowRoot);
+    const childEl = el.shadowRoot.querySelector('a2ui-basic-text');
+    assert.ok(childEl);
+  });
+
+  it('should map accessibility attributes to host element', async () => {
+    const el = document.createElement('a2ui-card') as A2uiCardElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'card_a11y');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    assert.strictEqual(el.getAttribute('role'), 'region');
+    assert.strictEqual(el.getAttribute('aria-label'), 'Featured product info');
+    assert.strictEqual(el.getAttribute('aria-describedby'), 'Detailed specifications and price');
+  });
+});

--- a/renderers/lit/src/v0_9/tests/components/Image.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/Image.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom, asyncUpdate} from '../dom-setup.js';
+import assert from 'node:assert';
+import {describe, it, beforeEach, afterEach, after, before} from 'node:test';
+import {
+  ComponentContext,
+  MessageProcessor,
+  Catalog,
+  ComponentApi,
+  SurfaceModel,
+} from '@a2ui/web_core/v0_9';
+import type {A2uiImageElement} from '../../catalogs/basic/components/Image.js';
+
+describe('Image Component', () => {
+  let basicCatalog: Catalog<ComponentApi>;
+
+  before(async () => {
+    setupTestDom();
+    basicCatalog = (await import('../../catalogs/basic/index.js')).basicCatalog;
+    await import('../../catalogs/basic/components/Image.js');
+  });
+
+  after(teardownTestDom);
+
+  let processor: MessageProcessor<ComponentApi>;
+  let surface: SurfaceModel;
+  let element: A2uiImageElement | null = null;
+
+  beforeEach(() => {
+    processor = new MessageProcessor([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'img_normal',
+              component: 'Image',
+              url: 'https://example.com/image.png',
+              description: 'A beautiful sunset',
+            },
+            {
+              id: 'img_a11y_label',
+              component: 'Image',
+              url: 'https://example.com/image.png',
+              description: 'Fallback description',
+              accessibility: {
+                label: 'Sunset at the beach',
+              },
+            },
+            {
+              id: 'img_a11y_desc',
+              component: 'Image',
+              url: 'https://example.com/image.png',
+              description: 'Fallback description',
+              accessibility: {
+                description: 'Sunset at the beach with waves crashing',
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
+  });
+
+  afterEach(() => {
+    if (element) {
+      element.remove();
+      element = null;
+    }
+  });
+
+  it('should render image with src and alt description', async () => {
+    const el = document.createElement('a2ui-image') as A2uiImageElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'img_normal');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const img = el.shadowRoot?.querySelector('img');
+    assert.ok(img);
+    assert.strictEqual(img.getAttribute('src'), 'https://example.com/image.png');
+    assert.strictEqual(img.getAttribute('alt'), 'A beautiful sunset');
+  });
+
+  it('should prioritize accessibility label for alt attribute', async () => {
+    const el = document.createElement('a2ui-image') as A2uiImageElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'img_a11y_label');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const img = el.shadowRoot?.querySelector('img');
+    assert.ok(img);
+    assert.strictEqual(img.getAttribute('alt'), 'Sunset at the beach');
+  });
+
+  it('should fall back to accessibility description for alt attribute', async () => {
+    const el = document.createElement('a2ui-image') as A2uiImageElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'img_a11y_desc');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const img = el.shadowRoot?.querySelector('img');
+    assert.ok(img);
+    assert.strictEqual(img.getAttribute('alt'), 'Sunset at the beach with waves crashing');
+  });
+});

--- a/renderers/lit/src/v0_9/tests/components/Text.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/Text.test.ts
@@ -163,6 +163,6 @@ describe('Text Component', () => {
     });
 
     assert.strictEqual(el.getAttribute('aria-label'), 'Custom label');
-    assert.strictEqual(el.getAttribute('aria-describedby'), 'Custom description');
+    assert.strictEqual(el.getAttribute('aria-description'), 'Custom description');
   });
 });

--- a/renderers/lit/src/v0_9/tests/components/Text.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/Text.test.ts
@@ -75,6 +75,15 @@ describe('Text Component', () => {
               text: 'Caption text',
               variant: 'caption',
             },
+            {
+              id: 't_accessible',
+              component: 'Text',
+              text: 'Accessible text',
+              accessibility: {
+                label: 'Custom label',
+                description: 'Custom description',
+              },
+            },
           ],
         },
       },
@@ -141,5 +150,19 @@ describe('Text Component', () => {
     const innerSpan = captionSpan.querySelector('.no-markdown-renderer');
     assert.ok(innerSpan);
     assert.strictEqual(innerSpan.textContent?.trim(), 'Caption text');
+  });
+
+  it('should apply accessibility attributes', async () => {
+    const el = document.createElement('a2ui-basic-text') as A2uiBasicTextElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 't_accessible');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    assert.strictEqual(el.getAttribute('aria-label'), 'Custom label');
+    assert.strictEqual(el.getAttribute('aria-describedby'), 'Custom description');
   });
 });

--- a/renderers/lit/src/v0_9/tests/components/TextField.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/TextField.test.ts
@@ -80,6 +80,27 @@ describe('TextField Component', () => {
               isValid: false,
               validationErrors: ['Email is invalid'],
             },
+            {
+              id: 'field_a11y',
+              component: 'TextField',
+              label: 'Username',
+              value: '',
+              accessibility: {
+                label: 'Enter your username',
+                description: 'Must be alphanumeric',
+              },
+            },
+            {
+              id: 'field_long_a11y',
+              component: 'TextField',
+              label: 'Bio',
+              value: '',
+              variant: 'longText',
+              accessibility: {
+                label: 'Tell us about yourself',
+                description: 'Max 200 words',
+              },
+            },
           ],
         },
       },
@@ -170,5 +191,37 @@ describe('TextField Component', () => {
     const input = el.shadowRoot?.querySelector('input');
     assert.ok(input);
     assert.ok(input.classList.contains('invalid'));
+  });
+
+  it('should render accessibility attributes when provided', async () => {
+    const el = document.createElement('a2ui-basic-textfield') as A2uiBasicTextFieldElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'field_a11y');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const input = el.shadowRoot?.querySelector('input');
+    assert.ok(input);
+    assert.strictEqual(input.getAttribute('aria-label'), 'Enter your username');
+    assert.strictEqual(input.getAttribute('aria-describedby'), 'Must be alphanumeric');
+  });
+
+  it('should render accessibility attributes on textarea when variant is longText', async () => {
+    const el = document.createElement('a2ui-basic-textfield') as A2uiBasicTextFieldElement;
+    element = el;
+    document.body.appendChild(el);
+
+    const context = new ComponentContext(surface, 'field_long_a11y');
+    await asyncUpdate(el, e => {
+      e.context = context;
+    });
+
+    const textarea = el.shadowRoot?.querySelector('textarea');
+    assert.ok(textarea);
+    assert.strictEqual(textarea.getAttribute('aria-label'), 'Tell us about yourself');
+    assert.strictEqual(textarea.getAttribute('aria-describedby'), 'Max 200 words');
   });
 });

--- a/renderers/lit/src/v0_9/tests/components/TextField.test.ts
+++ b/renderers/lit/src/v0_9/tests/components/TextField.test.ts
@@ -206,7 +206,7 @@ describe('TextField Component', () => {
     const input = el.shadowRoot?.querySelector('input');
     assert.ok(input);
     assert.strictEqual(input.getAttribute('aria-label'), 'Enter your username');
-    assert.strictEqual(input.getAttribute('aria-describedby'), 'Must be alphanumeric');
+    assert.strictEqual(input.getAttribute('aria-description'), 'Must be alphanumeric');
   });
 
   it('should render accessibility attributes on textarea when variant is longText', async () => {
@@ -222,6 +222,6 @@ describe('TextField Component', () => {
     const textarea = el.shadowRoot?.querySelector('textarea');
     assert.ok(textarea);
     assert.strictEqual(textarea.getAttribute('aria-label'), 'Tell us about yourself');
-    assert.strictEqual(textarea.getAttribute('aria-describedby'), 'Max 200 words');
+    assert.strictEqual(textarea.getAttribute('aria-description'), 'Max 200 words');
   });
 });

--- a/renderers/web_core/src/v0_9/schema/common-types.ts
+++ b/renderers/web_core/src/v0_9/schema/common-types.ts
@@ -162,6 +162,9 @@ export const AccessibilityAttributesSchema = z
     description: DynamicStringSchema.optional().describe(
       'REF:common_types.json#/$defs/DynamicString|Additional information provided by assistive technologies about an element.',
     ),
+    role: DynamicStringSchema.optional().describe(
+      'REF:common_types.json#/$defs/DynamicString|The ARIA role of the element.',
+    ),
   })
   .describe(
     'REF:common_types.json#/$defs/AccessibilityAttributes|Attributes to enhance accessibility.',


### PR DESCRIPTION
### What
This PR implements accessibility attribute mapping for the basic catalog components: `Button`, `Image`, `TextField`, `Card`, and `Text`.
Specifically, it maps:
- `aria-label` (mapped from `label`)
- `aria-describedby` (mapped from `description`)
- `role` (mapped from `role` inside `accessibility`)

It updates both Lit and Angular renderers:
- **Lit components** are updated using `setAttribute` in the `updated()` lifecycle or inline template bindings where applicable.
- **Angular components** are updated using host bindings with signals.

It also adds unit tests for both Lit and Angular to verify the correct attribute mapping.

### Why
To address Issue 1410 and ensure that A2UI components render standard ARIA attributes correctly when provided in the component properties.

### Effect
Assistive technologies will now be able to read accessibility attributes from these basic components.