### PR TITLE
fix(python-sdk): rebuild $defs.anyComponent when merging inlineCatalogs

### DIFF
--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/direct_json/format.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/direct_json/format.py
@@ -228,30 +228,37 @@ class DirectJsonFormat(InferenceFormat):
                 inline_components = inline_catalog_schema.get(
                     CATALOG_COMPONENTS_KEY, {}
                 )
-                merged_schema.setdefault(CATALOG_COMPONENTS_KEY, {}).update(inline_components)
+                if merged_schema.get(CATALOG_COMPONENTS_KEY) is None:
+                    merged_schema[CATALOG_COMPONENTS_KEY] = {}
+                merged_schema[CATALOG_COMPONENTS_KEY].update(inline_components)
                 inline_functions = inline_catalog_schema.get("functions", {})
                 if inline_functions:
-                    merged_schema.setdefault("functions", {}).update(inline_functions)
+                    if merged_schema.get("functions") is None:
+                        merged_schema["functions"] = {}
+                    merged_schema["functions"].update(inline_functions)
 
             if "$defs" in merged_schema and "anyComponent" in merged_schema["$defs"]:
                 components = merged_schema.get(CATALOG_COMPONENTS_KEY) or {}
-                merged_schema["$defs"]["anyComponent"] = {
-                    "oneOf": [
-                        {"$ref": f"#/{CATALOG_COMPONENTS_KEY}/{name}"}
-                        for name in sorted(components.keys())
-                    ],
-                    "discriminator": {"propertyName": "component"},
-                }
+                if components:
+                    any_comp = merged_schema["$defs"]["anyComponent"]
+                    if isinstance(any_comp, dict):
+                        any_comp["oneOf"] = [
+                            {"$ref": f"#/{CATALOG_COMPONENTS_KEY}/{name}"}
+                            for name in sorted(components.keys())
+                        ]
+                        any_comp.setdefault(
+                            "discriminator", {"propertyName": "component"}
+                        )
 
             if "$defs" in merged_schema and "anyFunction" in merged_schema["$defs"]:
                 functions = merged_schema.get("functions") or {}
                 if functions:
-                    merged_schema["$defs"]["anyFunction"] = {
-                        "oneOf": [
+                    any_func = merged_schema["$defs"]["anyFunction"]
+                    if isinstance(any_func, dict):
+                        any_func["oneOf"] = [
                             {"$ref": f"#/functions/{name}"}
                             for name in sorted(functions.keys())
-                        ],
-                    }
+                        ]
 
             return A2uiCatalog(
                 version=self._version,
@@ -261,7 +268,6 @@ class DirectJsonFormat(InferenceFormat):
                 common_types_schema=self._common_types_schema,
                 experiments=self.experiments,
             )
-
 
         if not client_supported_catalog_ids:
             return self._supported_catalogs[0]

--- a/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/direct_json/format.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/inference_formats/direct_json/format.py
@@ -228,7 +228,30 @@ class DirectJsonFormat(InferenceFormat):
                 inline_components = inline_catalog_schema.get(
                     CATALOG_COMPONENTS_KEY, {}
                 )
-                merged_schema[CATALOG_COMPONENTS_KEY].update(inline_components)
+                merged_schema.setdefault(CATALOG_COMPONENTS_KEY, {}).update(inline_components)
+                inline_functions = inline_catalog_schema.get("functions", {})
+                if inline_functions:
+                    merged_schema.setdefault("functions", {}).update(inline_functions)
+
+            if "$defs" in merged_schema and "anyComponent" in merged_schema["$defs"]:
+                components = merged_schema.get(CATALOG_COMPONENTS_KEY) or {}
+                merged_schema["$defs"]["anyComponent"] = {
+                    "oneOf": [
+                        {"$ref": f"#/{CATALOG_COMPONENTS_KEY}/{name}"}
+                        for name in sorted(components.keys())
+                    ],
+                    "discriminator": {"propertyName": "component"},
+                }
+
+            if "$defs" in merged_schema and "anyFunction" in merged_schema["$defs"]:
+                functions = merged_schema.get("functions") or {}
+                if functions:
+                    merged_schema["$defs"]["anyFunction"] = {
+                        "oneOf": [
+                            {"$ref": f"#/functions/{name}"}
+                            for name in sorted(functions.keys())
+                        ],
+                    }
 
             return A2uiCatalog(
                 version=self._version,
@@ -238,6 +261,7 @@ class DirectJsonFormat(InferenceFormat):
                 common_types_schema=self._common_types_schema,
                 experiments=self.experiments,
             )
+
 
         if not client_supported_catalog_ids:
             return self._supported_catalogs[0]

--- a/agent_sdks/python/a2ui_agent/tests/schema/test_direct_json_format.py
+++ b/agent_sdks/python/a2ui_agent/tests/schema/test_direct_json_format.py
@@ -155,3 +155,87 @@ def test_direct_json_parser_no_supported_catalogs():
     direct_json_format._supported_catalogs = []
     with pytest.raises(A2uiCatalogError, match="No supported catalogs configured"):
         _ = direct_json_format.parser
+
+
+def test_select_catalog_rebuilds_any_component_with_inline_catalogs():
+    from a2ui.schema.constants import VERSION_0_9
+
+    fmt = DirectJsonFormat(
+        VERSION_0_9,
+        catalogs=[BasicCatalog.get_config(VERSION_0_9)],
+        accepts_inline_catalogs=True,
+    )
+
+    caps = {
+        "supportedCatalogIds": [
+            "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
+        ],
+        "inlineCatalogs": [
+            {
+                "catalogId": "example_inline",
+                "components": {
+                    "StatusChip": {
+                        "type": "object",
+                        "allOf": [
+                            {
+                                "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentCommon"
+                            },
+                            {"$ref": "#/$defs/CatalogComponentCommon"},
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "component": {"const": "StatusChip"},
+                                    "label": {
+                                        "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString"
+                                    },
+                                },
+                                "required": ["component", "label"],
+                            },
+                        ],
+                    }
+                },
+            }
+        ],
+    }
+
+    catalog = fmt.get_selected_catalog(client_ui_capabilities=caps)
+
+    # 1. Custom component is in components map
+    assert "StatusChip" in catalog.catalog_schema["components"]
+
+    # 2. $defs.anyComponent.oneOf contains reference to StatusChip
+    any_comp = catalog.catalog_schema.get("$defs", {}).get("anyComponent", {})
+    one_of_refs = [item.get("$ref") for item in any_comp.get("oneOf", []) if isinstance(item, dict)]
+    assert "#/components/StatusChip" in one_of_refs
+    assert "#/components/Text" in one_of_refs
+
+    # 3. Payload with StatusChip validates successfully
+    test_message = {
+        "version": "v0.9",
+        "updateComponents": {
+            "surfaceId": "main",
+            "components": [
+                {
+                    "id": "root",
+                    "component": "StatusChip",
+                    "label": "OK",
+                }
+            ],
+        },
+    }
+    catalog.validator.validate(test_message)
+
+    # 4. Streaming parser processes payload containing StatusChip
+    parser = DirectJsonParser(catalog)
+    cat_id = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
+    payload_str = (
+        '<a2ui-json>\n'
+        '[\n'
+        f'  {{"version": "v0.9", "createSurface": {{"surfaceId": "main", "catalogId": "{cat_id}"}}}},\n'
+        '  {"version": "v0.9", "updateComponents": {"surfaceId": "main", "components": [{"id": "root", "component": "StatusChip", "label": "OK"}]}}\n'
+        ']\n'
+        '</a2ui-json>'
+    )
+    parts = parser.process_chunk(payload_str)
+    assert len(parts) >= 1
+

--- a/agent_sdks/python/a2ui_agent/tests/schema/test_direct_json_format.py
+++ b/agent_sdks/python/a2ui_agent/tests/schema/test_direct_json_format.py
@@ -10,7 +10,9 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import io
+import json
 import pytest
+
 from unittest.mock import patch, MagicMock
 from a2ui.core import A2uiCatalogError
 from a2ui.inference_formats.direct_json import DirectJsonFormat, DirectJsonParser
@@ -170,32 +172,34 @@ def test_select_catalog_rebuilds_any_component_with_inline_catalogs():
         "supportedCatalogIds": [
             "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
         ],
-        "inlineCatalogs": [
-            {
-                "catalogId": "example_inline",
-                "components": {
-                    "StatusChip": {
-                        "type": "object",
-                        "allOf": [
-                            {
-                                "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentCommon"
-                            },
-                            {"$ref": "#/$defs/CatalogComponentCommon"},
-                            {
-                                "type": "object",
-                                "properties": {
-                                    "component": {"const": "StatusChip"},
-                                    "label": {
-                                        "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString"
-                                    },
+        "inlineCatalogs": [{
+            "catalogId": "example_inline",
+            "components": {
+                "StatusChip": {
+                    "type": "object",
+                    "allOf": [
+                        {
+                            "$ref": (
+                                "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentCommon"
+                            )
+                        },
+                        {"$ref": "#/$defs/CatalogComponentCommon"},
+                        {
+                            "type": "object",
+                            "properties": {
+                                "component": {"const": "StatusChip"},
+                                "label": {
+                                    "$ref": (
+                                        "https://a2ui.org/specification/v0_9/common_types.json#/$defs/DynamicString"
+                                    )
                                 },
-                                "required": ["component", "label"],
                             },
-                        ],
-                    }
-                },
-            }
-        ],
+                            "required": ["component", "label"],
+                        },
+                    ],
+                }
+            },
+        }],
     }
 
     catalog = fmt.get_selected_catalog(client_ui_capabilities=caps)
@@ -205,7 +209,9 @@ def test_select_catalog_rebuilds_any_component_with_inline_catalogs():
 
     # 2. $defs.anyComponent.oneOf contains reference to StatusChip
     any_comp = catalog.catalog_schema.get("$defs", {}).get("anyComponent", {})
-    one_of_refs = [item.get("$ref") for item in any_comp.get("oneOf", []) if isinstance(item, dict)]
+    one_of_refs = [
+        item.get("$ref") for item in any_comp.get("oneOf", []) if isinstance(item, dict)
+    ]
     assert "#/components/StatusChip" in one_of_refs
     assert "#/components/Text" in one_of_refs
 
@@ -214,13 +220,11 @@ def test_select_catalog_rebuilds_any_component_with_inline_catalogs():
         "version": "v0.9",
         "updateComponents": {
             "surfaceId": "main",
-            "components": [
-                {
-                    "id": "root",
-                    "component": "StatusChip",
-                    "label": "OK",
-                }
-            ],
+            "components": [{
+                "id": "root",
+                "component": "StatusChip",
+                "label": "OK",
+            }],
         },
     }
     catalog.validator.validate(test_message)
@@ -228,14 +232,21 @@ def test_select_catalog_rebuilds_any_component_with_inline_catalogs():
     # 4. Streaming parser processes payload containing StatusChip
     parser = DirectJsonParser(catalog)
     cat_id = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
-    payload_str = (
-        '<a2ui-json>\n'
-        '[\n'
-        f'  {{"version": "v0.9", "createSurface": {{"surfaceId": "main", "catalogId": "{cat_id}"}}}},\n'
-        '  {"version": "v0.9", "updateComponents": {"surfaceId": "main", "components": [{"id": "root", "component": "StatusChip", "label": "OK"}]}}\n'
-        ']\n'
-        '</a2ui-json>'
-    )
+    messages = [
+        {
+            "version": "v0.9",
+            "createSurface": {"surfaceId": "main", "catalogId": cat_id},
+        },
+        {
+            "version": "v0.9",
+            "updateComponents": {
+                "surfaceId": "main",
+                "components": [
+                    {"id": "root", "component": "StatusChip", "label": "OK"}
+                ],
+            },
+        },
+    ]
+    payload_str = f"<a2ui-json>\n{json.dumps(messages)}\n</a2ui-json>"
     parts = parser.process_chunk(payload_str)
     assert len(parts) >= 1
-


### PR DESCRIPTION
# Description

### Problem
When client capabilities supply custom inline catalogs (`inlineCatalogs`), `DirectJsonFormat._select_catalog` was only updating `catalog_schema["components"]` and was not rebuilding `$defs.anyComponent.oneOf`.

Because envelope schemas validate component arrays against `$ref: "catalog.json#/$defs/anyComponent"`, messages containing these custom inline components failed schema validation and stream parsing with `Unknown component type` / `is not valid under any of the given schemas`.

### Solution
- Updated `DirectJsonFormat._select_catalog` to rebuild `$defs.anyComponent.oneOf` for all merged components after applying inline catalogs.
- Also rebuilt `$defs.anyFunction.oneOf` if custom functions are present in inline catalogs.
- Added unit tests in `test_direct_json_format.py` verifying that merged custom components pass both schema validation and streaming parsing.

Fixes #2115

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have built and run at least one [sample].

For this PR:

- [ ] I have updated the relevant CHANGELOG.md file.
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [x] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
