### PR TITLE
fix(web_core): preserve descriptive Zod validation error messages and log diagnostics

### DIFF
--- a/renderers/web_core/src/v0_9/processing/message-processor.test.ts
+++ b/renderers/web_core/src/v0_9/processing/message-processor.test.ts
@@ -16,7 +16,7 @@
 
 import * as assert from 'node:assert';
 import {describe, it, beforeEach} from 'node:test';
-import {MessageProcessor} from './message-processor.js';
+import {MessageProcessor, formatZodIssue} from './message-processor.js';
 import {Catalog, ComponentApi} from '../catalog/types.js';
 import {ButtonApi} from '../basic_catalog/index.js';
 import {A2uiValidationError} from '../errors.js';
@@ -734,5 +734,104 @@ describe('MessageProcessor', () => {
     assert.strictEqual(processor.resolvePath('foo', '/bar'), '/bar/foo');
     assert.strictEqual(processor.resolvePath('foo', '/bar/'), '/bar/foo');
     assert.strictEqual(processor.resolvePath('foo'), '/foo');
+  });
+
+  describe('formatZodIssue and error reporting', () => {
+    it('formats unrecognized keys with exact property names', () => {
+      const issue: any = {
+        code: 'unrecognized_keys',
+        keys: ['color', 'gap'],
+        path: ['header'],
+        message: 'Unrecognized key(s) in object: color, gap',
+      };
+      assert.strictEqual(
+        formatZodIssue(issue),
+        "header: Unrecognized key(s) in object: 'color', 'gap'",
+      );
+    });
+
+    it('formats unrecognized keys at root level', () => {
+      const issue: any = {
+        code: 'unrecognized_keys',
+        keys: ['color'],
+        path: [],
+        message: 'Expected undefined, received undefined', // simulates minified corrupted message
+      };
+      assert.strictEqual(formatZodIssue(issue), "root: Unrecognized key(s) in object: 'color'");
+    });
+
+    it('formats invalid enum values', () => {
+      const issue: any = {
+        code: 'invalid_enum_value',
+        options: ['primary', 'secondary'],
+        received: 'invalid',
+        path: ['variant'],
+        message: 'Invalid enum value',
+      };
+      assert.strictEqual(
+        formatZodIssue(issue),
+        "variant: Invalid enum value. Expected primary | secondary, received 'invalid'",
+      );
+    });
+
+    it('falls back to expected/received when message is corrupted with undefined', () => {
+      const issue: any = {
+        code: 'invalid_type',
+        expected: 'string',
+        received: 'number',
+        path: ['label'],
+        message: 'Expected undefined, received undefined',
+      };
+      assert.strictEqual(formatZodIssue(issue), 'label: Expected string, received number');
+    });
+
+    it('surfaces unrecognized property validation error and details when processing component updates', () => {
+      const strictButtonApi: ComponentApi = {
+        name: 'MaterialButton',
+        schema: z
+          .object({
+            label: z.string(),
+          })
+          .strict(),
+      };
+      const proc = new MessageProcessor([new Catalog('cat-m3', [strictButtonApi])]);
+      proc.processMessages([
+        {
+          version: 'v0.9',
+          createSurface: {surfaceId: 's1', catalogId: 'cat-m3'},
+        },
+      ]);
+
+      assert.throws(
+        () => {
+          proc.processMessages([
+            {
+              version: 'v0.9',
+              updateComponents: {
+                surfaceId: 's1',
+                components: [
+                  {
+                    id: 'btn1',
+                    component: 'MaterialButton',
+                    label: 'Submit',
+                    color: 'primary',
+                  } as any,
+                ],
+              },
+            },
+          ]);
+        },
+        (err: any) => {
+          assert.ok(err instanceof A2uiValidationError);
+          assert.strictEqual(
+            err.message,
+            "Validation failed for component 'MaterialButton' (btn1): root: Unrecognized key(s) in object: 'color'",
+          );
+          assert.ok(Array.isArray(err.details));
+          assert.strictEqual(err.details[0].code, 'unrecognized_keys');
+          return true;
+        },
+      );
+    });
   });
 });

--- a/renderers/web_core/src/v0_9/processing/message-processor.ts
+++ b/renderers/web_core/src/v0_9/processing/message-processor.ts
@@ -80,8 +80,8 @@ export function formatZodIssue(err: z.ZodIssue): string {
     return `${path}: ${err.message}`;
   }
 
-  if ('expected' in err && (err as any).expected && (err as any).received) {
-    return `${path}: Expected ${(err as any).expected}, received ${(err as any).received}`;
+  if ('expected' in err && (err as any).expected !== undefined && (err as any).received !== undefined) {
+    return path + ": Expected " + (err as any).expected + ", received " + (err as any).received;
   }
 
   return `${path}: Validation error (${err.code || 'invalid'})`;

--- a/renderers/web_core/src/v0_9/processing/message-processor.ts
+++ b/renderers/web_core/src/v0_9/processing/message-processor.ts
@@ -360,8 +360,8 @@ export class MessageProcessor<T extends ComponentApi> {
           const validationResult = componentApi.schema.safeParse(properties);
           if (!validationResult.success) {
             const formattedErrors = validationResult.error.errors.map(formatZodIssue).join(', ');
-            console.error(`[A2UI Validation Error] Component '${componentType}' (${id}):`, {
-              properties,
+            console.error("[A2UI Validation Error] Component '" + componentType + "' (" + id + "):", {
+              propertyKeys: Object.keys(properties),
               issues: validationResult.error.issues,
             });
             throw new A2uiValidationError(

--- a/renderers/web_core/src/v0_9/processing/message-processor.ts
+++ b/renderers/web_core/src/v0_9/processing/message-processor.ts
@@ -80,8 +80,12 @@ export function formatZodIssue(err: z.ZodIssue): string {
     return `${path}: ${err.message}`;
   }
 
-  if ('expected' in err && (err as any).expected !== undefined && (err as any).received !== undefined) {
-    return path + ": Expected " + (err as any).expected + ", received " + (err as any).received;
+  if (
+    'expected' in err &&
+    (err as any).expected !== undefined &&
+    (err as any).received !== undefined
+  ) {
+    return path + ': Expected ' + (err as any).expected + ', received ' + (err as any).received;
   }
 
   return `${path}: Validation error (${err.code || 'invalid'})`;
@@ -360,10 +364,13 @@ export class MessageProcessor<T extends ComponentApi> {
           const validationResult = componentApi.schema.safeParse(properties);
           if (!validationResult.success) {
             const formattedErrors = validationResult.error.errors.map(formatZodIssue).join(', ');
-            console.error("[A2UI Validation Error] Component '" + componentType + "' (" + id + "):", {
-              propertyKeys: Object.keys(properties),
-              issues: validationResult.error.issues,
-            });
+            console.error(
+              "[A2UI Validation Error] Component '" + componentType + "' (" + id + '):',
+              {
+                propertyKeys: Object.keys(properties),
+                issues: validationResult.error.issues,
+              },
+            );
             throw new A2uiValidationError(
               `Validation failed for component '${componentType}' (${id}): ${formattedErrors}`,
               validationResult.error.issues,

--- a/renderers/web_core/src/v0_9/processing/message-processor.ts
+++ b/renderers/web_core/src/v0_9/processing/message-processor.ts
@@ -20,6 +20,7 @@ import {SurfaceGroupModel} from '../state/surface-group-model.js';
 import {ComponentModel} from '../state/component-model.js';
 import {Subscription} from '../common/events.js';
 import {zodToJsonSchema} from 'zod-to-json-schema';
+import {z} from 'zod';
 
 import {
   A2uiMessage,
@@ -49,6 +50,41 @@ export interface CapabilitiesOptions {
 export interface MessageProcessorOptions {
   /** The default protocol version to use for capability generation and data model reporting. Defaults to 'v0.9'. */
   version?: 'v0.9' | 'v0.9.1';
+}
+
+/**
+ * Formats a Zod validation issue into a descriptive, human-readable string.
+ *
+ * Direct attribute extraction is used so that issue details (such as unrecognized
+ * property keys or invalid enum options) are preserved even when running in
+ * optimized/minified production builds where Zod's internal error map messages
+ * may degrade into generic strings (e.g. "Expected undefined, received undefined").
+ */
+export function formatZodIssue(err: z.ZodIssue): string {
+  const path = err.path.join('.') || 'root';
+
+  // 1. Unrecognized keys on .strict() schemas
+  if ('keys' in err && Array.isArray((err as any).keys) && (err as any).keys.length > 0) {
+    const keysStr = (err as any).keys.map((k: string) => `'${k}'`).join(', ');
+    return `${path}: Unrecognized key(s) in object: ${keysStr}`;
+  }
+
+  // 2. Invalid enum values
+  if (err.code === 'invalid_enum_value' && Array.isArray((err as any).options)) {
+    const optionsStr = (err as any).options.join(' | ');
+    return `${path}: Invalid enum value. Expected ${optionsStr}, received '${(err as any).received}'`;
+  }
+
+  // 3. Fallback when message is corrupted into "Expected undefined, received undefined"
+  if (err.message && !err.message.includes('Expected undefined, received undefined')) {
+    return `${path}: ${err.message}`;
+  }
+
+  if ('expected' in err && (err as any).expected && (err as any).received) {
+    return `${path}: Expected ${(err as any).expected}, received ${(err as any).received}`;
+  }
+
+  return `${path}: Validation error (${err.code || 'invalid'})`;
 }
 
 /**
@@ -323,11 +359,14 @@ export class MessageProcessor<T extends ComponentApi> {
         if (componentApi) {
           const validationResult = componentApi.schema.safeParse(properties);
           if (!validationResult.success) {
-            const formattedErrors = validationResult.error.errors
-              .map(err => `${err.path.join('.') || 'root'}: ${err.message}`)
-              .join(', ');
+            const formattedErrors = validationResult.error.errors.map(formatZodIssue).join(', ');
+            console.error(`[A2UI Validation Error] Component '${componentType}' (${id}):`, {
+              properties,
+              issues: validationResult.error.issues,
+            });
             throw new A2uiValidationError(
               `Validation failed for component '${componentType}' (${id}): ${formattedErrors}`,
+              validationResult.error.issues,
             );
           }
         }


### PR DESCRIPTION
## Summary

In minified production builds, Zod validation errors on component schemas can degrade into generic strings such as "Expected undefined, received undefined". This PR extracts validation details directly from Zod issue objects and logs diagnostic context when component property validation fails.

## Changes

- Added `formatZodIssue` in `renderers/web_core/src/v0_9/processing/message-processor.ts` to format unrecognized key lists, invalid enum options, and expected vs. received types directly from Zod issue attributes.
- Updated `MessageProcessor.processMessages` to use `formatZodIssue` for error string formatting and attached `validationResult.error.issues` as details to thrown `A2uiValidationError` instances.
- Added diagnostic `console.error` logging in `MessageProcessor.processMessages` to log component properties and validation issues on validation failure.
- Added unit tests in `renderers/web_core/src/v0_9/processing/message-processor.test.ts` covering `formatZodIssue` formatting edge cases and `A2uiValidationError` payload verification.

## Impact & Risks

- **Impact**: Validation error messages remain human-readable across minified production bundles, and validation errors include structured issue details.
- **Risks**: Low. Console logging only executes when component validation fails.

## Testing

- Unit tests added in `renderers/web_core/src/v0_9/processing/message-processor.test.ts` to verify:
  - Formatting unrecognized keys at root and nested object paths.
  - Formatting invalid enum values with expected choices and received values.
  - Fallback string formatting when error messages contain "Expected undefined, received undefined".
  - Error throwing, message formatting, and `details` payload matching on `A2uiValidationError`.
