### PR TITLE
Add OrcaRouter as an eval model provider

### DIFF
--- a/specification/v0_9_1/eval/.env.example
+++ b/specification/v0_9_1/eval/.env.example
@@ -9,3 +9,6 @@ OPENAI_API_KEY=your_openai_api_key_here
 
 # Anthropic API Key - https://console.anthropic.com/settings/keys
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# OrcaRouter API Key - https://www.orcarouter.ai
+ORCAROUTER_API_KEY=your_orcarouter_api_key_here

--- a/specification/v0_9_1/eval/README.md
+++ b/specification/v0_9_1/eval/README.md
@@ -11,6 +11,7 @@ To use the models, you need to set the following environment variables with your
 - `GEMINI_API_KEY`
 - `OPENAI_API_KEY`
 - `ANTHROPIC_API_KEY`
+- `ORCAROUTER_API_KEY` (optional; enables [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible router that serves models from OpenAI, Anthropic, Google and others through one endpoint and one key)
 
 You can set these in a `.env` file in the root of the project, or in your shell's configuration file (e.g., `.bashrc`, `.zshrc`).
 

--- a/specification/v0_9_1/eval/src/ai.ts
+++ b/specification/v0_9_1/eval/src/ai.ts
@@ -19,6 +19,7 @@ import {genkit} from 'genkit';
 import {openAI} from '@genkit-ai/compat-oai/openai';
 import {anthropic} from 'genkitx-anthropic';
 import {logger} from './logger';
+import {orcarouter} from './models';
 
 const plugins = [];
 
@@ -38,6 +39,10 @@ if (process.env.OPENAI_API_KEY) {
 if (process.env.ANTHROPIC_API_KEY) {
   logger.info('Initializing Anthropic plugin...');
   plugins.push(anthropic({apiKey: process.env.ANTHROPIC_API_KEY!}));
+}
+if (process.env.ORCAROUTER_API_KEY) {
+  logger.info('Initializing OrcaRouter plugin...');
+  plugins.push(orcarouter);
 }
 
 export const ai = genkit({

--- a/specification/v0_9_1/eval/src/models.ts
+++ b/specification/v0_9_1/eval/src/models.ts
@@ -16,7 +16,19 @@
 
 import {googleAI} from '@genkit-ai/google-genai';
 import {openAI} from '@genkit-ai/compat-oai/openai';
+import {openAICompatible} from '@genkit-ai/compat-oai';
 import {claude35Haiku, claude4Sonnet} from 'genkitx-anthropic';
+
+// OrcaRouter is an OpenAI-compatible model router that serves models from OpenAI,
+// Anthropic, Google, DeepSeek and others behind a single endpoint and API key.
+// Model names use the `provider/model` namespace (e.g. `anthropic/claude-sonnet-4.6`).
+const orcarouter = openAICompatible({
+  name: 'orcarouter',
+  apiKey: process.env.ORCAROUTER_API_KEY,
+  baseURL: 'https://api.orcarouter.ai/v1',
+});
+
+export {orcarouter};
 
 export interface ModelConfiguration {
   model: any;
@@ -96,5 +108,19 @@ export const modelsToTest: ModelConfiguration[] = [
     config: {},
     requestsPerMinute: 50,
     tokensPerMinute: 50000,
+  },
+  {
+    model: 'orcarouter/anthropic/claude-sonnet-4.6',
+    name: 'orcarouter-claude-sonnet-4.6',
+    config: {},
+    requestsPerMinute: 50,
+    tokensPerMinute: 30000,
+  },
+  {
+    model: 'orcarouter/openai/gpt-4o',
+    name: 'orcarouter-gpt-4o',
+    config: {},
+    requestsPerMinute: 500,
+    tokensPerMinute: 30000,
   },
 ];

--- a/specification/v1_0/eval/.env.example
+++ b/specification/v1_0/eval/.env.example
@@ -9,3 +9,6 @@ OPENAI_API_KEY=your_openai_api_key_here
 
 # Anthropic API Key - https://console.anthropic.com/settings/keys
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# OrcaRouter API Key - https://www.orcarouter.ai
+ORCAROUTER_API_KEY=your_orcarouter_api_key_here

--- a/specification/v1_0/eval/README.md
+++ b/specification/v1_0/eval/README.md
@@ -11,6 +11,7 @@ To use the models, you need to set the following environment variables with your
 - `GEMINI_API_KEY`
 - `OPENAI_API_KEY`
 - `ANTHROPIC_API_KEY`
+- `ORCAROUTER_API_KEY` (optional; enables [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible router that serves models from OpenAI, Anthropic, Google and others through one endpoint and one key)
 
 You can set these in a `.env` file in the root of the project, or in your shell's configuration file (e.g., `.bashrc`, `.zshrc`).
 

--- a/specification/v1_0/eval/src/ai.ts
+++ b/specification/v1_0/eval/src/ai.ts
@@ -19,6 +19,7 @@ import {genkit} from 'genkit';
 import {openAI} from '@genkit-ai/compat-oai/openai';
 import {anthropic} from 'genkitx-anthropic';
 import {logger} from './logger';
+import {orcarouter} from './models';
 
 const plugins = [];
 
@@ -38,6 +39,10 @@ if (process.env.OPENAI_API_KEY) {
 if (process.env.ANTHROPIC_API_KEY) {
   logger.info('Initializing Anthropic plugin...');
   plugins.push(anthropic({apiKey: process.env.ANTHROPIC_API_KEY!}));
+}
+if (process.env.ORCAROUTER_API_KEY) {
+  logger.info('Initializing OrcaRouter plugin...');
+  plugins.push(orcarouter);
 }
 
 export const ai = genkit({

--- a/specification/v1_0/eval/src/models.ts
+++ b/specification/v1_0/eval/src/models.ts
@@ -16,7 +16,19 @@
 
 import {googleAI} from '@genkit-ai/google-genai';
 import {openAI} from '@genkit-ai/compat-oai/openai';
+import {openAICompatible} from '@genkit-ai/compat-oai';
 import {claude35Haiku, claude4Sonnet} from 'genkitx-anthropic';
+
+// OrcaRouter is an OpenAI-compatible model router that serves models from OpenAI,
+// Anthropic, Google, DeepSeek and others behind a single endpoint and API key.
+// Model names use the `provider/model` namespace (e.g. `anthropic/claude-sonnet-4.6`).
+const orcarouter = openAICompatible({
+  name: 'orcarouter',
+  apiKey: process.env.ORCAROUTER_API_KEY,
+  baseURL: 'https://api.orcarouter.ai/v1',
+});
+
+export {orcarouter};
 
 export interface ModelConfiguration {
   model: any;
@@ -96,5 +108,19 @@ export const modelsToTest: ModelConfiguration[] = [
     config: {},
     requestsPerMinute: 50,
     tokensPerMinute: 50000,
+  },
+  {
+    model: 'orcarouter/anthropic/claude-sonnet-4.6',
+    name: 'orcarouter-claude-sonnet-4.6',
+    config: {},
+    requestsPerMinute: 50,
+    tokensPerMinute: 30000,
+  },
+  {
+    model: 'orcarouter/openai/gpt-4o',
+    name: 'orcarouter-gpt-4o',
+    config: {},
+    requestsPerMinute: 500,
+    tokensPerMinute: 30000,
   },
 ];


### PR DESCRIPTION
# Description

Adds [OrcaRouter](https://www.orcarouter.ai) as a named model provider in the A2UI evaluation harness for the v0.9.1 and v1.0 specs. With one API key, users get 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single OpenAI-compatible endpoint (`https://api.orcarouter.ai/v1`).

Because the model provider registration is a thin base-URL and key swap (mirroring how the harness already registers the Google AI, OpenAI and Anthropic plugins), the eval harness can now benchmark UI generation through OrcaRouter without further code changes. Model references use OrcaRouter's `provider/model` namespace, e.g. `orcarouter/anthropic/claude-sonnet-4.6` and `orcarouter/openai/gpt-4o`.

[OrcaRouter](https://www.orcarouter.ai) also provides gateway-level, zero-trust security controls for AI agents — with no application code changes. The gateway screens every prompt and response and governs every tool call on a default-deny basis, across four layers:

- **Scoped keys** — bind a key to specific models, IPs, spend caps, and expiry.
- **Guardrails** — screen for PII, secret leakage, prompt injection, and unsafe output.
- **Agent firewall** — tool allow-lists with per-argument validation.
- **Audit trail** — a record of every match, verdict, and approval decision.

Changes:

- `src/ai.ts` — register the OrcaRouter plugin (`openAICompatible` from `@genkit-ai/compat-oai`, already a dependency) when `ORCAROUTER_API_KEY` is set.
- `src/models.ts` — add two OrcaRouter-routed model entries alongside the existing models.
- `.env.example` and `README.md` — document the new optional `ORCAROUTER_API_KEY`.

No issues are fixed by this PR.

## Pre-launch Checklist

One time:

- [ ] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have built and run at least one [sample].

For this PR:

- [ ] I have updated the relevant CHANGELOG.md file.
- [x] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

## Additional context

- This change is limited to the evaluation harness. The eval packages do not ship a CHANGELOG (only the renderer packages do), and they have no unit test suite; verification was `tsc --noEmit`, `prettier --check`, and `eslint` (all clean), plus a live smoke test: generating through the new provider with a placeholder `ORCAROUTER_API_KEY` reached `https://api.orcarouter.ai/v1/chat/completions` and returned OrcaRouter's `401 Invalid token` for both `orcarouter/anthropic/claude-sonnet-4.6` and `orcarouter/openai/gpt-4o`, confirming the endpoint, key and model-name namespace are wired correctly.
- The v0.8 eval harness uses a different, legacy structure (no `src/ai.ts`) and is left untouched; v0.9 is superseded by v0.9.1.
- Contributions to this project require a signed [Google Contributor License Agreement](https://cla.developers.google.com/); this change is submitted on that basis.

I'm an engineer on the OrcaRouter team.

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
