### PR TITLE
ci: Prepare packages for release.

### DIFF
--- a/agent_sdks/python/a2ui_agent/CHANGELOG.md
+++ b/agent_sdks/python/a2ui_agent/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.5.0
+
 - Rename inference format `Transport` / `transport` terminology to `Direct JSON` / `direct_json` (`DirectJsonFormat`, `DirectJsonParser`, `DirectJsonStreamParser`). Deprecate `a2ui.inference_formats.transport` module alias.
 - Cache `A2uiValidator` on `A2uiCatalog.validator` using `functools.cached_property` to avoid redundant construction on every access (#1972).
 

--- a/renderers/angular/CHANGELOG.md
+++ b/renderers/angular/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.10.5
+
 - Add standalone helper `provideA2Ui` configuration function. [#2061](https://github.com/a2ui-project/a2ui/pull/2061)
 - Standardize package entry points to `index.ts` while maintaining `public-api.ts` wrappers for backward compatibility.
 - (v0_8) Export `A2uiMessageSchema` in public API.

--- a/renderers/angular/package.json
+++ b/renderers/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/angular",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "license": "Apache-2.0",
   "homepage": "https://a2ui.org/",
   "repository": {

--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.10.3
+
 - Enable `inlineSources` in `tsconfig.json` to populate `sourcesContent` in sourcemaps.
 
 ## 0.10.2

--- a/renderers/lit/package.json
+++ b/renderers/lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/lit",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "A2UI Lit Library",
   "author": "Google",
   "license": "Apache-2.0",

--- a/renderers/markdown/markdown-it/CHANGELOG.md
+++ b/renderers/markdown/markdown-it/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.1.1
+
 - Enable `inlineSources` in `tsconfig.json` to populate `sourcesContent` in sourcemaps.
 
 ## 0.1.0

--- a/renderers/markdown/markdown-it/package.json
+++ b/renderers/markdown/markdown-it/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a2ui/markdown-it",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A Markdown renderer using markdown-it and dompurify.",
   "repository": {
     "directory": "renderers/markdown/markdown-it",

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.10.6
+
 - (v0_9) Validate component properties against catalog schema in `MessageProcessor` to prevent malformed component actions.
 - (v0_9) Add prototype pollution protection and safe property lookup to `DataModel` (non-breaking security fix).
 - (v0_8) Export `A2uiMessageSchema` in public API.


### PR DESCRIPTION
Prepares the following web renderers and Python SDK for release:

- **`@a2ui/web_core`**: `0.10.7`
- **`@a2ui/angular`**: `0.10.5`
- **`@a2ui/lit`**: `0.10.3`
- **`@a2ui/markdown-it`**: `0.1.1`
- **`a2ui_agent` (Python SDK)**: `0.5.0`