### PR TITLE
feat(angular): support universal web components in v0.9 renderer

### DIFF
--- a/renderers/angular/CHANGELOG.md
+++ b/renderers/angular/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
-- (v0_9) Implement `createComponentImplementation` helper and deprecate `extraComponents` and `functions` in `BasicCatalogOptions` to align with the core API. [#2060](https://github.com/a2ui-project/a2ui/pull/2060)
+- (v0_9) Support universal Web Components in the v0.9 renderer:
+  - Migrate default Basic Catalog implementations from Angular components to universal Web Components from `@a2ui/web_core`.
+  - Add `toWebComponent` adapter to convert custom Angular `@Component` implementations into Web Components.
+  - Update `SurfaceComponent` and `AngularCatalog` to dynamically render custom element tags and manage component lifecycle reactively.
 
 ## 0.10.5
 

--- a/renderers/angular/a2ui_explorer/scripts/closure-compiler/apply-closure-compiler.mjs
+++ b/renderers/angular/a2ui_explorer/scripts/closure-compiler/apply-closure-compiler.mjs
@@ -174,6 +174,24 @@ for (const f of files) {
     'if(t!==void 0&&t!==null){if(typeof t!=="object")throw new TypeError("Object expected");if(l=g(t.get))',
   );
 
+  // Safe fallback for Lit directive constructor resultType check in Closure Compiler minified bundle
+  if (c.includes('this.constructor.resultType')) {
+    c = c.replace(
+      /this\.constructor\.resultType\s*===\s*void 0/g,
+      '(this.constructor.resultType || 1) === void 0',
+    );
+    changed = true;
+  }
+
+  // Safe fallback for Lit DEV_MODE enabledWarnings check in Closure Compiler minified bundle
+  if (c.includes('this.constructor.enabledWarnings')) {
+    c = c.replace(
+      /this\.constructor\.enabledWarnings\.includes/g,
+      '(this.constructor.enabledWarnings||[]).includes',
+    );
+    changed = true;
+  }
+
   // 3. Inject /** @nocollapse */ onto static Ivy fields (static ɵcmp, ɵfac, __NG_ELEMENT_ID__, etc.).
   // Why: Closure Compiler normally "collapses" static properties, flattening Class.prop into global
   // variables (Class$prop) to compress names. If it collapses Ivy definitions off class constructors,

--- a/renderers/angular/a2ui_explorer/scripts/closure-compiler/externs/globals.externs.js
+++ b/renderers/angular/a2ui_explorer/scripts/closure-compiler/externs/globals.externs.js
@@ -32,6 +32,15 @@ let Hammer;
 /** @type {?} */ Object.prototype.kind;
 /** @type {?} */ Object.prototype.access;
 /** @type {?} */ Object.prototype.addInitializer;
+/** @type {?} */ Object.prototype.adoptedStyleSheets;
+/** @type {?} */ Object.prototype.replaceSync;
+/** @type {?} */ Object.prototype._$litStatic$;
+/** @type {?} */ Object.prototype.strings;
+/** @type {?} */ Object.prototype.values;
+/** @type {?} */ Object.prototype.r;
+/** @type {?} */ Object.prototype.raw;
+/** @type {?} */ Object.prototype._processedSheet;
+/** @type {?} */ Object.prototype._processedCss;
 
 /**
  * Externs for Lit (`@lit/reactive-element`, `lit-element`, `lit-html`).
@@ -45,6 +54,9 @@ function LitElementExterns() {}
 /** @type {?} */ LitElementExterns.prototype.renderOptions;
 /** @type {?} */ LitElementExterns.prototype.styles;
 /** @type {?} */ LitElementExterns.prototype.properties;
+/** @type {?} */ LitElementExterns.prototype.enabledWarnings;
+/** @type {?} */ LitElementExterns.prototype.enableWarning;
+/** @type {?} */ LitElementExterns.prototype.disableWarning;
 
 /**
  * Externs for TC39 2023 Decorators context object (`kind`, `name`, `static`, `private`, `access`, `addInitializer`).

--- a/renderers/angular/a2ui_explorer/scripts/closure-compiler/serve-dist.mjs
+++ b/renderers/angular/a2ui_explorer/scripts/closure-compiler/serve-dist.mjs
@@ -59,7 +59,15 @@ const server = http.createServer((req, res) => {
   let filePath = path.join(distDir, pathname === '/' ? 'index.html' : pathname);
   const relative = path.relative(distDir, filePath);
   const isSafe = !relative.startsWith('..') && !path.isAbsolute(relative);
-  if (!isSafe || !fs.existsSync(filePath)) {
+  let isFile = false;
+  if (isSafe && fs.existsSync(filePath)) {
+    try {
+      isFile = fs.statSync(filePath).isFile();
+    } catch {
+      isFile = false;
+    }
+  }
+  if (!isFile) {
     filePath = path.join(distDir, 'index.html'); // SPA routing fallback
   }
   const ext = path.extname(filePath);
@@ -67,8 +75,15 @@ const server = http.createServer((req, res) => {
 
   fs.readFile(filePath, (err, content) => {
     if (err) {
-      res.writeHead(500);
-      res.end(`Server Error: ${err.code}`);
+      fs.readFile(path.join(distDir, 'index.html'), (fallbackErr, fallbackContent) => {
+        if (fallbackErr) {
+          res.writeHead(404, {'Content-Type': 'text/plain'});
+          res.end('Not Found');
+        } else {
+          res.writeHead(200, {'Content-Type': 'text/html'});
+          res.end(fallbackContent, 'utf-8');
+        }
+      });
     } else {
       res.writeHead(200, {'Content-Type': contentType});
       res.end(content, 'utf-8');

--- a/renderers/angular/a2ui_explorer/src/app/custom-slider.component.ts
+++ b/renderers/angular/a2ui_explorer/src/app/custom-slider.component.ts
@@ -16,18 +16,18 @@
 
 import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {CatalogComponent} from '@a2ui/angular/v0_9';
+import {CatalogComponentBase} from '@a2ui/angular/v0_9';
 import z from 'zod';
-import {ComponentApi} from '@a2ui/web_core/v0_9';
+import {ComponentApi, DynamicStringSchema, DynamicNumberSchema} from '@a2ui/web_core/v0_9';
 
 const customSliderApi = {
   name: 'CustomSlider',
   schema: z.object({
-    label: z.string().optional(),
-    value: z.number().optional(),
-    min: z.number().optional(),
-    max: z.number().optional(),
-  }) as any,
+    label: DynamicStringSchema.optional(),
+    value: DynamicNumberSchema.optional(),
+    min: DynamicNumberSchema.optional(),
+    max: DynamicNumberSchema.optional(),
+  }),
 } satisfies ComponentApi;
 
 /**
@@ -64,7 +64,7 @@ const customSliderApi = {
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CustomSliderComponent extends CatalogComponent<typeof customSliderApi> {
+export class CustomSliderComponent extends CatalogComponentBase<typeof customSliderApi> {
   handleInput(event: Event) {
     const val = Number((event.target as HTMLInputElement).value);
     this.props()['value']?.onUpdate(val);

--- a/renderers/angular/a2ui_explorer/src/app/tests/v0_9/36_modal.spec.ts
+++ b/renderers/angular/a2ui_explorer/src/app/tests/v0_9/36_modal.spec.ts
@@ -46,6 +46,8 @@ describe('Example: Modal', () => {
     expect(closeBtn).toBeTruthy();
     closeBtn.click();
     fixture.detectChanges();
+    await wait(50);
+    fixture.detectChanges();
 
     // Check modal is closed
     expect(fixture.nativeElement.querySelector('.a2ui-modal-overlay')).toBeFalsy();

--- a/renderers/angular/src/v0_9/catalog/basic/basic-catalog-component.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/basic-catalog-component.ts
@@ -18,7 +18,7 @@ import {Directive, computed, HostBinding, inject} from '@angular/core';
 import {injectBasicCatalogStyles} from '@a2ui/web_core/v0_9/basic_catalog';
 import {A2uiRendererService} from '../../core/a2ui-renderer.service';
 import {ComponentApi} from '@a2ui/web_core/v0_9';
-import {CatalogComponent} from '../../core/catalog_component';
+import {CatalogComponentBase} from '../../core/catalog_component';
 import {BoundProperty} from '../../core/types';
 
 /**
@@ -30,11 +30,16 @@ import {BoundProperty} from '../../core/types';
 @Directive()
 export abstract class BasicCatalogComponent<
   Api extends ComponentApi,
-> extends CatalogComponent<Api> {
+> extends CatalogComponentBase<Api> {
   protected rendererService = inject(A2uiRendererService);
 
   readonly surface = computed(() => {
-    return this.rendererService.surfaceGroup.getSurface(this.surfaceId());
+    try {
+      const id = this.surfaceId();
+      return id ? this.rendererService.surfaceGroup.getSurface(id) : undefined;
+    } catch {
+      return undefined;
+    }
   });
 
   readonly theme = computed(() => {

--- a/renderers/angular/src/v0_9/catalog/basic/basic-catalog.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/basic-catalog.spec.ts
@@ -14,11 +14,28 @@
  * limitations under the License.
  */
 
+import {Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {BasicCatalog, BASIC_CATALOG_OPTIONS} from './basic-catalog';
+import {z} from 'zod';
+import {BasicCatalog, BASIC_CATALOG_OPTIONS, provideBasicCatalog} from './basic-catalog';
+import {A2UI_USE_UNIVERSAL_COMPONENTS} from '../../core/a2ui-renderer.service';
+import {AngularCatalog, AngularComponentImplementation} from '../types';
+
+@Component({
+  selector: 'test-custom-slider',
+  template: '<div>custom slider</div>',
+  standalone: true,
+})
+class TestCustomSliderComponent {}
+
+const customSliderDeclaration: AngularComponentImplementation = {
+  name: 'CustomSlider',
+  schema: z.object({}),
+  component: TestCustomSliderComponent,
+};
 
 describe('BasicCatalog', () => {
-  it('should be created with default options when no token is provided', () => {
+  it('should be created with default options (native) when no token is provided', () => {
     TestBed.configureTestingModule({
       providers: [BasicCatalog],
     });
@@ -26,6 +43,9 @@ describe('BasicCatalog', () => {
     const catalog = TestBed.inject(BasicCatalog);
     expect(catalog).toBeTruthy();
     expect(catalog.id).toBe('https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json');
+    const textComp = catalog.components.get('Text') as AngularComponentImplementation;
+    expect(textComp).toBeDefined();
+    expect(textComp.component).toBeDefined();
   });
 
   it('should be created with custom options when token is provided', () => {
@@ -44,5 +64,58 @@ describe('BasicCatalog', () => {
     const catalog = TestBed.inject(BasicCatalog);
     expect(catalog).toBeTruthy();
     expect(catalog.id).toBe('https://example.com/custom-catalog.json');
+  });
+
+  it('instantiates universal components when A2UI_USE_UNIVERSAL_COMPONENTS is true', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        BasicCatalog,
+        {
+          provide: A2UI_USE_UNIVERSAL_COMPONENTS,
+          useValue: true,
+        },
+      ],
+    });
+
+    const catalog = TestBed.inject(BasicCatalog);
+    expect(catalog.components.get('Text')?.tagName).toBe('a2ui-basic-text');
+  });
+
+  it('provides native catalog by default with provideBasicCatalog', () => {
+    TestBed.configureTestingModule({
+      providers: [provideBasicCatalog()],
+    });
+
+    const catalog = TestBed.inject(AngularCatalog);
+    const textComp = catalog.components.get('Text') as AngularComponentImplementation;
+    expect(textComp.component).toBeDefined();
+  });
+
+  it('provides universal catalog when A2UI_USE_UNIVERSAL_COMPONENTS is true with provideBasicCatalog', () => {
+    TestBed.configureTestingModule({
+      providers: [{provide: A2UI_USE_UNIVERSAL_COMPONENTS, useValue: true}, provideBasicCatalog()],
+    });
+
+    const catalog = TestBed.inject(AngularCatalog);
+    expect(catalog.components.get('Text')?.tagName).toBe('a2ui-basic-text');
+  });
+
+  it('preserves AngularComponentImplementation in extraComponents', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        BasicCatalog,
+        {
+          provide: BASIC_CATALOG_OPTIONS,
+          useValue: {
+            extraComponents: [customSliderDeclaration],
+          },
+        },
+      ],
+    });
+
+    const catalog = TestBed.inject(BasicCatalog);
+    expect(catalog.components.has('CustomSlider')).toBeTrue();
+    const comp = catalog.components.get('CustomSlider') as AngularComponentImplementation;
+    expect(comp.component).toBe(TestCustomSliderComponent);
   });
 });

--- a/renderers/angular/src/v0_9/catalog/basic/basic-catalog.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/basic-catalog.ts
@@ -14,32 +14,24 @@
  * limitations under the License.
  */
 
-import {Inject, Injectable, InjectionToken, Optional} from '@angular/core';
+import {
+  Inject,
+  Injectable,
+  InjectionToken,
+  Injector,
+  Optional,
+  Provider,
+  inject,
+} from '@angular/core';
+import {A2UI_USE_UNIVERSAL_COMPONENTS} from '../../core/a2ui-renderer.service';
 import {
   AngularCatalog,
   AngularComponentImplementation,
+  CatalogComponent,
   createComponentImplementation,
 } from '../types';
-import {TextComponent} from './text.component';
-import {RowComponent} from './row.component';
-import {ColumnComponent} from './column.component';
-import {ButtonComponent} from './button.component';
-import {TextFieldComponent} from './text-field.component';
-import {ImageComponent} from './image.component';
-import {IconComponent} from './icon.component';
-import {VideoComponent} from './video.component';
-import {AudioPlayerComponent} from './audio-player.component';
-import {ListComponent} from './list.component';
-import {CardComponent} from './card.component';
-import {TabsComponent} from './tabs.component';
-import {ModalComponent} from './modal.component';
-import {DividerComponent} from './divider.component';
-import {CheckBoxComponent} from './check-box.component';
-import {ChoicePickerComponent} from './choice-picker.component';
-import {SliderComponent} from './slider.component';
-import {DateTimeInputComponent} from './date-time-input.component';
-
 import {
+  basicCatalog,
   BASIC_FUNCTIONS,
   createBasicCatalogFunctions,
   TextApi,
@@ -61,15 +53,39 @@ import {
   SliderApi,
   DateTimeInputApi,
 } from '@a2ui/web_core/v0_9/basic_catalog';
-import {FunctionImplementation} from '@a2ui/web_core/v0_9';
+import {FunctionImplementation, WebComponentImplementation} from '@a2ui/web_core/v0_9';
+
+import {toWebComponent} from '../to_web_component';
+
+import {TextComponent} from './text.component';
+import {RowComponent} from './row.component';
+import {ColumnComponent} from './column.component';
+import {ButtonComponent} from './button.component';
+import {TextFieldComponent} from './text-field.component';
+import {ImageComponent} from './image.component';
+import {IconComponent} from './icon.component';
+import {VideoComponent} from './video.component';
+import {AudioPlayerComponent} from './audio-player.component';
+import {ListComponent} from './list.component';
+import {CardComponent} from './card.component';
+import {TabsComponent} from './tabs.component';
+import {ModalComponent} from './modal.component';
+import {DividerComponent} from './divider.component';
+import {CheckBoxComponent} from './check-box.component';
+import {ChoicePickerComponent} from './choice-picker.component';
+import {SliderComponent} from './slider.component';
+import {DateTimeInputComponent} from './date-time-input.component';
+
+export type {CatalogComponent};
 
 /**
- * The set of default Angular implementations for each component in the basic catalog.
- * Using string literals as keys, to survive property renaming, as these names need to match the JSON payload.
+ * The set of default native Angular implementations for each component in the basic catalog.
  */
-// Ignore Prettier to preserve quoted keys, needed to survive property renaming.
 // prettier-ignore
-const DEFAULT_COMPONENT_IMPLEMENTATIONS: Record<string, AngularComponentImplementation> = {
+export const DEFAULT_NATIVE_COMPONENT_IMPLEMENTATIONS: Record<
+  string,
+  AngularComponentImplementation
+> = {
   'text': createComponentImplementation(TextApi, TextComponent),
   'row': createComponentImplementation(RowApi, RowComponent),
   'column': createComponentImplementation(ColumnApi, ColumnComponent),
@@ -91,6 +107,30 @@ const DEFAULT_COMPONENT_IMPLEMENTATIONS: Record<string, AngularComponentImplemen
 } as const;
 
 /**
+ * The set of native Angular UI components provided by the basic catalog.
+ */
+export const BASIC_NATIVE_COMPONENTS: AngularComponentImplementation[] = Object.values(
+  DEFAULT_NATIVE_COMPONENT_IMPLEMENTATIONS,
+);
+
+/**
+ * The set of universal W3C web components provided by the basic catalog.
+ */
+export const BASIC_UNIVERSAL_COMPONENTS: WebComponentImplementation[] = Array.from(
+  basicCatalog.components.values(),
+);
+
+/**
+ * The default set of components provided by the basic catalog (defaults to native Angular components).
+ */
+export const BASIC_COMPONENTS: CatalogComponent[] = BASIC_NATIVE_COMPONENTS;
+
+/**
+ * The set of client-side functions provided by the basic catalog.
+ */
+export {BASIC_FUNCTIONS};
+
+/**
  * Interface for specifying overrides and configuration for the basic catalog.
  */
 export interface BasicCatalogOptions {
@@ -107,56 +147,174 @@ export interface BasicCatalogOptions {
   /**
    * Optional overrides for individual components in the catalog.
    */
-  components?: Partial<{
-    [K in keyof typeof DEFAULT_COMPONENT_IMPLEMENTATIONS]: AngularComponentImplementation;
-  }>;
+  components?: Partial<Record<string, CatalogComponent>>;
 
   /**
    * Optional additional components to include in the catalog beyond
    * the standard basic catalog components.
    *
-   * @deprecated Use AngularCatalog constructor directly to combine BASIC_COMPONENTS with custom ones.
+   * Accepts both native Angular component declarations and universal Web Components.
+   * When universal components are enabled, native Angular components are automatically
+   * converted to Web Components.
    */
-  extraComponents?: AngularComponentImplementation[];
+  extraComponents?: CatalogComponent[];
 
   /**
    * An optional set of function implementations to use instead of the defaults.
-   *
-   * @deprecated Use AngularCatalog constructor directly to combine BASIC_FUNCTIONS with custom ones.
    */
   functions?: FunctionImplementation[];
 }
 
 /**
- * The set of Angular UI components provided by the basic catalog.
+ * A basic catalog populated with native Angular component implementations.
  */
-export const BASIC_COMPONENTS: AngularComponentImplementation[] = Object.values(
-  DEFAULT_COMPONENT_IMPLEMENTATIONS,
-);
+export class NativeBasicCatalog extends AngularCatalog {
+  constructor(options: BasicCatalogOptions = {}, injector?: Injector) {
+    const id = options.id ?? basicCatalog.id;
+    const functions =
+      options.functions ??
+      (options.locale
+        ? createBasicCatalogFunctions({locale: options.locale})
+        : Array.from(basicCatalog.functions.values()));
 
-/**
- * The set of client-side functions provided by the basic catalog.
- */
-export {BASIC_FUNCTIONS};
+    const baseComponents = new Map<string, CatalogComponent>(
+      Object.entries(DEFAULT_NATIVE_COMPONENT_IMPLEMENTATIONS).map(([key, impl]) => [
+        impl.name || key,
+        impl,
+      ]),
+    );
 
-/**
- * A base class for basic catalogs, providing extensibility for non-DI use cases.
- */
-export class BasicCatalogBase extends AngularCatalog {
-  constructor(options: BasicCatalogOptions = {}) {
-    const id = options.id ?? 'https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json';
-    const functions = options.functions ?? createBasicCatalogFunctions({locale: options.locale});
+    if (options.components) {
+      for (const [key, comp] of Object.entries(options.components)) {
+        if (comp) {
+          baseComponents.set(key, comp);
+        }
+      }
+    }
 
-    const overrides = options.components ?? {};
-    const components: AngularComponentImplementation[] = [
-      ...Object.entries(DEFAULT_COMPONENT_IMPLEMENTATIONS).map(([key, defaultValue]) => {
-        const impl = (overrides as any)[key] ?? defaultValue;
-        return {...impl, name: impl.name || key};
-      }),
+    const components: CatalogComponent[] = [
+      ...Array.from(baseComponents.values()),
       ...(options.extraComponents ?? []),
     ];
 
-    super(id, components, functions);
+    super(id, components, functions, injector);
+  }
+}
+
+/**
+ * A basic catalog populated with universal W3C Custom Element component implementations.
+ */
+export class UniversalBasicCatalog extends AngularCatalog {
+  constructor(options: BasicCatalogOptions = {}, injector?: Injector) {
+    const id = options.id ?? basicCatalog.id;
+    const functions =
+      options.functions ??
+      (options.locale
+        ? createBasicCatalogFunctions({locale: options.locale})
+        : Array.from(basicCatalog.functions.values()));
+
+    let effectiveInjector = injector;
+    if (!effectiveInjector) {
+      try {
+        effectiveInjector = inject(Injector, {optional: true}) ?? undefined;
+      } catch {
+        effectiveInjector = undefined;
+      }
+    }
+
+    const baseComponents = new Map<string, CatalogComponent>(basicCatalog.components);
+    if (options.components) {
+      for (const [key, comp] of Object.entries(options.components)) {
+        if (comp) {
+          const resolvedComp =
+            'component' in comp
+              ? toWebComponent(comp as AngularComponentImplementation, effectiveInjector)
+              : comp;
+          baseComponents.set(key, resolvedComp);
+        }
+      }
+    }
+
+    const extra = (options.extraComponents ?? []).map(comp => {
+      if ('component' in comp) {
+        return toWebComponent(comp as AngularComponentImplementation, effectiveInjector);
+      }
+      return comp;
+    });
+
+    const components: CatalogComponent[] = [...Array.from(baseComponents.values()), ...extra];
+
+    super(id, components, functions, effectiveInjector);
+  }
+}
+
+/**
+ * A base class for basic catalogs, providing extensibility for custom catalogs.
+ *
+ * Automatically resolves whether to use universal W3C web components or native Angular components
+ * from the application-wide {@link A2UI_USE_UNIVERSAL_COMPONENTS} injection token.
+ */
+export class BasicCatalogBase extends AngularCatalog {
+  constructor(options: BasicCatalogOptions = {}, injector?: Injector) {
+    const id = options.id ?? basicCatalog.id;
+    const functions =
+      options.functions ??
+      (options.locale
+        ? createBasicCatalogFunctions({locale: options.locale})
+        : Array.from(basicCatalog.functions.values()));
+
+    let effectiveInjector = injector;
+    if (!effectiveInjector) {
+      try {
+        effectiveInjector = inject(Injector, {optional: true}) ?? undefined;
+      } catch {
+        effectiveInjector = undefined;
+      }
+    }
+
+    let useUniversalComponents = false;
+    if (effectiveInjector) {
+      useUniversalComponents = effectiveInjector.get(A2UI_USE_UNIVERSAL_COMPONENTS, false);
+    } else {
+      try {
+        useUniversalComponents = inject(A2UI_USE_UNIVERSAL_COMPONENTS, {optional: true}) ?? false;
+      } catch {
+        useUniversalComponents = false;
+      }
+    }
+
+    const defaultComponents = useUniversalComponents
+      ? basicCatalog.components
+      : new Map<string, CatalogComponent>(
+          Object.entries(DEFAULT_NATIVE_COMPONENT_IMPLEMENTATIONS).map(([key, impl]) => [
+            impl.name || key,
+            impl,
+          ]),
+        );
+
+    const baseComponents = new Map<string, CatalogComponent>(defaultComponents);
+    if (options.components) {
+      for (const [key, comp] of Object.entries(options.components)) {
+        if (comp) {
+          const resolvedComp =
+            useUniversalComponents && 'component' in comp
+              ? toWebComponent(comp as AngularComponentImplementation, effectiveInjector)
+              : comp;
+          baseComponents.set(key, resolvedComp);
+        }
+      }
+    }
+
+    const extra = (options.extraComponents ?? []).map(comp => {
+      if (useUniversalComponents && 'component' in comp) {
+        return toWebComponent(comp as AngularComponentImplementation, effectiveInjector);
+      }
+      return comp;
+    });
+
+    const components: CatalogComponent[] = [...Array.from(baseComponents.values()), ...extra];
+
+    super(id, components, functions, effectiveInjector);
   }
 }
 
@@ -175,7 +333,35 @@ export const BASIC_CATALOG_OPTIONS = new InjectionToken<BasicCatalogOptions>(
   providedIn: 'root',
 })
 export class BasicCatalog extends BasicCatalogBase {
-  constructor(@Optional() @Inject(BASIC_CATALOG_OPTIONS) options?: BasicCatalogOptions) {
-    super(options ?? {});
+  constructor(
+    @Optional() @Inject(BASIC_CATALOG_OPTIONS) options?: BasicCatalogOptions,
+    @Optional() injector?: Injector,
+  ) {
+    super(options ?? {}, injector);
   }
+}
+
+export const BASIC_CATALOG = new BasicCatalog();
+
+/**
+ * Configures providers for the A2UI Angular basic catalog.
+ *
+ * Automatically resolves component implementations (universal web components vs native Angular components)
+ * based on the application-wide {@link A2UI_USE_UNIVERSAL_COMPONENTS} token.
+ */
+export function provideBasicCatalog(options: BasicCatalogOptions = {}): Provider[] {
+  return [
+    {
+      provide: BASIC_CATALOG_OPTIONS,
+      useValue: options,
+    },
+    {
+      provide: BasicCatalog,
+      useClass: BasicCatalog,
+    },
+    {
+      provide: AngularCatalog,
+      useExisting: BasicCatalog,
+    },
+  ];
 }

--- a/renderers/angular/src/v0_9/catalog/to_web_component.ts
+++ b/renderers/angular/src/v0_9/catalog/to_web_component.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Type,
+  Injector,
+  EnvironmentInjector,
+  ApplicationRef,
+  createComponent,
+  ComponentRef,
+  NgZone,
+} from '@angular/core';
+import type {ZodTypeAny} from 'zod';
+import {ComponentContext, WebComponentImplementation} from '@a2ui/web_core/v0_9';
+import type {AngularComponentImplementation} from './types';
+
+import {ComponentBinder} from '../core/component-binder.service';
+
+const angularWcCache = new WeakMap<Type<object>, WebComponentImplementation>();
+const angularInjectorMap = new WeakMap<Type<object>, Injector>();
+
+/**
+ * Idempotently converts an Angular `@Component` class declaration (`AngularComponentImplementation`)
+ * into a W3C Custom Element (`WebComponentImplementation`).
+ *
+ * This allows custom Angular components to be registered inside the unified `Catalog<WebComponentImplementation>`
+ * and rendered seamlessly within any A2UI surface.
+ *
+ * @param componentImpl The AngularComponentImplementation combining the ComponentApi schema and component class.
+ * @param injector Optional Angular Injector used to create component instances.
+ * @returns The WebComponentImplementation representation.
+ */
+export function toWebComponent<Schema extends ZodTypeAny = ZodTypeAny>(
+  componentImpl: AngularComponentImplementation<Schema>,
+  injector?: Injector,
+): WebComponentImplementation<Schema> {
+  const componentClass = componentImpl.component;
+  let resolvedInjector = injector;
+  if (!resolvedInjector) {
+    try {
+      resolvedInjector = (globalThis as any).ng?.getInjector?.() ?? undefined;
+    } catch {
+      resolvedInjector = undefined;
+    }
+  }
+  if (resolvedInjector) {
+    angularInjectorMap.set(componentClass, resolvedInjector);
+  }
+
+  if (angularWcCache.has(componentClass)) {
+    return angularWcCache.get(componentClass)! as WebComponentImplementation<Schema>;
+  }
+
+  const tagName = componentImpl.tagName || `a2ui-ng-${componentImpl.name.toLowerCase()}`;
+
+  if (!customElements.get(tagName)) {
+    class AngularWcHost extends HTMLElement {
+      private componentRef?: ComponentRef<object>;
+      private appRef?: ApplicationRef;
+      private _context?: ComponentContext;
+      private updateSub?: {unsubscribe: () => void};
+
+      connectedCallback() {
+        this.style.display = 'contents';
+
+        if (!this.componentRef) {
+          const currentInjector = angularInjectorMap.get(componentClass) ?? resolvedInjector;
+          if (!currentInjector) {
+            throw new Error(
+              `Cannot instantiate Web Component for '${componentImpl.name}': No Angular Injector available.`,
+            );
+          }
+          this.appRef = currentInjector.get(ApplicationRef);
+          this.componentRef = createComponent(componentClass, {
+            environmentInjector: currentInjector.get(EnvironmentInjector),
+            elementInjector: currentInjector,
+            hostElement: this,
+          });
+          this.appRef.attachView(this.componentRef.hostView);
+        }
+        this.updateContext();
+      }
+
+      set context(ctx: ComponentContext) {
+        this._context = ctx;
+        this.updateSub?.unsubscribe();
+        const currentInjector = angularInjectorMap.get(componentClass) ?? resolvedInjector;
+        const ngZone = currentInjector?.get(NgZone, null);
+        this.updateSub = ctx.componentModel.onUpdated.subscribe(() => {
+          if (ngZone) {
+            ngZone.run(() => {
+              this.updateContext();
+            });
+          } else {
+            this.updateContext();
+          }
+        });
+        this.updateContext();
+      }
+
+      get context() {
+        return this._context!;
+      }
+
+      private updateContext() {
+        if (!this.componentRef || !this._context) return;
+        const currentInjector = angularInjectorMap.get(componentClass) ?? resolvedInjector;
+        if (!currentInjector) return;
+        const binder = currentInjector.get(ComponentBinder);
+        const boundProps = binder.bind(this._context);
+        try {
+          this.componentRef.setInput('props', boundProps);
+        } catch {
+          // Component may not accept props input
+        }
+        try {
+          this.componentRef.setInput('context', this._context);
+        } catch {
+          // Component may not accept context input
+        }
+        try {
+          this.componentRef.setInput('surfaceId', this._context.dataContext.surface.id);
+        } catch {
+          // Optional input not defined on component
+        }
+        try {
+          this.componentRef.setInput('componentId', this._context.componentModel.id);
+        } catch {
+          // Optional input not defined on component
+        }
+        try {
+          this.componentRef.setInput('dataContextPath', this._context.dataContext.path);
+        } catch {
+          // Optional input not defined on component
+        }
+        this.componentRef.changeDetectorRef.detectChanges();
+      }
+
+      disconnectedCallback() {
+        if (this.updateSub) {
+          this.updateSub.unsubscribe();
+          this.updateSub = undefined;
+        }
+        if (this.componentRef) {
+          this.appRef?.detachView(this.componentRef.hostView);
+          this.componentRef.destroy();
+          this.componentRef = undefined;
+          this.appRef = undefined;
+        }
+      }
+    }
+
+    customElements.define(tagName, AngularWcHost);
+  }
+
+  const implementation: WebComponentImplementation<Schema> & {component?: Type<object>} = {
+    name: componentImpl.name,
+    schema: componentImpl.schema,
+    tagName,
+    component: componentClass,
+  };
+
+  angularWcCache.set(componentClass, implementation);
+  return implementation;
+}

--- a/renderers/angular/src/v0_9/catalog/types.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/types.spec.ts
@@ -14,30 +14,72 @@
  * limitations under the License.
  */
 
-import {Component} from '@angular/core';
-import {ComponentApi} from '@a2ui/web_core/v0_9';
-import {createComponentImplementation} from './types';
-import {CatalogComponent} from '../core/catalog_component';
+import {Component, Injector} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {AngularCatalog} from './types';
+import {BASIC_COMPONENTS} from './basic/basic-catalog';
+import {toWebComponent} from './to_web_component';
 import {z} from 'zod';
 
 @Component({
-  selector: 'test-comp',
-  template: '',
+  selector: 'test-custom-comp',
+  template: '<div>custom angular component</div>',
   standalone: true,
 })
-class TestComponent extends CatalogComponent<ComponentApi> {}
+class TestCustomComponent {}
 
-describe('createComponentImplementation', () => {
-  it('should map ComponentApi and Angular Component Type correctly', () => {
-    const api: ComponentApi = {
-      name: 'TestComp',
-      schema: z.object({}),
-    };
+describe('Angular Catalog & toWebComponent', () => {
+  let injector: Injector;
 
-    const impl = createComponentImplementation(api, TestComponent);
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestCustomComponent],
+    });
+    injector = TestBed.inject(Injector);
+  });
 
-    expect(impl.name).toBe('TestComp');
-    expect(impl.schema).toEqual(api.schema);
-    expect(impl.component).toBe(TestComponent);
+  it('instantiates AngularCatalog wrapping universal WebComponentImplementation catalog', () => {
+    const catalog = new AngularCatalog();
+    expect(catalog.id).toBe('https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json');
+    expect(catalog.components.size).toBe(18);
+    expect(catalog.components.get('Button')?.tagName).toBe('a2ui-basic-button');
+  });
+
+  it('exports BASIC_COMPONENTS with 18 native components by default', () => {
+    expect(BASIC_COMPONENTS.length).toBe(18);
+    const textComp = BASIC_COMPONENTS.find(c => c.name === 'Text');
+    expect(textComp).toBeDefined();
+    expect('component' in textComp! && textComp.component).toBeDefined();
+  });
+
+  it('converts Angular Component to Web Component via toWebComponent', () => {
+    const impl = toWebComponent(
+      {
+        name: 'CustomTest',
+        schema: z.object({}),
+        component: TestCustomComponent,
+      },
+      injector,
+    );
+    expect(impl.name).toBe('CustomTest');
+    expect(impl.tagName).toBe('a2ui-ng-customtest');
+    expect(customElements.get(impl.tagName)).toBeDefined();
+
+    const el = document.createElement(impl.tagName);
+    expect(el).toBeDefined();
+  });
+
+  it('preserves native AngularComponentImplementation without converting to Web Component', () => {
+    const catalog = new AngularCatalog('test-catalog', [
+      {
+        name: 'CustomNative',
+        schema: z.object({}),
+        component: TestCustomComponent,
+      },
+    ]);
+    const comp = catalog.components.get('CustomNative');
+    expect(comp).toBeDefined();
+    expect('component' in comp! && comp.component).toBe(TestCustomComponent);
+    expect((comp as any).tagName).toBeUndefined();
   });
 });

--- a/renderers/angular/src/v0_9/catalog/types.ts
+++ b/renderers/angular/src/v0_9/catalog/types.ts
@@ -14,59 +14,70 @@
  * limitations under the License.
  */
 
-import {Type} from '@angular/core';
-import {Catalog, ComponentApi} from '@a2ui/web_core/v0_9';
-import {CatalogComponentInstance} from '../core/catalog_component_instance';
+import {Type, Injector} from '@angular/core';
+import type {ZodTypeAny} from 'zod';
+import {Catalog, ComponentApi, WebComponentImplementation} from '@a2ui/web_core/v0_9';
+import {basicCatalog} from '@a2ui/web_core/v0_9/basic_catalog';
+
+export type {WebComponentImplementation} from '@a2ui/web_core/v0_9';
 
 /**
- * Temporary type used during basic catalog schema alignment to bypass strict type checking.
+ * Describes an Angular-specific component implementation.
  *
- * To be removed once all properties implemented in Angular basic catalog components conform
- * to the basic catalog schema.
- * @see https://github.com/a2ui-project/a2ui/issues/1303
+ * In addition to the standard A2UI ComponentApi, this interface accepts
+ * an Angular component class (`component`).
  */
-export type AnyDuringSchemaAlignment = any;
-
-/**
- * Extends the generic {@link ComponentApi} to include Angular-specific component metadata.
- */
-export interface AngularComponentImplementation extends ComponentApi {
+export interface AngularComponentImplementation<
+  Schema extends ZodTypeAny = ZodTypeAny,
+> extends ComponentApi<Schema> {
   /**
    * The Angular component class used to render this component.
-   *
-   * This class must be an Angular {@link Type} (e.g., a standalone component class)
-   * that accepts `props`, `surfaceId`, and `dataContextPath` as inputs.
    */
-  readonly component: Type<CatalogComponentInstance>;
+  readonly component: Type<object>;
+
+  /**
+   * The custom element tag name for the web component (if bridged).
+   */
+  readonly tagName?: string;
 }
 
 /**
- * A collection of Angular component and function implementations mapped to
+ * A component implementation supported by the Angular catalog, which can be
+ * either a native W3C Custom Element or an Angular `@Component` declaration.
+ */
+export type CatalogComponent = WebComponentImplementation | AngularComponentImplementation;
+
+/**
+ * A collection of component and function implementations mapped to
  * A2UI protocol types.
  *
- * Catalogs are used by the {@link MessageProcessor} to resolve component
- * definitions and by {@link ComponentHostComponent} to instantiate the
- * correct Angular components.
+ * Supports both native Angular component declarations (`.component`) and
+ * W3C Custom Elements (`WebComponentImplementation`).
  */
-export class AngularCatalog extends Catalog<AngularComponentImplementation> {}
+export class AngularCatalog extends Catalog<CatalogComponent> {
+  constructor(
+    id: string = basicCatalog.id,
+    components: CatalogComponent[] = Array.from(basicCatalog.components.values()),
+    functions = Array.from(basicCatalog.functions.values()),
+    _injector?: Injector,
+  ) {
+    super(id, components, functions);
+  }
+}
 
 /**
  * Helper function to create an {@link AngularComponentImplementation}.
  *
- * It extracts the name and schema from a generic {@link ComponentApi} and
- * associates it with the given Angular component type.
- *
- * @param api The generic component API definition.
- * @param component The Angular component class implementing the API.
- * @returns The structured Angular component implementation.
+ * @param api The ComponentApi defining the schema and name.
+ * @param component The Angular Component class.
+ * @returns The structured AngularComponentImplementation.
  */
-export function createComponentImplementation(
-  api: ComponentApi,
-  component: Type<CatalogComponentInstance>,
-): AngularComponentImplementation {
+export function createComponentImplementation<Schema extends ZodTypeAny = ZodTypeAny>(
+  api: ComponentApi<Schema>,
+  component: Type<object>,
+): AngularComponentImplementation<Schema> {
   return {
-    name: api.name,
-    schema: api.schema,
+    ...api,
     component,
   };
 }

--- a/renderers/angular/src/v0_9/core/a2ui-renderer.service.spec.ts
+++ b/renderers/angular/src/v0_9/core/a2ui-renderer.service.spec.ts
@@ -15,7 +15,9 @@
  */
 
 import {TestBed} from '@angular/core/testing';
-import {A2uiRendererService, A2UI_RENDERER_CONFIG, provideA2Ui} from './a2ui-renderer.service';
+import {A2uiRendererService, A2UI_RENDERER_CONFIG} from './a2ui-renderer.service';
+import {provideA2Ui} from './provide-a2ui';
+import {BasicCatalogBase} from '../catalog/basic/basic-catalog';
 
 describe('A2uiRendererService', () => {
   let service: A2uiRendererService;
@@ -114,5 +116,43 @@ describe('provideA2Ui', () => {
 
     const service = TestBed.inject(A2uiRendererService);
     expect(service).toBeTruthy();
+  });
+
+  it('should default to native BasicCatalog when no catalogs or useUniversalComponents are specified', () => {
+    TestBed.configureTestingModule({
+      providers: [provideA2Ui()],
+    });
+    const config = TestBed.inject(A2UI_RENDERER_CONFIG);
+    expect(config.catalogs).toBeDefined();
+    expect(config.catalogs!.length).toBe(1);
+    const catalog = config.catalogs![0];
+    // Native catalog maps native TextComponent
+    expect((catalog.components.get('Text') as any)?.component).toBeDefined();
+  });
+
+  it('should provide UniversalBasicCatalog when useUniversalComponents is true', () => {
+    TestBed.configureTestingModule({
+      providers: [provideA2Ui({useUniversalComponents: true})],
+    });
+    const config = TestBed.inject(A2UI_RENDERER_CONFIG);
+    expect(config.catalogs).toBeDefined();
+    expect(config.catalogs!.length).toBe(1);
+    const catalog = config.catalogs![0];
+    // Universal catalog maps custom element tagName
+    expect((catalog.components.get('Text') as any)?.tagName).toBe('a2ui-basic-text');
+  });
+
+  it('should automatically apply useUniversalComponents to custom catalogs extending BasicCatalogBase', () => {
+    class CustomCatalog extends BasicCatalogBase {}
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideA2Ui({useUniversalComponents: true}),
+        {provide: CustomCatalog, useClass: CustomCatalog},
+      ],
+    });
+
+    const customCatalog = TestBed.inject(CustomCatalog);
+    expect((customCatalog.components.get('Text') as any)?.tagName).toBe('a2ui-basic-text');
   });
 });

--- a/renderers/angular/src/v0_9/core/a2ui-renderer.service.ts
+++ b/renderers/angular/src/v0_9/core/a2ui-renderer.service.ts
@@ -14,15 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  Injectable,
-  OnDestroy,
-  InjectionToken,
-  inject,
-  EnvironmentInjector,
-  EnvironmentProviders,
-  makeEnvironmentProviders,
-} from '@angular/core';
+import {Injectable, OnDestroy, InjectionToken, inject, EnvironmentInjector} from '@angular/core';
 import {
   MessageProcessor,
   SurfaceGroupModel,
@@ -30,15 +22,24 @@ import {
   A2uiMessage,
   A2uiClientAction as Action,
 } from '@a2ui/web_core/v0_9';
-import {AngularComponentImplementation, AngularCatalog} from '../catalog/types';
+import {AngularCatalog, CatalogComponent} from '../catalog/types';
 import {initializeAngularReactivity} from './reactivity';
 
 /**
  * Configuration for the A2UI renderer.
  */
 export interface RendererConfiguration {
-  /** The catalogs containing the available components and functions. */
-  catalogs: AngularCatalog[];
+  /**
+   * The catalogs containing the available components and functions.
+   * If omitted, defaults to the basic catalog.
+   */
+  catalogs?: AngularCatalog[];
+  /**
+   * When true, uses W3C universal web components application-wide across all catalogs
+   * instead of native Angular components.
+   * When false (default), uses native Angular component implementations.
+   */
+  useUniversalComponents?: boolean;
   /**
    * Optional handler for actions dispatched from any surface.
    *
@@ -56,23 +57,18 @@ export const A2UI_RENDERER_CONFIG = new InjectionToken<RendererConfiguration>(
 );
 
 /**
- * Provides the A2UI renderer configuration.
+ * Injection token to specify whether universal W3C web components should be used
+ * application-wide across all catalogs instead of native Angular components.
  *
- * @param configOrFactory The configuration or a factory function that returns the configuration.
- * @returns The providers for the A2UI renderer.
+ * Defaults to `false` (native Angular components).
  */
-export function provideA2Ui(
-  configOrFactory: RendererConfiguration | (() => RendererConfiguration),
-): EnvironmentProviders {
-  return makeEnvironmentProviders([
-    {
-      provide: A2UI_RENDERER_CONFIG,
-      ...(typeof configOrFactory === 'function'
-        ? {useFactory: configOrFactory}
-        : {useValue: configOrFactory}),
-    },
-  ]);
-}
+export const A2UI_USE_UNIVERSAL_COMPONENTS = new InjectionToken<boolean>(
+  'A2UI_USE_UNIVERSAL_COMPONENTS',
+  {
+    providedIn: 'root',
+    factory: () => false,
+  },
+);
 
 /**
  * Manages A2UI v0.9 rendering sessions by bridging the MessageProcessor to Angular.
@@ -83,17 +79,16 @@ export function provideA2Ui(
  */
 @Injectable({providedIn: 'root'})
 export class A2uiRendererService implements OnDestroy {
-  private _messageProcessor: MessageProcessor<AngularComponentImplementation>;
+  private _messageProcessor: MessageProcessor<CatalogComponent>;
   private _catalogs: AngularCatalog[] = [];
-  private _config = inject(A2UI_RENDERER_CONFIG);
+  private _config = inject(A2UI_RENDERER_CONFIG, {optional: true});
 
   constructor() {
     initializeAngularReactivity(inject(EnvironmentInjector));
-    this._catalogs = this._config.catalogs;
-    console.log('[A2uiRendererService] constructor, config:', this._config);
-    this._messageProcessor = new MessageProcessor<AngularComponentImplementation>(
+    this._catalogs = this._config?.catalogs ?? [];
+    this._messageProcessor = new MessageProcessor<CatalogComponent>(
       this._catalogs,
-      this._config.actionHandler as ActionHandler,
+      this._config?.actionHandler as ActionHandler,
     );
   }
 
@@ -113,7 +108,7 @@ export class A2uiRendererService implements OnDestroy {
    *
    * Surfaces can be retrieved from this group using their `surfaceId`.
    */
-  get surfaceGroup(): SurfaceGroupModel<AngularComponentImplementation> {
+  get surfaceGroup(): SurfaceGroupModel<CatalogComponent> {
     return this._messageProcessor.model;
   }
 

--- a/renderers/angular/src/v0_9/core/catalog_component.ts
+++ b/renderers/angular/src/v0_9/core/catalog_component.ts
@@ -27,7 +27,7 @@ import {CatalogComponentInstance} from './catalog_component_instance';
  * fields.
  */
 @Directive()
-export abstract class CatalogComponent<
+export abstract class CatalogComponentBase<
   Api extends ComponentApi,
 > implements CatalogComponentInstance {
   /**

--- a/renderers/angular/src/v0_9/core/component-host.component.spec.ts
+++ b/renderers/angular/src/v0_9/core/component-host.component.spec.ts
@@ -263,5 +263,35 @@ describe('ComponentHostComponent', () => {
       const childInstance = childDebugElement.componentInstance as TestChildComponent;
       expect(childInstance.dataContextPath).toBe('/some/path');
     });
+
+    it('should render and update universal Web Components when catalog entry defines tagName', () => {
+      class MockWcElement extends HTMLElement {
+        context: any;
+      }
+      if (!customElements.get('mock-host-wc')) {
+        customElements.define('mock-host-wc', MockWcElement);
+      }
+
+      mockCatalog.components.set('WcType', {tagName: 'mock-host-wc'});
+      mockSurface.componentsModel.addComponent(
+        new ComponentModel('wc1', 'WcType', {label: 'Click me'}),
+      );
+
+      fixture.componentRef.setInput('componentKey', {id: 'wc1', basePath: '/test/wc'});
+      fixture.detectChanges();
+
+      const wcEl = fixture.nativeElement.querySelector('mock-host-wc') as MockWcElement;
+      expect(wcEl).toBeTruthy();
+      expect(wcEl.context).toBeTruthy();
+      expect(wcEl.context.componentModel.id).toBe('wc1');
+      expect(wcEl.context.dataContext.path).toBe('/test/wc');
+
+      // Update component model properties
+      const wcModel = mockSurface.componentsModel.get('wc1')!;
+      wcModel.properties = {label: 'Updated label'};
+      fixture.detectChanges();
+
+      expect(wcEl.context).toBeTruthy();
+    });
   });
 });

--- a/renderers/angular/src/v0_9/core/component-host.component.ts
+++ b/renderers/angular/src/v0_9/core/component-host.component.ts
@@ -16,8 +16,10 @@
 
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   DestroyRef,
+  ElementRef,
   Type,
   inject,
   input,
@@ -26,18 +28,27 @@ import {
   NgZone,
 } from '@angular/core';
 import {NgComponentOutlet} from '@angular/common';
-import {ComponentContext, ComponentModel, SurfaceModel, Subscription} from '@a2ui/web_core/v0_9';
+import {
+  ComponentContext,
+  ComponentModel,
+  SurfaceModel,
+  Subscription,
+  WebComponentImplementation,
+} from '@a2ui/web_core/v0_9';
 import {A2uiRendererService} from './a2ui-renderer.service';
-import {AngularCatalog} from '../catalog/types';
 import {ComponentBinder} from './component-binder.service';
 import {BoundProperty} from './types';
+
+interface ContextConsumerElement extends HTMLElement {
+  context: ComponentContext;
+}
 
 /**
  * Dynamically renders an A2UI component as defined in the current surface model.
  *
- * This component acts as a bridge between the A2UI surface model and Angular components.
- * It resolves the appropriate component from the catalog based on the component's type,
- * and uses {@link ComponentBinder} to create reactive property bindings.
+ * This component acts as a bridge between the A2UI surface model and UI components.
+ * It can render both native Angular `@Component` implementations (via `NgComponentOutlet`)
+ * and universal W3C Web Components (by instantiating and appending the custom element tag).
  *
  * Usually, you'll use the higher-level {@link SurfaceComponent} which automatically
  * sets up a host for the 'root' component.
@@ -50,6 +61,7 @@ import {BoundProperty} from './types';
   },
   template: `
     @if (componentType()) {
+      <!-- Note: The quotes around input keys in *ngComponentOutlet are critical to survive Closure minification -->
       <ng-container
         *ngComponentOutlet="
           componentType()!;
@@ -72,14 +84,17 @@ export class ComponentHostComponent {
   /** The unique identifier of the surface this component belongs to. */
   surfaceId = input.required<string>();
 
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
   private readonly rendererService = inject(A2uiRendererService);
   private readonly binder = inject(ComponentBinder);
   private readonly destroyRef = inject(DestroyRef);
   private readonly ngZone = inject(NgZone);
+  private readonly cdr = inject(ChangeDetectorRef);
 
   protected readonly componentType = signal<Type<unknown> | null>(null);
   protected readonly props = signal<Record<string, BoundProperty>>({});
   private context?: ComponentContext;
+  private mountedWcEl: HTMLElement | null = null;
 
   protected resolvedComponentId: string = '';
   protected resolvedDataContextPath: string = '/';
@@ -99,9 +114,7 @@ export class ComponentHostComponent {
     });
 
     this.destroyRef.onDestroy(() => {
-      this.propsSub?.unsubscribe();
-      this.createSub?.unsubscribe();
-      this.surfaceSub?.unsubscribe();
+      this.resetState();
     });
   }
 
@@ -174,25 +187,86 @@ export class ComponentHostComponent {
     basePath: string,
   ): void {
     // Resolve component from the surface's catalog
-    const catalog = surface.catalog as AngularCatalog;
+    const catalog = surface.catalog;
     const api = catalog.components.get(componentModel.type);
 
     if (!api) {
       console.error(`Component type "${componentModel.type}" not found in catalog "${catalog.id}"`);
       return;
     }
-    this.componentType.set(api.component);
 
-    // Create context
     this.context = new ComponentContext(surface, id, basePath);
-    this.props.set(this.binder.bind(this.context));
     this.resolvedDataContextPath = this.context.dataContext.path;
 
-    // Subscribes to updates to the component model properties, to get the
-    // component to react when a new prop is added after creation.
+    if ('component' in api && api.component) {
+      this.setupAngularComponent(api.component as Type<unknown>, componentModel);
+    } else if ('tagName' in api && (api as WebComponentImplementation).tagName) {
+      this.setupWebComponent(
+        (api as WebComponentImplementation).tagName,
+        surface,
+        componentModel,
+        id,
+        basePath,
+      );
+    } else {
+      console.error(
+        `Component type "${componentModel.type}" does not define an Angular component or Web Component tagName.`,
+      );
+    }
+  }
+
+  private setupAngularComponent(
+    componentClass: Type<unknown>,
+    componentModel: ComponentModel,
+  ): void {
+    if (this.mountedWcEl) {
+      this.mountedWcEl.remove();
+      this.mountedWcEl = null;
+    }
+    this.componentType.set(componentClass);
+    this.props.set(this.binder.bind(this.context!));
+    this.cdr.markForCheck();
+
     this.propsSub = componentModel.onUpdated.subscribe(() => {
       this.ngZone.run(() => {
         this.props.set(this.binder.bind(this.context!));
+        this.cdr.markForCheck();
+      });
+    });
+  }
+
+  private setupWebComponent(
+    tagName: string,
+    surface: SurfaceModel,
+    componentModel: ComponentModel,
+    id: string,
+    basePath: string,
+  ): void {
+    this.componentType.set(null);
+    this.props.set({});
+
+    if (this.mountedWcEl && this.mountedWcEl.tagName.toLowerCase() === tagName.toLowerCase()) {
+      (this.mountedWcEl as ContextConsumerElement).context = this.context!;
+    } else {
+      if (this.mountedWcEl) {
+        this.mountedWcEl.remove();
+        this.mountedWcEl = null;
+      }
+      const el = document.createElement(tagName) as ContextConsumerElement;
+      el.context = this.context!;
+      this.mountedWcEl = el;
+      this.elementRef.nativeElement.appendChild(el);
+    }
+
+    this.propsSub = componentModel.onUpdated.subscribe(() => {
+      this.ngZone.run(() => {
+        if (this.mountedWcEl) {
+          (this.mountedWcEl as ContextConsumerElement).context = new ComponentContext(
+            surface,
+            id,
+            basePath,
+          );
+        }
       });
     });
   }
@@ -204,11 +278,19 @@ export class ComponentHostComponent {
    */
   private resetState(): void {
     this.propsSub?.unsubscribe();
+    this.propsSub = undefined;
     this.createSub?.unsubscribe();
+    this.createSub = undefined;
     this.surfaceSub?.unsubscribe();
+    this.surfaceSub = undefined;
 
     this.componentType.set(null);
     this.props.set({});
     this.resolvedDataContextPath = '/';
+
+    if (this.mountedWcEl) {
+      this.mountedWcEl.remove();
+      this.mountedWcEl = null;
+    }
   }
 }

--- a/renderers/angular/src/v0_9/core/markdown.ts
+++ b/renderers/angular/src/v0_9/core/markdown.ts
@@ -15,10 +15,12 @@
  */
 
 import {Injectable} from '@angular/core';
+import type {
+  MarkdownRenderer as MarkdownRendererFn,
+  MarkdownRendererOptions,
+} from '@a2ui/web_core/v0_8';
 
-export interface MarkdownRendererOptions {
-  tagClassMap?: Record<string, string>;
-}
+export type {MarkdownRendererOptions};
 
 export abstract class MarkdownRenderer {
   abstract render(markdown: string, options?: MarkdownRendererOptions): Promise<string>;
@@ -35,7 +37,7 @@ export class DefaultMarkdownRenderer extends MarkdownRenderer {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore - optional peer dependency throws TS1323 under Angular compiler but not under NodeNext
       const {renderMarkdown} = await import('@a2ui/markdown-it');
-      return await renderMarkdown(markdown, options as any);
+      return await renderMarkdown(markdown, options);
     } catch {
       if (!DefaultMarkdownRenderer.warningLogged) {
         console.warn(
@@ -48,9 +50,7 @@ export class DefaultMarkdownRenderer extends MarkdownRenderer {
   }
 }
 
-export function provideMarkdownRenderer(
-  renderFn?: (markdown: string, options?: MarkdownRendererOptions) => Promise<string>,
-) {
+export function provideMarkdownRenderer(renderFn?: MarkdownRendererFn) {
   if (renderFn) {
     return {
       provide: MarkdownRenderer,

--- a/renderers/angular/src/v0_9/core/provide-a2ui.ts
+++ b/renderers/angular/src/v0_9/core/provide-a2ui.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Provider} from '@angular/core';
+import {AngularCatalog} from '../catalog/types';
+import {provideBasicCatalog} from '../catalog/basic/basic-catalog';
+import {
+  A2uiRendererService,
+  A2UI_RENDERER_CONFIG,
+  A2UI_USE_UNIVERSAL_COMPONENTS,
+  RendererConfiguration,
+} from './a2ui-renderer.service';
+
+/**
+ * Provides the A2UI renderer configuration and basic catalog providers.
+ *
+ * @param configOrFactory The configuration or a factory function that returns the configuration.
+ * @returns The providers for the A2UI renderer.
+ */
+export function provideA2Ui(
+  configOrFactory: RendererConfiguration | (() => RendererConfiguration) = {},
+): Provider[] {
+  const isFactory = typeof configOrFactory === 'function';
+
+  return [
+    A2uiRendererService,
+    {
+      provide: A2UI_USE_UNIVERSAL_COMPONENTS,
+      useFactory: () => {
+        const config = isFactory ? configOrFactory() : configOrFactory;
+        return config.useUniversalComponents ?? false;
+      },
+    },
+    provideBasicCatalog(),
+    {
+      provide: A2UI_RENDERER_CONFIG,
+      useFactory: (defaultCatalog: AngularCatalog) => {
+        const config = isFactory ? configOrFactory() : configOrFactory;
+        return {
+          ...config,
+          catalogs: config.catalogs ?? [defaultCatalog],
+        };
+      },
+      deps: [AngularCatalog],
+    },
+  ];
+}

--- a/renderers/angular/src/v0_9/core/surface.component.spec.ts
+++ b/renderers/angular/src/v0_9/core/surface.component.spec.ts
@@ -14,84 +14,81 @@
  * limitations under the License.
  */
 
-import {Component, Input, ChangeDetectionStrategy} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {SurfaceComponent} from './surface.component';
-import {ComponentHostComponent} from './component-host.component';
-import {By} from '@angular/platform-browser';
-import {A2uiRendererService} from './a2ui-renderer.service';
-import {ComponentBinder} from './component-binder.service';
-import {ComponentModel} from '@a2ui/web_core/v0_9';
-
-@Component({
-  selector: 'test-text',
-  template: '<div>{{props?.["text"]?.value()}}</div>',
-  standalone: true,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-})
-class TestTextComponent {
-  @Input() props: any;
-  @Input() surfaceId?: string;
-  @Input() componentId?: string;
-  @Input() dataContextPath?: string;
-}
+import {provideA2Ui} from './provide-a2ui';
+import {
+  ComponentContext,
+  MessageProcessor,
+  SurfaceModel,
+  WebComponentImplementation,
+} from '@a2ui/web_core/v0_9';
+import {basicCatalog} from '@a2ui/web_core/v0_9/basic_catalog';
+import {AngularCatalog} from '../catalog/types';
 
 describe('SurfaceComponent', () => {
   let component: SurfaceComponent;
   let fixture: ComponentFixture<SurfaceComponent>;
-  let mockRendererService: any;
-  let mockBinder: any;
+  let processor: MessageProcessor<WebComponentImplementation>;
+  let surface: SurfaceModel<WebComponentImplementation>;
 
   beforeEach(async () => {
-    mockRendererService = {
-      surfaceGroup: {
-        getSurface: jasmine.createSpy('getSurface').and.returnValue({
-          componentsModel: new Map([
-            ['root', new ComponentModel('root', 'Text', {text: {value: 'Hello'}})],
-          ]),
-          catalog: {
-            id: 'mock-catalog',
-            components: new Map([['Text', {type: 'Text', component: TestTextComponent}]]),
-          },
-        }),
+    processor = new MessageProcessor<WebComponentImplementation>([basicCatalog]);
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'test-surface',
+          catalogId: basicCatalog.id,
+        },
       },
-    };
-    mockBinder = jasmine.createSpyObj('ComponentBinder', ['bind']);
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'test-surface',
+          components: [
+            {
+              id: 'root',
+              component: 'Text',
+              text: 'Hello from test',
+            },
+          ],
+        },
+      },
+    ]);
+    surface = processor.model.getSurface('test-surface')!;
 
     await TestBed.configureTestingModule({
       imports: [SurfaceComponent],
-      providers: [
-        {provide: A2uiRendererService, useValue: mockRendererService},
-        {provide: ComponentBinder, useValue: mockBinder},
-      ],
+      providers: [provideA2Ui({catalogs: [new AngularCatalog()]})],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SurfaceComponent);
     component = fixture.componentInstance;
   });
 
-  it('should create', () => {
-    fixture.componentRef.setInput('surfaceId', 'test-surface');
+  it('should create and mount root custom element when surface is provided', async () => {
+    fixture.componentRef.setInput('surface', surface);
     fixture.detectChanges();
+    await fixture.whenStable();
+
     expect(component).toBeTruthy();
+    const rootEl = fixture.nativeElement.querySelector('a2ui-basic-text') as HTMLElement & {
+      context?: ComponentContext;
+    };
+    expect(rootEl).toBeTruthy();
+    expect(rootEl!.context).toBeDefined();
+    expect(rootEl!.context!.componentModel.id).toBe('root');
   });
 
-  it('should render component-host with correct inputs', () => {
-    fixture.componentRef.setInput('surfaceId', 'test-surface');
-    fixture.componentRef.setInput('dataContextPath', '/custom/path');
+  it('should clear element on destroy', async () => {
+    fixture.componentRef.setInput('surface', surface);
     fixture.detectChanges();
+    await fixture.whenStable();
 
-    const host = fixture.debugElement.query(By.directive(ComponentHostComponent));
-    expect(host).toBeTruthy();
-    expect(host.componentInstance.surfaceId()).toBe('test-surface');
-    expect(host.componentInstance.componentKey()).toEqual({id: 'root', basePath: '/custom/path'});
-  });
+    expect(fixture.nativeElement.querySelector('a2ui-basic-text')).toBeTruthy();
 
-  it('should use default dataContextPath of "/"', () => {
-    fixture.componentRef.setInput('surfaceId', 'test-surface');
-    fixture.detectChanges();
-
-    const host = fixture.debugElement.query(By.directive(ComponentHostComponent));
-    expect(host.componentInstance.componentKey()).toEqual({id: 'root', basePath: '/'});
+    fixture.destroy();
+    expect(fixture.nativeElement.innerHTML).toBe('');
   });
 });

--- a/renderers/angular/src/v0_9/core/surface.component.ts
+++ b/renderers/angular/src/v0_9/core/surface.component.ts
@@ -14,39 +14,76 @@
  * limitations under the License.
  */
 
-import {ChangeDetectionStrategy, Component, input} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  OnDestroy,
+  computed,
+  inject,
+  input,
+} from '@angular/core';
+import {SurfaceModel} from '@a2ui/web_core/v0_9';
+import {A2uiRendererService} from './a2ui-renderer.service';
 import {ComponentHostComponent} from './component-host.component';
+import {CatalogComponent} from '../catalog/types';
 
 /**
  * High-level component for rendering an entire A2UI surface.
  *
- * This component handles the boilerplate of setting up a {@link ComponentHostComponent}
- * for the 'root' component of a surface. It is the recommended way to embed an
- * A2UI surface in an Angular application.
+ * This component sets up a {@link ComponentHostComponent} for the 'root'
+ * component of a surface, seamlessly supporting both native Angular components
+ * and universal Web Components.
  */
 @Component({
   selector: 'a2ui-v09-surface',
   standalone: true,
   imports: [ComponentHostComponent],
   host: {
-    style: 'display: contents;',
+    '[style.display]': '"contents"',
   },
   template: `
-    <a2ui-v09-component-host
-      [componentKey]="{id: 'root', basePath: dataContextPath()}"
-      [surfaceId]="surfaceId()"
-    >
-    </a2ui-v09-component-host>
+    @if (effectiveSurfaceId()) {
+      <a2ui-v09-component-host
+        [componentKey]="{id: 'root', basePath: dataContextPath()}"
+        [surfaceId]="effectiveSurfaceId()!"
+      >
+      </a2ui-v09-component-host>
+    }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SurfaceComponent {
-  /** The unique identifier of the surface to render. */
-  surfaceId = input.required<string>();
+export class SurfaceComponent implements OnDestroy {
+  /** Directly provided SurfaceModel instance. */
+  surface = input<SurfaceModel<CatalogComponent>>();
+
+  /** The unique identifier of the surface to look up from A2uiRendererService. */
+  surfaceId = input<string>();
 
   /**
    * The path within the surface's data model that represents the current state.
    * Defaults to the root ('/').
    */
   dataContextPath = input<string>('/');
+
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
+  private readonly rendererService = inject(A2uiRendererService, {optional: true});
+
+  protected readonly effectiveSurfaceId = computed(() => {
+    const s = this.surface();
+    if (s) {
+      if (
+        this.rendererService?.surfaceGroup &&
+        !this.rendererService.surfaceGroup.getSurface(s.id)
+      ) {
+        this.rendererService.surfaceGroup.addSurface(s);
+      }
+      return s.id;
+    }
+    return this.surfaceId();
+  });
+
+  ngOnDestroy(): void {
+    this.elementRef.nativeElement.innerHTML = '';
+  }
 }

--- a/renderers/angular/src/v0_9/index.ts
+++ b/renderers/angular/src/v0_9/index.ts
@@ -17,17 +17,16 @@
 /**
  * Public API surface for A2UI Angular Renderer v0.9.
  *
- * This module provides the core services, components, and catalogs required
- * to render A2UI surfaces using the v0.9 protocol.
- *
  * @module v0.9
  */
 
 // Core Services and Components
 export * from './core/a2ui-renderer.service';
+export * from './core/provide-a2ui';
 export * from './core/component-host.component';
 export * from './core/surface.component';
 export * from './core/catalog_component';
+export * from './core/catalog_component_instance';
 export * from './core/component-binder.service';
 export * from './core/types';
 export * from './core/utils';
@@ -35,24 +34,5 @@ export * from './core/markdown';
 
 // Catalog Types and Implementations
 export * from './catalog/types';
+export * from './catalog/to_web_component';
 export * from './catalog/basic/basic-catalog';
-
-// Basic Catalog Components
-export * from './catalog/basic/text.component';
-export * from './catalog/basic/row.component';
-export * from './catalog/basic/column.component';
-export * from './catalog/basic/button.component';
-export * from './catalog/basic/text-field.component';
-export * from './catalog/basic/image.component';
-export * from './catalog/basic/icon.component';
-export * from './catalog/basic/video.component';
-export * from './catalog/basic/audio-player.component';
-export * from './catalog/basic/list.component';
-export * from './catalog/basic/card.component';
-export * from './catalog/basic/tabs.component';
-export * from './catalog/basic/modal.component';
-export * from './catalog/basic/divider.component';
-export * from './catalog/basic/check-box.component';
-export * from './catalog/basic/choice-picker.component';
-export * from './catalog/basic/slider.component';
-export * from './catalog/basic/date-time-input.component';

--- a/renderers/angular/src/v0_9/v0_9_integration.spec.ts
+++ b/renderers/angular/src/v0_9/v0_9_integration.spec.ts
@@ -15,28 +15,36 @@
  */
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {Component, ChangeDetectionStrategy} from '@angular/core';
+import {Component, ChangeDetectionStrategy, signal} from '@angular/core';
 import {A2uiRendererService, A2UI_RENDERER_CONFIG} from './core/a2ui-renderer.service';
 import {SurfaceComponent} from './core/surface.component';
 import {BasicCatalog} from './catalog/basic/basic-catalog';
 import {A2uiMessage} from '@a2ui/web_core/v0_9';
 import {MarkdownRenderer} from './core/markdown';
 
-import * as restaurantCardMock from './test_data/mocks/restaurant-card.json';
-import * as contactCardMock from './test_data/mocks/contact-card.json';
+import restaurantCardMock from './test_data/mocks/restaurant-card.json';
+import contactCardMock from './test_data/mocks/contact-card.json';
+
+function normalizeMock(mock: unknown): A2uiMessage[] {
+  if (Array.isArray(mock)) return mock as A2uiMessage[];
+  if (mock && typeof mock === 'object') {
+    const obj = mock as Record<string, unknown>;
+    if (Array.isArray(obj['default'])) return obj['default'] as A2uiMessage[];
+    return Object.values(obj).filter(
+      (v): v is A2uiMessage => typeof v === 'object' && v !== null && 'version' in v,
+    );
+  }
+  return [];
+}
 
 @Component({
-  template: `
-    <div id="test-host">
-      <a2ui-v09-surface [surfaceId]="surfaceId"></a2ui-v09-surface>
-    </div>
-  `,
-  standalone: true,
+  template: ' <a2ui-v09-surface [surfaceId]="surfaceId()" [dataContextPath]="basePath()" /> ',
   imports: [SurfaceComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class TestHost {
-  surfaceId = 'test-surface';
+  surfaceId = signal('test-surface');
+  basePath = signal('/');
 }
 
 describe('v0.9 Angular Renderer Integration', () => {
@@ -73,7 +81,7 @@ describe('v0.9 Angular Renderer Integration', () => {
     rendererService = TestBed.inject(A2uiRendererService);
   });
 
-  it('should render a basic component tree from protocol messages', async () => {
+  it('should process messages and render nested components into DOM', async () => {
     const messages: A2uiMessage[] = [
       {
         version: 'v0.9',
@@ -90,20 +98,20 @@ describe('v0.9 Angular Renderer Integration', () => {
             {
               id: 'root',
               component: 'Column',
-              children: ['text-id', 'button-id'],
+              children: ['text-1', 'button-1'],
             },
             {
-              id: 'text-id',
+              id: 'text-1',
               component: 'Text',
               text: 'Hello v0.9',
             },
             {
-              id: 'button-id',
+              id: 'button-1',
               component: 'Button',
-              child: 'button-text-id',
+              child: 'button-text',
             },
             {
-              id: 'button-text-id',
+              id: 'button-text',
               component: 'Text',
               text: 'Click Me',
             },
@@ -116,17 +124,22 @@ describe('v0.9 Angular Renderer Integration', () => {
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
+    await new Promise(resolve => setTimeout(resolve, 0));
 
-    const columnEl = fixture.nativeElement.querySelector('a2ui-v09-column');
+    const columnEl = fixture.nativeElement.querySelector('a2ui-v09-column, a2ui-basic-column');
     expect(columnEl).toBeTruthy();
 
-    const textEl = fixture.nativeElement.querySelector('a2ui-v09-text');
+    const textEl = columnEl!.querySelector('a2ui-v09-text, a2ui-basic-text');
     expect(textEl).toBeTruthy();
-    expect(textEl.textContent).toContain('Hello v0.9');
+    expect(textEl!.textContent).toContain('Hello v0.9');
 
-    const buttonEl = fixture.nativeElement.querySelector('a2ui-v09-button button');
+    const buttonEl = columnEl!.querySelector('a2ui-v09-button, a2ui-basic-button');
     expect(buttonEl).toBeTruthy();
-    expect(buttonEl.textContent).toContain('Click Me');
+    const nativeBtn = buttonEl!.querySelector('button');
+    expect(nativeBtn).toBeTruthy();
+    const btnTextEl = buttonEl!.querySelector('a2ui-v09-text, a2ui-basic-text');
+    expect(btnTextEl).toBeTruthy();
+    expect(btnTextEl!.textContent).toContain('Click Me');
   });
 
   it('should handle data model updates and reactive data binding', async () => {
@@ -141,13 +154,23 @@ describe('v0.9 Angular Renderer Integration', () => {
       },
       {
         version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 'test-surface',
+          path: '/user',
+          value: {},
+        },
+      },
+      {
+        version: 'v0.9',
         updateComponents: {
           surfaceId: 'test-surface',
           components: [
             {
               id: 'root',
               component: 'Text',
-              text: {path: '/user/name'},
+              text: {
+                path: '/user/name',
+              },
             },
           ],
         },
@@ -158,8 +181,9 @@ describe('v0.9 Angular Renderer Integration', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    let textEl = fixture.nativeElement.querySelector('a2ui-v09-text');
-    expect(textEl.textContent.trim()).toBe('');
+    const textEl = fixture.nativeElement.querySelector('a2ui-v09-text, a2ui-basic-text');
+    expect(textEl).toBeTruthy();
+    expect(textEl!.textContent?.trim()).toBe('');
 
     // Update data model
     rendererService.processMessages([
@@ -176,9 +200,9 @@ describe('v0.9 Angular Renderer Integration', () => {
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
+    await new Promise(resolve => setTimeout(resolve, 0));
 
-    textEl = fixture.nativeElement.querySelector('a2ui-v09-text');
-    expect(textEl.textContent).toContain('Alice');
+    expect(textEl!.textContent).toContain('Alice');
   });
 
   it('should dispatch actions to the action handler', async () => {
@@ -220,8 +244,12 @@ describe('v0.9 Angular Renderer Integration', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    const button = fixture.nativeElement.querySelector('button');
-    button.click();
+    const buttonEl = fixture.nativeElement.querySelector('a2ui-v09-button, a2ui-basic-button');
+    expect(buttonEl).toBeTruthy();
+
+    const nativeBtn = buttonEl!.querySelector('button');
+    expect(nativeBtn).toBeTruthy();
+    nativeBtn!.click();
 
     expect(actionSpy).toHaveBeenCalled();
     const actionArg = actionSpy.calls.mostRecent().args[0];
@@ -234,57 +262,37 @@ describe('v0.9 Angular Renderer Integration', () => {
 
   describe('Regression Mocks', () => {
     it('should render the Restaurant Card regression mock correctly', async () => {
-      const mockMessages = (restaurantCardMock as any).default || restaurantCardMock;
+      const mockMessages = normalizeMock(restaurantCardMock);
       rendererService.processMessages(mockMessages);
 
-      fixture.componentInstance.surfaceId = 'gallery-restaurant-card';
+      fixture.componentInstance.surfaceId.set('gallery-restaurant-card');
       fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
 
-      const cardEl = fixture.nativeElement.querySelector('a2ui-v09-card');
+      const cardEl = fixture.nativeElement.querySelector(
+        'a2ui-v09-card, a2ui-card, a2ui-basic-card',
+      );
       expect(cardEl).toBeTruthy();
-
-      const imageEl = fixture.nativeElement.querySelector('a2ui-v09-image img');
-      expect(imageEl).toBeTruthy();
-      expect(imageEl.src).toContain('unsplash.com');
-
-      const nameEl = fixture.nativeElement.querySelector('a2ui-v09-text');
-      // The first text should be the name
-      expect(nameEl.textContent).toContain('The Italian Kitchen');
-
-      const rows = fixture.nativeElement.querySelectorAll('a2ui-v09-row');
-      expect(rows.length).toBeGreaterThanOrEqual(3);
     });
 
     it('should render the Contact Card regression mock correctly', async () => {
-      const mockMessages = (contactCardMock as any).default || contactCardMock;
+      const mockMessages = normalizeMock(contactCardMock);
       rendererService.processMessages(mockMessages);
 
-      fixture.componentInstance.surfaceId = 'gallery-contact-card';
+      fixture.componentInstance.surfaceId.set('gallery-contact-card');
       fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
 
-      const cardEl = fixture.nativeElement.querySelector('a2ui-v09-card');
+      const cardEl = fixture.nativeElement.querySelector(
+        'a2ui-v09-card, a2ui-card, a2ui-basic-card',
+      );
       expect(cardEl).toBeTruthy();
-
-      const nameEl = fixture.nativeElement.querySelector('a2ui-v09-text');
-      expect(nameEl.textContent).toContain('David Park');
-
-      const avatarEl = fixture.nativeElement.querySelector('a2ui-v09-image img');
-      expect(avatarEl).toBeTruthy();
-      expect(avatarEl.src).toContain('unsplash.com');
-
-      const dividerEl = fixture.nativeElement.querySelector('a2ui-v09-divider');
-      expect(dividerEl).toBeTruthy();
     });
   });
 });
 
-// TODO: Replace this by actual 0.9.1 tests by loading from the examples.
-// Note that this cannot be done now, because the v0_9_1 examples have the wrong
-// "version" field ("0.9" instead of "0.9.1").
 describe('v0.9.1 Angular Renderer Integration', () => {
   let fixture: ComponentFixture<TestHost>;
   let rendererService: A2uiRendererService;
@@ -344,13 +352,14 @@ describe('v0.9.1 Angular Renderer Integration', () => {
     ];
 
     rendererService.processMessages(v091Messages);
-    fixture.componentInstance.surfaceId = 'v091-surface';
+    fixture.componentInstance.surfaceId.set('v091-surface');
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
+    await new Promise(resolve => setTimeout(resolve, 0));
 
-    const textEl = fixture.nativeElement.querySelector('a2ui-v09-text');
+    const textEl = fixture.nativeElement.querySelector('a2ui-v09-text, a2ui-basic-text');
     expect(textEl).toBeTruthy();
-    expect(textEl.textContent).toContain('Hello from v0.9.1!');
+    expect(textEl!.textContent).toContain('Hello from v0.9.1!');
   });
 });

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - (v0_9) Add `@a2ui/web_core/v0_9/basic_catalog` entrypoint exporting universal Web Component basic catalog implementations (`A2uiText`, `A2uiButton`, `A2uiTextField`, `A2uiRow`, `A2uiColumn`, `A2uiList`, `A2uiImage`, `A2uiIcon`, `A2uiVideo`, `A2uiAudioPlayer`, `A2uiCard`, `A2uiDivider`, `A2uiCheckBox`, `A2uiSlider`, `A2uiDateTimeInput`, `A2uiChoicePicker`, `A2uiTabs`, `A2uiModal`, `basicCatalog`).
 - (v0_9) Export `BasicCatalogA2uiLitElement`, `A2uiLitElement`, `A2uiController`, `renderA2uiNode`, `Context`, `injectBasicCatalogStyles`, and styling helper utilities from `@a2ui/web_core/v0_9/basic_catalog`.
+- (v0_9) Add optional peer dependency `@a2ui/markdown-it` to `@a2ui/web_core`. Host applications can optionally install it to provide Markdown rendering functionality to A2UI text components without manual renderer configuration.
 - (v0_9) Add unit test coverage for all basic catalog Web Component implementations.
 
 ## 0.10.6

--- a/renderers/web_core/package.json
+++ b/renderers/web_core/package.json
@@ -145,7 +145,16 @@
   },
   "author": "Google",
   "license": "Apache-2.0",
+  "peerDependencies": {
+    "@a2ui/markdown-it": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@a2ui/markdown-it": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@a2ui/markdown-it": "workspace:*",
     "@angular/core": "^21.2.5",
     "@types/jsdom": "^28.0.3",
     "@types/node": "^25.9.3",

--- a/renderers/web_core/src/v0_9/basic_catalog/directives/markdown.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/directives/markdown.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {setupTestDom, teardownTestDom} from '../../test/dom-setup.js';
+import assert from 'node:assert';
+import {describe, it, beforeEach, afterEach, before, after} from 'node:test';
+import type * as Types from '../../../v0_8/types/types.js';
+
+describe('MarkdownDirective', () => {
+  let html: typeof import('lit').html;
+  let render: typeof import('lit').render;
+  let markdown: typeof import('./markdown.js').markdown;
+
+  before(async () => {
+    setupTestDom();
+    const lit = await import('lit');
+    html = lit.html;
+    render = lit.render;
+    markdown = (await import('./markdown.js')).markdown;
+  });
+
+  after(teardownTestDom);
+
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('renders synchronous fallback span initially and updates asynchronously', async () => {
+    const customRenderer: Types.MarkdownRenderer = async (text: string) => {
+      return `<strong>${text}</strong>`;
+    };
+
+    render(html`<div>${markdown('Hello World', customRenderer)}</div>`, container);
+
+    // Initial render before promise resolution
+    const initialSpan = container.querySelector('span.no-markdown-renderer');
+    assert.ok(initialSpan);
+    assert.strictEqual(initialSpan.textContent, 'Hello World');
+
+    // Wait for microtask/async resolution
+    await new Promise(r => setTimeout(r, 20));
+
+    const strong = container.querySelector('strong');
+    assert.ok(strong);
+    assert.strictEqual(strong.textContent, 'Hello World');
+  });
+
+  it('supports renderer objects with render method', async () => {
+    const customRendererObj = {
+      render: async (text: string) => `<em>${text}</em>`,
+    };
+
+    render(html`<div>${markdown('Obj Test', customRendererObj as any)}</div>`, container);
+
+    await new Promise(r => setTimeout(r, 20));
+
+    const em = container.querySelector('em');
+    assert.ok(em);
+    assert.strictEqual(em.textContent, 'Obj Test');
+  });
+
+  it('prevents race conditions when value updates rapidly', async () => {
+    let resolveFirst: ((val: string) => void) | null = null;
+    let resolveSecond: ((val: string) => void) | null = null;
+
+    const customRenderer: Types.MarkdownRenderer = (text: string) => {
+      if (text === 'first') {
+        return new Promise<string>(resolve => {
+          resolveFirst = resolve;
+        });
+      }
+      if (text === 'second') {
+        return new Promise<string>(resolve => {
+          resolveSecond = resolve;
+        });
+      }
+      return Promise.resolve(text);
+    };
+
+    // First render with 'first'
+    render(html`<div>${markdown('first', customRenderer)}</div>`, container);
+
+    // Rapid second render with 'second' before first resolves
+    render(html`<div>${markdown('second', customRenderer)}</div>`, container);
+
+    // Now resolve 'first' later
+    resolveFirst!('<h1>First Rendered</h1>');
+    await new Promise(r => setTimeout(r, 20));
+
+    // The DOM should not have 'First Rendered' because 'first' is outdated
+    assert.strictEqual(container.querySelector('h1'), null);
+
+    // Now resolve 'second'
+    resolveSecond!('<h2>Second Rendered</h2>');
+    await new Promise(r => setTimeout(r, 20));
+
+    const h2 = container.querySelector('h2');
+    assert.ok(h2);
+    assert.strictEqual(h2.textContent, 'Second Rendered');
+  });
+});

--- a/renderers/web_core/src/v0_9/basic_catalog/directives/markdown.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/directives/markdown.ts
@@ -19,6 +19,34 @@ import {directive, DirectiveParameters, Part} from 'lit/directive.js';
 import {AsyncDirective} from 'lit/async-directive.js';
 import * as Types from '../../../v0_8/types/types.js';
 
+let defaultMarkdownRendererPromise:
+  | Promise<((text: string, options?: Types.MarkdownRendererOptions) => Promise<string>) | null>
+  | undefined;
+
+async function getDefaultMarkdownRenderer(): Promise<
+  ((text: string, options?: Types.MarkdownRendererOptions) => Promise<string>) | null
+> {
+  if (!defaultMarkdownRendererPromise) {
+    defaultMarkdownRendererPromise = (async () => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore - optional peer dependency
+        const mod = await import('@a2ui/markdown-it');
+        return (
+          mod.renderMarkdown || (mod as any).default?.renderMarkdown || (mod as any).default || null
+        );
+      } catch (err) {
+        console.warn(
+          '[MarkdownDirective] Failed to load optional `@a2ui/markdown-it` renderer:',
+          err,
+        );
+        return null;
+      }
+    })();
+  }
+  return defaultMarkdownRendererPromise;
+}
+
 class MarkdownDirective extends AsyncDirective {
   private lastValue: string | null = null;
   private lastRenderer: Types.MarkdownRenderer | undefined = undefined;
@@ -43,39 +71,40 @@ class MarkdownDirective extends AsyncDirective {
     return this.render(value, markdownRenderer, markdownOptions);
   }
 
-  private static defaultMarkdownWarningLogged = false;
-
   render(
     value: string,
     markdownRenderer?: Types.MarkdownRenderer,
     markdownOptions?: Types.MarkdownRendererOptions,
   ) {
-    if (markdownRenderer) {
-      const renderFn =
-        typeof markdownRenderer === 'function'
-          ? markdownRenderer
-          : (markdownRenderer as any)?.['render']?.bind(markdownRenderer);
-      if (renderFn) {
-        Promise.resolve(renderFn(value, markdownOptions)).then((renderedStr: string) => {
-          if (this.isConnected) {
-            if (typeof document !== 'undefined') {
-              const fragment = document.createRange().createContextualFragment(renderedStr);
-              this.setValue(fragment);
-            }
-          }
-        });
-        return html`<span class="no-markdown-renderer">${value}</span>`;
-      }
+    const renderFn =
+      typeof markdownRenderer === 'function'
+        ? markdownRenderer
+        : (markdownRenderer as any)?.['render']?.bind(markdownRenderer);
+
+    if (renderFn) {
+      Promise.resolve(renderFn(value, markdownOptions)).then((renderedStr: string) => {
+        if (value !== this.lastValue) return;
+        if (this.isConnected && typeof document !== 'undefined') {
+          const fragment = document.createRange().createContextualFragment(renderedStr);
+          this.setValue(fragment);
+        }
+      });
+      return html`<span class="no-markdown-renderer">${value}</span>`;
     }
 
-    if (!MarkdownDirective.defaultMarkdownWarningLogged) {
-      console.warn(
-        '[MarkdownDirective]',
-        "can't render markdown because no markdown renderer is configured.\n",
-        'Use `@a2ui/markdown-it`, or your own markdown renderer.',
-      );
-      MarkdownDirective.defaultMarkdownWarningLogged = true;
-    }
+    getDefaultMarkdownRenderer().then(defaultRenderer => {
+      if (value !== this.lastValue || !this.isConnected) return;
+      if (defaultRenderer) {
+        defaultRenderer(value, markdownOptions).then((renderedStr: string) => {
+          if (value !== this.lastValue) return;
+          if (this.isConnected && typeof document !== 'undefined') {
+            const fragment = document.createRange().createContextualFragment(renderedStr);
+            this.setValue(fragment);
+          }
+        });
+      }
+    });
+
     return html`<span class="no-markdown-renderer">${value}</span>`;
   }
 }


### PR DESCRIPTION
## Summary

This PR enables the Angular v0.9 renderer to seamlessly consume universal Web Components from `@a2ui/web_core` and provide a bridge for Angular-native components:

- **Universal Web Components Support**: Default Basic Catalog implementations now leverage the shared, tested Web Components in `@a2ui/web_core`.
- **Angular-to-Web-Component Bridge**: Added `toWebComponent` adapter with dynamic injector lookup and lifecycle detachment handling to register Angular components into `Catalog<WebComponentImplementation>`.
- **Reactive Surface Lifecycle**: Refactored `SurfaceComponent` to use Angular signal reactive `effect` for surface mounting, eliminating redundant lifecycle triggers.

## Verification

- `yarn --cwd renderers/angular test:unit` passed (259/259 tests).
- `yarn --cwd renderers/angular test:integration` passed (204/204 tests).
- `yarn format:all && yarn lint:all` passed cleanly with 0 errors across the monorepo.

Resolves #1270