### PR TITLE
fix(docs): resolve macro rendering errors and format callouts in docs (#2151)

### DIFF
--- a/docs/public/concepts/catalogs.md
+++ b/docs/public/concepts/catalogs.md
@@ -236,6 +236,8 @@ export const HelloWorldBannerApi = {
 
 Next, implement the component extending `CatalogComponent`:
 
+{% raw %}
+
 ```typescript
 // hello_world_banner.ts
 import {CatalogComponent} from '@a2ui/angular/v0_9';
@@ -256,6 +258,8 @@ export class HelloWorldBanner extends CatalogComponent<typeof HelloWorldBannerAp
   protected readonly backgroundColor = computed(() => this.props()['backgroundColor']?.value() || '#f0f0f0');
 }
 ```
+
+{% endraw %}
 
 Finally, register your custom components in an `AngularCatalog`:
 

--- a/docs/public/concepts/catalogs.md
+++ b/docs/public/concepts/catalogs.md
@@ -283,10 +283,10 @@ export const MY_CATALOG = new AngularCatalog(
 
 You can see a working example of a client renderer in the [Orchestrator demo](../../../samples/community/client/angular/projects/orchestrator/src/a2ui-catalog/catalog.ts).
 
-> [!NOTE]
-> The Orchestrator demo currently uses v0.8 APIs. For a v0.9 example of catalog registration, see the [DemoCatalog](../../../renderers/angular/a2ui_explorer/src/app/demo-catalog.ts) in the Angular explorer.
->
-> Additionally, for client-side functions, the client determines the function's execution boundary (such as `clientOnly` status) at runtime by reading its configuration from the active catalog definition.
+!!! note ""
+The Orchestrator demo currently uses v0.8 APIs. For a v0.9 example of catalog registration, see the [DemoCatalog](../../../renderers/angular/a2ui_explorer/src/app/demo-catalog.ts) in the Angular explorer.
+
+    Additionally, for client-side functions, the client determines the function's execution boundary (such as `clientOnly` status) at runtime by reading its configuration from the active catalog definition.
 
 ## A2UI Catalog Negotiation
 

--- a/docs/public/guides/a2ui-in-mcp-apps.md
+++ b/docs/public/guides/a2ui-in-mcp-apps.md
@@ -156,29 +156,27 @@ MCP Apps are typically delivered as a single HTML resource from the MCP Server. 
 2.  Use a post-build script (like the [`inline.js`](../../../samples/community/mcp/a2ui-in-mcpapps/server/apps/src/inline.js) script in the sample) to read the `index.html` and replace external `<script src="...">` and `<link rel="stylesheet" href="...">` tags with inline `<script>` and `<style>` tags containing the actual file contents.
 3.  This produces a self-contained HTML file that can be safely loaded via `srcdoc` in the restricted iframe.
 
-> [!TIP]
-> **Using Vite to inline**
->
-> If your project uses Vite (common for React, Vue, or Lit), you can achieve the same single-file output automatically using plugins like `vite-plugin-singlefile`. This eliminates the need for a custom post-build script by handling the inlining during the build process itself.
->
-> **How to use it:**
->
-> 1. **Install the plugin**:
->     ```bash
->     npm install -D vite-plugin-singlefile
->     ```
-> 2. **Configure Vite**: Add the plugin to your `vite.config.ts` (or `.js`):
->
->     ```typescript
->     import {defineConfig} from 'vite';
->     import {viteSingleFile} from 'vite-plugin-singlefile';
->
->     export default defineConfig({
->       plugins: [viteSingleFile()],
->     });
->     ```
->
->     This will ensure that all JS and CSS assets are inlined into the `index.html` file on build, making it ready to be served by your MCP server as a single resource.
+!!! tip "Using Vite to inline"
+If your project uses Vite (common for React, Vue, or Lit), you can achieve the same single-file output automatically using plugins like `vite-plugin-singlefile`. This eliminates the need for a custom post-build script by handling the inlining during the build process itself.
+
+    **How to use it:**
+
+    1. **Install the plugin**:
+        ```bash
+        npm install -D vite-plugin-singlefile
+        ```
+    2. **Configure Vite**: Add the plugin to your `vite.config.ts` (or `.js`):
+
+        ```typescript
+        import {defineConfig} from 'vite';
+        import {viteSingleFile} from 'vite-plugin-singlefile';
+
+        export default defineConfig({
+          plugins: [viteSingleFile()],
+        });
+        ```
+
+        This will ensure that all JS and CSS assets are inlined into the `index.html` file on build, making it ready to be served by your MCP server as a single resource.
 
 ### Step 2: Leveraging A2UI-over-MCP
 

--- a/docs/public/guides/a2ui_over_mcp.md
+++ b/docs/public/guides/a2ui_over_mcp.md
@@ -57,8 +57,8 @@ In the Inspector:
 
 For a fully rendered interactive experience that visually demonstrates A2UI over MCP, run the included web application:
 
-> [!NOTE]
-> **Package Manager Usage:** Running the built-in sample applications within the A2UI repository requires Yarn (`yarn install` / `yarn dev`) as configured by Corepack workspaces. For your own regular usage and standalone projects outside this repository, use the package manager of your choice (e.g. npm, pnpm).
+!!! note ""
+**Package Manager Usage:** Running the built-in sample applications within the A2UI repository requires Yarn (`yarn install` / `yarn dev`) as configured by Corepack workspaces. For your own regular usage and standalone projects outside this repository, use the package manager of your choice (e.g. npm, pnpm).
 
 1. In a new terminal window, navigate to the client directory:
     ```bash
@@ -89,9 +89,8 @@ There are two primary ways an MCP server can deliver A2UI content to a client:
 
 In both cases, the client detects the `application/a2ui+json` MIME type and routes the payload to an A2UI renderer.
 
-> [!IMPORTANT]
-> **MIME Type Uniformity**
-> Regardless of the delivery channel (whether fetched directly as a Resource or returned inside a Tool's `CallToolResult`), the A2UI JSON payload is always identified by the `application/a2ui+json` MIME type. In Tool responses, the payload must be wrapped inside an `EmbeddedResource` carrying this MIME type. This uniform identification allows client-side middleware to seamlessly intercept and route both static resources and dynamic tool responses to A2UI.
+!!! info "MIME Type Uniformity"
+Regardless of the delivery channel (whether fetched directly as a Resource or returned inside a Tool's `CallToolResult`), the A2UI JSON payload is always identified by the `application/a2ui+json` MIME type. In Tool responses, the payload must be wrapped inside an `EmbeddedResource` carrying this MIME type. This uniform identification allows client-side middleware to seamlessly intercept and route both static resources and dynamic tool responses to A2UI.
 
 ### 1. Resource-based Delivery Flow (`resources/read`)
 

--- a/docs/public/guides/authoring-components.md
+++ b/docs/public/guides/authoring-components.md
@@ -140,6 +140,8 @@ export const ChartApi = {
 
 Now implement the Angular component:
 
+{% raw %}
+
 ```typescript
 import {CatalogComponent} from '@a2ui/angular/v0_9';
 import {Component, computed} from '@angular/core';
@@ -172,6 +174,8 @@ export class Chart extends CatalogComponent<typeof ChartApi> {
   });
 }
 ```
+
+{% endraw %}
 
 Keep these key points in mind when implementing components:
 

--- a/docs/public/guides/client-setup.md
+++ b/docs/public/guides/client-setup.md
@@ -111,8 +111,8 @@ export ENABLE_STREAMING=false
 yarn start restaurant
 ```
 
-> [!NOTE]
-> **Package Manager Usage:** The `yarn start` command above is specific to running the sample application within the A2UI monorepo repository. For your own regular usage and standalone projects outside this repository, use the package manager of your choice (e.g. npm, pnpm).
+!!! note ""
+**Package Manager Usage:** The `yarn start` command above is specific to running the sample application within the A2UI monorepo repository. For your own regular usage and standalone projects outside this repository, use the package manager of your choice (e.g. npm, pnpm).
 
 ## React
 

--- a/docs/public/guides/mcp-apps-in-a2ui.md
+++ b/docs/public/guides/mcp-apps-in-a2ui.md
@@ -187,8 +187,8 @@ To run the samples, ensure you have the following installed:
 - **Node.js 18+** and **Yarn** — Required for building and running the sample client apps within this monorepo workspace.
 - **A `GEMINI_API_KEY`** — Required by all ADK-based agents. Get one from [Google AI Studio](https://aistudio.google.com/apikey)
 
-> [!NOTE]
-> **Package Manager Usage:** Running the built-in sample applications within the A2UI repository requires Yarn as configured by Corepack workspaces. For your own regular usage and standalone projects outside this repository, use the package manager of your choice (e.g. npm, pnpm).
+!!! note ""
+**Package Manager Usage:** Running the built-in sample applications within the A2UI repository requires Yarn as configured by Corepack workspaces. For your own regular usage and standalone projects outside this repository, use the package manager of your choice (e.g. npm, pnpm).
 
 > ⚠️ **Environment variable setup**: You can either export `GEMINI_API_KEY` in your shell or create a `.env` file in each agent directory. The agents use `dotenv` to load `.env` files automatically.
 >

--- a/docs/public/quickstart.md
+++ b/docs/public/quickstart.md
@@ -58,14 +58,14 @@ yarn install
 yarn demo:restaurant
 ```
 
-> [!TIP]
-> **macOS Homebrew Users:** If you have standalone package managers installed, unlink conflicts before installing Corepack so Corepack can manage versions per-project:
->
-> ```bash
-> brew unlink yarn pnpm
-> brew install corepack
-> corepack enable
-> ```
+!!! tip ""
+**macOS Homebrew Users:** If you have standalone package managers installed, unlink conflicts before installing Corepack so Corepack can manage versions per-project:
+
+    ```bash
+    brew unlink yarn pnpm
+    brew install corepack
+    corepack enable
+    ```
 
 This command will:
 
@@ -77,8 +77,8 @@ This command will:
 
 The source code for the Restaurant Finder agent is located in [`samples/agent/adk/restaurant_finder`](../../samples/agent/adk/restaurant_finder).
 
-> [!NOTE]
-> **Package Manager Usage:** Running the quickstart demo application within the A2UI repository requires Yarn as configured by Corepack workspaces. For your own regular usage and standalone projects outside this repository, use the package manager of your choice (e.g. npm, pnpm).
+!!! note ""
+**Package Manager Usage:** Running the quickstart demo application within the A2UI repository requires Yarn as configured by Corepack workspaces. For your own regular usage and standalone projects outside this repository, use the package manager of your choice (e.g. npm, pnpm).
 
 ### Running Manually (Alternative)
 

--- a/docs/public/reference/components.md
+++ b/docs/public/reference/components.md
@@ -634,8 +634,8 @@ cd samples/client/angular
 yarn start gallery
 ```
 
-> [!NOTE]
-> **Package Manager Usage:** Running the built-in sample applications within the A2UI repository requires Yarn (`yarn start gallery`) as configured by Corepack workspaces. For your own regular usage and standalone projects outside this repository, use the package manager of your choice (e.g. npm, pnpm).
+!!! note ""
+**Package Manager Usage:** Running the built-in sample applications within the A2UI repository requires Yarn (`yarn start gallery`) as configured by Corepack workspaces. For your own regular usage and standalone projects outside this repository, use the package manager of your choice (e.g. npm, pnpm).
 
 ## Further Reading
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -201,7 +201,8 @@ hooks:
 # Plugins
 plugins:
   - search
-  - macros
+  - macros:
+      on_undefined: keep
   # - include-markdown
   - mermaid2
   - redirects:


### PR DESCRIPTION
### Summary & Rationale
In `mkdocs.yaml`, the `mkdocs-macros-plugin` (`macros`) evaluates Jinja2 expressions (`{{ ... }}`) across Markdown documentation files before rendering them to HTML. Angular code examples in `docs/public/concepts/catalogs.md` (`{{ message() }}`) and `docs/public/guides/authoring-components.md` (`{{ title() }}`) caused Jinja2 `UndefinedError` during the MkDocs build. Furthermore, Admonition callouts in several documentation files were using raw GitHub callout syntax (`> [!NOTE]`), which did not render properly under MkDocs Material styling.

This PR wraps the Angular code examples containing double curly brace interpolation inside `{% raw %}` ... `{% endraw %}` blocks and configures `on_undefined: keep` under the `macros` plugin in `mkdocs.yaml`. It also formats callout blocks to use MkDocs Material admonition syntax across the docs.

### Key Changes
- **`docs/public/concepts/catalogs.md`**: Wrapped Angular component implementation example (containing `{{ message() }}`) in `{% raw %}` / `{% endraw }`.
- **`docs/public/guides/authoring-components.md`**: Wrapped Angular component implementation example (containing `{{ title() }}`) in `{% raw %}` / `{% endraw }`.
- **`mkdocs.yaml`**: Set `on_undefined: keep` under the `macros` plugin configuration to preserve unescaped Jinja2-like tokens without failing builds.
- **Documentation Callouts (`docs/public/`)**: Converted `> [!NOTE]`, `> [!IMPORTANT]`, and `> [!TIP]` blocks into standard MkDocs Material admonitions (`!!! note ""`, `!!! info`, `!!! tip ""`) across `a2ui_over_mcp.md`, `client-setup.md`, `mcp-apps-in-a2ui.md`, `quickstart.md`, and `reference/components.md`.

### Verification & Testing
- Built the documentation site using `./bin/mkdocs build` and confirmed clean output with 0 errors.
- Inspected generated HTML pages (`site/concepts/catalogs/index.html` and `site/guides/authoring-components/index.html`) to verify `{{ message() }}` and `{{ title() }}` render correctly in Angular code blocks.
- Executed unit tests via `./bin/pytest docs/scripts/test_convert_docs.py` (11 passed cleanly).

Closes #2151