### PR TITLE
feat(angular): add native angular container component sample to explorer

### DIFF
--- a/renderers/angular/a2ui_explorer/e2e/closure-compiler.spec.ts
+++ b/renderers/angular/a2ui_explorer/e2e/closure-compiler.spec.ts
@@ -195,3 +195,25 @@ test('renders Incremental example without errors in minified production build', 
   await expect(canvas).toContainText('Pizzeria Roma');
   await expectNoErrors(page, errors);
 });
+
+test('renders native Angular container grid with native and universal children in minified production build', async ({
+  page,
+}) => {
+  const errors = setupErrorMonitoring(page);
+
+  await page.goto('/');
+  await expectNoErrors(page, errors);
+
+  // Click on 'Native Grid' example in sidebar
+  await page
+    .locator('.sidebar .example-list li')
+    .filter({has: page.locator('.ex-name', {hasText: /Native Grid/i})})
+    .click();
+
+  const canvas = page.locator('.rendered-content');
+  await expect(canvas).toContainText('Native Container Component Showcase');
+  await expect(canvas).toContainText('Master Volume (Native)');
+  await expect(canvas).toContainText('Universal Web Component: Text & Card');
+  await expect(canvas).toContainText('Universal Button Action');
+  await expectNoErrors(page, errors);
+});

--- a/renderers/angular/a2ui_explorer/scripts/closure-compiler/externs/a2ui_explorer.externs.js
+++ b/renderers/angular/a2ui_explorer/scripts/closure-compiler/externs/a2ui_explorer.externs.js
@@ -93,3 +93,13 @@ ExampleDataModelExterns.prototype.responseMessage;
 ExampleDataModelExterns.prototype.isValid;
 /** @type {?|undefined} */
 ExampleDataModelExterns.prototype.validationErrors;
+/** @type {?|undefined} */
+ExampleDataModelExterns.prototype.sliderValue;
+/** @type {?|undefined} */
+ExampleDataModelExterns.prototype.sliderLabel;
+/** @type {?|undefined} */
+ExampleDataModelExterns.prototype.status;
+/** @type {?|undefined} */
+ExampleDataModelExterns.prototype.actionResult;
+/** @type {?|undefined} */
+ExampleDataModelExterns.prototype.currentSlider;

--- a/renderers/angular/a2ui_explorer/src/app/custom-grid.component.spec.ts
+++ b/renderers/angular/a2ui_explorer/src/app/custom-grid.component.spec.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {CustomGridComponent} from './custom-grid.component';
+import {signal} from '@angular/core';
+
+describe('CustomGridComponent', () => {
+  let fixture: ComponentFixture<CustomGridComponent>;
+  let component: CustomGridComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CustomGridComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CustomGridComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render title and description when provided', () => {
+    fixture.componentRef.setInput('props', {
+      title: {value: signal('My 4x4 Grid'), onUpdate: () => {}, raw: 'My 4x4 Grid'},
+      description: {
+        value: signal('Sample container layout'),
+        onUpdate: () => {},
+        raw: 'Sample container layout',
+      },
+      children: {value: signal([]), onUpdate: () => {}, raw: []},
+    });
+    fixture.componentRef.setInput('surfaceId', 'test-surface');
+    fixture.componentRef.setInput('componentId', 'grid-1');
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.grid-title')?.textContent).toContain('My 4x4 Grid');
+    expect(compiled.querySelector('.grid-description')?.textContent).toContain(
+      'Sample container layout',
+    );
+  });
+
+  it('should render 4 grid slots and display empty placeholders when no children provided', () => {
+    fixture.componentRef.setInput('props', {
+      children: {value: signal([]), onUpdate: () => {}, raw: []},
+    });
+    fixture.componentRef.setInput('surfaceId', 'test-surface');
+    fixture.componentRef.setInput('componentId', 'grid-1');
+    fixture.detectChanges();
+
+    const cells = fixture.nativeElement.querySelectorAll('.grid-cell');
+    expect(cells.length).toBe(4);
+
+    const emptyPlaceholders = fixture.nativeElement.querySelectorAll('.empty-placeholder');
+    expect(emptyPlaceholders.length).toBe(4);
+  });
+});

--- a/renderers/angular/a2ui_explorer/src/app/custom-grid.component.ts
+++ b/renderers/angular/a2ui_explorer/src/app/custom-grid.component.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Component, ChangeDetectionStrategy, computed} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {
+  CatalogComponentBase,
+  ComponentHostComponent,
+  createComponentImplementation,
+} from '@a2ui/angular/v0_9';
+import z from 'zod';
+import {ComponentApi, DynamicStringSchema, ChildListSchema} from '@a2ui/web_core/v0_9';
+
+const customGridApi = {
+  name: 'CustomGrid',
+  schema: z.object({
+    title: DynamicStringSchema.optional(),
+    description: DynamicStringSchema.optional(),
+    children: ChildListSchema.optional(),
+  }),
+} satisfies ComponentApi;
+
+/**
+ * A custom container component written in native Angular.
+ * Demonstrates a 2x2 grid layout capable of instantiating up to four child
+ * components (either native Angular components or universal web components).
+ */
+@Component({
+  selector: 'a2ui-custom-grid',
+  standalone: true,
+  imports: [CommonModule, ComponentHostComponent],
+  template: `
+    <div class="custom-grid-wrapper">
+      @if (props()['title']?.value()) {
+        <div class="grid-header">
+          <h3 class="grid-title">{{ props()['title']?.value() }}</h3>
+          @if (props()['description']?.value()) {
+            <p class="grid-description">{{ props()['description']?.value() }}</p>
+          }
+        </div>
+      }
+      <div class="custom-grid-container">
+        @for (child of gridSlots(); track $index) {
+          <div class="grid-cell" [class.has-content]="!!child" [class.empty-cell]="!child">
+            <div class="cell-badge">Slot {{ $index + 1 }}</div>
+            @if (child) {
+              <div class="cell-content">
+                <a2ui-v09-component-host
+                  [surfaceId]="surfaceId()"
+                  [componentKey]="child"
+                ></a2ui-v09-component-host>
+              </div>
+            } @else {
+              <div class="empty-placeholder">
+                <span>Empty child</span>
+              </div>
+            }
+          </div>
+        }
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      .custom-grid-wrapper {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        padding: 16px;
+        border: 2px dashed #4f46e5;
+        border-radius: 12px;
+        background-color: #f8fafc;
+        color: #1e293b;
+        box-sizing: border-box;
+        width: 100%;
+      }
+
+      .grid-header {
+        border-bottom: 1px solid #e2e8f0;
+        padding-bottom: 8px;
+      }
+
+      .grid-title {
+        margin: 0;
+        font-size: 1.1rem;
+        font-weight: 600;
+        color: #312e81;
+      }
+
+      .grid-description {
+        margin: 4px 0 0;
+        font-size: 0.85rem;
+        color: #64748b;
+      }
+
+      .custom-grid-container {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        grid-template-rows: repeat(2, 1fr);
+        gap: 16px;
+        min-height: 240px;
+      }
+
+      @media (max-width: 600px) {
+        .custom-grid-container {
+          grid-template-columns: 1fr;
+          grid-template-rows: auto;
+        }
+      }
+
+      .grid-cell {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        border: 1px solid #cbd5e1;
+        border-radius: 8px;
+        background-color: #ffffff;
+        padding: 12px;
+        min-height: 100px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+      }
+
+      .grid-cell.empty-cell {
+        border-style: dashed;
+        background-color: #f1f5f9;
+        justify-content: center;
+        align-items: center;
+      }
+
+      .cell-badge {
+        font-size: 0.65rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #6366f1;
+        margin-bottom: 8px;
+      }
+
+      .cell-content {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .empty-placeholder {
+        color: #94a3b8;
+        font-size: 0.8rem;
+        font-style: italic;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .custom-grid-wrapper {
+          background-color: #1e293b;
+          color: #f8fafc;
+          border-color: #818cf8;
+        }
+
+        .grid-header {
+          border-bottom-color: #334155;
+        }
+
+        .grid-title {
+          color: #c7d2fe;
+        }
+
+        .grid-description {
+          color: #cbd5e1;
+        }
+
+        .grid-cell {
+          background-color: #0f172a;
+          border-color: #475569;
+          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+        }
+
+        .grid-cell.empty-cell {
+          background-color: #1e293b;
+        }
+
+        .cell-badge {
+          color: #a5b4fc;
+        }
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CustomGridComponent extends CatalogComponentBase<typeof customGridApi> {
+  protected readonly gridSlots = computed(() => {
+    const children = this.props()['children']?.value() ?? [];
+    return [children[0] ?? null, children[1] ?? null, children[2] ?? null, children[3] ?? null];
+  });
+}
+
+export const customGridComponentDeclaration = createComponentImplementation(
+  customGridApi,
+  CustomGridComponent,
+);

--- a/renderers/angular/a2ui_explorer/src/app/custom-slider.component.ts
+++ b/renderers/angular/a2ui_explorer/src/app/custom-slider.component.ts
@@ -16,7 +16,7 @@
 
 import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {CatalogComponentBase} from '@a2ui/angular/v0_9';
+import {CatalogComponentBase, createComponentImplementation} from '@a2ui/angular/v0_9';
 import z from 'zod';
 import {ComponentApi, DynamicStringSchema, DynamicNumberSchema} from '@a2ui/web_core/v0_9';
 
@@ -71,7 +71,7 @@ export class CustomSliderComponent extends CatalogComponentBase<typeof customSli
   }
 }
 
-export const customSliderComponentDeclaration = {
-  ...customSliderApi,
-  component: CustomSliderComponent,
-};
+export const customSliderComponentDeclaration = createComponentImplementation(
+  customSliderApi,
+  CustomSliderComponent,
+);

--- a/renderers/angular/a2ui_explorer/src/app/demo-catalog.ts
+++ b/renderers/angular/a2ui_explorer/src/app/demo-catalog.ts
@@ -15,8 +15,9 @@
  */
 
 import {Injectable} from '@angular/core';
-import {AngularCatalog, BASIC_COMPONENTS, BASIC_FUNCTIONS} from '@a2ui/angular/v0_9';
+import {BasicCatalogBase} from '@a2ui/angular/v0_9';
 import {customSliderComponentDeclaration} from './custom-slider.component';
+import {customGridComponentDeclaration} from './custom-grid.component';
 
 /**
  * A catalog specific to the demo, extending the basic catalog with custom components.
@@ -24,12 +25,10 @@ import {customSliderComponentDeclaration} from './custom-slider.component';
 @Injectable({
   providedIn: 'root',
 })
-export class DemoCatalog extends AngularCatalog {
+export class DemoCatalog extends BasicCatalogBase {
   constructor() {
-    super(
-      'https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json',
-      [...BASIC_COMPONENTS, customSliderComponentDeclaration],
-      BASIC_FUNCTIONS,
-    );
+    super({
+      extraComponents: [customSliderComponentDeclaration, customGridComponentDeclaration],
+    });
   }
 }

--- a/renderers/angular/a2ui_explorer/src/app/demo.component.ts
+++ b/renderers/angular/a2ui_explorer/src/app/demo.component.ts
@@ -24,13 +24,16 @@ import {
   signal,
 } from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {A2uiRendererService, A2UI_RENDERER_CONFIG} from '@a2ui/angular/v0_9';
+import {
+  A2uiRendererService,
+  AngularCatalog,
+  provideA2Ui,
+  SurfaceComponent as SurfaceComponentV09,
+} from '@a2ui/angular/v0_9';
 import {AgentStubService} from './agent-stub.service';
 import {AgentStubV08Service} from './agent-stub-v08.service';
 import {AgentStubV09Service} from './agent-stub-v09.service';
-import {SurfaceComponent as SurfaceComponentV09} from '@a2ui/angular/v0_9';
 import {provideMarkdownRenderer, Surface as SurfaceV08} from '@a2ui/angular/v0_8';
-import {AngularCatalog} from '@a2ui/angular/v0_9';
 import {DemoCatalog} from './demo-catalog';
 import {A2uiClientAction} from '@a2ui/web_core/v0_9';
 import {A2uiExample, A2UI_VERSION, A2UI_EXAMPLES, Version} from './types';
@@ -559,7 +562,13 @@ import {Catalog as CatalogV08, DEFAULT_CATALOG as DEFAULT_CATALOG_V08} from '@a2
     `,
   ],
   providers: [
-    A2uiRendererService,
+    provideA2Ui(() => {
+      const dispatcher = inject(ActionDispatcher);
+      return {
+        useUniversalComponents: true,
+        actionHandler: (action: A2uiClientAction) => dispatcher.dispatch(action),
+      };
+    }),
     {provide: AngularCatalog, useClass: DemoCatalog},
     {provide: CatalogV08, useValue: DEFAULT_CATALOG_V08},
     provideMarkdownRenderer(),
@@ -573,14 +582,6 @@ import {Catalog as CatalogV08, DEFAULT_CATALOG as DEFAULT_CATALOG_V08} from '@a2
     },
     AgentStubV08Service,
     AgentStubV09Service,
-    {
-      provide: A2UI_RENDERER_CONFIG,
-      useFactory: (catalog: AngularCatalog, dispatcher: ActionDispatcher) => ({
-        catalogs: [catalog],
-        actionHandler: (action: A2uiClientAction) => dispatcher.dispatch(action),
-      }),
-      deps: [AngularCatalog, ActionDispatcher],
-    },
   ],
 })
 export class DemoComponent implements OnInit, OnDestroy {

--- a/renderers/angular/a2ui_explorer/src/app/tests/v0_9/37_native-grid.spec.ts
+++ b/renderers/angular/a2ui_explorer/src/app/tests/v0_9/37_native-grid.spec.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ApplicationRef} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {getCanvas, loadExample, wait} from '../utils';
+
+describe('Example: Native Angular Grid', () => {
+  let canvas: HTMLElement;
+
+  beforeEach(async () => {
+    await loadExample('Native Grid');
+    await wait(50);
+    TestBed.inject(ApplicationRef).tick();
+    canvas = getCanvas();
+  });
+
+  it('should render the native Angular container component and header content', () => {
+    const textContent = canvas.textContent || '';
+    expect(textContent).toContain('Native Container Component Showcase');
+    expect(textContent).toContain('Interactive 4x4 Component Grid');
+    expect(
+      canvas.querySelector('a2ui-custom-grid') || canvas.querySelector('a2ui-ng-customgrid'),
+    ).toBeTruthy();
+  });
+
+  it('should instantiate native Angular component children (CustomSlider)', () => {
+    const textContent = canvas.textContent || '';
+    expect(textContent).toContain('Master Volume (Native)');
+    expect(textContent).toContain('Brightness Level (Native)');
+
+    const customSliders = canvas.querySelectorAll('a2ui-custom-slider, a2ui-ng-customslider');
+    expect(customSliders.length).toBe(2);
+  });
+
+  it('should instantiate universal web component children (Card, Text, Button)', () => {
+    const textContent = canvas.textContent || '';
+    expect(textContent).toContain('Universal Web Component: Text & Card');
+    expect(textContent).toContain('Universal Button Action');
+
+    expect(
+      canvas.querySelector('a2ui-v09-card') ||
+        canvas.querySelector('a2ui-card') ||
+        canvas.querySelector('a2ui-basic-card'),
+    ).toBeTruthy();
+    expect(
+      canvas.querySelector('a2ui-v09-button') ||
+        canvas.querySelector('a2ui-basic-button') ||
+        canvas.querySelector('a2ui-button'),
+    ).toBeTruthy();
+  });
+
+  it('should update reactive data binding across native and universal components', async () => {
+    const slider = (canvas.querySelector('a2ui-custom-slider input[type="range"]') ||
+      canvas.querySelector('a2ui-ng-customslider input[type="range"]') ||
+      canvas.querySelector('input[type="range"]')) as HTMLInputElement;
+    expect(slider).toBeTruthy();
+
+    slider.value = '80';
+    slider.dispatchEvent(new Event('input'));
+    await wait(50);
+    TestBed.inject(ApplicationRef).tick();
+
+    const textContent = canvas.textContent || '';
+    expect(textContent).toContain('Vol: 80% | Bright: 30%');
+  });
+});

--- a/specification/v0_9/catalogs/basic/examples/37_native-grid.json
+++ b/specification/v0_9/catalogs/basic/examples/37_native-grid.json
@@ -1,0 +1,162 @@
+{
+  "name": "Native Grid",
+  "description": "A custom component container example.",
+  "messages": [
+    {
+      "version": "v0.9",
+      "createSurface": {
+        "surfaceId": "custom-grid-demo",
+        "catalogId": "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
+      }
+    },
+    {
+      "version": "v0.9",
+      "updateDataModel": {
+        "surfaceId": "custom-grid-demo",
+        "path": "/",
+        "value": {
+          "sliderValue1": 65,
+          "sliderValue2": 30,
+          "sliderLabel": "Volume Control",
+          "status": "Ready",
+          "actionResult": "No action triggered yet"
+        }
+      }
+    },
+    {
+      "version": "v0.9",
+      "updateComponents": {
+        "surfaceId": "custom-grid-demo",
+        "components": [
+          {
+            "id": "root",
+            "component": "Column",
+            "children": ["header-card", "grid-container", "footer-text"]
+          },
+          {
+            "id": "header-card",
+            "component": "Card",
+            "child": "header-col"
+          },
+          {
+            "id": "header-col",
+            "component": "Column",
+            "children": ["title-text", "subtitle-text"]
+          },
+          {
+            "id": "title-text",
+            "component": "Text",
+            "text": "Native Container Component Showcase",
+            "variant": "h2"
+          },
+          {
+            "id": "subtitle-text",
+            "component": "Text",
+            "text": "Demonstrates a custom container component (CustomGrid) implemented in the client application framework, rendering a 4-cell layout hosting both native components and universal web components as children.",
+            "variant": "caption"
+          },
+          {
+            "id": "grid-container",
+            "component": "CustomGrid",
+            "title": "Interactive 4x4 Component Grid",
+            "description": "Grid cells 1 & 3 contain native components (CustomSlider), while cells 2 & 4 contain universal Web Components (Card, Text, Button).",
+            "children": [
+              "child-native-slider-1",
+              "child-universal-card",
+              "child-native-slider-2",
+              "child-universal-button"
+            ]
+          },
+          {
+            "id": "child-native-slider-1",
+            "component": "CustomSlider",
+            "label": "Master Volume (Native)",
+            "value": {
+              "path": "/sliderValue1"
+            },
+            "min": 0,
+            "max": 100
+          },
+          {
+            "id": "child-universal-card",
+            "component": "Card",
+            "child": "card-inner-col"
+          },
+          {
+            "id": "card-inner-col",
+            "component": "Column",
+            "children": ["card-title", "card-status"]
+          },
+          {
+            "id": "card-title",
+            "component": "Text",
+            "text": "Universal Web Component: Text & Card",
+            "variant": "body"
+          },
+          {
+            "id": "card-status",
+            "component": "Text",
+            "text": {
+              "call": "formatString",
+              "args": {
+                "value": "Status: ${/status} | Vol: ${/sliderValue1}% | Bright: ${/sliderValue2}%"
+              }
+            },
+            "variant": "caption"
+          },
+          {
+            "id": "child-native-slider-2",
+            "component": "CustomSlider",
+            "label": "Brightness Level (Native)",
+            "value": {
+              "path": "/sliderValue2"
+            },
+            "min": 0,
+            "max": 100
+          },
+          {
+            "id": "child-universal-button",
+            "component": "Column",
+            "children": ["action-btn", "btn-desc"]
+          },
+          {
+            "id": "action-btn",
+            "component": "Button",
+            "child": "btn-label",
+            "variant": "primary",
+            "action": {
+              "event": {
+                "name": "grid_button_clicked",
+                "context": {
+                  "vol": {
+                    "path": "/sliderValue1"
+                  },
+                  "bright": {
+                    "path": "/sliderValue2"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "id": "btn-label",
+            "component": "Text",
+            "text": "Universal Button Action"
+          },
+          {
+            "id": "btn-desc",
+            "component": "Text",
+            "text": "Clicking dispatches an A2UI client action to the agent",
+            "variant": "caption"
+          },
+          {
+            "id": "footer-text",
+            "component": "Text",
+            "text": "Universal components and native components seamlessly coexist in the same A2UI surface.",
+            "variant": "caption"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Demonstrates how developers can build native Angular container components in A2UI that host both native Angular and universal Web Component children within the same A2UI surface.

### Key Changes
- **Native Container Component (`CustomGridComponent`)**: Implemented a 4-cell responsive grid container in `@a2ui/angular-explorer` using `@Component`, `CatalogComponent`, and `<a2ui-v09-component-host>` to instantiate child slots dynamically.
- **Example JSON (`37_native-grid.json`)**: Showcases `CustomGrid` hosting a mix of:
  - Native Angular components: `CustomSlider` with reactive two-way data binding mapped to independent paths (`/sliderValue1` and `/sliderValue2`).
  - Universal Web Components: `Card`, `Column`, `Text` (with dynamic `${/path}` string interpolation), and `Button` (with client action dispatching).
  - This example is placed in the core `specification/v0_9/catalogs/basic/examples` directory for cross-framework compatibility.
- **Test Suite & Formatting**:
  - Unit tests for `CustomGridComponent`.
  - Integration test suite (`37_native-grid.spec.ts`) verifying rendering, mixed child instantiation, and reactive data updates.
  - Ran `yarn format` across the `a2ui_explorer` workspace, updating standard formatting.

## Pre-launch Checklist
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] My code changes have tests.

Resolves #1270