### PR TITLE
fix(docs): fix invalid allOf schema syntax in catalog composition examples

### DIFF
--- a/docs/public/concepts/catalogs.md
+++ b/docs/public/concepts/catalogs.md
@@ -164,23 +164,24 @@ This catalog imports all elements from the Basic Catalog and adds a new `Suggest
 ```json
 {
   "$id": "https://github.com/.../hello_world_with_all_basic/v1/catalog.json",
+  "catalogId": "https://github.com/.../hello_world_with_all_basic/v1/catalog.json",
+  "allOf": [
+    {
+      "$ref": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
+    }
+  ],
   "components": {
-    "allOf": [
-      {"$ref": "basic_catalog_definition.json#/components"},
-      {
-        "SuggestionChips": {
-          "type": "object",
-          "description": "A list of suggested prompts",
-          "properties": {
-            "suggestions": {
-              "type": "array",
-              "description": "The suggested prompts."
-            }
-          },
-          "required": ["suggestions"]
+    "SuggestionChips": {
+      "type": "object",
+      "description": "A list of suggested prompts",
+      "properties": {
+        "suggestions": {
+          "type": "array",
+          "description": "The suggested prompts."
         }
-      }
-    ]
+      },
+      "required": ["suggestions"]
+    }
   }
 }
 ```
@@ -194,20 +195,21 @@ This catalog imports only `Text` from the Basic Catalog to build a simple Popup 
 ```json
 {
   "$id": "https://github.com/.../hello_world_with_some_basic/v1/catalog.json",
+  "catalogId": "https://github.com/.../hello_world_with_some_basic/v1/catalog.json",
   "components": {
-    "allOf": [
-      {"$ref": "catalogs/basic/catalog.json#/components/Text"},
-      {
-        "Popup": {
-          "type": "object",
-          "description": "A modal overlay that displays an icon and text.",
-          "properties": {
-            "text": {"$ref": "common_types.json#/$defs/ComponentId"}
-          },
-          "required": ["text"]
+    "Text": {
+      "$ref": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json#/components/Text"
+    },
+    "Popup": {
+      "type": "object",
+      "description": "A modal overlay that displays an icon and text.",
+      "properties": {
+        "text": {
+          "$ref": "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId"
         }
-      }
-    ]
+      },
+      "required": ["text"]
+    }
   }
 }
 ```

--- a/tools/build_catalog/README.md
+++ b/tools/build_catalog/README.md
@@ -84,24 +84,21 @@ uv run tools/build_catalog/assemble_catalog.py my_catalog.json --output-name ext
 ```json
 {
   "$id": "sample_popup_catalog",
+  "catalogId": "sample_popup_catalog",
   "components": {
-    "allOf": [
-      {
-        "$ref": "basic_catalog.json#/components/Text"
-      },
-      {
-        "Popup": {
-          "type": "object",
-          "description": "A modal overlay that displays an icon and text.",
-          "properties": {
-            "text": {
-              "$ref": "common_types.json#/$defs/ComponentId"
-            }
-          },
-          "required": ["text"]
+    "Text": {
+      "$ref": "basic_catalog.json#/components/Text"
+    },
+    "Popup": {
+      "type": "object",
+      "description": "A modal overlay that displays an icon and text.",
+      "properties": {
+        "text": {
+          "$ref": "common_types.json#/$defs/ComponentId"
         }
-      }
-    ]
+      },
+      "required": ["text"]
+    }
   }
 }
 ```


### PR DESCRIPTION
Update catalog composition and cherry-picking examples in
docs/public/concepts/catalogs.md and tools/build_catalog/README.md to use
valid JSON Schema syntax conforming to the A2UI Catalog meta-schema.

In the Catalog schema definition, components is a map of component names to
JSON Schema definitions. Placing 'allOf': [...] directly under components
treats 'allOf' as a component type name with an invalid array schema value.

Key Changes:
- docs/public/concepts/catalogs.md:
  - Position 'allOf' at the root catalog schema level for extending the basic catalog.
  - Define cherry-picked components as explicit entries under components using direct '$ref' pointers.
- tools/build_catalog/README.md:
  - Update sample_popup_catalog.json snippet to use valid cherry-picking syntax.

Closes #2219