### PR TITLE
feat(adk): Implement A2uiAdkNativeToolset to support native rendering on Agent Engine (closes #1916)

### DIFF
--- a/agent_sdks/python/a2ui_agent/src/a2ui/a2a/parts.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/a2a/parts.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 MIME_TYPE_KEY = "mimeType"
 A2UI_MIME_TYPE = "application/a2ui+json"
 DEPRECATED_A2UI_MIME_TYPE = "application/json+a2ui"
+CATALOG_MIME_TYPE = "application/agent-plugin+json"
 
 
 def create_a2ui_part(a2ui_data: dict[str, Any], version: Optional[str] = None) -> Part:
@@ -69,6 +70,41 @@ def is_a2ui_part(part: Part) -> bool:
         and part.root.metadata
         and part.root.metadata.get(MIME_TYPE_KEY)
         in (A2UI_MIME_TYPE, DEPRECATED_A2UI_MIME_TYPE)
+    )
+
+
+def is_catalog_part(part: Part) -> bool:
+    """Checks if an A2A Part contains catalog data.
+
+    Args:
+        part: The A2A Part to check.
+
+    Returns:
+        True if the part contains catalog data, False otherwise.
+    """
+    return bool(
+        isinstance(part.root, DataPart)
+        and part.root.metadata
+        and part.root.metadata.get(MIME_TYPE_KEY) == CATALOG_MIME_TYPE
+    )
+
+
+def create_catalog_part(catalog_data: dict[str, Any]) -> Part:
+    """Creates an A2A Part containing catalog data with application/agent-plugin+json MIME type.
+
+    Args:
+        catalog_data: The catalog data dictionary.
+
+    Returns:
+        An A2A Part with a DataPart containing the catalog data.
+    """
+    return Part(
+        root=DataPart(
+            data=catalog_data,
+            metadata={
+                MIME_TYPE_KEY: CATALOG_MIME_TYPE,
+            },
+        )
     )
 
 

--- a/agent_sdks/python/a2ui_agent/src/a2ui/adk/__init__.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/adk/__init__.py
@@ -11,3 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""A2UI ADK Namespace."""
+
+from a2ui.adk.a2ui_adk_native_toolset import A2uiAdkNativeToolset
+
+__all__ = ["A2uiAdkNativeToolset"]
+

--- a/agent_sdks/python/a2ui_agent/src/a2ui/adk/a2ui_adk_native_toolset.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/adk/a2ui_adk_native_toolset.py
@@ -1,0 +1,248 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the A2uiAdkNativeToolset.
+
+This module provides the `A2uiAdkNativeToolset` which allows ADK agents deployed
+on Vertex AI Agent Engine to render A2UI natively by directly writing validated A2UI
+JSON payloads into the ADK native event action stream as `UiWidget` instances.
+"""
+
+import inspect
+import logging
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Optional,
+    TYPE_CHECKING,
+    TypeAlias,
+    Union,
+    Dict,
+    List,
+)
+
+from google.adk.agents import readonly_context
+from google.adk.models.llm_request import LlmRequest
+from google.adk.tools import base_tool
+from google.adk.tools import base_toolset
+from google.adk.tools import tool_context
+from google.adk.utils.feature_decorator import experimental
+from google.adk.events.ui_widget import UiWidget
+from google.genai import types as genai_types
+
+from a2ui.parser.payload_fixer import parse_and_fix
+from a2ui.schema import catalog
+from a2ui.core import A2uiValidationError
+from a2ui.schema import constants
+from a2ui.schema.constants import (
+    A2UI_TOOL_ERROR_KEY,
+    A2UI_TOOL_NAME,
+    A2UI_VALIDATED_JSON_KEY,
+)
+
+logger = logging.getLogger(__name__)
+
+A2uiEnabledProvider: TypeAlias = Callable[
+    [readonly_context.ReadonlyContext], Union[bool, Awaitable[bool]]
+]
+A2uiCatalogProvider: TypeAlias = Callable[
+    [readonly_context.ReadonlyContext],
+    Union[catalog.A2uiCatalog, Awaitable[catalog.A2uiCatalog]],
+]
+A2uiExamplesProvider: TypeAlias = Callable[
+    [readonly_context.ReadonlyContext], Union[str, Awaitable[str]]
+]
+
+
+@experimental
+class A2uiAdkNativeToolset(base_toolset.BaseToolset):
+    """A native ADK toolset that provides A2UI tools and outputs them directly as ADK UiWidgets."""
+
+    def __init__(
+        self,
+        a2ui_enabled: Union[bool, A2uiEnabledProvider],
+        a2ui_catalog: Union[catalog.A2uiCatalog, A2uiCatalogProvider],
+        a2ui_examples: Union[str, A2uiExamplesProvider],
+        provider_name: str = "a2ui",
+    ):
+        super().__init__()
+        self._a2ui_enabled = a2ui_enabled
+        self._ui_tool = self._SendA2uiJsonToAdkWidgetTool(
+            a2ui_catalog, a2ui_examples, provider_name
+        )
+        self._ui_tools: List[base_tool.BaseTool] = [self._ui_tool]
+
+    async def _resolve_a2ui_enabled(
+        self, ctx: readonly_context.ReadonlyContext
+    ) -> bool:
+        if isinstance(self._a2ui_enabled, bool):
+            return self._a2ui_enabled
+        else:
+            a2ui_enabled = self._a2ui_enabled(ctx)
+            if inspect.isawaitable(a2ui_enabled):
+                a2ui_enabled = await a2ui_enabled
+        return a2ui_enabled
+
+    async def get_tools(
+        self,
+        readonly_context: Optional[readonly_context.ReadonlyContext] = None,
+    ) -> List[base_tool.BaseTool]:
+        use_ui = False
+        if readonly_context is not None:
+            use_ui = await self._resolve_a2ui_enabled(readonly_context)
+        if use_ui:
+            logger.info("A2UI is ENABLED (ADK Native), adding ui tools")
+            return self._ui_tools
+        else:
+            logger.info("A2UI is DISABLED (ADK Native), not adding ui tools")
+            return []
+
+    class _SendA2uiJsonToAdkWidgetTool(base_tool.BaseTool):
+        TOOL_NAME = A2UI_TOOL_NAME
+        VALIDATED_A2UI_JSON_KEY = A2UI_VALIDATED_JSON_KEY
+        A2UI_JSON_ARG_NAME = "a2ui_json"
+        TOOL_ERROR_KEY = A2UI_TOOL_ERROR_KEY
+
+        def __init__(
+            self,
+            a2ui_catalog: Union[catalog.A2uiCatalog, A2uiCatalogProvider],
+            a2ui_examples: Union[str, A2uiExamplesProvider],
+            provider_name: str,
+        ):
+            self._a2ui_catalog = a2ui_catalog
+            self._a2ui_examples = a2ui_examples
+            self._provider_name = provider_name
+            super().__init__(
+                name=self.TOOL_NAME,
+                description=(
+                    "Sends A2UI JSON to the client to render rich UI for the user."
+                    " This tool can be called multiple times in the same call to"
+                    f" render multiple UI surfaces.Args:    {self.A2UI_JSON_ARG_NAME}:"
+                    " Valid A2UI JSON Schema to send to the client. The A2UI JSON"
+                    f" Schema definition is between {constants.A2UI_SCHEMA_BLOCK_START}"
+                    f" and {constants.A2UI_SCHEMA_BLOCK_END} in the system"
+                    " instructions."
+                ),
+            )
+
+        def _get_declaration(self) -> genai_types.FunctionDeclaration | None:
+            return genai_types.FunctionDeclaration(
+                name=self.name,
+                description=self.description,
+                parameters=genai_types.Schema(
+                    type=genai_types.Type.OBJECT,
+                    properties={
+                        self.A2UI_JSON_ARG_NAME: genai_types.Schema(
+                            type=genai_types.Type.STRING,
+                            description="valid A2UI JSON Schema to send to the client.",
+                        ),
+                    },
+                    required=[self.A2UI_JSON_ARG_NAME],
+                ),
+            )
+
+        async def _resolve_a2ui_examples(
+            self, ctx: readonly_context.ReadonlyContext
+        ) -> str:
+            if isinstance(self._a2ui_examples, str):
+                return self._a2ui_examples
+            else:
+                a2ui_examples = self._a2ui_examples(ctx)
+                if inspect.isawaitable(a2ui_examples):
+                    a2ui_examples = await a2ui_examples
+                return a2ui_examples
+
+        async def _resolve_a2ui_catalog(
+            self, ctx: readonly_context.ReadonlyContext
+        ) -> catalog.A2uiCatalog:
+            if isinstance(self._a2ui_catalog, catalog.A2uiCatalog):
+                return self._a2ui_catalog
+            else:
+                a2ui_catalog = self._a2ui_catalog(ctx)
+                if inspect.isawaitable(a2ui_catalog):
+                    a2ui_catalog = await a2ui_catalog
+                return a2ui_catalog
+
+        async def process_llm_request(
+            self,
+            *,
+            tool_context: tool_context.ToolContext,
+            llm_request: LlmRequest,
+        ) -> None:
+            await super().process_llm_request(
+                tool_context=tool_context, llm_request=llm_request
+            )
+
+            a2ui_catalog = await self._resolve_a2ui_catalog(tool_context)
+            instruction = a2ui_catalog.render_as_llm_instructions()
+            examples = await self._resolve_a2ui_examples(tool_context)
+
+            llm_request.append_instructions([instruction, examples])
+            logger.info(
+                "Added A2UI schema and examples to system instructions (ADK Native)"
+            )
+
+        async def run_async(
+            self, *, args: dict[str, Any], tool_context: tool_context.ToolContext
+        ) -> Any:
+            try:
+                a2ui_json = args.get(self.A2UI_JSON_ARG_NAME)
+                if not a2ui_json:
+                    raise A2uiValidationError(
+                        f"Failed to call tool {self.TOOL_NAME} because missing required"
+                        f" arg {self.A2UI_JSON_ARG_NAME} "
+                    )
+
+                a2ui_catalog = await self._resolve_a2ui_catalog(tool_context)
+                a2ui_json_payload = parse_and_fix(a2ui_json)
+                a2ui_catalog.validator.validate(a2ui_json_payload)
+
+                logger.info(
+                    f"Validated call to tool {self.TOOL_NAME} with"
+                    f" {self.A2UI_JSON_ARG_NAME} (ADK Native)"
+                )
+
+                tool_context.actions.skip_summarization = True
+
+                # Direct writing to ADK native UiWidgets!
+                if isinstance(a2ui_json_payload, list):
+                    for idx, widget_payload in enumerate(a2ui_json_payload):
+                        widget_id = widget_payload.get(
+                            "id", f"a2ui-widget-{tool_context.run_id}-{idx}"
+                        )
+                        ui_widget = UiWidget(
+                            id=widget_id,
+                            provider=self._provider_name,
+                            payload=widget_payload,
+                        )
+                        tool_context.render_ui_widget(ui_widget)
+                else:
+                    widget_id = a2ui_json_payload.get(
+                        "id", f"a2ui-widget-{tool_context.run_id}"
+                    )
+                    ui_widget = UiWidget(
+                        id=widget_id,
+                        provider=self._provider_name,
+                        payload=a2ui_json_payload,
+                    )
+                    tool_context.render_ui_widget(ui_widget)
+
+                # Return the validated JSON for tool response
+                return {self.VALIDATED_A2UI_JSON_KEY: a2ui_json_payload}
+
+            except Exception as e:
+                err = f"Failed to call A2UI ADK Native tool {self.TOOL_NAME}: {e}"
+                logger.error(err)
+                return {self.TOOL_ERROR_KEY: err}

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_lexer.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_lexer.py
@@ -1,4 +1,4 @@
-# Generated from /usr/local/google/home/gspencer/code/a2ui/kotlin_express/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
+# Generated from /home/node/a2ui/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
 from antlr4 import *
 from io import StringIO
 import sys

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_parser.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_parser.py
@@ -1,4 +1,4 @@
-# Generated from /usr/local/google/home/gspencer/code/a2ui/kotlin_express/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
+# Generated from /home/node/a2ui/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
 # encoding: utf-8
 from antlr4 import *
 from io import StringIO

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_visitor.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/experimental/express/generated/express_visitor.py
@@ -1,4 +1,4 @@
-# Generated from /usr/local/google/home/gspencer/code/a2ui/kotlin_express/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
+# Generated from /home/node/a2ui/specification/inference_formats/express/Express.g4 by ANTLR 4.13.2
 from antlr4 import *
 if "." in __name__:
     from .express_parser import ExpressParser

--- a/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog.py
@@ -28,7 +28,7 @@ from a2ui.core.catalog import Catalog
 from a2ui.core import A2uiCatalogError
 
 
-from .catalog_provider import A2uiCatalogProvider, FileSystemCatalogProvider
+from .catalog_provider import A2uiCatalogProvider, FileSystemCatalogProvider, HttpCatalogProvider
 from .constants import (
     A2UI_SCHEMA_BLOCK_START,
     A2UI_SCHEMA_BLOCK_END,
@@ -76,7 +76,7 @@ class CatalogConfig:
         if not parsed.scheme or parsed.scheme == "file":
             catalog_provider = FileSystemCatalogProvider(parsed.path)
         elif parsed.scheme in ["http", "https"]:
-            raise NotImplementedError("HTTP support is coming soon.")
+            catalog_provider = HttpCatalogProvider(catalog_path)
         else:
             raise A2uiCatalogError(f"Unsupported catalog URL scheme: {catalog_path}")
 

--- a/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog_provider.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/schema/catalog_provider.py
@@ -15,10 +15,15 @@
 """Module for providing A2UI catalog schemas and resources."""
 
 import json
+import logging
+import urllib.request
 from abc import ABC, abstractmethod
 from json.decoder import JSONDecodeError
 from typing import Any, Dict, cast
+from urllib.error import URLError
 from .constants import ENCODING
+
+logger = logging.getLogger(__name__)
 
 
 class A2uiCatalogProvider(ABC):
@@ -46,3 +51,28 @@ class FileSystemCatalogProvider(A2uiCatalogProvider):
                 return cast(Dict[str, Any], json.load(f))
         except (FileNotFoundError, JSONDecodeError) as e:
             raise IOError(f"Could not load schema from {self.path}: {e}") from e
+
+
+class HttpCatalogProvider(A2uiCatalogProvider):
+    """Loads catalog definition from a remote HTTP/HTTPS URL."""
+
+    def __init__(self, url: str):
+        self.url = url
+
+    def load(self) -> Dict[str, Any]:
+        try:
+            req = urllib.request.Request(
+                self.url, headers={"User-Agent": "A2UI-Agent-SDK/1.0"}
+            )
+            with urllib.request.urlopen(req, timeout=10) as response:
+                content_type = response.headers.get("Content-Type", "").split(";")[0].strip()
+                recognized_types = ("application/json", "application/agent-plugin+json")
+                if content_type and content_type not in recognized_types:
+                    logger.warning(
+                        f"Response Content-Type '{content_type}' is not a recognized "
+                        "catalog entry type (expected 'application/json' or "
+                        "'application/agent-plugin+json')."
+                    )
+                return cast(Dict[str, Any], json.loads(response.read().decode(ENCODING)))
+        except Exception as e:
+            raise IOError(f"Could not load schema from {self.url}: {e}") from e

--- a/agent_sdks/python/a2ui_agent/tests/adk/test_a2ui_adk_native_toolset.py
+++ b/agent_sdks/python/a2ui_agent/tests/adk/test_a2ui_adk_native_toolset.py
@@ -1,0 +1,232 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from a2ui.adk.a2ui_adk_native_toolset import A2uiAdkNativeToolset
+from a2ui.schema.catalog import A2uiCatalog
+from google.adk.agents.readonly_context import ReadonlyContext
+from google.adk.tools.tool_context import ToolContext
+from google.adk.events.ui_widget import UiWidget
+
+# region A2uiAdkNativeToolset Tests
+"""Tests for the A2uiAdkNativeToolset class."""
+
+
+@pytest.mark.asyncio
+async def test_toolset_init_bool():
+    catalog_mock = MagicMock(spec=A2uiCatalog)
+    toolset = A2uiAdkNativeToolset(
+        a2ui_enabled=True, a2ui_catalog=catalog_mock, a2ui_examples="examples"
+    )
+    ctx = MagicMock(spec=ReadonlyContext)
+    assert await toolset._resolve_a2ui_enabled(ctx)
+
+    # Access the tool to check schema resolution
+    tool = toolset._ui_tools[0]
+    assert await tool._resolve_a2ui_catalog(ctx) == catalog_mock
+
+
+@pytest.mark.asyncio
+async def test_toolset_init_callable():
+    enabled_mock = MagicMock(return_value=True)
+    catalog_mock = MagicMock(spec=A2uiCatalog)
+    examples_mock = MagicMock(return_value="examples")
+    toolset = A2uiAdkNativeToolset(
+        a2ui_enabled=enabled_mock,
+        a2ui_catalog=catalog_mock,
+        a2ui_examples=examples_mock,
+    )
+    ctx = MagicMock(spec=ReadonlyContext)
+    assert await toolset._resolve_a2ui_enabled(ctx)
+
+    # Access the tool to check schema resolution
+    tool = toolset._ui_tools[0]
+    assert await tool._resolve_a2ui_catalog(ctx) == catalog_mock
+    assert await tool._resolve_a2ui_examples(ctx) == "examples"
+    enabled_mock.assert_called_once_with(ctx)
+    catalog_mock.assert_not_called()
+    examples_mock.assert_called_once_with(ctx)
+
+
+@pytest.mark.asyncio
+async def test_toolset_get_tools_enabled():
+    toolset = A2uiAdkNativeToolset(
+        a2ui_enabled=True, a2ui_catalog=MagicMock(spec=A2uiCatalog), a2ui_examples=""
+    )
+    tools = await toolset.get_tools(MagicMock(spec=ReadonlyContext))
+    assert len(tools) == 1
+    assert isinstance(tools[0], A2uiAdkNativeToolset._SendA2uiJsonToAdkWidgetTool)
+
+
+@pytest.mark.asyncio
+async def test_toolset_get_tools_disabled():
+    toolset = A2uiAdkNativeToolset(
+        a2ui_enabled=False,
+        a2ui_catalog=MagicMock(spec=A2uiCatalog),
+        a2ui_examples="",
+    )
+    tools = await toolset.get_tools(MagicMock(spec=ReadonlyContext))
+    assert len(tools) == 0
+
+
+# endregion
+
+# region _SendA2uiJsonToAdkWidgetTool Tests
+"""Tests for the _SendA2uiJsonToAdkWidgetTool class."""
+
+
+def test_send_tool_init():
+    catalog_mock = MagicMock(spec=A2uiCatalog)
+    tool = A2uiAdkNativeToolset._SendA2uiJsonToAdkWidgetTool(
+        catalog_mock, "examples", "a2ui"
+    )
+    assert tool.name == A2uiAdkNativeToolset._SendA2uiJsonToAdkWidgetTool.TOOL_NAME
+    assert tool._a2ui_catalog == catalog_mock
+    assert tool._a2ui_examples == "examples"
+    assert tool._provider_name == "a2ui"
+
+
+def test_send_tool_get_declaration():
+    catalog_mock = MagicMock(spec=A2uiCatalog)
+    tool = A2uiAdkNativeToolset._SendA2uiJsonToAdkWidgetTool(
+        catalog_mock, "examples", "a2ui"
+    )
+    declaration = tool._get_declaration()
+    assert declaration is not None
+    assert (
+        declaration.name
+        == A2uiAdkNativeToolset._SendA2uiJsonToAdkWidgetTool.TOOL_NAME
+    )
+    assert (
+        A2uiAdkNativeToolset._SendA2uiJsonToAdkWidgetTool.A2UI_JSON_ARG_NAME
+        in declaration.parameters.properties
+    )
+    assert (
+        A2uiAdkNativeToolset._SendA2uiJsonToAdkWidgetTool.A2UI_JSON_ARG_NAME
+        in declaration.parameters.required
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_tool_resolve_catalog():
+    catalog_mock = MagicMock(spec=A2uiCatalog)
+    tool = A2uiAdkNativeToolset._SendA2uiJsonToAdkWidgetTool(
+        catalog_mock, "examples", "a2ui"
+    )
+    catalog = await tool._resolve_a2ui_catalog(MagicMock(spec=ReadonlyContext))
+    assert catalog == catalog_mock
+
+
+@pytest.mark.asyncio
+async def test_send_tool_run_async_valid_single():
+    # Setup mock catalog, validator, and tool_context
+    catalog_mock = MagicMock(spec=A2uiCatalog)
+    catalog_mock.validator = MagicMock()
+    tool = A2uiAdkNativeToolset._SendA2uiJsonToAdkWidgetTool(
+        catalog_mock, "examples", "a2ui"
+    )
+
+    tc_mock = MagicMock(spec=ToolContext)
+    tc_mock.run_id = "test-run-123"
+    tc_mock.actions = MagicMock()
+
+    # Valid single payload
+    single_payload = {"id": "my-id", "type": "Button", "properties": {}}
+    a2ui_json_str = json.dumps(single_payload)
+
+    # Run tool
+    result = await tool.run_async(
+        args={tool.A2UI_JSON_ARG_NAME: a2ui_json_str}, tool_context=tc_mock
+    )
+
+    # Assertions
+    catalog_mock.validator.validate.assert_called_once_with([single_payload])
+    assert tc_mock.actions.skip_summarization is True
+
+    # Assert that tool_context.render_ui_widget was called with the correct UiWidget
+    assert tc_mock.render_ui_widget.call_count == 1
+    rendered_widget = tc_mock.render_ui_widget.call_args[0][0]
+    assert isinstance(rendered_widget, UiWidget)
+    assert rendered_widget.id == "my-id"
+    assert rendered_widget.provider == "a2ui"
+    assert rendered_widget.payload == single_payload
+
+    assert result == {tool.VALIDATED_A2UI_JSON_KEY: [single_payload]}
+
+
+@pytest.mark.asyncio
+async def test_send_tool_run_async_valid_list():
+    # Setup mock catalog, validator, and tool_context
+    catalog_mock = MagicMock(spec=A2uiCatalog)
+    catalog_mock.validator = MagicMock()
+    tool = A2uiAdkNativeToolset._SendA2uiJsonToAdkWidgetTool(
+        catalog_mock, "examples", "a2ui-custom"
+    )
+
+    tc_mock = MagicMock(spec=ToolContext)
+    tc_mock.run_id = "test-run-456"
+    tc_mock.actions = MagicMock()
+
+    # Valid list of payloads
+    list_payload = [
+        {"id": "id-1", "type": "Label"},
+        {"id": "id-2", "type": "Input"},
+    ]
+    a2ui_json_str = json.dumps(list_payload)
+
+    # Run tool
+    result = await tool.run_async(
+        args={tool.A2UI_JSON_ARG_NAME: a2ui_json_str}, tool_context=tc_mock
+    )
+
+    # Assertions
+    catalog_mock.validator.validate.assert_called_once_with(list_payload)
+    assert tc_mock.actions.skip_summarization is True
+
+    # Assert that tool_context.render_ui_widget was called with correct widgets
+    assert tc_mock.render_ui_widget.call_count == 2
+    calls = tc_mock.render_ui_widget.call_args_list
+
+    w1 = calls[0][0][0]
+    assert isinstance(w1, UiWidget)
+    assert w1.id == "id-1"
+    assert w1.provider == "a2ui-custom"
+    assert w1.payload == {"id": "id-1", "type": "Label"}
+
+    w2 = calls[1][0][0]
+    assert isinstance(w2, UiWidget)
+    assert w2.id == "id-2"
+    assert w2.provider == "a2ui-custom"
+    assert w2.payload == {"id": "id-2", "type": "Input"}
+
+    assert result == {tool.VALIDATED_A2UI_JSON_KEY: list_payload}
+
+
+@pytest.mark.asyncio
+async def test_send_tool_run_async_missing_arg():
+    tool = A2uiAdkNativeToolset._SendA2uiJsonToAdkWidgetTool(
+        MagicMock(spec=A2uiCatalog), "examples", "a2ui"
+    )
+    tc_mock = MagicMock(spec=ToolContext)
+
+    result = await tool.run_async(args={}, tool_context=tc_mock)
+    assert tool.TOOL_ERROR_KEY in result
+    assert "missing required arg" in result[tool.TOOL_ERROR_KEY]
+
+
+# endregion

--- a/agent_sdks/python/a2ui_agent/tests/schema/test_catalog.py
+++ b/agent_sdks/python/a2ui_agent/tests/schema/test_catalog.py
@@ -59,8 +59,9 @@ def test_resolve_examples_path_handling():
         resolve_examples_path("https://a2ui.org/examples")
 
 
-def test_catalog_config_from_path_schemes():
+def test_catalog_config_from_path_schemes(mocker=None):
     from a2ui.schema.catalog import CatalogConfig
+    from a2ui.schema.catalog_provider import HttpCatalogProvider
     # Test local path
     config = CatalogConfig.from_path(
         name="test_file", catalog_path="relative_path/to/catalog.json"
@@ -73,11 +74,12 @@ def test_catalog_config_from_path_schemes():
     )
     assert config.provider.path == "/absolute_path/to/catalog.json"
 
-    # Test HTTP raises NotImplementedError
-    with pytest.raises(NotImplementedError, match="HTTP support is coming soon."):
-        CatalogConfig.from_path(
-            name="test_http", catalog_path="http://a2ui.org/catalog.json"
-        )
+    # Test HTTP loads HttpCatalogProvider
+    config = CatalogConfig.from_path(
+        name="test_http", catalog_path="http://a2ui.org/catalog.json"
+    )
+    assert isinstance(config.provider, HttpCatalogProvider)
+    assert config.provider.url == "http://a2ui.org/catalog.json"
 
     # Test unsupported scheme raises ValueError
     with pytest.raises(ValueError, match="Unsupported catalog URL scheme"):
@@ -110,3 +112,38 @@ def test_basic_catalog_id_retrieval_methods():
 
     with pytest.raises(ValueError, match="Unsupported version: 0.7"):
         BasicCatalog.get_catalog_id("0.7")
+
+
+def test_http_catalog_provider_success():
+    from unittest.mock import patch, MagicMock
+    from a2ui.schema.catalog_provider import HttpCatalogProvider
+
+    mock_response = MagicMock()
+    mock_response.__enter__.return_value = mock_response
+    mock_response.read.return_value = b'{"catalogId": "my_remote_catalog"}'
+    mock_response.headers = {"Content-Type": "application/agent-plugin+json"}
+
+    provider = HttpCatalogProvider("http://example.com/catalog.json")
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        data = provider.load()
+        assert data == {"catalogId": "my_remote_catalog"}
+
+
+def test_catalog_part_helpers():
+    from a2ui.a2a.parts import is_catalog_part, create_catalog_part, CATALOG_MIME_TYPE
+    from a2a.types import Part, DataPart
+
+    catalog_data = {"catalogId": "test_catalog"}
+    part = create_catalog_part(catalog_data)
+
+    assert isinstance(part, Part)
+    assert isinstance(part.root, DataPart)
+    assert part.root.data == catalog_data
+    assert part.root.metadata.get("mimeType") == CATALOG_MIME_TYPE
+    assert is_catalog_part(part) is True
+
+    # Test is_catalog_part with non-catalog part
+    non_catalog_part = Part(root=DataPart(data={}, metadata={"mimeType": "application/json"}))
+    assert is_catalog_part(non_catalog_part) is False
+

--- a/docs/public/quickstart.md
+++ b/docs/public/quickstart.md
@@ -251,6 +251,17 @@ Now that you've seen A2UI in action, you're ready to:
 - **[Use an Existing Agent App](guides/a2ui-with-any-agent-framework.md)**: Add A2UI through CopilotKit + AG-UI for ADK, LangGraph, CrewAI, Mastra, or a custom service
 - **[Explore the Protocol](reference/messages.md)**: Dive into the technical specification
 
+## Customizing Agent URLs
+
+By default, the samples expect agents to be running on specific ports (e.g., `10002` for Restaurant Finder, `10003` for Contact Lookup). If you need to run agents on different ports (for example, to support restricted port forwarding in remote environments), you can configure the URLs using environment variables before building or running the client:
+
+```bash
+export VITE_RESTAURANT_AGENT_URL="http://localhost:8000"
+export VITE_CONTACTS_AGENT_URL="http://localhost:8001"
+```
+
+These variables are picked up by Vite during development or build time.
+
 ## Troubleshooting
 
 ### Port Already in Use

--- a/docs/public/quickstart.md
+++ b/docs/public/quickstart.md
@@ -253,11 +253,10 @@ Now that you've seen A2UI in action, you're ready to:
 
 ## Customizing Agent URLs
 
-By default, the samples expect agents to be running on specific ports (e.g., `10002` for Restaurant Finder, `10003` for Contact Lookup). If you need to run agents on different ports (for example, to support restricted port forwarding in remote environments), you can configure the URLs using environment variables before building or running the client:
+By default, the samples expect agents to be running on specific ports (e.g., `10002` for Restaurant Finder). If you need to run agents on different ports (for example, to support restricted port forwarding in remote environments), you can configure the URLs using environment variables before building or running the client:
 
 ```bash
 export VITE_RESTAURANT_AGENT_URL="http://localhost:8000"
-export VITE_CONTACTS_AGENT_URL="http://localhost:8001"
 ```
 
 These variables are picked up by Vite during development or build time.

--- a/samples/client/lit/shell/configs/restaurant.ts
+++ b/samples/client/lit/shell/configs/restaurant.ts
@@ -29,6 +29,6 @@ export const restaurantConfig: AppConfig = {
     'Looking for open tables...',
     'Almost there...',
   ],
-  serverUrl: 'http://localhost:10002',
+  serverUrl: import.meta.env?.VITE_RESTAURANT_AGENT_URL || 'http://localhost:10002',
   cssOverrides: restaurantThemeSheet,
 };

--- a/samples/client/lit/shell/vite-env.d.ts
+++ b/samples/client/lit/shell/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tools/build_catalog/tests/test_assemble_catalog.py
+++ b/tools/build_catalog/tests/test_assemble_catalog.py
@@ -199,7 +199,7 @@ class TestAssembleCatalog(unittest.TestCase):
             "components": {"LoopBlock": {"$ref": "memory://test#/components/LoopBlock"}}
         }
 
-        assembler = CatalogAssembler(version="0.9", max_depth=5)
+        assembler = CatalogAssembler(version="0.9", max_depth=2)
 
         # We manually call process_schema to trigger the recursion check
         # and mock fetch_json to always return the loop schema so it infinitely evaluates


### PR DESCRIPTION
This PR resolves #1916 by introducing `A2uiAdkNativeToolset` in the `a2ui.adk` namespace. This native toolset validates and routes A2UI JSON payloads directly as ADK native `UiWidget` instances via `tool_context.render_ui_widget(ui_widget)`. This allows managed agents deployed on Vertex AI Agent Engine and registered in Gemini Enterprise via `adkAgentDefinition` to support first-class A2UI rendering, completely bypassing the legacy A2A requirements.