### PR TITLE
fix(lit): align basic catalog component behaviors with angular implementation

### DIFF
--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Unreleased
 
 - (v0_9) Migrate basic catalog components from Shadow DOM to Light DOM rendering with shared basic catalog styling.
+- (v0_9) Updated basic catalog component behaviors to match Angular implementations:
+  - Text: Caption variant (`variant: caption`) now wraps text in `<em>`, rendering in italic style by default.
+  - TextField: Validation error messages now display all failed validation messages simultaneously instead of only the first one.
+  - Column: Column container element now defaults to `width: 100%`.
+  - Image: No longer sets `width: 100%` by default on the image container element.
 
 ## 0.10.3
 

--- a/renderers/lit/a2ui_explorer/tests/v0_9/29_movie-card.test.ts
+++ b/renderers/lit/a2ui_explorer/tests/v0_9/29_movie-card.test.ts
@@ -67,8 +67,8 @@ describe('Example: Movie Card', () => {
     button.click();
     await whenSettled(gallery);
 
-    const modal = querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0] as HTMLDialogElement;
-    expect(modal?.open).toBeTruthy();
+    const modal = querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0] as HTMLElement;
+    expect(modal).toBeTruthy();
 
     const video = querySelectorAllDeep(surface, 'video')[0] as HTMLVideoElement;
     expect(video).toBeTruthy();

--- a/renderers/lit/a2ui_explorer/tests/v0_9/36_modal.test.ts
+++ b/renderers/lit/a2ui_explorer/tests/v0_9/36_modal.test.ts
@@ -39,18 +39,14 @@ describe('Example: Modal', () => {
     expect(trigger).toBeTruthy();
 
     // Check modal is closed initially
-    expect(
-      (querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0] as HTMLDialogElement)?.open,
-    ).toBeFalsy();
+    expect(querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0]).toBeFalsy();
 
     // Click trigger
     trigger.click();
     await whenSettled(gallery);
 
     // Check modal is open
-    expect(
-      (querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0] as HTMLDialogElement)?.open,
-    ).toBeTruthy();
+    expect(querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0]).toBeTruthy();
 
     // Check content
     expect(getDeepTextContent(querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0])).toContain(
@@ -64,8 +60,6 @@ describe('Example: Modal', () => {
     await whenSettled(gallery);
 
     // Check modal is closed
-    expect(
-      (querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0] as HTMLDialogElement)?.open,
-    ).toBeFalsy();
+    expect(querySelectorAllDeep(surface, '.a2ui-modal-overlay')[0]).toBeFalsy();
   });
 });

--- a/renderers/lit/src/v0_9/catalogs/basic/components/Modal.ts
+++ b/renderers/lit/src/v0_9/catalogs/basic/components/Modal.ts
@@ -15,7 +15,7 @@
  */
 
 import {html, nothing, css} from 'lit';
-import {customElement, query} from 'lit/decorators.js';
+import {customElement, state} from 'lit/decorators.js';
 import {ModalApi} from '@a2ui/web_core/v0_9/basic_catalog';
 import {BasicCatalogA2uiLitElement} from '../basic-catalog-a2ui-lit-element.js';
 import {A2uiController} from '../../../a2ui-controller.js';
@@ -24,41 +24,94 @@ import {LitComponentApi} from '../../../types.js';
 @customElement('a2ui-modal')
 export class A2uiLitModal extends BasicCatalogA2uiLitElement<typeof ModalApi> {
   static override styles = css`
-    dialog {
-      border: 1px solid var(--a2ui-color-border, #ccc);
-      border-radius: var(--a2ui-modal-border-radius, 8px);
-      padding: var(--a2ui-modal-padding, 24px);
-      min-width: 300px;
-      background: var(--a2ui-color-surface, #fff);
+    .a2ui-modal-wrapper {
+      display: inline-block;
     }
-    dialog::backdrop {
+    .a2ui-modal-trigger {
+      cursor: pointer;
+    }
+    .a2ui-modal-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
       background: var(--a2ui-modal-backdrop-bg, rgba(0, 0, 0, 0.5));
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      z-index: 1000;
+    }
+    .a2ui-modal-content {
+      background: var(--a2ui-modal-background, var(--a2ui-color-surface, white));
+      padding: var(--a2ui-modal-padding, var(--a2ui-spacing-xl, 32px));
+      border-radius: var(--a2ui-modal-border-radius, var(--a2ui-border-radius, 8px));
+      position: relative;
+      min-width: 300px;
+      max-width: 80%;
+      max-height: 80%;
+      overflow-y: auto;
+      box-shadow: var(--a2ui-modal-box-shadow, 0 10px 25px rgba(0, 0, 0, 0.2));
+    }
+    .a2ui-modal-close {
+      position: absolute;
+      top: 10px;
+      right: 15px;
+      border: none;
+      background: none;
+      font-size: 24px;
+      cursor: pointer;
+      color: var(--a2ui-text-caption-color, #999);
+    }
+    .a2ui-modal-close:hover {
+      color: var(--a2ui-text-color, #333);
     }
   `;
+
+  @state() accessor isOpen = false;
+
+  openModal() {
+    this.isOpen = true;
+  }
+
+  closeModal() {
+    this.isOpen = false;
+  }
 
   protected createController() {
     return new A2uiController(this, ModalApi);
   }
-  @query('dialog') accessor dialog!: HTMLDialogElement;
 
   override render() {
-    const props = this.controller.props;
+    const props = this.controller?.props;
     if (!props) return nothing;
 
     return html`
-      <div
-        @click=${() => this.dialog?.showModal()}
-        class="a2ui-modal-trigger"
-        style="display: contents;"
-      >
-        ${props.trigger ? html`${this.renderNode(props.trigger)}` : nothing}
+      <div class="a2ui-modal-wrapper">
+        <div @click=${() => this.openModal()} class="a2ui-modal-trigger">
+          ${props.trigger ? this.renderNode(props.trigger) : nothing}
+        </div>
+
+        ${this.isOpen
+          ? html`
+              <div
+                class="a2ui-modal-overlay a2ui-modal"
+                @click=${(e: MouseEvent) => {
+                  if (e.target === e.currentTarget) {
+                    this.closeModal();
+                  }
+                }}
+              >
+                <div class="a2ui-modal-content" @click=${(e: Event) => e.stopPropagation()}>
+                  <button type="button" class="a2ui-modal-close" @click=${() => this.closeModal()}>
+                    &times;
+                  </button>
+                  ${props.content ? this.renderNode(props.content) : nothing}
+                </div>
+              </div>
+            `
+          : nothing}
       </div>
-      <dialog class="a2ui-modal a2ui-modal-overlay">
-        <form method="dialog" style="text-align: right;">
-          <button class="a2ui-modal-close">×</button>
-        </form>
-        ${props.content ? html`${this.renderNode(props.content)}` : nothing}
-      </dialog>
     `;
   }
 }


### PR DESCRIPTION
## Description

This PR is **Part 2** of the Universal Web Components stack (stacked on top of #2202).

### Changes
- Aligns `@a2ui/lit` Basic Catalog component behaviors with the Angular implementation:
  - **Text**: `variant: 'caption'` wraps text in `<em>` (italicized caption styling).
  - **TextField**: Renders all validation errors in the `validationErrors` array rather than only the first one.
  - **Column**: Adds `width: 100%` default styling to column layout container.
  - **Image**: Removes `width: 100%` from default image wrapper styling.
  - **Modal**: Updates overlay container to `.a2ui-modal-overlay` and manages open state via `@state() isOpen`.