### PR TITLE
feat(web_core): implement Stage 3 Sauce-TS bidirectional RPC and @index function

### DIFF
--- a/typescript/web_core/src/errors.ts
+++ b/typescript/web_core/src/errors.ts
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-/**
- * This interface is needed for typescript to allow us to access the V8-only
- * `captureStackTrace` property in Errors.
- */
+/** Internal extension of `ErrorConstructor` adding V8 `captureStackTrace` support. */
 interface V8ErrorConstructor extends ErrorConstructor {
+  /** Captures a V8 stack trace onto the target object. */
   captureStackTrace(targetObject: object, constructorOpt?: Function): void;
 }
 
@@ -27,11 +25,22 @@ interface V8ErrorConstructor extends ErrorConstructor {
  *
  * Includes a machine-readable `code` for categorical handling and ensures
  * proper stack trace capturing.
+ *
+ * @example
+ * ```ts
+ * throw new A2uiError('Failed to process payload', 'PROCESSING_ERROR');
+ * ```
  */
 export class A2uiError extends Error {
   /** A machine-readable string identifying the error category. */
   public readonly code: string;
 
+  /**
+   * Creates an instance of `A2uiError`.
+   *
+   * @param message Human-readable error description.
+   * @param code Machine-readable error category code.
+   */
   constructor(message: string, code: string = 'UNKNOWN_ERROR') {
     super(message);
     this.name = this.constructor.name;
@@ -45,9 +54,15 @@ export class A2uiError extends Error {
 }
 
 /**
- * Thrown when JSON validation fails or schemas are mismatched.
+ * Error thrown when JSON validation fails or schema validation mismatches occur.
  */
 export class A2uiValidationError extends A2uiError {
+  /**
+   * Creates an instance of `A2uiValidationError`.
+   *
+   * @param message Error description detailing the validation failure.
+   * @param details Additional error context or Zod validation issues.
+   */
   constructor(
     message: string,
     public readonly details?: any,
@@ -57,9 +72,15 @@ export class A2uiValidationError extends A2uiError {
 }
 
 /**
- * Thrown during DataModel mutations (invalid paths, type mismatches).
+ * Error thrown during DataModel mutations (invalid paths, type mismatches).
  */
 export class A2uiDataError extends A2uiError {
+  /**
+   * Creates an instance of `A2uiDataError`.
+   *
+   * @param message Error description.
+   * @param path Target data model path where the mutation failed.
+   */
   constructor(
     message: string,
     public readonly path?: string,
@@ -69,9 +90,16 @@ export class A2uiDataError extends A2uiError {
 }
 
 /**
- * Thrown during string interpolation and function evaluation.
+ * Error thrown during string interpolation and function evaluation.
  */
 export class A2uiExpressionError extends A2uiError {
+  /**
+   * Creates an instance of `A2uiExpressionError`.
+   *
+   * @param message Error description.
+   * @param expression Evaluated expression string.
+   * @param details Additional error details.
+   */
   constructor(
     message: string,
     public readonly expression?: string,
@@ -82,27 +110,42 @@ export class A2uiExpressionError extends A2uiError {
 }
 
 /**
- * Thrown for structural issues in the UI tree (missing surfaces, duplicate components).
+ * Error thrown for structural issues in the UI tree (missing surfaces, duplicate components).
  */
 export class A2uiStateError extends A2uiError {
+  /**
+   * Creates an instance of `A2uiStateError`.
+   *
+   * @param message Error description.
+   */
   constructor(message: string) {
     super(message, 'STATE_ERROR');
   }
 }
 
 /**
- * Thrown when component tree integrity checks fail (duplicate IDs, dangling references, missing root).
+ * Error thrown when component tree integrity checks fail (duplicate IDs, dangling references, missing root).
  */
 export class A2uiIntegrityError extends A2uiError {
+  /**
+   * Creates an instance of `A2uiIntegrityError`.
+   *
+   * @param message Error description.
+   */
   constructor(message: string) {
     super(message, 'INTEGRITY_ERROR');
   }
 }
 
 /**
- * Thrown when global or function call recursion depth limits are exceeded.
+ * Error thrown when global or function call recursion depth limits are exceeded.
  */
 export class A2uiRecursionError extends A2uiError {
+  /**
+   * Creates an instance of `A2uiRecursionError`.
+   *
+   * @param message Error description.
+   */
   constructor(message: string) {
     super(message, 'RECURSION_ERROR');
   }

--- a/typescript/web_core/src/errors.ts
+++ b/typescript/web_core/src/errors.ts
@@ -89,3 +89,21 @@ export class A2uiStateError extends A2uiError {
     super(message, 'STATE_ERROR');
   }
 }
+
+/**
+ * Thrown when component tree integrity checks fail (duplicate IDs, dangling references, missing root).
+ */
+export class A2uiIntegrityError extends A2uiError {
+  constructor(message: string) {
+    super(message, 'INTEGRITY_ERROR');
+  }
+}
+
+/**
+ * Thrown when global or function call recursion depth limits are exceeded.
+ */
+export class A2uiRecursionError extends A2uiError {
+  constructor(message: string) {
+    super(message, 'RECURSION_ERROR');
+  }
+}

--- a/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -452,8 +452,7 @@ export const OpenUrlImplementation = createFunctionImplementation(OpenUrlApi, ar
  * Returns the loop index offset from context.
  */
 export const IndexImplementation = createFunctionImplementation(IndexApi, (args, context) => {
-  const offset =
-    typeof args.offset === 'number' && Number.isFinite(args.offset) ? args.offset : 0;
+  const offset = typeof args.offset === 'number' && Number.isFinite(args.offset) ? args.offset : 0;
   let index = 0;
   if (typeof (context as any)?.getIndex === 'function') {
     index = (context as any).getIndex();

--- a/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -452,16 +452,16 @@ export const OpenUrlImplementation = createFunctionImplementation(OpenUrlApi, ar
  * Returns the loop index offset from context.
  */
 export const IndexImplementation = createFunctionImplementation(IndexApi, (args, context) => {
-  const offset = typeof args.offset === 'number' ? args.offset : 0;
+  const offset =
+    typeof args.offset === 'number' && Number.isFinite(args.offset) ? args.offset : 0;
   let index = 0;
   if (typeof (context as any)?.getIndex === 'function') {
     index = (context as any).getIndex();
   } else if (context?.path) {
     const parts = context.path.split('/').filter(Boolean);
     for (let i = parts.length - 1; i >= 0; i--) {
-      const num = parseInt(parts[i], 10);
-      if (!isNaN(num)) {
-        index = num;
+      if (/^\d+$/.test(parts[i])) {
+        index = parseInt(parts[i], 10);
         break;
       }
     }

--- a/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {z} from 'zod';
 import {ExpressionParser} from '../../../expressions/expression_parser.js';
 import {computed, isSignal, getValue} from '../../../reactivity/signals.js';
 import {createFunctionImplementation, FunctionImplementation} from '../../../catalog/types.js';
@@ -46,7 +45,6 @@ import {
   PluralizeApi,
   OpenUrlApi,
 } from './basic_functions_api.js';
-import {IndexApi} from '../../../v1_0/functions/system_functions.js';
 import {A2uiExpressionError} from '../../../errors.js';
 
 // Arithmetic
@@ -448,27 +446,6 @@ export const OpenUrlImplementation = createFunctionImplementation(OpenUrlApi, ar
 });
 
 /**
- * Implementation of the `@index` function.
- * Returns the loop index offset from context.
- */
-export const IndexImplementation = createFunctionImplementation(IndexApi, (args, context) => {
-  const offset = typeof args.offset === 'number' && Number.isFinite(args.offset) ? args.offset : 0;
-  let index = 0;
-  if (typeof (context as any)?.getIndex === 'function') {
-    index = (context as any).getIndex();
-  } else if (context?.path) {
-    const parts = context.path.split('/').filter(Boolean);
-    for (let i = parts.length - 1; i >= 0; i--) {
-      if (/^\d+$/.test(parts[i])) {
-        index = parseInt(parts[i], 10);
-        break;
-      }
-    }
-  }
-  return index + offset;
-});
-
-/**
  * Creates standard function implementations for the Basic Catalog.
  *
  * @param options Configuration options.
@@ -502,7 +479,6 @@ export function createBasicCatalogFunctions(options?: {locale?: string}): Functi
     FormatDateImplementation,
     createPluralizeImplementation(locale),
     OpenUrlImplementation,
-    IndexImplementation,
   ];
 }
 

--- a/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -45,8 +45,8 @@ import {
   FormatDateApi,
   PluralizeApi,
   OpenUrlApi,
-  IndexApi,
 } from './basic_functions_api.js';
+import {IndexApi} from '../../../v1_0/functions/system_functions.js';
 import {A2uiExpressionError} from '../../../errors.js';
 
 // Arithmetic

--- a/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -45,6 +45,7 @@ import {
   FormatDateApi,
   PluralizeApi,
   OpenUrlApi,
+  IndexApi,
 } from './basic_functions_api.js';
 import {A2uiExpressionError} from '../../../errors.js';
 
@@ -447,6 +448,28 @@ export const OpenUrlImplementation = createFunctionImplementation(OpenUrlApi, ar
 });
 
 /**
+ * Implementation of the `@index` function.
+ * Returns the loop index offset from context.
+ */
+export const IndexImplementation = createFunctionImplementation(IndexApi, (args, context) => {
+  const offset = typeof args.offset === 'number' ? args.offset : 0;
+  let index = 0;
+  if (typeof (context as any)?.getIndex === 'function') {
+    index = (context as any).getIndex();
+  } else if (context?.path) {
+    const parts = context.path.split('/').filter(Boolean);
+    for (let i = parts.length - 1; i >= 0; i--) {
+      const num = parseInt(parts[i], 10);
+      if (!isNaN(num)) {
+        index = num;
+        break;
+      }
+    }
+  }
+  return index + offset;
+});
+
+/**
  * Creates standard function implementations for the Basic Catalog.
  *
  * @param options Configuration options.
@@ -480,6 +503,7 @@ export function createBasicCatalogFunctions(options?: {locale?: string}): Functi
     FormatDateImplementation,
     createPluralizeImplementation(locale),
     OpenUrlImplementation,
+    IndexImplementation,
   ];
 }
 
@@ -488,33 +512,3 @@ export function createBasicCatalogFunctions(options?: {locale?: string}): Functi
  * These functions cover arithmetic, comparison, logic, string manipulation, validation, and formatting.
  */
 export const BASIC_FUNCTIONS: FunctionImplementation[] = createBasicCatalogFunctions();
-
-/**
- * Implementation of the `@index` function.
- * Returns the loop index offset from context.
- */
-export const IndexApi = {
-  name: '@index',
-  returnType: 'number' as const,
-  schema: z.object({
-    offset: z.number().optional(),
-  }),
-};
-
-export const IndexImplementation = createFunctionImplementation(IndexApi, (args, context) => {
-  const offset = typeof args.offset === 'number' ? args.offset : 0;
-  let index = 0;
-  if (typeof (context as any).getIndex === 'function') {
-    index = (context as any).getIndex();
-  } else if (context.path) {
-    const parts = context.path.split('/').filter(Boolean);
-    for (let i = parts.length - 1; i >= 0; i--) {
-      const num = parseInt(parts[i], 10);
-      if (!isNaN(num)) {
-        index = num;
-        break;
-      }
-    }
-  }
-  return index + offset;
-});

--- a/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {z} from 'zod';
 import {ExpressionParser} from '../../../expressions/expression_parser.js';
 import {computed, isSignal, getValue} from '../../../reactivity/signals.js';
 import {createFunctionImplementation, FunctionImplementation} from '../../../catalog/types.js';
@@ -487,3 +488,33 @@ export function createBasicCatalogFunctions(options?: {locale?: string}): Functi
  * These functions cover arithmetic, comparison, logic, string manipulation, validation, and formatting.
  */
 export const BASIC_FUNCTIONS: FunctionImplementation[] = createBasicCatalogFunctions();
+
+/**
+ * Implementation of the `@index` function.
+ * Returns the loop index offset from context.
+ */
+export const IndexApi = {
+  name: '@index',
+  returnType: 'number' as const,
+  schema: z.object({
+    offset: z.number().optional(),
+  }),
+};
+
+export const IndexImplementation = createFunctionImplementation(IndexApi, (args, context) => {
+  const offset = typeof args.offset === 'number' ? args.offset : 0;
+  let index = 0;
+  if (typeof (context as any).getIndex === 'function') {
+    index = (context as any).getIndex();
+  } else if (context.path) {
+    const parts = context.path.split('/').filter(Boolean);
+    for (let i = parts.length - 1; i >= 0; i--) {
+      const num = parseInt(parts[i], 10);
+      if (!isNaN(num)) {
+        index = num;
+        break;
+      }
+    }
+  }
+  return index + offset;
+});

--- a/typescript/web_core/src/v1_0/functions/system_functions.ts
+++ b/typescript/web_core/src/v1_0/functions/system_functions.ts
@@ -15,6 +15,7 @@
  */
 
 import {z} from 'zod';
+import {createFunctionImplementation, FunctionImplementation} from '../../catalog/types.js';
 
 /**
  * Universal v1.0 system function to calculate the current 0-based iteration index in array contexts.
@@ -29,3 +30,29 @@ export const IndexApi = {
     'offset': z.coerce.number().optional(),
   }),
 };
+
+/**
+ * Implementation of the `@index` function.
+ * Returns the loop index offset from context.
+ */
+export const IndexImplementation = createFunctionImplementation(IndexApi, (args, context) => {
+  const offset = typeof args.offset === 'number' && Number.isFinite(args.offset) ? args.offset : 0;
+  let index = 0;
+  if (typeof (context as any)?.getIndex === 'function') {
+    index = (context as any).getIndex();
+  } else if (context?.path) {
+    const parts = context.path.split('/').filter(Boolean);
+    for (let i = parts.length - 1; i >= 0; i--) {
+      if (/^\d+$/.test(parts[i])) {
+        index = parseInt(parts[i], 10);
+        break;
+      }
+    }
+  }
+  return index + offset;
+});
+
+/**
+ * Standard v1.0 system function implementations.
+ */
+export const SYSTEM_FUNCTIONS: FunctionImplementation[] = [IndexImplementation];

--- a/typescript/web_core/src/v1_0/index.ts
+++ b/typescript/web_core/src/v1_0/index.ts
@@ -18,3 +18,4 @@ export * from './schema/index.js';
 export * from './functions/system_functions.js';
 export * from './functions/validation_functions_api.js';
 export * from './functions/validation_functions.js';
+export * from './rpc/rpc-handler.js';

--- a/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
@@ -51,6 +51,7 @@ export class RpcError extends Error {
   ) {
     super(`[${code}] ${message}`);
     this.name = 'RpcError';
+    Object.setPrototypeOf(this, RpcError.prototype);
   }
 }
 
@@ -146,7 +147,14 @@ export class RpcHandler {
     const {call, catalogId, args} = callFunction;
 
     // 1. Resolve catalog (fallback to surface default catalog if catalogId is omitted)
-    const targetCatalogId = catalogId || context.surface.catalog.id;
+    const targetCatalogId = catalogId || context?.surface?.catalog?.id;
+    if (!targetCatalogId) {
+      return this.createResponseError(
+        functionCallId,
+        RpcErrorCode.INVALID_FUNCTION_CALL,
+        'No catalogId provided and surface catalog is unavailable.',
+      );
+    }
     const catalog = this.catalogs.find(c => c.id === targetCatalogId);
     if (!catalog) {
       return this.createResponseError(
@@ -285,7 +293,11 @@ export class RpcHandler {
     } else {
       call = functionCallIdOrCall;
       const opts = (callOrOptions as {functionCallId?: string; timeoutMs?: number}) ?? {};
-      functionCallId = opts.functionCallId ?? crypto.randomUUID();
+      functionCallId =
+        opts.functionCallId ??
+        (typeof globalThis.crypto?.randomUUID === 'function'
+          ? globalThis.crypto.randomUUID()
+          : `call-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`);
       effectiveTimeoutMs = opts.timeoutMs ?? this.defaultTimeoutMs;
     }
 

--- a/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import {Catalog, ComponentApi} from '../../catalog/types.js';
+import {Catalog} from '../../catalog/types.js';
 import {DataContext} from '../../rendering/data-context.js';
 import {isSignal, getValue} from '../../reactivity/signals.js';
+import {FunctionCall} from '../schema/common-types.js';
 import {
   CallRendererFunctionMessage,
   AgentFunctionResponseMessage,
@@ -27,14 +28,53 @@ import {
 } from '../schema/renderer-to-agent.js';
 
 /**
- * A callback function to emit outbound client messages to the agent.
+ * Standard error codes for A2UI RPC failures.
+ */
+export enum RpcErrorCode {
+  INVALID_FUNCTION_CALL = 'INVALID_FUNCTION_CALL',
+  EXECUTION_ERROR = 'EXECUTION_ERROR',
+  TIMEOUT = 'TIMEOUT',
+  CANCELLED = 'CANCELLED',
+  DISPOSED = 'DISPOSED',
+  DUPLICATE = 'DUPLICATE',
+  NO_LISTENER = 'NO_LISTENER',
+}
+
+/**
+ * Custom error class for A2UI RPC operation failures.
+ */
+export class RpcError extends Error {
+  constructor(
+    public readonly code: RpcErrorCode | string,
+    message: string,
+    public readonly functionCallId?: string,
+  ) {
+    super(`[${code}] ${message}`);
+    this.name = 'RpcError';
+  }
+}
+
+/**
+ * Callback function type receiving outbound renderer messages intended for the agent.
  */
 export type OutboundMessageListener = (
   message: RendererFunctionResponseMessage | CallAgentFunctionMessage,
-) => void;
+) => void | Promise<void>;
 
 /**
- * A pending agent function callback record.
+ * Options for configuring an RpcHandler instance.
+ */
+export interface RpcHandlerOptions {
+  /** Catalogs available for function resolution. */
+  catalogs: Catalog<any>[];
+  /** Listener receiving outbound renderer messages. Required for callAgentFunction. */
+  outboundListener?: OutboundMessageListener;
+  /** Default timeout in milliseconds for callAgentFunction requests (default: 30000ms). */
+  defaultTimeoutMs?: number;
+}
+
+/**
+ * Pending agent function callback record.
  */
 interface PendingAgentCall {
   resolve: (value: unknown) => void;
@@ -43,22 +83,37 @@ interface PendingAgentCall {
 
 /**
  * Manages bidirectional RPC function execution between renderer and server agent.
- *
- * @template T The concrete type of the ComponentApi.
  */
-export class RpcHandler<T extends ComponentApi> {
+export class RpcHandler {
+  private readonly catalogs: Catalog<any>[];
+  private readonly outboundListener?: OutboundMessageListener;
+  private readonly defaultTimeoutMs: number;
   private readonly pendingAgentCalls = new Map<string, PendingAgentCall>();
+  private isDisposed = false;
+
+  constructor(options: RpcHandlerOptions);
+  constructor(catalogs: Catalog<any>[], outboundListener?: OutboundMessageListener);
+  constructor(
+    optionsOrCatalogs: RpcHandlerOptions | Catalog<any>[],
+    outboundListener?: OutboundMessageListener,
+  ) {
+    if (Array.isArray(optionsOrCatalogs)) {
+      this.catalogs = optionsOrCatalogs;
+      this.outboundListener = outboundListener;
+      this.defaultTimeoutMs = 30000;
+    } else {
+      this.catalogs = optionsOrCatalogs.catalogs;
+      this.outboundListener = optionsOrCatalogs.outboundListener;
+      this.defaultTimeoutMs = optionsOrCatalogs.defaultTimeoutMs ?? 30000;
+    }
+  }
 
   /**
-   * Creates a new RpcHandler instance.
-   *
-   * @param catalogs The available catalogs for function lookup.
-   * @param outboundListener The listener receiving outbound renderer messages.
+   * Indicates whether this RpcHandler instance has been disposed.
    */
-  constructor(
-    private readonly catalogs: Catalog<T>[],
-    private readonly outboundListener?: OutboundMessageListener,
-  ) {}
+  get disposed(): boolean {
+    return this.isDisposed;
+  }
 
   /**
    * Executes a remote renderer function requested by the server agent.
@@ -72,10 +127,18 @@ export class RpcHandler<T extends ComponentApi> {
     context: DataContext,
     isUserActivated: boolean = false,
   ): Promise<RendererFunctionResponseMessage> {
+    if (this.isDisposed) {
+      return this.createResponseError(
+        message.callRendererFunction?.functionCallId ?? 'unknown',
+        RpcErrorCode.DISPOSED,
+        'RpcHandler has been disposed.',
+      );
+    }
+
     if (!message.callRendererFunction?.callFunction) {
       return this.createResponseError(
         message.callRendererFunction?.functionCallId ?? 'unknown',
-        'INVALID_FUNCTION_CALL',
+        RpcErrorCode.INVALID_FUNCTION_CALL,
         'Malformed message: missing callRendererFunction or callFunction.',
       );
     }
@@ -88,7 +151,7 @@ export class RpcHandler<T extends ComponentApi> {
     if (!catalog) {
       return this.createResponseError(
         functionCallId,
-        'INVALID_FUNCTION_CALL',
+        RpcErrorCode.INVALID_FUNCTION_CALL,
         `Catalog '${targetCatalogId}' not found.`,
       );
     }
@@ -98,7 +161,7 @@ export class RpcHandler<T extends ComponentApi> {
     if (!funcImpl) {
       return this.createResponseError(
         functionCallId,
-        'INVALID_FUNCTION_CALL',
+        RpcErrorCode.INVALID_FUNCTION_CALL,
         `Function '${call}' not found in catalog '${targetCatalogId}'.`,
       );
     }
@@ -108,7 +171,7 @@ export class RpcHandler<T extends ComponentApi> {
     if (boundary !== 'rendererOrAgent' && boundary !== 'agentOnly') {
       return this.createResponseError(
         functionCallId,
-        'INVALID_FUNCTION_CALL',
+        RpcErrorCode.INVALID_FUNCTION_CALL,
         `Function '${call}' cannot be called by agent (callableFrom is ${boundary}).`,
       );
     }
@@ -117,7 +180,7 @@ export class RpcHandler<T extends ComponentApi> {
     if (funcImpl.requiresUserActivation && !isUserActivated) {
       return this.createResponseError(
         functionCallId,
-        'INVALID_FUNCTION_CALL',
+        RpcErrorCode.INVALID_FUNCTION_CALL,
         `Function '${call}' requires user activation context to execute.`,
       );
     }
@@ -132,17 +195,16 @@ export class RpcHandler<T extends ComponentApi> {
       const errMsg = err instanceof Error ? err.message : String(err);
       return this.createResponseError(
         functionCallId,
-        'INVALID_FUNCTION_CALL',
+        RpcErrorCode.INVALID_FUNCTION_CALL,
         `Invalid function arguments for '${call}': ${errMsg}`,
       );
     }
 
     // 6. Execute function safely
-    let responseMsg: RendererFunctionResponseMessage;
     try {
       const rawResult = await Promise.resolve(funcImpl.execute(safeArgs, context));
       const result = isSignal(rawResult) ? getValue(rawResult) : rawResult;
-      responseMsg = {
+      return {
         version: 'v1.0',
         rendererFunctionResponse: {
           functionCallId,
@@ -151,22 +213,17 @@ export class RpcHandler<T extends ComponentApi> {
       };
     } catch (err: unknown) {
       const errMsg = err instanceof Error ? err.message : String(err);
-      responseMsg = {
+      return {
         version: 'v1.0',
         rendererFunctionResponse: {
           functionCallId,
           error: {
-            code: 'EXECUTION_ERROR',
+            code: RpcErrorCode.EXECUTION_ERROR,
             message: errMsg || 'An error occurred during function execution.',
           },
         },
       };
     }
-
-    if (this.outboundListener) {
-      this.outboundListener(responseMsg);
-    }
-    return responseMsg;
   }
 
   /**
@@ -182,7 +239,7 @@ export class RpcHandler<T extends ComponentApi> {
 
     this.pendingAgentCalls.delete(functionCallId);
     if (error) {
-      pending.reject(new Error(`[${error.code}] ${error.message}`));
+      pending.reject(new RpcError(error.code, error.message, functionCallId));
     } else {
       pending.resolve(value);
     }
@@ -192,38 +249,71 @@ export class RpcHandler<T extends ComponentApi> {
    * Invokes a remote function on the server agent from the renderer.
    *
    * @param surfaceId The ID of the surface requesting execution.
-   * @param functionCallId The unique identifier for this RPC call.
-   * @param call The function call details.
-   * @param timeoutMs Optional timeout duration in milliseconds.
+   * @param functionCallIdOrCall The unique ID or function call details.
+   * @param callOrOptions The function call details or invocation options.
+   * @param timeoutMs Optional timeout duration in milliseconds (legacy signature).
    * @returns A promise resolving to the agent function return value.
    */
   callAgentFunction(
     surfaceId: string,
-    functionCallId: string,
-    call: {call: string; catalogId?: string; args?: Record<string, unknown>},
+    functionCallIdOrCall: string | FunctionCall,
+    callOrOptions?: FunctionCall | {functionCallId?: string; timeoutMs?: number},
     timeoutMs?: number,
   ): Promise<unknown> {
+    if (this.isDisposed) {
+      return Promise.reject(
+        new RpcError(RpcErrorCode.DISPOSED, 'RpcHandler has been disposed.'),
+      );
+    }
+    if (!this.outboundListener) {
+      return Promise.reject(
+        new RpcError(
+          RpcErrorCode.NO_LISTENER,
+          'Cannot call agent function without outboundListener configured.',
+        ),
+      );
+    }
+
+    let functionCallId: string;
+    let call: FunctionCall;
+    let effectiveTimeoutMs: number;
+
+    if (typeof functionCallIdOrCall === 'string') {
+      functionCallId = functionCallIdOrCall;
+      call = callOrOptions as FunctionCall;
+      effectiveTimeoutMs = timeoutMs ?? this.defaultTimeoutMs;
+    } else {
+      call = functionCallIdOrCall;
+      const opts = (callOrOptions as {functionCallId?: string; timeoutMs?: number}) ?? {};
+      functionCallId = opts.functionCallId ?? crypto.randomUUID();
+      effectiveTimeoutMs = opts.timeoutMs ?? this.defaultTimeoutMs;
+    }
+
     return new Promise((resolve, reject) => {
       if (this.pendingAgentCalls.has(functionCallId)) {
         reject(
-          new Error(
-            `[DUPLICATE] A call with functionCallId '${functionCallId}' is already pending.`,
+          new RpcError(
+            RpcErrorCode.DUPLICATE,
+            `A call with functionCallId '${functionCallId}' is already pending.`,
+            functionCallId,
           ),
         );
         return;
       }
       let timer: ReturnType<typeof setTimeout> | undefined;
-      if (timeoutMs && timeoutMs > 0) {
+      if (effectiveTimeoutMs > 0) {
         timer = setTimeout(() => {
           if (this.pendingAgentCalls.has(functionCallId)) {
             this.pendingAgentCalls.delete(functionCallId);
             reject(
-              new Error(
-                `[TIMEOUT] Agent function call '${call.call}' timed out after ${timeoutMs}ms.`,
+              new RpcError(
+                RpcErrorCode.TIMEOUT,
+                `Agent function call '${call.call}' timed out after ${effectiveTimeoutMs}ms.`,
+                functionCallId,
               ),
             );
           }
-        }, timeoutMs);
+        }, effectiveTimeoutMs);
       }
 
       this.pendingAgentCalls.set(functionCallId, {
@@ -246,14 +336,19 @@ export class RpcHandler<T extends ComponentApi> {
         },
       };
 
-      if (this.outboundListener) {
-        try {
-          this.outboundListener(outboundMsg);
-        } catch (err) {
-          if (timer) clearTimeout(timer);
-          this.pendingAgentCalls.delete(functionCallId);
-          reject(err);
+      try {
+        const result = this.outboundListener!(outboundMsg);
+        if (result && typeof (result as any).catch === 'function') {
+          (result as Promise<void>).catch(err => {
+            if (timer) clearTimeout(timer);
+            this.pendingAgentCalls.delete(functionCallId);
+            reject(err);
+          });
         }
+      } catch (err) {
+        if (timer) clearTimeout(timer);
+        this.pendingAgentCalls.delete(functionCallId);
+        reject(err);
       }
     });
   }
@@ -262,28 +357,31 @@ export class RpcHandler<T extends ComponentApi> {
    * Disposes the RpcHandler and rejects all pending agent function calls.
    */
   dispose(): void {
+    if (this.isDisposed) return;
+    this.isDisposed = true;
     for (const [id, pending] of this.pendingAgentCalls.entries()) {
-      pending.reject(new Error(`[CANCELLED] RpcHandler disposed while call '${id}' was pending.`));
+      pending.reject(
+        new RpcError(
+          RpcErrorCode.CANCELLED,
+          `RpcHandler disposed while call '${id}' was pending.`,
+          id,
+        ),
+      );
     }
     this.pendingAgentCalls.clear();
   }
 
   private createResponseError(
     functionCallId: string,
-    code: string,
+    code: RpcErrorCode | string,
     message: string,
   ): RendererFunctionResponseMessage {
-    const responseMsg: RendererFunctionResponseMessage = {
+    return {
       version: 'v1.0',
       rendererFunctionResponse: {
         functionCallId,
         error: {code, message},
       },
     };
-
-    if (this.outboundListener) {
-      this.outboundListener(responseMsg);
-    }
-    return responseMsg;
   }
 }

--- a/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
@@ -103,9 +103,10 @@ export class RpcHandler {
       this.outboundListener = outboundListener;
       this.defaultTimeoutMs = 30000;
     } else {
-      this.catalogs = optionsOrCatalogs.catalogs;
-      this.outboundListener = optionsOrCatalogs.outboundListener;
-      this.defaultTimeoutMs = optionsOrCatalogs.defaultTimeoutMs ?? 30000;
+      const options = optionsOrCatalogs ?? {};
+      this.catalogs = options.catalogs ?? [];
+      this.outboundListener = options.outboundListener;
+      this.defaultTimeoutMs = options.defaultTimeoutMs ?? 30000;
     }
   }
 
@@ -128,6 +129,14 @@ export class RpcHandler {
     context: DataContext,
     isUserActivated: boolean = false,
   ): Promise<RendererFunctionResponseMessage> {
+    if (!message) {
+      return this.createResponseError(
+        'unknown',
+        RpcErrorCode.INVALID_FUNCTION_CALL,
+        'Inbound message is null or undefined.',
+      );
+    }
+
     if (this.isDisposed) {
       return this.createResponseError(
         message.callRendererFunction?.functionCallId ?? 'unknown',
@@ -240,7 +249,7 @@ export class RpcHandler {
    * @param message The inbound agentFunctionResponse message.
    */
   handleAgentFunctionResponse(message: AgentFunctionResponseMessage): void {
-    if (!message.agentFunctionResponse) return;
+    if (!message || !message.agentFunctionResponse) return;
     const {functionCallId, value, error} = message.agentFunctionResponse;
     const pending = this.pendingAgentCalls.get(functionCallId);
     if (!pending) return;
@@ -269,9 +278,7 @@ export class RpcHandler {
     timeoutMs?: number,
   ): Promise<unknown> {
     if (this.isDisposed) {
-      return Promise.reject(
-        new RpcError(RpcErrorCode.DISPOSED, 'RpcHandler has been disposed.'),
-      );
+      return Promise.reject(new RpcError(RpcErrorCode.DISPOSED, 'RpcHandler has been disposed.'));
     }
     if (!this.outboundListener) {
       return Promise.reject(
@@ -299,6 +306,12 @@ export class RpcHandler {
           ? globalThis.crypto.randomUUID()
           : `call-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`);
       effectiveTimeoutMs = opts.timeoutMs ?? this.defaultTimeoutMs;
+    }
+
+    if (!call || !call.call) {
+      return Promise.reject(
+        new RpcError(RpcErrorCode.INVALID_FUNCTION_CALL, 'Missing or invalid function call name.'),
+      );
     }
 
     return new Promise((resolve, reject) => {

--- a/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Catalog, ComponentApi} from '../../catalog/types.js';
+import {DataContext} from '../../rendering/data-context.js';
+import {isSignal, getValue} from '../../reactivity/signals.js';
+import {
+  CallRendererFunctionMessage,
+  AgentFunctionResponseMessage,
+} from '../schema/agent-to-renderer.js';
+import {
+  RendererFunctionResponseMessage,
+  CallAgentFunctionMessage,
+} from '../schema/renderer-to-agent.js';
+
+/**
+ * A callback function to emit outbound client messages to the agent.
+ */
+export type OutboundMessageListener = (
+  message: RendererFunctionResponseMessage | CallAgentFunctionMessage,
+) => void;
+
+/**
+ * A pending agent function callback record.
+ */
+interface PendingAgentCall {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+}
+
+/**
+ * Manages bidirectional RPC function execution between renderer and server agent.
+ *
+ * @template T The concrete type of the ComponentApi.
+ */
+export class RpcHandler<T extends ComponentApi> {
+  private readonly pendingAgentCalls = new Map<string, PendingAgentCall>();
+
+  /**
+   * Creates a new RpcHandler instance.
+   *
+   * @param catalogs The available catalogs for function lookup.
+   * @param outboundListener The listener receiving outbound renderer messages.
+   */
+  constructor(
+    private readonly catalogs: Catalog<T>[],
+    private readonly outboundListener?: OutboundMessageListener,
+  ) {}
+
+  /**
+   * Executes a remote renderer function requested by the server agent.
+   *
+   * @param message The inbound callRendererFunction message.
+   * @param context The current DataContext for function execution.
+   * @param isUserActivated Whether execution occurs in an active user gesture context.
+   */
+  async handleCallRendererFunction(
+    message: CallRendererFunctionMessage,
+    context: DataContext,
+    isUserActivated: boolean = false,
+  ): Promise<RendererFunctionResponseMessage> {
+    if (!message.callRendererFunction?.callFunction) {
+      return this.createResponseError(
+        message.callRendererFunction?.functionCallId ?? 'unknown',
+        'INVALID_FUNCTION_CALL',
+        'Malformed message: missing callRendererFunction or callFunction.',
+      );
+    }
+    const {functionCallId, callFunction} = message.callRendererFunction;
+    const {call, catalogId, args} = callFunction;
+
+    // 1. Resolve catalog (fallback to surface default catalog if catalogId is omitted)
+    const targetCatalogId = catalogId || context.surface.catalog.id;
+    const catalog = this.catalogs.find(c => c.id === targetCatalogId);
+    if (!catalog) {
+      return this.createResponseError(
+        functionCallId,
+        'INVALID_FUNCTION_CALL',
+        `Catalog '${targetCatalogId}' not found.`,
+      );
+    }
+
+    // 2. Resolve function implementation
+    const funcImpl = catalog.functions?.get(call);
+    if (!funcImpl) {
+      return this.createResponseError(
+        functionCallId,
+        'INVALID_FUNCTION_CALL',
+        `Function '${call}' not found in catalog '${targetCatalogId}'.`,
+      );
+    }
+
+    // 3. Validate boundary execution constraint (callableFrom)
+    const boundary = funcImpl.callableFrom ?? 'rendererOnly';
+    if (boundary !== 'rendererOrAgent' && boundary !== 'agentOnly') {
+      return this.createResponseError(
+        functionCallId,
+        'INVALID_FUNCTION_CALL',
+        `Function '${call}' cannot be called by agent (callableFrom is ${boundary}).`,
+      );
+    }
+
+    // 4. Validate user activation constraint
+    if (funcImpl.requiresUserActivation && !isUserActivated) {
+      return this.createResponseError(
+        functionCallId,
+        'INVALID_FUNCTION_CALL',
+        `Function '${call}' requires user activation context to execute.`,
+      );
+    }
+
+    // 5. Enforce argument schema parsing
+    let safeArgs: Record<string, unknown>;
+    try {
+      safeArgs = funcImpl.schema
+        ? (funcImpl.schema.parse(args ?? {}) as Record<string, unknown>)
+        : (args ?? {});
+    } catch (err: unknown) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      return this.createResponseError(
+        functionCallId,
+        'INVALID_FUNCTION_CALL',
+        `Invalid function arguments for '${call}': ${errMsg}`,
+      );
+    }
+
+    // 6. Execute function safely
+    let responseMsg: RendererFunctionResponseMessage;
+    try {
+      const rawResult = await Promise.resolve(funcImpl.execute(safeArgs, context));
+      const result = isSignal(rawResult) ? getValue(rawResult) : rawResult;
+      responseMsg = {
+        version: 'v1.0',
+        rendererFunctionResponse: {
+          functionCallId,
+          value: result !== undefined ? result : null,
+        },
+      };
+    } catch (err: unknown) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      responseMsg = {
+        version: 'v1.0',
+        rendererFunctionResponse: {
+          functionCallId,
+          error: {
+            code: 'EXECUTION_ERROR',
+            message: errMsg || 'An error occurred during function execution.',
+          },
+        },
+      };
+    }
+
+    if (this.outboundListener) {
+      this.outboundListener(responseMsg);
+    }
+    return responseMsg;
+  }
+
+  /**
+   * Resolves a pending outbound callAgentFunction request upon receiving agentFunctionResponse.
+   *
+   * @param message The inbound agentFunctionResponse message.
+   */
+  handleAgentFunctionResponse(message: AgentFunctionResponseMessage): void {
+    if (!message.agentFunctionResponse) return;
+    const {functionCallId, value, error} = message.agentFunctionResponse;
+    const pending = this.pendingAgentCalls.get(functionCallId);
+    if (!pending) return;
+
+    this.pendingAgentCalls.delete(functionCallId);
+    if (error) {
+      pending.reject(new Error(`[${error.code}] ${error.message}`));
+    } else {
+      pending.resolve(value);
+    }
+  }
+
+  /**
+   * Invokes a remote function on the server agent from the renderer.
+   *
+   * @param surfaceId The ID of the surface requesting execution.
+   * @param functionCallId The unique identifier for this RPC call.
+   * @param call The function call details.
+   * @param timeoutMs Optional timeout duration in milliseconds.
+   * @returns A promise resolving to the agent function return value.
+   */
+  callAgentFunction(
+    surfaceId: string,
+    functionCallId: string,
+    call: {call: string; catalogId?: string; args?: Record<string, unknown>},
+    timeoutMs?: number,
+  ): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      if (this.pendingAgentCalls.has(functionCallId)) {
+        reject(
+          new Error(
+            `[DUPLICATE] A call with functionCallId '${functionCallId}' is already pending.`,
+          ),
+        );
+        return;
+      }
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      if (timeoutMs && timeoutMs > 0) {
+        timer = setTimeout(() => {
+          if (this.pendingAgentCalls.has(functionCallId)) {
+            this.pendingAgentCalls.delete(functionCallId);
+            reject(
+              new Error(
+                `[TIMEOUT] Agent function call '${call.call}' timed out after ${timeoutMs}ms.`,
+              ),
+            );
+          }
+        }, timeoutMs);
+      }
+
+      this.pendingAgentCalls.set(functionCallId, {
+        resolve: val => {
+          if (timer) clearTimeout(timer);
+          resolve(val);
+        },
+        reject: err => {
+          if (timer) clearTimeout(timer);
+          reject(err);
+        },
+      });
+
+      const outboundMsg: CallAgentFunctionMessage = {
+        version: 'v1.0',
+        callAgentFunction: {
+          surfaceId,
+          functionCallId,
+          callFunction: call,
+        },
+      };
+
+      if (this.outboundListener) {
+        try {
+          this.outboundListener(outboundMsg);
+        } catch (err) {
+          if (timer) clearTimeout(timer);
+          this.pendingAgentCalls.delete(functionCallId);
+          reject(err);
+        }
+      }
+    });
+  }
+
+  /**
+   * Disposes the RpcHandler and rejects all pending agent function calls.
+   */
+  dispose(): void {
+    for (const [id, pending] of this.pendingAgentCalls.entries()) {
+      pending.reject(new Error(`[CANCELLED] RpcHandler disposed while call '${id}' was pending.`));
+    }
+    this.pendingAgentCalls.clear();
+  }
+
+  private createResponseError(
+    functionCallId: string,
+    code: string,
+    message: string,
+  ): RendererFunctionResponseMessage {
+    const responseMsg: RendererFunctionResponseMessage = {
+      version: 'v1.0',
+      rendererFunctionResponse: {
+        functionCallId,
+        error: {code, message},
+      },
+    };
+
+    if (this.outboundListener) {
+      this.outboundListener(responseMsg);
+    }
+    return responseMsg;
+  }
+}

--- a/typescript/web_core/src/v1_0/rpc/rpc.test.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc.test.ts
@@ -201,8 +201,10 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
         },
       });
 
-      handler.callAgentFunction('s1', {call: 'testFunc'});
+      const callPromise = handler.callAgentFunction('s1', {call: 'testFunc'});
       assert.ok(emittedMsg.callAgentFunction.functionCallId.startsWith('call-'));
+      handler.dispose();
+      await assert.rejects(callPromise, /CANCELLED/);
     } finally {
       if (originalCrypto) {
         Object.defineProperty(globalThis, 'crypto', originalCrypto);

--- a/typescript/web_core/src/v1_0/rpc/rpc.test.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc.test.ts
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {describe, it} from 'node:test';
+import * as assert from 'node:assert';
+import {z} from 'zod';
+import {RpcHandler} from './rpc-handler.js';
+import {
+  Catalog,
+  createFunctionImplementation,
+} from '../../catalog/types.js';
+import {DataContext} from '../../rendering/data-context.js';
+import {SurfaceModel} from '../../state/surface-model.js';
+import {IndexImplementation} from '../../v0_9/basic_catalog/functions/basic_functions.js';
+
+describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', () => {
+  const customRpcApi = {
+    name: 'customRpc',
+    returnType: 'string' as const,
+    schema: z.object({text: z.string()}),
+    callableFrom: 'rendererOrAgent' as const,
+  };
+  const customRpcImpl = createFunctionImplementation(
+    customRpcApi,
+    args => `Processed: ${args.text}`,
+  );
+
+  const rendererOnlyApi = {
+    name: 'internalRenderer',
+    returnType: 'void' as const,
+    schema: z.object({}),
+    callableFrom: 'rendererOnly' as const,
+  };
+  const rendererOnlyImpl = createFunctionImplementation(rendererOnlyApi, () => {});
+
+  const restrictedApi = {
+    name: 'userActionOnly',
+    returnType: 'boolean' as const,
+    schema: z.object({}),
+    callableFrom: 'rendererOrAgent' as const,
+    requiresUserActivation: true,
+  };
+  const restrictedImpl = createFunctionImplementation(restrictedApi, () => true);
+
+  const mockCatalog = new Catalog(
+    'basic',
+    [],
+    [customRpcImpl, rendererOnlyImpl, restrictedImpl, IndexImplementation],
+  );
+
+  it('executes valid callRendererFunction remote RPC and returns value payload', async () => {
+    const handler = new RpcHandler([mockCatalog]);
+    const surface = new SurfaceModel('s1', mockCatalog);
+    const context = new DataContext(surface, '/');
+
+    const message = {
+      version: 'v1.0' as const,
+      callRendererFunction: {
+        functionCallId: 'rpc-1',
+        callFunction: {
+          call: 'customRpc',
+          catalogId: 'basic',
+          args: {text: 'Hello A2UI'},
+        },
+      },
+    };
+
+    const response = await handler.handleCallRendererFunction(message, context, false);
+    assert.strictEqual(response.version, 'v1.0');
+    assert.strictEqual(response.rendererFunctionResponse.functionCallId, 'rpc-1');
+    assert.strictEqual(response.rendererFunctionResponse.value, 'Processed: Hello A2UI');
+    assert.strictEqual(response.rendererFunctionResponse.error, undefined);
+  });
+
+  it('rejects callRendererFunction targeting rendererOnly function with INVALID_FUNCTION_CALL', async () => {
+    const handler = new RpcHandler([mockCatalog]);
+    const surface = new SurfaceModel('s1', mockCatalog);
+    const context = new DataContext(surface, '/');
+
+    const message = {
+      version: 'v1.0' as const,
+      callRendererFunction: {
+        functionCallId: 'rpc-2',
+        callFunction: {
+          call: 'internalRenderer',
+          catalogId: 'basic',
+        },
+      },
+    };
+
+    const response = await handler.handleCallRendererFunction(message, context, false);
+    assert.strictEqual(response.rendererFunctionResponse.functionCallId, 'rpc-2');
+    assert.strictEqual(response.rendererFunctionResponse.value, undefined);
+    assert.strictEqual(response.rendererFunctionResponse.error?.code, 'INVALID_FUNCTION_CALL');
+  });
+
+  it('rejects function call requiring user activation when isUserActivated is false', async () => {
+    const handler = new RpcHandler([mockCatalog]);
+    const surface = new SurfaceModel('s1', mockCatalog);
+    const context = new DataContext(surface, '/');
+
+    const message = {
+      version: 'v1.0' as const,
+      callRendererFunction: {
+        functionCallId: 'rpc-3',
+        callFunction: {
+          call: 'userActionOnly',
+          catalogId: 'basic',
+        },
+      },
+    };
+
+    const response = await handler.handleCallRendererFunction(message, context, false);
+    assert.strictEqual(response.rendererFunctionResponse.error?.code, 'INVALID_FUNCTION_CALL');
+
+    const authorizedResponse = await handler.handleCallRendererFunction(message, context, true);
+    assert.strictEqual(authorizedResponse.rendererFunctionResponse.value, true);
+  });
+
+  it('tracks outbound callAgentFunction and resolves promise via handleAgentFunctionResponse', async () => {
+    let emittedMessage: any;
+    const handler = new RpcHandler([mockCatalog], msg => {
+      emittedMessage = msg;
+    });
+
+    const callPromise = handler.callAgentFunction('surface-1', 'agent-call-100', {
+      call: 'fetchRemoteData',
+      catalogId: 'basic',
+      args: {query: 'test'},
+    });
+
+    assert.strictEqual(emittedMessage.version, 'v1.0');
+    assert.strictEqual(emittedMessage.callAgentFunction.functionCallId, 'agent-call-100');
+
+    handler.handleAgentFunctionResponse({
+      version: 'v1.0',
+      agentFunctionResponse: {
+        functionCallId: 'agent-call-100',
+        value: {items: [1, 2, 3]},
+      },
+    });
+
+    const result = await callPromise;
+    assert.deepStrictEqual(result, {items: [1, 2, 3]});
+  });
+
+  it('evaluates @index function returning loop index from nested DataContext path with offset', () => {
+    const surface = new SurfaceModel('s1', mockCatalog);
+    const context = new DataContext(surface, '/items/3/user/address');
+    const indexValue = IndexImplementation.execute({offset: 1}, context);
+    assert.strictEqual(indexValue, 4);
+  });
+
+  it('rejects pending agent function calls when RpcHandler is disposed', async () => {
+    const handler = new RpcHandler([mockCatalog]);
+    const promise = handler.callAgentFunction('surface-1', 'pending-1', {
+      call: 'slowFunc',
+    });
+    handler.dispose();
+    await assert.rejects(promise, /CANCELLED/);
+  });
+
+  it('times out callAgentFunction when timeoutMs is exceeded', async () => {
+    const handler = new RpcHandler([mockCatalog]);
+    const promise = handler.callAgentFunction(
+      'surface-1',
+      'pending-timeout',
+      {call: 'timeoutFunc'},
+      10,
+    );
+    await assert.rejects(promise, /TIMEOUT/);
+  });
+
+  it('falls back to surface default catalog when catalogId is omitted', async () => {
+    const handler = new RpcHandler([mockCatalog]);
+    const surface = new SurfaceModel('s1', mockCatalog);
+    const dataContext = new DataContext(surface, '/');
+
+    const res = await handler.handleCallRendererFunction(
+      {
+        version: 'v1.0',
+        callRendererFunction: {
+          functionCallId: 'call-default-cat',
+          callFunction: {
+            call: 'customRpc',
+            catalogId: 'basic',
+            args: {text: 'hello'},
+          },
+        },
+      },
+      dataContext,
+      true,
+    );
+
+    assert.strictEqual(res.rendererFunctionResponse.value, 'Processed: hello');
+  });
+
+  it('rejects callRendererFunction with INVALID_FUNCTION_CALL when argument schema validation fails', async () => {
+    const handler = new RpcHandler([mockCatalog]);
+    const surface = new SurfaceModel('s1', mockCatalog);
+    const dataContext = new DataContext(surface, '/');
+
+    const res = await handler.handleCallRendererFunction(
+      {
+        version: 'v1.0',
+        callRendererFunction: {
+          functionCallId: 'call-invalid-args',
+          callFunction: {
+            call: 'customRpc',
+            catalogId: 'basic',
+            args: {text: 12345}, // Number instead of expected string
+          },
+        },
+      },
+      dataContext,
+      true,
+    );
+
+    assert.ok(res.rendererFunctionResponse.error);
+    assert.strictEqual(res.rendererFunctionResponse.error.code, 'INVALID_FUNCTION_CALL');
+  });
+
+  it('cleans up pending agent call when outboundListener throws', async () => {
+    const handler = new RpcHandler([mockCatalog], () => {
+      throw new Error('Connection failed');
+    });
+
+    await assert.rejects(
+      handler.callAgentFunction('surface-1', 'fail-outbound', {call: 'testFunc'}),
+      /Connection failed/,
+    );
+  });
+});

--- a/typescript/web_core/src/v1_0/rpc/rpc.test.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc.test.ts
@@ -17,7 +17,7 @@
 import {describe, it} from 'node:test';
 import * as assert from 'node:assert';
 import {z} from 'zod';
-import {RpcHandler} from './rpc-handler.js';
+import {RpcHandler, RpcError, RpcErrorCode} from './rpc-handler.js';
 import {
   Catalog,
   createFunctionImplementation,
@@ -61,8 +61,16 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     [customRpcImpl, rendererOnlyImpl, restrictedImpl, IndexImplementation],
   );
 
+  it('instantiates via options bag RpcHandlerOptions', () => {
+    const handler = new RpcHandler({
+      catalogs: [mockCatalog],
+      defaultTimeoutMs: 5000,
+    });
+    assert.strictEqual(handler.disposed, false);
+  });
+
   it('executes valid callRendererFunction remote RPC and returns value payload', async () => {
-    const handler = new RpcHandler([mockCatalog]);
+    const handler = new RpcHandler({catalogs: [mockCatalog]});
     const surface = new SurfaceModel('s1', mockCatalog);
     const context = new DataContext(surface, '/');
 
@@ -104,7 +112,7 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     const response = await handler.handleCallRendererFunction(message, context, false);
     assert.strictEqual(response.rendererFunctionResponse.functionCallId, 'rpc-2');
     assert.strictEqual(response.rendererFunctionResponse.value, undefined);
-    assert.strictEqual(response.rendererFunctionResponse.error?.code, 'INVALID_FUNCTION_CALL');
+    assert.strictEqual(response.rendererFunctionResponse.error?.code, RpcErrorCode.INVALID_FUNCTION_CALL);
   });
 
   it('rejects function call requiring user activation when isUserActivated is false', async () => {
@@ -124,7 +132,7 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     };
 
     const response = await handler.handleCallRendererFunction(message, context, false);
-    assert.strictEqual(response.rendererFunctionResponse.error?.code, 'INVALID_FUNCTION_CALL');
+    assert.strictEqual(response.rendererFunctionResponse.error?.code, RpcErrorCode.INVALID_FUNCTION_CALL);
 
     const authorizedResponse = await handler.handleCallRendererFunction(message, context, true);
     assert.strictEqual(authorizedResponse.rendererFunctionResponse.value, true);
@@ -132,8 +140,11 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
 
   it('tracks outbound callAgentFunction and resolves promise via handleAgentFunctionResponse', async () => {
     let emittedMessage: any;
-    const handler = new RpcHandler([mockCatalog], msg => {
-      emittedMessage = msg;
+    const handler = new RpcHandler({
+      catalogs: [mockCatalog],
+      outboundListener: msg => {
+        emittedMessage = msg;
+      },
     });
 
     const callPromise = handler.callAgentFunction('surface-1', 'agent-call-100', {
@@ -165,23 +176,83 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
   });
 
   it('rejects pending agent function calls when RpcHandler is disposed', async () => {
-    const handler = new RpcHandler([mockCatalog]);
+    const handler = new RpcHandler({
+      catalogs: [mockCatalog],
+      outboundListener: () => {},
+    });
     const promise = handler.callAgentFunction('surface-1', 'pending-1', {
       call: 'slowFunc',
     });
     handler.dispose();
-    await assert.rejects(promise, /CANCELLED/);
+    assert.strictEqual(handler.disposed, true);
+    await assert.rejects(promise, (err: any) => {
+      assert.ok(err instanceof RpcError);
+      assert.strictEqual(err.code, RpcErrorCode.CANCELLED);
+      return true;
+    });
+  });
+
+  it('fails fast on post-disposal calls', async () => {
+    const handler = new RpcHandler({
+      catalogs: [mockCatalog],
+      outboundListener: () => {},
+    });
+    handler.dispose();
+
+    const surface = new SurfaceModel('s1', mockCatalog);
+    const context = new DataContext(surface, '/');
+    const response = await handler.handleCallRendererFunction(
+      {
+        version: 'v1.0',
+        callRendererFunction: {
+          functionCallId: 'call-post-dispose',
+          callFunction: {call: 'customRpc', catalogId: 'basic', args: {text: 'hi'}},
+        },
+      },
+      context,
+      true,
+    );
+
+    assert.strictEqual(response.rendererFunctionResponse.error?.code, RpcErrorCode.DISPOSED);
+
+    await assert.rejects(
+      handler.callAgentFunction('surface-1', {call: 'test'}),
+      (err: any) => {
+        assert.ok(err instanceof RpcError);
+        assert.strictEqual(err.code, RpcErrorCode.DISPOSED);
+        return true;
+      },
+    );
+  });
+
+  it('fails fast when calling callAgentFunction without outboundListener', async () => {
+    const handler = new RpcHandler({catalogs: [mockCatalog]});
+    await assert.rejects(
+      handler.callAgentFunction('surface-1', {call: 'test'}),
+      (err: any) => {
+        assert.ok(err instanceof RpcError);
+        assert.strictEqual(err.code, RpcErrorCode.NO_LISTENER);
+        return true;
+      },
+    );
   });
 
   it('times out callAgentFunction when timeoutMs is exceeded', async () => {
-    const handler = new RpcHandler([mockCatalog]);
+    const handler = new RpcHandler({
+      catalogs: [mockCatalog],
+      outboundListener: () => {},
+    });
     const promise = handler.callAgentFunction(
       'surface-1',
       'pending-timeout',
       {call: 'timeoutFunc'},
       10,
     );
-    await assert.rejects(promise, /TIMEOUT/);
+    await assert.rejects(promise, (err: any) => {
+      assert.ok(err instanceof RpcError);
+      assert.strictEqual(err.code, RpcErrorCode.TIMEOUT);
+      return true;
+    });
   });
 
   it('falls back to surface default catalog when catalogId is omitted', async () => {
@@ -230,7 +301,7 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     );
 
     assert.ok(res.rendererFunctionResponse.error);
-    assert.strictEqual(res.rendererFunctionResponse.error.code, 'INVALID_FUNCTION_CALL');
+    assert.strictEqual(res.rendererFunctionResponse.error.code, RpcErrorCode.INVALID_FUNCTION_CALL);
   });
 
   it('cleans up pending agent call when outboundListener throws', async () => {

--- a/typescript/web_core/src/v1_0/rpc/rpc.test.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc.test.ts
@@ -173,6 +173,41 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     const context = new DataContext(surface, '/items/3/user/address');
     const indexValue = IndexImplementation.execute({offset: 1}, context);
     assert.strictEqual(indexValue, 4);
+
+    // Alphanumeric segment starting with digit should be ignored
+    const context2 = new DataContext(surface, '/order_99/items/2');
+    const indexValue2 = IndexImplementation.execute({offset: 0}, context2);
+    assert.strictEqual(indexValue2, 2);
+
+    // Schema coercion parses string offsets and falls back safely on NaN
+    const parsedArgs = IndexImplementation.schema?.parse({offset: '5'});
+    const indexValue3 = IndexImplementation.execute(parsedArgs, context2);
+    assert.strictEqual(indexValue3, 7);
+  });
+
+  it('generates fallback call function ID when globalThis.crypto is unavailable', async () => {
+    const originalCrypto = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
+    try {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: undefined,
+        configurable: true,
+        writable: true,
+      });
+      let emittedMsg: any;
+      const handler = new RpcHandler({
+        catalogs: [mockCatalog],
+        outboundListener: msg => {
+          emittedMsg = msg;
+        },
+      });
+
+      handler.callAgentFunction('s1', {call: 'testFunc'});
+      assert.ok(emittedMsg.callAgentFunction.functionCallId.startsWith('call-'));
+    } finally {
+      if (originalCrypto) {
+        Object.defineProperty(globalThis, 'crypto', originalCrypto);
+      }
+    }
   });
 
   it('rejects pending agent function calls when RpcHandler is disposed', async () => {

--- a/typescript/web_core/src/v1_0/rpc/rpc.test.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc.test.ts
@@ -18,10 +18,7 @@ import {describe, it} from 'node:test';
 import * as assert from 'node:assert';
 import {z} from 'zod';
 import {RpcHandler, RpcError, RpcErrorCode} from './rpc-handler.js';
-import {
-  Catalog,
-  createFunctionImplementation,
-} from '../../catalog/types.js';
+import {Catalog, createFunctionImplementation} from '../../catalog/types.js';
 import {DataContext} from '../../rendering/data-context.js';
 import {SurfaceModel} from '../../state/surface-model.js';
 import {IndexImplementation} from '../../v0_9/basic_catalog/functions/basic_functions.js';
@@ -112,7 +109,10 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     const response = await handler.handleCallRendererFunction(message, context, false);
     assert.strictEqual(response.rendererFunctionResponse.functionCallId, 'rpc-2');
     assert.strictEqual(response.rendererFunctionResponse.value, undefined);
-    assert.strictEqual(response.rendererFunctionResponse.error?.code, RpcErrorCode.INVALID_FUNCTION_CALL);
+    assert.strictEqual(
+      response.rendererFunctionResponse.error?.code,
+      RpcErrorCode.INVALID_FUNCTION_CALL,
+    );
   });
 
   it('rejects function call requiring user activation when isUserActivated is false', async () => {
@@ -132,7 +132,10 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     };
 
     const response = await handler.handleCallRendererFunction(message, context, false);
-    assert.strictEqual(response.rendererFunctionResponse.error?.code, RpcErrorCode.INVALID_FUNCTION_CALL);
+    assert.strictEqual(
+      response.rendererFunctionResponse.error?.code,
+      RpcErrorCode.INVALID_FUNCTION_CALL,
+    );
 
     const authorizedResponse = await handler.handleCallRendererFunction(message, context, true);
     assert.strictEqual(authorizedResponse.rendererFunctionResponse.value, true);
@@ -252,26 +255,20 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
 
     assert.strictEqual(response.rendererFunctionResponse.error?.code, RpcErrorCode.DISPOSED);
 
-    await assert.rejects(
-      handler.callAgentFunction('surface-1', {call: 'test'}),
-      (err: any) => {
-        assert.ok(err instanceof RpcError);
-        assert.strictEqual(err.code, RpcErrorCode.DISPOSED);
-        return true;
-      },
-    );
+    await assert.rejects(handler.callAgentFunction('surface-1', {call: 'test'}), (err: any) => {
+      assert.ok(err instanceof RpcError);
+      assert.strictEqual(err.code, RpcErrorCode.DISPOSED);
+      return true;
+    });
   });
 
   it('fails fast when calling callAgentFunction without outboundListener', async () => {
     const handler = new RpcHandler({catalogs: [mockCatalog]});
-    await assert.rejects(
-      handler.callAgentFunction('surface-1', {call: 'test'}),
-      (err: any) => {
-        assert.ok(err instanceof RpcError);
-        assert.strictEqual(err.code, RpcErrorCode.NO_LISTENER);
-        return true;
-      },
-    );
+    await assert.rejects(handler.callAgentFunction('surface-1', {call: 'test'}), (err: any) => {
+      assert.ok(err instanceof RpcError);
+      assert.strictEqual(err.code, RpcErrorCode.NO_LISTENER);
+      return true;
+    });
   });
 
   it('times out callAgentFunction when timeoutMs is exceeded', async () => {
@@ -350,5 +347,36 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
       handler.callAgentFunction('surface-1', 'fail-outbound', {call: 'testFunc'}),
       /Connection failed/,
     );
+  });
+
+  it('rejects callAgentFunction when function call or call name is missing', async () => {
+    const handler = new RpcHandler([mockCatalog], () => {});
+    await assert.rejects(
+      handler.callAgentFunction('surface-1', 'call-1', undefined as any),
+      (err: RpcError) => err.code === RpcErrorCode.INVALID_FUNCTION_CALL,
+    );
+  });
+
+  it('handles null/undefined message gracefully in handleCallRendererFunction', async () => {
+    const handler = new RpcHandler([mockCatalog]);
+    const surface = new SurfaceModel('s1', mockCatalog);
+    const dataContext = new DataContext(surface, '/');
+    const res = await handler.handleCallRendererFunction(null as any, dataContext);
+    assert.strictEqual(
+      res.rendererFunctionResponse.error?.code,
+      RpcErrorCode.INVALID_FUNCTION_CALL,
+    );
+  });
+
+  it('handles null/undefined message gracefully in handleAgentFunctionResponse', () => {
+    const handler = new RpcHandler([mockCatalog]);
+    assert.doesNotThrow(() => {
+      handler.handleAgentFunctionResponse(null as any);
+    });
+  });
+
+  it('handles null/undefined options in RpcHandler constructor', () => {
+    const handler = new RpcHandler(null as any);
+    assert.strictEqual(handler.disposed, false);
   });
 });

--- a/typescript/web_core/src/v1_0/rpc/rpc.test.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc.test.ts
@@ -21,7 +21,7 @@ import {RpcHandler, RpcError, RpcErrorCode} from './rpc-handler.js';
 import {Catalog, createFunctionImplementation} from '../../catalog/types.js';
 import {DataContext} from '../../rendering/data-context.js';
 import {SurfaceModel} from '../../state/surface-model.js';
-import {IndexImplementation} from '../../v0_9/basic_catalog/functions/basic_functions.js';
+import {IndexImplementation} from '../functions/system_functions.js';
 
 describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', () => {
   const customRpcApi = {

--- a/typescript/web_core/src/v1_0/schema/agent-to-renderer.ts
+++ b/typescript/web_core/src/v1_0/schema/agent-to-renderer.ts
@@ -17,13 +17,7 @@
 // AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 // Generated from specification/v1_0/json/ via scripts/generate-zod-schemas.mjs
 import {z} from 'zod';
-import {
-  CallIdSchema,
-  ComponentCommonSchema,
-  ExtensionsSchema,
-  FunctionCallSchema,
-  FunctionResponseSchema,
-} from './common-types.js';
+import {CallIdSchema, ComponentCommonSchema, ExtensionsSchema, FunctionCallSchema, FunctionResponseSchema} from './common-types.js';
 
 /** Zod schema validating any component payload in a v1.0 message (excluding Surface). */
 export const AnyComponentSchema = ComponentCommonSchema.extend({
@@ -40,134 +34,29 @@ export type AnyComponent = z.infer<typeof AnyComponentSchema>;
 export const ComponentsListSchema = z.array(AnyComponentSchema).min(1);
 export type ComponentsList = z.infer<typeof ComponentsListSchema>;
 
-export const CreateSurfaceMessageSchema = z
-  .object({
-    'version': z.literal('v1.0'),
-    'createSurface': z
-      .object({
-        'surfaceId': z
-          .string()
-          .describe(
-            "The unique identifier for the UI surface to be rendered. It must be globally unique for the renderer's lifetime.",
-          ),
-        'catalogId': z
-          .string()
-          .describe(
-            "A string that uniquely identifies the default catalog for this surface. It is recommended to prefix this with an internet domain that you own, to avoid conflicts e.g. 'mycompany.com:somecatalog'. Components and function calls that do not explicitly specify a catalogId will use this surface-level default catalogId.",
-          )
-          .optional(),
-        'sendDataModel': z
-          .boolean()
-          .describe(
-            'If true, the renderer will send the full data model of this surface in the metadata of every A2A message sent to the agent that created the surface. Defaults to false.',
-          )
-          .optional(),
-        'components': ComponentsListSchema.optional(),
-        'dataModel': z
-          .record(z.string(), z.any())
-          .describe('The initial root data model object for the surface.')
-          .optional(),
-        'metadata': z
-          .object({'extensions': ExtensionsSchema.optional()})
-          .strict()
-          .describe('Optional surface-level metadata.')
-          .optional(),
-      })
-      .strict()
-      .describe(
-        "Signals the renderer to create a new surface and begin rendering it. Creating a surface implicitly instantiates the canonical 'Surface' container component ('common_types.json#/$defs/Surface') with 'child': 'root'. It is an error to try to create a surface with an existing ID without first deleting it; surfaceId MUST be globally unique for the renderer's lifetime. When this message is sent, the renderer expects 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId to define the component tree.",
-      ),
-  })
-  .strict();
-export type CreateSurfaceMessage = z.infer<typeof CreateSurfaceMessageSchema>;
+export const CreateSurfaceMessageSchema = z.object({ "version": z.literal("v1.0"), "createSurface": z.object({ "surfaceId": z.string().describe("The unique identifier for the UI surface to be rendered. It must be globally unique for the renderer's lifetime."), "catalogId": z.string().describe("A string that uniquely identifies the default catalog for this surface. It is recommended to prefix this with an internet domain that you own, to avoid conflicts e.g. 'mycompany.com:somecatalog'. Components and function calls that do not explicitly specify a catalogId will use this surface-level default catalogId.").optional(), "sendDataModel": z.boolean().describe("If true, the renderer will send the full data model of this surface in the metadata of every A2A message sent to the agent that created the surface. Defaults to false.").optional(), "components": ComponentsListSchema.optional(), "dataModel": z.record(z.string(), z.any()).describe("The initial root data model object for the surface.").optional(), "metadata": z.object({ "extensions": ExtensionsSchema.optional() }).strict().describe("Optional surface-level metadata.").optional() }).strict().describe("Signals the renderer to create a new surface and begin rendering it. Creating a surface implicitly instantiates the canonical 'Surface' container component ('common_types.json#/$defs/Surface') with 'child': 'root'. It is an error to try to create a surface with an existing ID without first deleting it; surfaceId MUST be globally unique for the renderer's lifetime. When this message is sent, the renderer expects 'updateComponents' and/or 'updateDataModel' messages for the same surfaceId to define the component tree.") }).strict()
+export type CreateSurfaceMessage = z.infer<typeof CreateSurfaceMessageSchema>
 
-export const UpdateComponentsMessageSchema = z
-  .object({
-    'version': z.literal('v1.0'),
-    'updateComponents': z
-      .object({
-        'surfaceId': z
-          .string()
-          .describe(
-            "The unique identifier for the UI surface to be updated. It must be globally unique for the renderer's lifetime.",
-          ),
-        'components': ComponentsListSchema,
-      })
-      .strict()
-      .describe(
-        "Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. The createSurface message MUST have been previously sent for this surfaceId.",
-      ),
-  })
-  .strict();
-export type UpdateComponentsMessage = z.infer<typeof UpdateComponentsMessageSchema>;
 
-export const UpdateDataModelMessageSchema = z
-  .object({
-    'version': z.literal('v1.0'),
-    'updateDataModel': z
-      .object({
-        'surfaceId': z
-          .string()
-          .describe(
-            "The unique identifier for the UI surface this data model update applies to. It must be globally unique for the renderer's lifetime.",
-          ),
-        'path': z
-          .string()
-          .describe(
-            "An optional path to a location within the data model (e.g., '/user/name'). If omitted, or set to '/', refers to the entire data model.",
-          )
-          .optional(),
-        'value': z
-          .any()
-          .describe(
-            "The data to be updated in the data model. To delete the key/value at 'path', set 'value' explicitly to null.",
-          ),
-      })
-      .strict()
-      .describe(
-        'Updates the data model for an existing surface. This message can be sent multiple times to update the data model. The createSurface message MUST have been previously sent for this surfaceId.',
-      ),
-  })
-  .strict();
-export type UpdateDataModelMessage = z.infer<typeof UpdateDataModelMessageSchema>;
+export const UpdateComponentsMessageSchema = z.object({ "version": z.literal("v1.0"), "updateComponents": z.object({ "surfaceId": z.string().describe("The unique identifier for the UI surface to be updated. It must be globally unique for the renderer's lifetime."), "components": ComponentsListSchema }).strict().describe("Updates a surface with a new set of components. This message can be sent multiple times to update the component tree of an existing surface. One of the components in one of the components lists MUST have an 'id' of 'root' to serve as the root of the component tree. The createSurface message MUST have been previously sent for this surfaceId.") }).strict()
+export type UpdateComponentsMessage = z.infer<typeof UpdateComponentsMessageSchema>
 
-export const DeleteSurfaceMessageSchema = z
-  .object({
-    'version': z.literal('v1.0'),
-    'deleteSurface': z
-      .object({
-        'surfaceId': z
-          .string()
-          .describe(
-            "The unique identifier for the UI surface to be deleted. It must be globally unique for the renderer's lifetime.",
-          ),
-      })
-      .strict()
-      .describe(
-        "Signals the renderer to delete the surface identified by 'surfaceId'. The createSurface message MUST have been previously sent for this surfaceId.",
-      ),
-  })
-  .strict();
-export type DeleteSurfaceMessage = z.infer<typeof DeleteSurfaceMessageSchema>;
 
-export const CallRendererFunctionMessageSchema = z
-  .object({
-    'version': z.literal('v1.0'),
-    'callRendererFunction': z
-      .object({
-        'functionCallId': CallIdSchema,
-        'callFunction': z.intersection(FunctionCallSchema, z.any()),
-      })
-      .strict()
-      .describe('Signals the renderer to execute a function locally on behalf of the agent.'),
-  })
-  .strict();
-export type CallRendererFunctionMessage = z.infer<typeof CallRendererFunctionMessageSchema>;
+export const UpdateDataModelMessageSchema = z.object({ "version": z.literal("v1.0"), "updateDataModel": z.object({ "surfaceId": z.string().describe("The unique identifier for the UI surface this data model update applies to. It must be globally unique for the renderer's lifetime."), "path": z.string().describe("An optional path to a location within the data model (e.g., '/user/name'). If omitted, or set to '/', refers to the entire data model.").optional(), "value": z.any().describe("The data to be updated in the data model. To delete the key/value at 'path', set 'value' explicitly to null.") }).strict().describe("Updates the data model for an existing surface. This message can be sent multiple times to update the data model. The createSurface message MUST have been previously sent for this surfaceId.") }).strict()
+export type UpdateDataModelMessage = z.infer<typeof UpdateDataModelMessageSchema>
 
-export const AgentFunctionResponseMessageSchema = z
-  .object({'version': z.literal('v1.0'), 'agentFunctionResponse': FunctionResponseSchema})
-  .strict();
-export type AgentFunctionResponseMessage = z.infer<typeof AgentFunctionResponseMessageSchema>;
+
+export const DeleteSurfaceMessageSchema = z.object({ "version": z.literal("v1.0"), "deleteSurface": z.object({ "surfaceId": z.string().describe("The unique identifier for the UI surface to be deleted. It must be globally unique for the renderer's lifetime.") }).strict().describe("Signals the renderer to delete the surface identified by 'surfaceId'. The createSurface message MUST have been previously sent for this surfaceId.") }).strict()
+export type DeleteSurfaceMessage = z.infer<typeof DeleteSurfaceMessageSchema>
+
+
+export const CallRendererFunctionMessageSchema = z.object({ "version": z.literal("v1.0"), "callRendererFunction": z.object({ "functionCallId": CallIdSchema, "callFunction": z.intersection(FunctionCallSchema, z.any()) }).strict().describe("Signals the renderer to execute a function locally on behalf of the agent.") }).strict()
+export type CallRendererFunctionMessage = z.infer<typeof CallRendererFunctionMessageSchema>
+
+
+export const AgentFunctionResponseMessageSchema = z.object({ "version": z.literal("v1.0"), "agentFunctionResponse": FunctionResponseSchema }).strict()
+export type AgentFunctionResponseMessage = z.infer<typeof AgentFunctionResponseMessageSchema>
+
 
 /** Union schema validating any incoming v1.0 agent-to-renderer message envelope. */
 export const AgentToRendererMessageSchema = z.union([

--- a/typescript/web_core/src/v1_0/schema/catalog-definition.ts
+++ b/typescript/web_core/src/v1_0/schema/catalog-definition.ts
@@ -19,174 +19,55 @@
 import {z} from 'zod';
 import {ExtensionsSchema} from './common-types.js';
 
-export const FunctionCallValidationSchemaSchema = z
-  .record(z.string(), z.any())
-  .and(
-    z.any().superRefine((x, ctx) => {
-      const schemas = [
-        z.object({
-          'type': z.literal('object'),
-          'description': z.string().optional(),
-          'properties': z
-            .object({
-              'call': z.object({'const': z.string()}),
-              'catalogId': z
-                .record(z.string(), z.any())
-                .describe('Optional catalog ID override for this function call.')
-                .optional(),
-              'args': z
-                .record(z.string(), z.any())
-                .describe(
-                  'A JSON Schema describing the expected arguments (args) for this function.',
-                )
-                .optional(),
-            })
-            .strict(),
-          'required': z.array(z.string()),
-          'unevaluatedProperties': z.boolean().optional(),
-          'additionalProperties': z.boolean().optional(),
-        }),
-        z.object({
-          'type': z.literal('object'),
-          'description': z.string().optional(),
-          'allOf': z.array(z.record(z.string(), z.any())).min(1),
-          'unevaluatedProperties': z.boolean().optional(),
-          'additionalProperties': z.boolean().optional(),
-        }),
-      ];
-      const {errors, failed} = schemas.reduce<{
-        errors: z.ZodIssue[];
-        failed: number;
-      }>(
-        ({errors, failed}, schema) =>
-          (result =>
-            result.error
-              ? {
-                  errors: [...errors, ...result.error.issues],
-                  failed: failed + 1,
-                }
-              : {errors, failed})(schema.safeParse(x)),
-        {errors: [], failed: 0},
-      );
-      const passed = schemas.length - failed;
-      if (passed !== 1) {
-        ctx.addIssue(
-          errors.length
+export const FunctionCallValidationSchemaSchema = z.record(z.string(), z.any()).and(z.any().superRefine((x, ctx) => {
+    const schemas = [z.object({ "type": z.literal("object"), "description": z.string().optional(), "properties": z.object({ "call": z.object({ "const": z.string() }), "catalogId": z.record(z.string(), z.any()).describe("Optional catalog ID override for this function call.").optional(), "args": z.record(z.string(), z.any()).describe("A JSON Schema describing the expected arguments (args) for this function.").optional() }).strict(), "required": z.array(z.string()), "unevaluatedProperties": z.boolean().optional(), "additionalProperties": z.boolean().optional() }), z.object({ "type": z.literal("object"), "description": z.string().optional(), "allOf": z.array(z.record(z.string(), z.any())).min(1), "unevaluatedProperties": z.boolean().optional(), "additionalProperties": z.boolean().optional() })];
+    const { errors, failed } = schemas.reduce<{
+      errors: z.ZodIssue[];
+      failed: number;
+    }>(
+      ({ errors, failed }, schema) =>
+        ((result) =>
+          result.error
             ? {
-                path: [],
-                code: 'invalid_union',
-                errors: [errors],
-                message: 'Invalid input: Should pass single schema. Passed ' + passed,
+                errors: [...errors, ...result.error.issues],
+                failed: failed + 1,
               }
-            : ({
-                path: [],
-                code: 'custom',
-                errors: [errors],
-                message: 'Invalid input: Should pass single schema. Passed ' + passed,
-              } as any),
-        );
-      }
-    }),
-  )
-  .describe('JSON Schema structure that validates a wire-level FunctionCall object.');
-export type FunctionCallValidationSchema = z.infer<typeof FunctionCallValidationSchemaSchema>;
+            : { errors, failed })(
+          schema.safeParse(x),
+        ),
+      { errors: [], failed: 0 },
+    );
+    const passed = schemas.length - failed;
+    if (passed !== 1) {
+      ctx.addIssue(errors.length ? {
+        path: [],
+        code: "invalid_union",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } : {
+        path: [],
+        code: "custom",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } as any);
+    }
+  })).describe("JSON Schema structure that validates a wire-level FunctionCall object.")
+export type FunctionCallValidationSchema = z.infer<typeof FunctionCallValidationSchemaSchema>
 
 export type FunctionCallValidationSchemaInput = z.input<typeof FunctionCallValidationSchemaSchema>;
 
-export const FunctionDefinitionSchema = z
-  .record(z.string(), z.any())
-  .and(
-    z.intersection(
-      FunctionCallValidationSchemaSchema,
-      z.intersection(
-        z.object({
-          'returnType': z
-            .enum([
-              'string',
-              'number',
-              'boolean',
-              'array',
-              'object',
-              'validationResult',
-              'any',
-              'void',
-            ])
-            .describe('The type of value this function returns.'),
-          'callableFrom': z
-            .enum(['rendererOnly', 'agentOnly', 'rendererOrAgent'])
-            .describe('Specifies where this function can be invoked from.')
-            .default('rendererOnly'),
-          'requiresUserActivation': z
-            .boolean()
-            .describe(
-              'Specifies whether this function requires a user activation context to execute.',
-            )
-            .default(false),
-        }),
-        z.any(),
-      ),
-    ),
-  )
-  .describe("Describes a function's validation schema and interface metadata.");
-export type FunctionDefinition = z.infer<typeof FunctionDefinitionSchema>;
+export const FunctionDefinitionSchema = z.record(z.string(), z.any()).and(z.intersection(FunctionCallValidationSchemaSchema, z.intersection(z.object({ "returnType": z.enum(["string","number","boolean","array","object","validationResult","any","void"]).describe("The type of value this function returns."), "callableFrom": z.enum(["rendererOnly","agentOnly","rendererOrAgent"]).describe("Specifies where this function can be invoked from.").default("rendererOnly"), "requiresUserActivation": z.boolean().describe("Specifies whether this function requires a user activation context to execute.").default(false) }), z.any()))).describe("Describes a function's validation schema and interface metadata.")
+export type FunctionDefinition = z.infer<typeof FunctionDefinitionSchema>
 
 export type FunctionDefinitionInput = z.input<typeof FunctionDefinitionSchema>;
 
-export const ComponentDefinitionSchema = z
-  .record(z.string(), z.any())
-  .and(
-    z.intersection(
-      z.any(),
-      z.object({
-        'allowedParents': z
-          .array(z.string())
-          .refine(
-            arr => arr.every((item, i) => arr.indexOf(item) === i),
-            'All items must be unique!',
-          )
-          .describe(
-            'The list of parent component type names that can contain this component type. If omitted, all parent component types are allowed. To restrict a component so it can appear only as the top-level component (id=\'root\') of a surface, set "allowedParents": ["Surface"]. To allow a component as either the top-level component of a surface or a child of a specific container, specify both (e.g., "allowedParents": ["Surface", "CanvasContainer"]).',
-          )
-          .optional(),
-        'allowedChildren': z
-          .array(z.string())
-          .refine(
-            arr => arr.every((item, i) => arr.indexOf(item) === i),
-            'All items must be unique!',
-          )
-          .describe(
-            'The list of child component type names allowed inside this container or slot. If omitted, all child component types are allowed.',
-          )
-          .optional(),
-        'metadata': z
-          .object({'extensions': ExtensionsSchema.optional()})
-          .strict()
-          .describe('Optional static metadata.')
-          .optional(),
-      }),
-    ),
-  )
-  .describe("Describes a component's validation schema and composition constraints.");
-export type ComponentDefinition = z.infer<typeof ComponentDefinitionSchema>;
+export const ComponentDefinitionSchema = z.record(z.string(), z.any()).and(z.intersection(z.any(), z.object({ "allowedParents": z.array(z.string()).refine((arr) => arr.every((item, i) => arr.indexOf(item) === i), "All items must be unique!").describe("The list of parent component type names that can contain this component type. If omitted, all parent component types are allowed. To restrict a component so it can appear only as the top-level component (id='root') of a surface, set \"allowedParents\": [\"Surface\"]. To allow a component as either the top-level component of a surface or a child of a specific container, specify both (e.g., \"allowedParents\": [\"Surface\", \"CanvasContainer\"]).").optional(), "allowedChildren": z.array(z.string()).refine((arr) => arr.every((item, i) => arr.indexOf(item) === i), "All items must be unique!").describe("The list of child component type names allowed inside this container or slot. If omitted, all child component types are allowed.").optional(), "metadata": z.object({ "extensions": ExtensionsSchema.optional() }).strict().describe("Optional static metadata.").optional() }))).describe("Describes a component's validation schema and composition constraints.")
+export type ComponentDefinition = z.infer<typeof ComponentDefinitionSchema>
 
 export type ComponentDefinitionInput = z.input<typeof ComponentDefinitionSchema>;
 
-export const ValidationResultSchema = z
-  .object({
-    'valid': z.boolean().describe('Whether the check passed.'),
-    'code': z
-      .string()
-      .describe('Machine-readable error code (e.g. EXPIRED_CARD, OUT_OF_RANGE).')
-      .optional(),
-    'message': z.string().describe('Human-readable error or warning message.').optional(),
-    'severity': z
-      .enum(['error', 'warning', 'info'])
-      .describe('Severity level of the validation result.')
-      .default('error'),
-  })
-  .describe(
-    'Dynamic validation result object returned by a validation condition function or data binding.',
-  );
-export type ValidationResult = z.infer<typeof ValidationResultSchema>;
+export const ValidationResultSchema = z.object({ "valid": z.boolean().describe("Whether the check passed."), "code": z.string().describe("Machine-readable error code (e.g. EXPIRED_CARD, OUT_OF_RANGE).").optional(), "message": z.string().describe("Human-readable error or warning message.").optional(), "severity": z.enum(["error","warning","info"]).describe("Severity level of the validation result.").default("error") }).describe("Dynamic validation result object returned by a validation condition function or data binding.")
+export type ValidationResult = z.infer<typeof ValidationResultSchema>
 
 export type ValidationResultInput = z.input<typeof ValidationResultSchema>;
+

--- a/typescript/web_core/src/v1_0/schema/common-types.ts
+++ b/typescript/web_core/src/v1_0/schema/common-types.ts
@@ -18,616 +18,438 @@
 // Generated from specification/v1_0/json/ via scripts/generate-zod-schemas.mjs
 import {z} from 'zod';
 
-export const ComponentIdSchema = z
-  .string()
-  .describe(
-    'The unique identifier for a component, used for both definitions and references within the same surface.',
-  );
-export type ComponentId = z.infer<typeof ComponentIdSchema>;
+export const ComponentIdSchema = z.string().describe("The unique identifier for a component, used for both definitions and references within the same surface.")
+export type ComponentId = z.infer<typeof ComponentIdSchema>
 
-export const CallIdSchema = z.string().describe('The unique identifier for a function call.');
-export type CallId = z.infer<typeof CallIdSchema>;
 
-export const DataBindingSchema = z
-  .object({'path': z.string().describe('A JSON Pointer path to a value in the data model.')})
-  .strict();
-export type DataBinding = z.infer<typeof DataBindingSchema>;
+export const CallIdSchema = z.string().describe("The unique identifier for a function call.")
+export type CallId = z.infer<typeof CallIdSchema>
 
-export const DynamicValueSchema = z
-  .any()
-  .superRefine((x, ctx) => {
-    const schemas = [
-      z.string(),
-      z.number(),
-      z.boolean(),
-      z.array(z.any()),
-      z.record(z.string(), z.any()).refine(obj => !obj || (!('path' in obj) && !('call' in obj))),
-      DataBindingSchema,
-      z.lazy(() => FunctionCallSchema),
-    ];
-    const {errors, failed} = schemas.reduce<{
+
+export const DataBindingSchema = z.object({ "path": z.string().describe("A JSON Pointer path to a value in the data model.") }).strict()
+export type DataBinding = z.infer<typeof DataBindingSchema>
+
+
+export const DynamicValueSchema = z.any().superRefine((x, ctx) => {
+    const schemas = [z.string(), z.number(), z.boolean(), z.array(z.any()), z.record(z.string(), z.any()).refine((obj) => !obj || (!('path' in obj) && !('call' in obj))), DataBindingSchema, z.lazy(() => FunctionCallSchema)];
+    const { errors, failed } = schemas.reduce<{
       errors: z.ZodIssue[];
       failed: number;
     }>(
-      ({errors, failed}, schema) =>
-        (result =>
+      ({ errors, failed }, schema) =>
+        ((result) =>
           result.error
             ? {
                 errors: [...errors, ...result.error.issues],
                 failed: failed + 1,
               }
-            : {errors, failed})(schema.safeParse(x)),
-      {errors: [], failed: 0},
+            : { errors, failed })(
+          schema.safeParse(x),
+        ),
+      { errors: [], failed: 0 },
     );
     const passed = schemas.length - failed;
     if (passed !== 1) {
-      ctx.addIssue(
-        errors.length
-          ? {
-              path: [],
-              code: 'invalid_union',
-              errors: [errors],
-              message: 'Invalid input: Should pass single schema. Passed ' + passed,
-            }
-          : ({
-              path: [],
-              code: 'custom',
-              errors: [errors],
-              message: 'Invalid input: Should pass single schema. Passed ' + passed,
-            } as any),
-      );
+      ctx.addIssue(errors.length ? {
+        path: [],
+        code: "invalid_union",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } : {
+        path: [],
+        code: "custom",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } as any);
     }
-  })
-  .describe('A value that can be a literal, a path, or a function call returning any type.');
-export type DynamicValue = z.infer<typeof DynamicValueSchema>;
+  }).describe("A value that can be a literal, a path, or a function call returning any type.")
+export type DynamicValue = z.infer<typeof DynamicValueSchema>
 
-export const DynamicNumberSchema = z
-  .any()
-  .superRefine((x, ctx) => {
+
+export const DynamicNumberSchema = z.any().superRefine((x, ctx) => {
     const schemas = [z.number(), DataBindingSchema, FunctionCallSchema];
-    const {errors, failed} = schemas.reduce<{
+    const { errors, failed } = schemas.reduce<{
       errors: z.ZodIssue[];
       failed: number;
     }>(
-      ({errors, failed}, schema) =>
-        (result =>
+      ({ errors, failed }, schema) =>
+        ((result) =>
           result.error
             ? {
                 errors: [...errors, ...result.error.issues],
                 failed: failed + 1,
               }
-            : {errors, failed})(schema.safeParse(x)),
-      {errors: [], failed: 0},
+            : { errors, failed })(
+          schema.safeParse(x),
+        ),
+      { errors: [], failed: 0 },
     );
     const passed = schemas.length - failed;
     if (passed !== 1) {
-      ctx.addIssue(
-        errors.length
-          ? {
-              path: [],
-              code: 'invalid_union',
-              errors: [errors],
-              message: 'Invalid input: Should pass single schema. Passed ' + passed,
-            }
-          : ({
-              path: [],
-              code: 'custom',
-              errors: [errors],
-              message: 'Invalid input: Should pass single schema. Passed ' + passed,
-            } as any),
-      );
+      ctx.addIssue(errors.length ? {
+        path: [],
+        code: "invalid_union",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } : {
+        path: [],
+        code: "custom",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } as any);
     }
-  })
-  .describe(
-    'Represents a value that can be either a literal number, a path to a number in the data model, or a function call returning a number.',
-  );
-export type DynamicNumber = z.infer<typeof DynamicNumberSchema>;
+  }).describe("Represents a value that can be either a literal number, a path to a number in the data model, or a function call returning a number.")
+export type DynamicNumber = z.infer<typeof DynamicNumberSchema>
 
-export const IndexSystemFunctionSchema = z
-  .object({
-    'call': z.literal('@index'),
-    'args': z.object({'offset': DynamicNumberSchema.optional()}).optional(),
-  })
-  .describe(
-    'Returns the 0-based index of the current item when rendering a dynamic list from a template. This function MUST ONLY be available when evaluating template items within a list context.',
-  );
-export type IndexSystemFunction = z.infer<typeof IndexSystemFunctionSchema>;
 
-export const FunctionCallSchema = z
-  .object({
-    'call': z.string().describe('The name of the function to call.'),
-    'catalogId': z
-      .string()
-      .describe('The catalog ID for this function, overriding any surface-level default catalogId.')
-      .optional(),
-    'args': z
-      .record(
-        z.string(),
-        z.union([
-          DynamicValueSchema,
-          z.record(z.string(), z.any()).describe('A literal object argument (e.g. configuration).'),
-        ]),
-      )
-      .describe('Arguments passed to the function.')
-      .optional(),
-  })
-  .and(
-    z.any().superRefine((x, ctx) => {
-      const schemas = [FunctionCallSchema, IndexSystemFunctionSchema];
-      const {errors, failed} = schemas.reduce<{
-        errors: z.ZodIssue[];
-        failed: number;
-      }>(
-        ({errors, failed}, schema) =>
-          (result =>
-            result.error
-              ? {
-                  errors: [...errors, ...result.error.issues],
-                  failed: failed + 1,
-                }
-              : {errors, failed})(schema.safeParse(x)),
-        {errors: [], failed: 0},
-      );
-      const passed = schemas.length - failed;
-      if (passed !== 1) {
-        ctx.addIssue(
-          errors.length
+export const IndexSystemFunctionSchema = z.object({ "call": z.literal("@index"), "args": z.object({ "offset": DynamicNumberSchema.optional() }).optional() }).describe("Returns the 0-based index of the current item when rendering a dynamic list from a template. This function MUST ONLY be available when evaluating template items within a list context.")
+export type IndexSystemFunction = z.infer<typeof IndexSystemFunctionSchema>
+
+
+export const FunctionCallSchema = z.object({ "call": z.string().describe("The name of the function to call."), "catalogId": z.string().describe("The catalog ID for this function, overriding any surface-level default catalogId.").optional(), "args": z.record(z.string(), z.union([DynamicValueSchema, z.record(z.string(), z.any()).describe("A literal object argument (e.g. configuration).")])).describe("Arguments passed to the function.").optional() }).and(z.any().superRefine((x, ctx) => {
+    const schemas = [FunctionCallSchema, IndexSystemFunctionSchema];
+    const { errors, failed } = schemas.reduce<{
+      errors: z.ZodIssue[];
+      failed: number;
+    }>(
+      ({ errors, failed }, schema) =>
+        ((result) =>
+          result.error
             ? {
-                path: [],
-                code: 'invalid_union',
-                errors: [errors],
-                message: 'Invalid input: Should pass single schema. Passed ' + passed,
+                errors: [...errors, ...result.error.issues],
+                failed: failed + 1,
               }
-            : ({
-                path: [],
-                code: 'custom',
-                errors: [errors],
-                message: 'Invalid input: Should pass single schema. Passed ' + passed,
-              } as any),
-        );
-      }
-    }),
-  )
-  .describe('Invokes a named function.');
-export type FunctionCall = z.infer<typeof FunctionCallSchema>;
+            : { errors, failed })(
+          schema.safeParse(x),
+        ),
+      { errors: [], failed: 0 },
+    );
+    const passed = schemas.length - failed;
+    if (passed !== 1) {
+      ctx.addIssue(errors.length ? {
+        path: [],
+        code: "invalid_union",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } : {
+        path: [],
+        code: "custom",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } as any);
+    }
+  })).describe("Invokes a named function.")
+export type FunctionCall = z.infer<typeof FunctionCallSchema>
 
-export const DynamicStringSchema = z
-  .any()
-  .superRefine((x, ctx) => {
+
+export const DynamicStringSchema = z.any().superRefine((x, ctx) => {
     const schemas = [z.string(), DataBindingSchema, FunctionCallSchema];
-    const {errors, failed} = schemas.reduce<{
+    const { errors, failed } = schemas.reduce<{
       errors: z.ZodIssue[];
       failed: number;
     }>(
-      ({errors, failed}, schema) =>
-        (result =>
+      ({ errors, failed }, schema) =>
+        ((result) =>
           result.error
             ? {
                 errors: [...errors, ...result.error.issues],
                 failed: failed + 1,
               }
-            : {errors, failed})(schema.safeParse(x)),
-      {errors: [], failed: 0},
+            : { errors, failed })(
+          schema.safeParse(x),
+        ),
+      { errors: [], failed: 0 },
     );
     const passed = schemas.length - failed;
     if (passed !== 1) {
-      ctx.addIssue(
-        errors.length
-          ? {
-              path: [],
-              code: 'invalid_union',
-              errors: [errors],
-              message: 'Invalid input: Should pass single schema. Passed ' + passed,
-            }
-          : ({
-              path: [],
-              code: 'custom',
-              errors: [errors],
-              message: 'Invalid input: Should pass single schema. Passed ' + passed,
-            } as any),
-      );
+      ctx.addIssue(errors.length ? {
+        path: [],
+        code: "invalid_union",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } : {
+        path: [],
+        code: "custom",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } as any);
     }
-  })
-  .describe('Represents a string');
-export type DynamicString = z.infer<typeof DynamicStringSchema>;
+  }).describe("Represents a string")
+export type DynamicString = z.infer<typeof DynamicStringSchema>
 
-export const DynamicBooleanSchema = z
-  .any()
-  .superRefine((x, ctx) => {
+
+export const DynamicBooleanSchema = z.any().superRefine((x, ctx) => {
     const schemas = [z.boolean(), DataBindingSchema, FunctionCallSchema];
-    const {errors, failed} = schemas.reduce<{
+    const { errors, failed } = schemas.reduce<{
       errors: z.ZodIssue[];
       failed: number;
     }>(
-      ({errors, failed}, schema) =>
-        (result =>
+      ({ errors, failed }, schema) =>
+        ((result) =>
           result.error
             ? {
                 errors: [...errors, ...result.error.issues],
                 failed: failed + 1,
               }
-            : {errors, failed})(schema.safeParse(x)),
-      {errors: [], failed: 0},
+            : { errors, failed })(
+          schema.safeParse(x),
+        ),
+      { errors: [], failed: 0 },
     );
     const passed = schemas.length - failed;
     if (passed !== 1) {
-      ctx.addIssue(
-        errors.length
-          ? {
-              path: [],
-              code: 'invalid_union',
-              errors: [errors],
-              message: 'Invalid input: Should pass single schema. Passed ' + passed,
-            }
-          : ({
-              path: [],
-              code: 'custom',
-              errors: [errors],
-              message: 'Invalid input: Should pass single schema. Passed ' + passed,
-            } as any),
-      );
+      ctx.addIssue(errors.length ? {
+        path: [],
+        code: "invalid_union",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } : {
+        path: [],
+        code: "custom",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } as any);
     }
-  })
-  .describe(
-    'A boolean value that can be a literal, a path, or a function call returning a boolean.',
-  );
-export type DynamicBoolean = z.infer<typeof DynamicBooleanSchema>;
+  }).describe("A boolean value that can be a literal, a path, or a function call returning a boolean.")
+export type DynamicBoolean = z.infer<typeof DynamicBooleanSchema>
 
-export const AccessibilityAttributesSchema = z
-  .object({
-    'label': DynamicStringSchema.optional(),
-    'description': DynamicStringSchema.optional(),
-    'live': z
-      .enum(['off', 'polite', 'assertive'])
-      .describe(
-        "Controls screen reader announcements for dynamic updates (WAI-ARIA aria-live). 'polite' waits for user pause; 'assertive' interrupts immediately for alerts.",
-      )
-      .default('off'),
-    'hidden': DynamicBooleanSchema.optional(),
-  })
-  .strict()
-  .describe(
-    'Attributes to enhance accessibility when using assistive technologies like screen readers or model understanding.',
-  );
-export type AccessibilityAttributes = z.infer<typeof AccessibilityAttributesSchema>;
 
-export const ExtensionsSchema = z
-  .record(z.string(), z.union([z.any(), z.never()]))
-  .superRefine((value, ctx) => {
-    for (const key in value) {
-      let evaluated = false;
-      if (key.match(new RegExp('^[\\p{XID_Start}_][\\p{XID_Continue}]*$'))) {
-        evaluated = true;
-        const result = z.any().safeParse(value[key]);
-        if (!result.success) {
-          ctx.addIssue({
-            path: [key],
-            code: 'custom',
-            message: `Invalid input: Key matching regex /${key}/ must match schema`,
-            params: {
-              issues: result.error.issues,
-            },
-          });
-        }
-      }
-      if (!evaluated) {
-        const result = z.never().safeParse(value[key]);
-        if (!result.success) {
-          ctx.addIssue({
-            path: [key],
-            code: 'custom',
-            message: `Invalid input: must match catchall schema`,
-            params: {
-              issues: result.error.issues,
-            },
-          });
-        }
-      }
-    }
-  })
-  .describe(
-    "Optional extension metadata. Keys MUST be Unicode identifiers (UAX #31). Keys starting with 'a2ui_' are reserved for official extensions.",
-  );
-export type Extensions = z.infer<typeof ExtensionsSchema>;
+export const AccessibilityAttributesSchema = z.object({ "label": DynamicStringSchema.optional(), "description": DynamicStringSchema.optional(), "live": z.enum(["off","polite","assertive"]).describe("Controls screen reader announcements for dynamic updates (WAI-ARIA aria-live). 'polite' waits for user pause; 'assertive' interrupts immediately for alerts.").default("off"), "hidden": DynamicBooleanSchema.optional() }).strict().describe("Attributes to enhance accessibility when using assistive technologies like screen readers or model understanding.")
+export type AccessibilityAttributes = z.infer<typeof AccessibilityAttributesSchema>
 
-export const ComponentCommonSchema = z.object({
-  'id': ComponentIdSchema,
-  'catalogId': z
-    .string()
-    .describe('The catalog ID for this component, overriding any surface-level default catalogId.')
-    .optional(),
-  'accessibility': AccessibilityAttributesSchema.optional(),
-  'metadata': z
-    .object({'extensions': ExtensionsSchema.optional()})
-    .strict()
-    .describe('Optional component-level metadata for vendor extensions.')
-    .optional(),
-});
-export type ComponentCommon = z.infer<typeof ComponentCommonSchema>;
 
-export const ChildSchema = ComponentIdSchema;
-export type Child = z.infer<typeof ChildSchema>;
+export const ExtensionsSchema = z.record(z.string(), z.union([z.any(), z.never()])).superRefine((value, ctx) => {
+for (const key in value) {
+let evaluated = false
+if (key.match(new RegExp("^[\\p{XID_Start}_][\\p{XID_Continue}]*$"))) {
+evaluated = true
+const result = z.any().safeParse(value[key])
+if (!result.success) {
+ctx.addIssue({
+          path: [key],
+          code: 'custom',
+          message: `Invalid input: Key matching regex /${key}/ must match schema`,
+          params: {
+            issues: result.error.issues
+          }
+        })
+}
+}
+if (!evaluated) {
+const result = z.never().safeParse(value[key])
+if (!result.success) {
+ctx.addIssue({
+          path: [key],
+          code: 'custom',
+          message: `Invalid input: must match catchall schema`,
+          params: {
+            issues: result.error.issues
+          }
+        })
+}
+}
+}
+}).describe("Optional extension metadata. Keys MUST be Unicode identifiers (UAX #31). Keys starting with 'a2ui_' are reserved for official extensions.")
+export type Extensions = z.infer<typeof ExtensionsSchema>
+
+
+export const ComponentCommonSchema = z.object({ "id": ComponentIdSchema, "catalogId": z.string().describe("The catalog ID for this component, overriding any surface-level default catalogId.").optional(), "accessibility": AccessibilityAttributesSchema.optional(), "metadata": z.object({ "extensions": ExtensionsSchema.optional() }).strict().describe("Optional component-level metadata for vendor extensions.").optional() })
+export type ComponentCommon = z.infer<typeof ComponentCommonSchema>
+
+
+export const ChildSchema = ComponentIdSchema
+export type Child = z.infer<typeof ChildSchema>
+
 
 export const ChildListSchema = z.any().superRefine((x, ctx) => {
-  const schemas = [
-    z.array(ComponentIdSchema).describe('A static list of child component IDs.'),
-    z
-      .object({
-        'componentId': ComponentIdSchema,
-        'path': z
-          .string()
-          .describe('The path to the list of component property objects in the data model.'),
-      })
-      .strict()
-      .describe(
-        'A template for generating a dynamic list of children from a data model list. The `componentId` is the component to use as a template.',
-      ),
-  ];
-  const {errors, failed} = schemas.reduce<{
-    errors: z.ZodIssue[];
-    failed: number;
-  }>(
-    ({errors, failed}, schema) =>
-      (result =>
-        result.error
-          ? {
-              errors: [...errors, ...result.error.issues],
-              failed: failed + 1,
-            }
-          : {errors, failed})(schema.safeParse(x)),
-    {errors: [], failed: 0},
-  );
-  const passed = schemas.length - failed;
-  if (passed !== 1) {
-    ctx.addIssue(
-      errors.length
-        ? {
-            path: [],
-            code: 'invalid_union',
-            errors: [errors],
-            message: 'Invalid input: Should pass single schema. Passed ' + passed,
-          }
-        : ({
-            path: [],
-            code: 'custom',
-            errors: [errors],
-            message: 'Invalid input: Should pass single schema. Passed ' + passed,
-          } as any),
+    const schemas = [z.array(ComponentIdSchema).describe("A static list of child component IDs."), z.object({ "componentId": ComponentIdSchema, "path": z.string().describe("The path to the list of component property objects in the data model.") }).strict().describe("A template for generating a dynamic list of children from a data model list. The `componentId` is the component to use as a template.")];
+    const { errors, failed } = schemas.reduce<{
+      errors: z.ZodIssue[];
+      failed: number;
+    }>(
+      ({ errors, failed }, schema) =>
+        ((result) =>
+          result.error
+            ? {
+                errors: [...errors, ...result.error.issues],
+                failed: failed + 1,
+              }
+            : { errors, failed })(
+          schema.safeParse(x),
+        ),
+      { errors: [], failed: 0 },
     );
-  }
-});
-export type ChildList = z.infer<typeof ChildListSchema>;
+    const passed = schemas.length - failed;
+    if (passed !== 1) {
+      ctx.addIssue(errors.length ? {
+        path: [],
+        code: "invalid_union",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } : {
+        path: [],
+        code: "custom",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } as any);
+    }
+  })
+export type ChildList = z.infer<typeof ChildListSchema>
 
-export const DynamicStringListSchema = z
-  .any()
-  .superRefine((x, ctx) => {
+
+export const DynamicStringListSchema = z.any().superRefine((x, ctx) => {
     const schemas = [z.array(z.string()), DataBindingSchema, FunctionCallSchema];
-    const {errors, failed} = schemas.reduce<{
+    const { errors, failed } = schemas.reduce<{
       errors: z.ZodIssue[];
       failed: number;
     }>(
-      ({errors, failed}, schema) =>
-        (result =>
+      ({ errors, failed }, schema) =>
+        ((result) =>
           result.error
             ? {
                 errors: [...errors, ...result.error.issues],
                 failed: failed + 1,
               }
-            : {errors, failed})(schema.safeParse(x)),
-      {errors: [], failed: 0},
+            : { errors, failed })(
+          schema.safeParse(x),
+        ),
+      { errors: [], failed: 0 },
     );
     const passed = schemas.length - failed;
     if (passed !== 1) {
-      ctx.addIssue(
-        errors.length
-          ? {
-              path: [],
-              code: 'invalid_union',
-              errors: [errors],
-              message: 'Invalid input: Should pass single schema. Passed ' + passed,
-            }
-          : ({
-              path: [],
-              code: 'custom',
-              errors: [errors],
-              message: 'Invalid input: Should pass single schema. Passed ' + passed,
-            } as any),
-      );
+      ctx.addIssue(errors.length ? {
+        path: [],
+        code: "invalid_union",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } : {
+        path: [],
+        code: "custom",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } as any);
     }
-  })
-  .describe(
-    'Represents a value that can be either a literal array of strings, a path to a string array in the data model, or a function call returning a string array.',
-  );
-export type DynamicStringList = z.infer<typeof DynamicStringListSchema>;
+  }).describe("Represents a value that can be either a literal array of strings, a path to a string array in the data model, or a function call returning a string array.")
+export type DynamicStringList = z.infer<typeof DynamicStringListSchema>
 
-export const FunctionCommonSchema = z.object({
-  'catalogId': z
-    .string()
-    .describe('The catalog ID for this function, overriding any surface-level default catalogId.')
-    .optional(),
-});
-export type FunctionCommon = z.infer<typeof FunctionCommonSchema>;
 
-export const CheckRuleSchema = z
-  .object({
-    'condition': z
-      .any()
-      .superRefine((x, ctx) => {
-        const schemas = [DataBindingSchema, FunctionCallSchema];
-        const {errors, failed} = schemas.reduce<{
-          errors: z.ZodIssue[];
-          failed: number;
-        }>(
-          ({errors, failed}, schema) =>
-            (result =>
-              result.error
-                ? {
-                    errors: [...errors, ...result.error.issues],
-                    failed: failed + 1,
-                  }
-                : {errors, failed})(schema.safeParse(x)),
-          {errors: [], failed: 0},
-        );
-        const passed = schemas.length - failed;
-        if (passed !== 1) {
-          ctx.addIssue(
-            errors.length
-              ? {
-                  path: [],
-                  code: 'invalid_union',
-                  errors: [errors],
-                  message: 'Invalid input: Should pass single schema. Passed ' + passed,
-                }
-              : ({
-                  path: [],
-                  code: 'custom',
-                  errors: [errors],
-                  message: 'Invalid input: Should pass single schema. Passed ' + passed,
-                } as any),
-          );
-        }
-      })
-      .describe('Path or function call evaluating to a structured validation result object.'),
-    'message': z.string().describe('Optional fallback error message.').optional(),
-  })
-  .strict()
-  .describe(
-    'A single validation check rule applied to an input component. The condition function or path evaluates to a structured validation result object.',
-  );
-export type CheckRule = z.infer<typeof CheckRuleSchema>;
+export const FunctionCommonSchema = z.object({ "catalogId": z.string().describe("The catalog ID for this function, overriding any surface-level default catalogId.").optional() })
+export type FunctionCommon = z.infer<typeof FunctionCommonSchema>
 
-export const CheckableSchema = z
-  .object({
-    'checks': z
-      .array(CheckRuleSchema)
-      .describe(
-        'A list of checks to perform. These are function calls that must return a boolean indicating validity.',
-      )
-      .optional(),
-  })
-  .describe('Properties for components that support renderer-side checks.');
-export type Checkable = z.infer<typeof CheckableSchema>;
 
-export const ActionSchema = z
-  .any()
-  .superRefine((x, ctx) => {
-    const schemas = [
-      z
-        .object({
-          'event': z
-            .object({
-              'name': z.string().describe('The name of the action to be dispatched to the agent.'),
-              'userMessage': DynamicStringSchema.optional(),
-              'context': z
-                .record(z.string(), DynamicValueSchema)
-                .describe(
-                  'A JSON object containing the key-value pairs for the action context. Values can be literals or paths. Use literal values unless the value must be dynamically bound to the data model. Do NOT use paths for static IDs.',
-                )
-                .optional(),
-            })
-            .strict()
-            .describe('The event to dispatch to the agent.'),
-        })
-        .strict()
-        .describe('Triggers an agent-side event.'),
-      z
-        .object({'functionCall': FunctionCallSchema})
-        .strict()
-        .describe('Executes a renderer or agent-side function.'),
-    ];
-    const {errors, failed} = schemas.reduce<{
+export const CheckRuleSchema = z.object({ "condition": z.any().superRefine((x, ctx) => {
+    const schemas = [DataBindingSchema, FunctionCallSchema];
+    const { errors, failed } = schemas.reduce<{
       errors: z.ZodIssue[];
       failed: number;
     }>(
-      ({errors, failed}, schema) =>
-        (result =>
+      ({ errors, failed }, schema) =>
+        ((result) =>
           result.error
             ? {
                 errors: [...errors, ...result.error.issues],
                 failed: failed + 1,
               }
-            : {errors, failed})(schema.safeParse(x)),
-      {errors: [], failed: 0},
+            : { errors, failed })(
+          schema.safeParse(x),
+        ),
+      { errors: [], failed: 0 },
     );
     const passed = schemas.length - failed;
     if (passed !== 1) {
-      ctx.addIssue(
-        errors.length
-          ? {
-              path: [],
-              code: 'invalid_union',
-              errors: [errors],
-              message: 'Invalid input: Should pass single schema. Passed ' + passed,
-            }
-          : ({
-              path: [],
-              code: 'custom',
-              errors: [errors],
-              message: 'Invalid input: Should pass single schema. Passed ' + passed,
-            } as any),
-      );
+      ctx.addIssue(errors.length ? {
+        path: [],
+        code: "invalid_union",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } : {
+        path: [],
+        code: "custom",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } as any);
     }
-  })
-  .describe(
-    'Defines an interaction handler that can either trigger an agent-side event or execute a local renderer-side function.',
-  );
-export type Action = z.infer<typeof ActionSchema>;
+  }).describe("Path or function call evaluating to a structured validation result object."), "message": z.string().describe("Optional fallback error message.").optional() }).strict().describe("A single validation check rule applied to an input component. The condition function or path evaluates to a structured validation result object.")
+export type CheckRule = z.infer<typeof CheckRuleSchema>
 
-export const SurfaceSchema = z
-  .object({'component': z.literal('Surface').optional(), 'child': z.literal('root').optional()})
-  .strict()
-  .describe(
-    "The reserved canonical container component representing an A2UI surface. The Surface component is immutable and always has 'child': 'root'.",
-  );
-export type Surface = z.infer<typeof SurfaceSchema>;
 
-export const FunctionResponseSchema = z
-  .object({
-    'functionCallId': CallIdSchema,
-    'value': z.any().describe('The return value of the function.').optional(),
-    'error': z
-      .object({'code': z.string(), 'message': z.string()})
-      .strict()
-      .describe('An error object indicating failure of the function execution.')
-      .optional(),
-  })
-  .strict()
-  .and(
-    z.any().superRefine((x, ctx) => {
-      const schemas = [z.any(), z.any()];
-      const {errors, failed} = schemas.reduce<{
-        errors: z.ZodIssue[];
-        failed: number;
-      }>(
-        ({errors, failed}, schema) =>
-          (result =>
-            result.error
-              ? {
-                  errors: [...errors, ...result.error.issues],
-                  failed: failed + 1,
-                }
-              : {errors, failed})(schema.safeParse(x)),
-        {errors: [], failed: 0},
-      );
-      const passed = schemas.length - failed;
-      if (passed !== 1) {
-        ctx.addIssue(
-          errors.length
+export const CheckableSchema = z.object({ "checks": z.array(CheckRuleSchema).describe("A list of checks to perform. These are function calls that must return a boolean indicating validity.").optional() }).describe("Properties for components that support renderer-side checks.")
+export type Checkable = z.infer<typeof CheckableSchema>
+
+
+export const ActionSchema = z.any().superRefine((x, ctx) => {
+    const schemas = [z.object({ "event": z.object({ "name": z.string().describe("The name of the action to be dispatched to the agent."), "userMessage": DynamicStringSchema.optional(), "context": z.record(z.string(), DynamicValueSchema).describe("A JSON object containing the key-value pairs for the action context. Values can be literals or paths. Use literal values unless the value must be dynamically bound to the data model. Do NOT use paths for static IDs.").optional() }).strict().describe("The event to dispatch to the agent.") }).strict().describe("Triggers an agent-side event."), z.object({ "functionCall": FunctionCallSchema }).strict().describe("Executes a renderer or agent-side function.")];
+    const { errors, failed } = schemas.reduce<{
+      errors: z.ZodIssue[];
+      failed: number;
+    }>(
+      ({ errors, failed }, schema) =>
+        ((result) =>
+          result.error
             ? {
-                path: [],
-                code: 'invalid_union',
-                errors: [errors],
-                message: 'Invalid input: Should pass single schema. Passed ' + passed,
+                errors: [...errors, ...result.error.issues],
+                failed: failed + 1,
               }
-            : ({
-                path: [],
-                code: 'custom',
-                errors: [errors],
-                message: 'Invalid input: Should pass single schema. Passed ' + passed,
-              } as any),
-        );
-      }
-    }),
-  )
-  .describe('The return response matching a callAgentFunction or callRendererFunction invocation.');
-export type FunctionResponse = z.infer<typeof FunctionResponseSchema>;
+            : { errors, failed })(
+          schema.safeParse(x),
+        ),
+      { errors: [], failed: 0 },
+    );
+    const passed = schemas.length - failed;
+    if (passed !== 1) {
+      ctx.addIssue(errors.length ? {
+        path: [],
+        code: "invalid_union",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } : {
+        path: [],
+        code: "custom",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } as any);
+    }
+  }).describe("Defines an interaction handler that can either trigger an agent-side event or execute a local renderer-side function.")
+export type Action = z.infer<typeof ActionSchema>
+
+
+export const SurfaceSchema = z.object({ "component": z.literal("Surface").optional(), "child": z.literal("root").optional() }).strict().describe("The reserved canonical container component representing an A2UI surface. The Surface component is immutable and always has 'child': 'root'.")
+export type Surface = z.infer<typeof SurfaceSchema>
+
+
+export const FunctionResponseSchema = z.object({ "functionCallId": CallIdSchema, "value": z.any().describe("The return value of the function.").optional(), "error": z.object({ "code": z.string(), "message": z.string() }).strict().describe("An error object indicating failure of the function execution.").optional() }).strict().and(z.any().superRefine((x, ctx) => {
+    const schemas = [z.any(), z.any()];
+    const { errors, failed } = schemas.reduce<{
+      errors: z.ZodIssue[];
+      failed: number;
+    }>(
+      ({ errors, failed }, schema) =>
+        ((result) =>
+          result.error
+            ? {
+                errors: [...errors, ...result.error.issues],
+                failed: failed + 1,
+              }
+            : { errors, failed })(
+          schema.safeParse(x),
+        ),
+      { errors: [], failed: 0 },
+    );
+    const passed = schemas.length - failed;
+    if (passed !== 1) {
+      ctx.addIssue(errors.length ? {
+        path: [],
+        code: "invalid_union",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } : {
+        path: [],
+        code: "custom",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } as any);
+    }
+  })).describe("The return response matching a callAgentFunction or callRendererFunction invocation.")
+export type FunctionResponse = z.infer<typeof FunctionResponseSchema>
+
+

--- a/typescript/web_core/src/v1_0/schema/renderer-capabilities.ts
+++ b/typescript/web_core/src/v1_0/schema/renderer-capabilities.ts
@@ -19,27 +19,16 @@
 import {z} from 'zod';
 
 /** Zod schema validating the strict v1.0 protocol renderer capabilities payload. */
-export const V10RendererCapabilitiesSchema = z
-  .object({
-    supportedCatalogIds: z
-      .array(z.string())
-      .describe(
-        'An array of string identifiers for each of the component and function catalogs supported by the renderer.',
-      ),
-    inlineCatalogs: z
-      .array(z.record(z.string(), z.any()))
-      .describe('An array of inline catalog definitions.')
-      .optional(),
-  })
-  .strict();
+export const V10RendererCapabilitiesSchema = z.object({
+  supportedCatalogIds: z.array(z.string()).describe("An array of string identifiers for each of the component and function catalogs supported by the renderer."),
+  inlineCatalogs: z.array(z.record(z.string(), z.any())).describe("An array of inline catalog definitions.").optional(),
+}).strict();
 export type V10RendererCapabilities = z.infer<typeof V10RendererCapabilitiesSchema>;
 
 /** Zod schema validating multi-version renderer capabilities maps across protocol versions. */
-export const RendererCapabilitiesSchema = z
-  .object({
-    'v1.0': V10RendererCapabilitiesSchema.optional(),
-    supportedCatalogIds: z.array(z.string()).optional(),
-    inlineCatalogs: z.array(z.record(z.string(), z.any())).optional(),
-  })
-  .catchall(z.any());
+export const RendererCapabilitiesSchema = z.object({
+  "v1.0": V10RendererCapabilitiesSchema.optional(),
+  supportedCatalogIds: z.array(z.string()).optional(),
+  inlineCatalogs: z.array(z.record(z.string(), z.any())).optional(),
+}).catchall(z.any());
 export type RendererCapabilities = z.infer<typeof RendererCapabilitiesSchema>;

--- a/typescript/web_core/src/v1_0/schema/renderer-to-agent.ts
+++ b/typescript/web_core/src/v1_0/schema/renderer-to-agent.ts
@@ -17,213 +17,87 @@
 // AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 // Generated from specification/v1_0/json/ via scripts/generate-zod-schemas.mjs
 import {z} from 'zod';
-import {
-  CallIdSchema,
-  ExtensionsSchema,
-  FunctionCallSchema,
-  FunctionResponseSchema,
-} from './common-types.js';
+import {CallIdSchema, ExtensionsSchema, FunctionCallSchema, FunctionResponseSchema} from './common-types.js';
 
-export const ActionMessageSchema = z
-  .object({
-    'version': z.literal('v1.0'),
-    'action': z
-      .object({
-        'name': z
-          .string()
-          .describe(
-            "The name of the action, taken from the component's action.event.name property.",
-          ),
-        'userMessage': z
-          .string()
-          .describe(
-            "An optional human-readable string describing the action performed by the user, taken from the component's action.event.userMessage property after resolving bindings.",
-          )
-          .optional(),
-        'surfaceId': z
-          .string()
-          .describe(
-            "The id of the surface where the event originated. It must be globally unique for the renderer's lifetime.",
-          ),
-        'sourceComponentId': z
-          .string()
-          .describe('The id of the component that triggered the event.'),
-        'timestamp': z
-          .string()
-          .datetime({offset: true})
-          .describe('An ISO 8601 timestamp of when the event occurred.'),
-        'context': z
-          .record(z.string(), z.any())
-          .describe(
-            "A JSON object containing the key-value pairs from the component's action.event.context, after resolving all data bindings.",
-          ),
-        'metadata': z
-          .object({'extensions': ExtensionsSchema.optional()})
-          .strict()
-          .describe('Optional renderer-side metadata to send back to the agent with the action.')
-          .optional(),
-      })
-      .describe('Reports a user-initiated action from a component.'),
-  })
-  .strict();
-export type ActionMessage = z.infer<typeof ActionMessageSchema>;
+export const ActionMessageSchema = z.object({ "version": z.literal("v1.0"), "action": z.object({ "name": z.string().describe("The name of the action, taken from the component's action.event.name property."), "userMessage": z.string().describe("An optional human-readable string describing the action performed by the user, taken from the component's action.event.userMessage property after resolving bindings.").optional(), "surfaceId": z.string().describe("The id of the surface where the event originated. It must be globally unique for the renderer's lifetime."), "sourceComponentId": z.string().describe("The id of the component that triggered the event."), "timestamp": z.string().datetime({ offset: true }).describe("An ISO 8601 timestamp of when the event occurred."), "context": z.record(z.string(), z.any()).describe("A JSON object containing the key-value pairs from the component's action.event.context, after resolving all data bindings."), "metadata": z.object({ "extensions": ExtensionsSchema.optional() }).strict().describe("Optional renderer-side metadata to send back to the agent with the action.").optional() }).describe("Reports a user-initiated action from a component.") }).strict()
+export type ActionMessage = z.infer<typeof ActionMessageSchema>
 
-export const CallAgentFunctionMessageSchema = z
-  .object({
-    'version': z.literal('v1.0'),
-    'callAgentFunction': z
-      .object({
-        'surfaceId': z.string().describe('The surface ID where the call originated.'),
-        'functionCallId': CallIdSchema,
-        'callFunction': FunctionCallSchema,
-      })
-      .strict()
-      .describe('Signals the agent to execute a function remotely on behalf of the renderer.'),
-  })
-  .strict();
-export type CallAgentFunctionMessage = z.infer<typeof CallAgentFunctionMessageSchema>;
 
-export const RendererFunctionResponseMessageSchema = z
-  .object({'version': z.literal('v1.0'), 'rendererFunctionResponse': FunctionResponseSchema})
-  .strict();
-export type RendererFunctionResponseMessage = z.infer<typeof RendererFunctionResponseMessageSchema>;
+export const CallAgentFunctionMessageSchema = z.object({ "version": z.literal("v1.0"), "callAgentFunction": z.object({ "surfaceId": z.string().describe("The surface ID where the call originated."), "functionCallId": CallIdSchema, "callFunction": FunctionCallSchema }).strict().describe("Signals the agent to execute a function remotely on behalf of the renderer.") }).strict()
+export type CallAgentFunctionMessage = z.infer<typeof CallAgentFunctionMessageSchema>
 
-export const ErrorMessageSchema = z
-  .object({
-    'version': z.literal('v1.0'),
-    'error': z
-      .any()
-      .superRefine((x, ctx) => {
-        const schemas = [
-          z
-            .object({
-              'code': z.enum(['VALIDATION_FAILED', 'UNALLOWED_PARENT', 'UNALLOWED_CHILD']),
-              'surfaceId': z
-                .string()
-                .describe(
-                  "The id of the surface where the error occurred. It must be globally unique for the renderer's lifetime.",
-                ),
-              'path': z
-                .string()
-                .describe(
-                  "The JSON pointer to the field that failed validation (e.g. '/components/0/text').",
-                ),
-              'message': z
-                .string()
-                .describe('A short one or two sentence description of why validation failed.'),
-            })
-            .strict(),
-          z
-            .object({
-              'code': z
-                .any()
-                .refine(
-                  value =>
-                    !z
-                      .enum(['VALIDATION_FAILED', 'UNALLOWED_PARENT', 'UNALLOWED_CHILD'])
-                      .safeParse(value).success,
-                  'Invalid input: Should NOT be valid against schema',
-                ),
-              'message': z
-                .string()
-                .describe('A short one or two sentence description of why the error occurred.'),
-              'surfaceId': z
-                .string()
-                .describe(
-                  "The id of the surface where the error occurred. It must be globally unique for the renderer's lifetime.",
-                )
-                .optional(),
-              'functionCallId': CallIdSchema.optional(),
-            })
-            .catchall(z.any())
-            .and(
-              z.any().superRefine((x, ctx) => {
-                const schemas = [
-                  z
-                    .any()
-                    .refine(
-                      value => !z.any().safeParse(value).success,
-                      'Invalid input: Should NOT be valid against schema',
-                    ),
-                  z
-                    .any()
-                    .refine(
-                      value => !z.any().safeParse(value).success,
-                      'Invalid input: Should NOT be valid against schema',
-                    ),
-                ];
-                const {errors, failed} = schemas.reduce<{
-                  errors: z.ZodIssue[];
-                  failed: number;
-                }>(
-                  ({errors, failed}, schema) =>
-                    (result =>
-                      result.error
-                        ? {
-                            errors: [...errors, ...result.error.issues],
-                            failed: failed + 1,
-                          }
-                        : {errors, failed})(schema.safeParse(x)),
-                  {errors: [], failed: 0},
-                );
-                const passed = schemas.length - failed;
-                if (passed !== 1) {
-                  ctx.addIssue(
-                    errors.length
-                      ? {
-                          path: [],
-                          code: 'invalid_union',
-                          errors: [errors],
-                          message: 'Invalid input: Should pass single schema. Passed ' + passed,
-                        }
-                      : ({
-                          path: [],
-                          code: 'custom',
-                          errors: [errors],
-                          message: 'Invalid input: Should pass single schema. Passed ' + passed,
-                        } as any),
-                  );
-                }
-              }),
-            ),
-        ];
-        const {errors, failed} = schemas.reduce<{
-          errors: z.ZodIssue[];
-          failed: number;
-        }>(
-          ({errors, failed}, schema) =>
-            (result =>
-              result.error
-                ? {
-                    errors: [...errors, ...result.error.issues],
-                    failed: failed + 1,
-                  }
-                : {errors, failed})(schema.safeParse(x)),
-          {errors: [], failed: 0},
-        );
-        const passed = schemas.length - failed;
-        if (passed !== 1) {
-          ctx.addIssue(
-            errors.length
-              ? {
-                  path: [],
-                  code: 'invalid_union',
-                  errors: [errors],
-                  message: 'Invalid input: Should pass single schema. Passed ' + passed,
-                }
-              : ({
-                  path: [],
-                  code: 'custom',
-                  errors: [errors],
-                  message: 'Invalid input: Should pass single schema. Passed ' + passed,
-                } as any),
-          );
-        }
-      })
-      .describe('Reports a renderer-side error.'),
-  })
-  .strict();
-export type ErrorMessage = z.infer<typeof ErrorMessageSchema>;
+
+export const RendererFunctionResponseMessageSchema = z.object({ "version": z.literal("v1.0"), "rendererFunctionResponse": FunctionResponseSchema }).strict()
+export type RendererFunctionResponseMessage = z.infer<typeof RendererFunctionResponseMessageSchema>
+
+
+export const ErrorMessageSchema = z.object({ "version": z.literal("v1.0"), "error": z.any().superRefine((x, ctx) => {
+    const schemas = [z.object({ "code": z.enum(["VALIDATION_FAILED","UNALLOWED_PARENT","UNALLOWED_CHILD"]), "surfaceId": z.string().describe("The id of the surface where the error occurred. It must be globally unique for the renderer's lifetime."), "path": z.string().describe("The JSON pointer to the field that failed validation (e.g. '/components/0/text')."), "message": z.string().describe("A short one or two sentence description of why validation failed.") }).strict(), z.object({ "code": z.any().refine((value) => !z.enum(["VALIDATION_FAILED","UNALLOWED_PARENT","UNALLOWED_CHILD"]).safeParse(value).success, "Invalid input: Should NOT be valid against schema"), "message": z.string().describe("A short one or two sentence description of why the error occurred."), "surfaceId": z.string().describe("The id of the surface where the error occurred. It must be globally unique for the renderer's lifetime.").optional(), "functionCallId": CallIdSchema.optional() }).catchall(z.any()).and(z.any().superRefine((x, ctx) => {
+    const schemas = [z.any().refine((value) => !z.any().safeParse(value).success, "Invalid input: Should NOT be valid against schema"), z.any().refine((value) => !z.any().safeParse(value).success, "Invalid input: Should NOT be valid against schema")];
+    const { errors, failed } = schemas.reduce<{
+      errors: z.ZodIssue[];
+      failed: number;
+    }>(
+      ({ errors, failed }, schema) =>
+        ((result) =>
+          result.error
+            ? {
+                errors: [...errors, ...result.error.issues],
+                failed: failed + 1,
+              }
+            : { errors, failed })(
+          schema.safeParse(x),
+        ),
+      { errors: [], failed: 0 },
+    );
+    const passed = schemas.length - failed;
+    if (passed !== 1) {
+      ctx.addIssue(errors.length ? {
+        path: [],
+        code: "invalid_union",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } : {
+        path: [],
+        code: "custom",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } as any);
+    }
+  }))];
+    const { errors, failed } = schemas.reduce<{
+      errors: z.ZodIssue[];
+      failed: number;
+    }>(
+      ({ errors, failed }, schema) =>
+        ((result) =>
+          result.error
+            ? {
+                errors: [...errors, ...result.error.issues],
+                failed: failed + 1,
+              }
+            : { errors, failed })(
+          schema.safeParse(x),
+        ),
+      { errors: [], failed: 0 },
+    );
+    const passed = schemas.length - failed;
+    if (passed !== 1) {
+      ctx.addIssue(errors.length ? {
+        path: [],
+        code: "invalid_union",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } : {
+        path: [],
+        code: "custom",
+        errors: [errors],
+        message: "Invalid input: Should pass single schema. Passed " + passed,
+      } as any);
+    }
+  }).describe("Reports a renderer-side error.") }).strict()
+export type ErrorMessage = z.infer<typeof ErrorMessageSchema>
+
 
 /** Union schema validating any outgoing v1.0 renderer-to-agent message envelope. */
 export const RendererToAgentMessageSchema = z.union([

--- a/typescript/web_core/src/validating/index.ts
+++ b/typescript/web_core/src/validating/index.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+/**
+ * Component integrity, path syntax, graph topology, and protocol envelope validators for A2UI.
+ */
+
 export * from './integrity-checker.js';
 export * from './topology-analyzer.js';
 export * from './validator.js';

--- a/typescript/web_core/src/validating/index.ts
+++ b/typescript/web_core/src/validating/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './integrity-checker.js';
+export * from './topology-analyzer.js';
+export * from './validator.js';

--- a/typescript/web_core/src/validating/integrity-checker.ts
+++ b/typescript/web_core/src/validating/integrity-checker.ts
@@ -47,10 +47,7 @@ function* extractPointers(val: any, currentPath: string): Generator<[string, str
   } else if (Array.isArray(val)) {
     for (let idx = 0; idx < val.length; idx++) {
       const item = val[idx];
-      const subPath =
-        typeof item === 'string' && !currentPath.includes('[')
-          ? currentPath
-          : `${currentPath}[${idx}]`;
+      const subPath = `${currentPath}[${idx}]`;
       yield* extractPointers(item, subPath);
     }
   } else if (typeof val === 'object' && val !== null) {
@@ -158,13 +155,13 @@ export function validateComponentIntegrity(
     ids.add(compIdStr);
   }
 
-  if (allowDanglingReferences) {
-    return;
-  }
-
   // 2. Check for root component
   if (!allowMissingRoot && !ids.has(rootId)) {
     throw new A2uiIntegrityError(`Missing root component: No component has id='${rootId}'`);
+  }
+
+  if (allowDanglingReferences) {
+    return;
   }
 
   // 3. Check for dangling references
@@ -204,12 +201,7 @@ function traverseRecursionAndPaths(item: any, globalDepth: number, funcDepth: nu
     const isFuncV09 = 'call' in item && 'args' in item;
 
     if (isFuncV08) {
-      if (funcDepth >= MAX_FUNC_CALL_DEPTH) {
-        throw new A2uiRecursionError(
-          `Recursion limit exceeded: functionCall depth > ${MAX_FUNC_CALL_DEPTH}`,
-        );
-      }
-      traverseRecursionAndPaths(item.functionCall, globalDepth + 1, funcDepth + 1);
+      traverseRecursionAndPaths(item.functionCall, globalDepth + 1, funcDepth);
     } else if (isFuncV09) {
       if (funcDepth >= MAX_FUNC_CALL_DEPTH) {
         throw new A2uiRecursionError(

--- a/typescript/web_core/src/validating/integrity-checker.ts
+++ b/typescript/web_core/src/validating/integrity-checker.ts
@@ -37,6 +37,31 @@ export const STANDARD_REF_MAP: ComponentRefMap = {
   'Node': [new Set(['next', 'child']), new Set(['children'])],
 };
 
+function* extractPointers(val: any, currentPath: string): Generator<[string, string]> {
+  if (typeof val === 'string') {
+    yield [val, currentPath];
+  } else if (Array.isArray(val)) {
+    for (let idx = 0; idx < val.length; idx++) {
+      const item = val[idx];
+      const subPath =
+        typeof item === 'string' && !currentPath.includes('[')
+          ? currentPath
+          : `${currentPath}[${idx}]`;
+      yield* extractPointers(item, subPath);
+    }
+  } else if (typeof val === 'object' && val !== null) {
+    if ('componentId' in val && typeof val.componentId === 'string') {
+      yield [val.componentId, `${currentPath}.componentId`];
+    } else if ('child' in val && typeof val.child === 'string') {
+      yield [val.child, `${currentPath}.child`];
+    } else {
+      for (const [subKey, subVal] of Object.entries(val)) {
+        yield* extractPointers(subVal, `${currentPath}.${subKey}`);
+      }
+    }
+  }
+}
+
 /**
  * Extracts child component IDs referenced by a component property definition.
  */
@@ -62,34 +87,7 @@ export function* getComponentReferences(
   const refTuple = refFieldsMap[compType];
   const singleRefs = refTuple ? refTuple[0] : new Set<string>();
   const listRefs = refTuple ? refTuple[1] : new Set<string>();
-
-  // Also check generic property names if not explicitly mapped
   const isGeneric = !refTuple;
-
-  function* extractPointers(val: any, currentPath: string): Generator<[string, string]> {
-    if (typeof val === 'string') {
-      yield [val, currentPath];
-    } else if (Array.isArray(val)) {
-      for (let idx = 0; idx < val.length; idx++) {
-        const item = val[idx];
-        const subPath =
-          typeof item === 'string' && !currentPath.includes('[')
-            ? currentPath
-            : `${currentPath}[${idx}]`;
-        yield* extractPointers(item, subPath);
-      }
-    } else if (typeof val === 'object' && val !== null) {
-      if ('componentId' in val && typeof val.componentId === 'string') {
-        yield [val.componentId, `${currentPath}.componentId`];
-      } else if ('child' in val && typeof val.child === 'string') {
-        yield [val.child, `${currentPath}.child`];
-      } else {
-        for (const [subKey, subVal] of Object.entries(val)) {
-          yield* extractPointers(subVal, `${currentPath}.${subKey}`);
-        }
-      }
-    }
-  }
 
   for (const [key, value] of Object.entries(props)) {
     if (isGeneric) {
@@ -126,10 +124,11 @@ export function validateComponentIntegrity(
   for (const comp of components) {
     const compId = comp.id;
     if (compId === undefined || compId === null) continue;
-    if (ids.has(compId)) {
-      throw new A2uiIntegrityError(`Duplicate component ID: ${compId}`);
+    const compIdStr = String(compId);
+    if (ids.has(compIdStr)) {
+      throw new A2uiIntegrityError(`Duplicate component ID: ${compIdStr}`);
     }
-    ids.add(compId);
+    ids.add(compIdStr);
   }
 
   if (allowDanglingReferences) {
@@ -143,7 +142,7 @@ export function validateComponentIntegrity(
 
   // 3. Check for dangling references
   for (const comp of components) {
-    const compId = comp.id ?? 'Unknown';
+    const compId = comp.id !== undefined && comp.id !== null ? String(comp.id) : 'Unknown';
     for (const [refId, fieldName] of getComponentReferences(comp, refFieldsMap)) {
       if (!ids.has(refId)) {
         throw new A2uiIntegrityError(
@@ -154,60 +153,60 @@ export function validateComponentIntegrity(
   }
 }
 
+function traverseRecursionAndPaths(item: any, globalDepth: number, funcDepth: number): void {
+  if (globalDepth > MAX_GLOBAL_DEPTH) {
+    throw new A2uiRecursionError(`Global recursion limit exceeded: Depth > ${MAX_GLOBAL_DEPTH}`);
+  }
+
+  if (Array.isArray(item)) {
+    for (const x of item) {
+      traverseRecursionAndPaths(x, globalDepth + 1, funcDepth);
+    }
+    return;
+  }
+
+  if (typeof item === 'object' && item !== null) {
+    if ('path' in item && typeof item.path === 'string') {
+      const path = item.path;
+      if (!RELAXED_PATH_PATTERN.test(path)) {
+        throw new A2uiValidationError(`Invalid path syntax: '${path}'`);
+      }
+    }
+
+    const isFuncV08 = 'functionCall' in item && typeof item.functionCall === 'object';
+    const isFuncV09 = 'call' in item && 'args' in item;
+
+    if (isFuncV08) {
+      if (funcDepth >= MAX_FUNC_CALL_DEPTH) {
+        throw new A2uiRecursionError(
+          `Recursion limit exceeded: functionCall depth > ${MAX_FUNC_CALL_DEPTH}`,
+        );
+      }
+      traverseRecursionAndPaths(item.functionCall, globalDepth + 1, funcDepth + 1);
+    } else if (isFuncV09) {
+      if (funcDepth >= MAX_FUNC_CALL_DEPTH) {
+        throw new A2uiRecursionError(
+          `Recursion limit exceeded: functionCall depth > ${MAX_FUNC_CALL_DEPTH}`,
+        );
+      }
+      for (const [k, v] of Object.entries(item)) {
+        if (k === 'args') {
+          traverseRecursionAndPaths(v, globalDepth + 1, funcDepth + 1);
+        } else {
+          traverseRecursionAndPaths(v, globalDepth + 1, funcDepth);
+        }
+      }
+    } else {
+      for (const v of Object.values(item)) {
+        traverseRecursionAndPaths(v, globalDepth + 1, funcDepth);
+      }
+    }
+  }
+}
+
 /**
  * Traverses a JSON data payload to validate path syntax and recursion limits.
  */
 export function validateRecursionAndPaths(data: any): void {
-  function traverse(item: any, globalDepth: number, funcDepth: number): void {
-    if (globalDepth > MAX_GLOBAL_DEPTH) {
-      throw new A2uiRecursionError(`Global recursion limit exceeded: Depth > ${MAX_GLOBAL_DEPTH}`);
-    }
-
-    if (Array.isArray(item)) {
-      for (const x of item) {
-        traverse(x, globalDepth + 1, funcDepth);
-      }
-      return;
-    }
-
-    if (typeof item === 'object' && item !== null) {
-      if ('path' in item && typeof item.path === 'string') {
-        const path = item.path;
-        if (!RELAXED_PATH_PATTERN.test(path)) {
-          throw new A2uiValidationError(`Invalid path syntax: '${path}'`);
-        }
-      }
-
-      const isFuncV08 = 'functionCall' in item && typeof item.functionCall === 'object';
-      const isFuncV09 = 'call' in item && 'args' in item;
-
-      if (isFuncV08) {
-        if (funcDepth >= MAX_FUNC_CALL_DEPTH) {
-          throw new A2uiRecursionError(
-            `Recursion limit exceeded: functionCall depth > ${MAX_FUNC_CALL_DEPTH}`,
-          );
-        }
-        traverse(item.functionCall, globalDepth + 1, funcDepth + 1);
-      } else if (isFuncV09) {
-        if (funcDepth >= MAX_FUNC_CALL_DEPTH) {
-          throw new A2uiRecursionError(
-            `Recursion limit exceeded: functionCall depth > ${MAX_FUNC_CALL_DEPTH}`,
-          );
-        }
-        for (const [k, v] of Object.entries(item)) {
-          if (k === 'args') {
-            traverse(v, globalDepth + 1, funcDepth + 1);
-          } else {
-            traverse(v, globalDepth + 1, funcDepth);
-          }
-        }
-      } else {
-        for (const v of Object.values(item)) {
-          traverse(v, globalDepth + 1, funcDepth);
-        }
-      }
-    }
-  }
-
-  traverse(data, 0, 0);
+  traverseRecursionAndPaths(data, 0, 0);
 }

--- a/typescript/web_core/src/validating/integrity-checker.ts
+++ b/typescript/web_core/src/validating/integrity-checker.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {A2uiIntegrityError, A2uiRecursionError, A2uiValidationError} from '../errors.js';
+
+export const MAX_GLOBAL_DEPTH = 50;
+export const MAX_FUNC_CALL_DEPTH = 5;
+
+/** Regex pattern matching valid JSON Pointer syntax (RFC 6901 compliant with optional relative path). */
+export const RELAXED_PATH_PATTERN =
+  /^(?:(?:\/(?:[^~/]|~[01])*)*|(?:[^~/]|~[01])+(?:\/(?:[^~/]|~[01])*)*)$/;
+
+export type ComponentRefMap = Record<string, [Set<string>, Set<string>]>;
+
+/** Default component reference map for standard basic catalog component types. */
+export const STANDARD_REF_MAP: ComponentRefMap = {
+  'Column': [new Set(), new Set(['children'])],
+  'Row': [new Set(), new Set(['children'])],
+  'Card': [new Set(['child']), new Set()],
+  'Box': [new Set(['child']), new Set()],
+  'List': [new Set(), new Set(['children'])],
+  'Tabs': [new Set(), new Set(['tabs'])],
+  'Container': [new Set(['singleChild', 'nestedObj']), new Set(['childrenList', 'tabs'])],
+  'Node': [new Set(['next', 'child']), new Set(['children'])],
+};
+
+/**
+ * Extracts child component IDs referenced by a component property definition.
+ */
+export function* getComponentReferences(
+  component: Record<string, any>,
+  refFieldsMap: ComponentRefMap = STANDARD_REF_MAP,
+): Generator<[string, string]> {
+  const compVal = component.component;
+  let compType = '';
+  let props: Record<string, any> = component;
+
+  if (typeof compVal === 'string') {
+    compType = compVal;
+  } else if (typeof compVal === 'object' && compVal !== null) {
+    compType = Object.keys(compVal)[0] ?? '';
+    props = compVal[compType] ?? {};
+  }
+
+  if (!compType || typeof props !== 'object' || props === null) {
+    return;
+  }
+
+  const refTuple = refFieldsMap[compType];
+  const singleRefs = refTuple ? refTuple[0] : new Set<string>();
+  const listRefs = refTuple ? refTuple[1] : new Set<string>();
+
+  // Also check generic property names if not explicitly mapped
+  const isGeneric = !refTuple;
+
+  function* extractPointers(val: any, currentPath: string): Generator<[string, string]> {
+    if (typeof val === 'string') {
+      yield [val, currentPath];
+    } else if (Array.isArray(val)) {
+      for (let idx = 0; idx < val.length; idx++) {
+        const item = val[idx];
+        const subPath =
+          typeof item === 'string' && !currentPath.includes('[')
+            ? currentPath
+            : `${currentPath}[${idx}]`;
+        yield* extractPointers(item, subPath);
+      }
+    } else if (typeof val === 'object' && val !== null) {
+      if ('componentId' in val && typeof val.componentId === 'string') {
+        yield [val.componentId, `${currentPath}.componentId`];
+      } else if ('child' in val && typeof val.child === 'string') {
+        yield [val.child, `${currentPath}.child`];
+      } else {
+        for (const [subKey, subVal] of Object.entries(val)) {
+          yield* extractPointers(subVal, `${currentPath}.${subKey}`);
+        }
+      }
+    }
+  }
+
+  for (const [key, value] of Object.entries(props)) {
+    if (isGeneric) {
+      if (key === 'child' || key === 'children' || key === 'next') {
+        yield* extractPointers(value, key);
+      }
+    } else if (singleRefs.has(key) || listRefs.has(key)) {
+      yield* extractPointers(value, key);
+    }
+  }
+}
+
+export interface IntegrityOptions {
+  rootId?: string;
+  allowDanglingReferences?: boolean;
+  allowMissingRoot?: boolean;
+}
+
+/**
+ * Validates the structural integrity of a list of component definitions.
+ */
+export function validateComponentIntegrity(
+  components: Array<Record<string, any>>,
+  refFieldsMap: ComponentRefMap = STANDARD_REF_MAP,
+  options: IntegrityOptions = {},
+): void {
+  const rootId = options.rootId ?? 'root';
+  const allowDanglingReferences = options.allowDanglingReferences ?? false;
+  const allowMissingRoot = options.allowMissingRoot ?? false;
+
+  const ids = new Set<string>();
+
+  // 1. Collect IDs and check for duplicates
+  for (const comp of components) {
+    const compId = comp.id;
+    if (compId === undefined || compId === null) continue;
+    if (ids.has(compId)) {
+      throw new A2uiIntegrityError(`Duplicate component ID: ${compId}`);
+    }
+    ids.add(compId);
+  }
+
+  if (allowDanglingReferences) {
+    return;
+  }
+
+  // 2. Check for root component
+  if (!allowMissingRoot && !ids.has(rootId)) {
+    throw new A2uiIntegrityError(`Missing root component: No component has id='${rootId}'`);
+  }
+
+  // 3. Check for dangling references
+  for (const comp of components) {
+    const compId = comp.id ?? 'Unknown';
+    for (const [refId, fieldName] of getComponentReferences(comp, refFieldsMap)) {
+      if (!ids.has(refId)) {
+        throw new A2uiIntegrityError(
+          `Component '${compId}' references non-existent component '${refId}' in field '${fieldName}'`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Traverses a JSON data payload to validate path syntax and recursion limits.
+ */
+export function validateRecursionAndPaths(data: any): void {
+  function traverse(item: any, globalDepth: number, funcDepth: number): void {
+    if (globalDepth > MAX_GLOBAL_DEPTH) {
+      throw new A2uiRecursionError(`Global recursion limit exceeded: Depth > ${MAX_GLOBAL_DEPTH}`);
+    }
+
+    if (Array.isArray(item)) {
+      for (const x of item) {
+        traverse(x, globalDepth + 1, funcDepth);
+      }
+      return;
+    }
+
+    if (typeof item === 'object' && item !== null) {
+      if ('path' in item && typeof item.path === 'string') {
+        const path = item.path;
+        if (!RELAXED_PATH_PATTERN.test(path)) {
+          throw new A2uiValidationError(`Invalid path syntax: '${path}'`);
+        }
+      }
+
+      const isFuncV08 = 'functionCall' in item && typeof item.functionCall === 'object';
+      const isFuncV09 = 'call' in item && 'args' in item;
+
+      if (isFuncV08) {
+        if (funcDepth >= MAX_FUNC_CALL_DEPTH) {
+          throw new A2uiRecursionError(
+            `Recursion limit exceeded: functionCall depth > ${MAX_FUNC_CALL_DEPTH}`,
+          );
+        }
+        traverse(item.functionCall, globalDepth + 1, funcDepth + 1);
+      } else if (isFuncV09) {
+        if (funcDepth >= MAX_FUNC_CALL_DEPTH) {
+          throw new A2uiRecursionError(
+            `Recursion limit exceeded: functionCall depth > ${MAX_FUNC_CALL_DEPTH}`,
+          );
+        }
+        for (const [k, v] of Object.entries(item)) {
+          if (k === 'args') {
+            traverse(v, globalDepth + 1, funcDepth + 1);
+          } else {
+            traverse(v, globalDepth + 1, funcDepth);
+          }
+        }
+      } else {
+        for (const v of Object.values(item)) {
+          traverse(v, globalDepth + 1, funcDepth);
+        }
+      }
+    }
+  }
+
+  traverse(data, 0, 0);
+}

--- a/typescript/web_core/src/validating/integrity-checker.ts
+++ b/typescript/web_core/src/validating/integrity-checker.ts
@@ -16,13 +16,17 @@
 
 import {A2uiIntegrityError, A2uiRecursionError, A2uiValidationError} from '../errors.js';
 
+/** Maximum permitted nesting depth for JSON objects and array structures. */
 export const MAX_GLOBAL_DEPTH = 50;
+
+/** Maximum permitted recursion depth for nested function calls. */
 export const MAX_FUNC_CALL_DEPTH = 5;
 
 /** Regex pattern matching valid JSON Pointer syntax (RFC 6901 compliant with optional relative path). */
 export const RELAXED_PATH_PATTERN =
   /^(?:(?:\/(?:[^~/]|~[01])*)*|(?:[^~/]|~[01])+(?:\/(?:[^~/]|~[01])*)*)$/;
 
+/** Map of component type names to sets of single and list child reference property names. */
 export type ComponentRefMap = Record<string, [Set<string>, Set<string>]>;
 
 /** Default component reference map for standard basic catalog component types. */
@@ -64,6 +68,15 @@ function* extractPointers(val: any, currentPath: string): Generator<[string, str
 
 /**
  * Extracts child component IDs referenced by a component property definition.
+ *
+ * @param component Component definition object containing properties and metadata.
+ * @param refFieldsMap Mapping defining single and list reference fields per component type.
+ * @yields Tuple of `[referencedId, propertyPath]` for each child reference found.
+ *
+ * @example
+ * ```ts
+ * const refs = Array.from(getComponentReferences(boxComponent, STANDARD_REF_MAP));
+ * ```
  */
 export function* getComponentReferences(
   component: Record<string, any>,
@@ -100,14 +113,28 @@ export function* getComponentReferences(
   }
 }
 
+/** Configuration options for component integrity validation. */
 export interface IntegrityOptions {
+  /** Expected identifier for the root component in the hierarchy. Defaults to 'root'. */
   rootId?: string;
+  /** Whether to permit references to non-existent component identifiers. */
   allowDanglingReferences?: boolean;
+  /** Whether to allow a component tree that does not contain a root component. */
   allowMissingRoot?: boolean;
 }
 
 /**
  * Validates the structural integrity of a list of component definitions.
+ *
+ * @param components Array of component definition objects to audit.
+ * @param refFieldsMap Component reference field mapping definitions.
+ * @param options Integrity configuration options.
+ * @throws {A2uiIntegrityError} If duplicate IDs, missing root, or dangling references are found.
+ *
+ * @example
+ * ```ts
+ * validateComponentIntegrity(components, STANDARD_REF_MAP, { rootId: 'root' });
+ * ```
  */
 export function validateComponentIntegrity(
   components: Array<Record<string, any>>,
@@ -206,6 +233,10 @@ function traverseRecursionAndPaths(item: any, globalDepth: number, funcDepth: nu
 
 /**
  * Traverses a JSON data payload to validate path syntax and recursion limits.
+ *
+ * @param data Data payload or component hierarchy to evaluate.
+ * @throws {A2uiRecursionError} If global structure depth or function call depth exceeds limits.
+ * @throws {A2uiValidationError} If an invalid JSON Pointer path format is encountered.
  */
 export function validateRecursionAndPaths(data: any): void {
   traverseRecursionAndPaths(data, 0, 0);

--- a/typescript/web_core/src/validating/topology-analyzer.ts
+++ b/typescript/web_core/src/validating/topology-analyzer.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {A2uiIntegrityError, A2uiRecursionError} from '../errors.js';
+import {
+  ComponentRefMap,
+  getComponentReferences,
+  MAX_GLOBAL_DEPTH,
+  STANDARD_REF_MAP,
+} from './integrity-checker.js';
+
+export interface TopologyOptions {
+  rootId?: string;
+  allowOrphanComponents?: boolean;
+  allowMissingRoot?: boolean;
+}
+
+/**
+ * Analyzes the graph topology of a component tree to detect cycles, self-references, and orphans.
+ */
+export function analyzeTopology(
+  components: Array<Record<string, any>>,
+  refFieldsMap: ComponentRefMap = STANDARD_REF_MAP,
+  options: TopologyOptions = {},
+): Set<string> {
+  const rootId = options.rootId ?? 'root';
+  const allowOrphanComponents = options.allowOrphanComponents ?? false;
+  const allowMissingRoot = options.allowMissingRoot ?? false;
+
+  const adjList: Record<string, string[]> = {};
+  const allIds = new Set<string>();
+
+  // 1. Build Adjacency List
+  for (const comp of components) {
+    const compId = comp.id;
+    if (compId === undefined || compId === null) continue;
+
+    allIds.add(compId);
+    if (!adjList[compId]) {
+      adjList[compId] = [];
+    }
+
+    for (const [refId, fieldName] of getComponentReferences(comp, refFieldsMap)) {
+      if (refId === compId) {
+        throw new A2uiRecursionError(
+          `Self-reference detected: Component '${compId}' references itself in field '${fieldName}'`,
+        );
+      }
+      adjList[compId].push(refId);
+    }
+  }
+
+  // 2. Detect Cycles and Depth via DFS
+  const visited = new Set<string>();
+  const recursionStack = new Set<string>();
+
+  function dfs(nodeId: string, depth: number): void {
+    if (depth > MAX_GLOBAL_DEPTH) {
+      throw new A2uiRecursionError(
+        `Global recursion limit exceeded: logical depth > ${MAX_GLOBAL_DEPTH}`,
+      );
+    }
+
+    visited.add(nodeId);
+    recursionStack.add(nodeId);
+
+    const neighbors = adjList[nodeId] ?? [];
+    for (const neighbor of neighbors) {
+      if (!visited.has(neighbor)) {
+        dfs(neighbor, depth + 1);
+      } else if (recursionStack.has(neighbor)) {
+        throw new A2uiRecursionError(
+          `Circular reference detected involving component '${neighbor}'`,
+        );
+      }
+    }
+
+    recursionStack.delete(nodeId);
+  }
+
+  if (allowMissingRoot) {
+    const sortedIds = Array.from(allIds).sort();
+    for (const nodeId of sortedIds) {
+      if (!visited.has(nodeId)) {
+        dfs(nodeId, 0);
+      }
+    }
+  } else {
+    if (allIds.has(rootId)) {
+      dfs(rootId, 0);
+    }
+
+    if (!allowOrphanComponents) {
+      const orphans = Array.from(allIds).filter(id => !visited.has(id));
+      if (orphans.length > 0) {
+        orphans.sort();
+        throw new A2uiIntegrityError(`Component '${orphans[0]}' is not reachable from '${rootId}'`);
+      }
+    }
+  }
+
+  return visited;
+}

--- a/typescript/web_core/src/validating/topology-analyzer.ts
+++ b/typescript/web_core/src/validating/topology-analyzer.ts
@@ -28,6 +28,34 @@ export interface TopologyOptions {
   allowMissingRoot?: boolean;
 }
 
+function dfsTopology(
+  nodeId: string,
+  depth: number,
+  adjList: Record<string, string[]>,
+  visited: Set<string>,
+  recursionStack: Set<string>,
+): void {
+  if (depth > MAX_GLOBAL_DEPTH) {
+    throw new A2uiRecursionError(
+      `Global recursion limit exceeded: logical depth > ${MAX_GLOBAL_DEPTH}`,
+    );
+  }
+
+  visited.add(nodeId);
+  recursionStack.add(nodeId);
+
+  const neighbors = adjList[nodeId] ?? [];
+  for (const neighbor of neighbors) {
+    if (!visited.has(neighbor)) {
+      dfsTopology(neighbor, depth + 1, adjList, visited, recursionStack);
+    } else if (recursionStack.has(neighbor)) {
+      throw new A2uiRecursionError(`Circular reference detected involving component '${neighbor}'`);
+    }
+  }
+
+  recursionStack.delete(nodeId);
+}
+
 /**
  * Analyzes the graph topology of a component tree to detect cycles, self-references, and orphans.
  */
@@ -48,18 +76,19 @@ export function analyzeTopology(
     const compId = comp.id;
     if (compId === undefined || compId === null) continue;
 
-    allIds.add(compId);
-    if (!adjList[compId]) {
-      adjList[compId] = [];
+    const compIdStr = String(compId);
+    allIds.add(compIdStr);
+    if (!adjList[compIdStr]) {
+      adjList[compIdStr] = [];
     }
 
     for (const [refId, fieldName] of getComponentReferences(comp, refFieldsMap)) {
-      if (refId === compId) {
+      if (refId === compIdStr) {
         throw new A2uiRecursionError(
-          `Self-reference detected: Component '${compId}' references itself in field '${fieldName}'`,
+          `Self-reference detected: Component '${compIdStr}' references itself in field '${fieldName}'`,
         );
       }
-      adjList[compId].push(refId);
+      adjList[compIdStr].push(refId);
     }
   }
 
@@ -67,40 +96,16 @@ export function analyzeTopology(
   const visited = new Set<string>();
   const recursionStack = new Set<string>();
 
-  function dfs(nodeId: string, depth: number): void {
-    if (depth > MAX_GLOBAL_DEPTH) {
-      throw new A2uiRecursionError(
-        `Global recursion limit exceeded: logical depth > ${MAX_GLOBAL_DEPTH}`,
-      );
-    }
-
-    visited.add(nodeId);
-    recursionStack.add(nodeId);
-
-    const neighbors = adjList[nodeId] ?? [];
-    for (const neighbor of neighbors) {
-      if (!visited.has(neighbor)) {
-        dfs(neighbor, depth + 1);
-      } else if (recursionStack.has(neighbor)) {
-        throw new A2uiRecursionError(
-          `Circular reference detected involving component '${neighbor}'`,
-        );
-      }
-    }
-
-    recursionStack.delete(nodeId);
-  }
-
   if (allowMissingRoot) {
     const sortedIds = Array.from(allIds).sort();
     for (const nodeId of sortedIds) {
       if (!visited.has(nodeId)) {
-        dfs(nodeId, 0);
+        dfsTopology(nodeId, 0, adjList, visited, recursionStack);
       }
     }
   } else {
     if (allIds.has(rootId)) {
-      dfs(rootId, 0);
+      dfsTopology(rootId, 0, adjList, visited, recursionStack);
     }
 
     if (!allowOrphanComponents) {

--- a/typescript/web_core/src/validating/topology-analyzer.ts
+++ b/typescript/web_core/src/validating/topology-analyzer.ts
@@ -22,9 +22,13 @@ import {
   STANDARD_REF_MAP,
 } from './integrity-checker.js';
 
+/** Configuration options for component topology analysis. */
 export interface TopologyOptions {
+  /** Expected root component identifier. Defaults to 'root'. */
   rootId?: string;
+  /** Whether to allow components that are not reachable from the root node. */
   allowOrphanComponents?: boolean;
+  /** Whether to perform analysis when the root component is absent. */
   allowMissingRoot?: boolean;
 }
 
@@ -58,6 +62,18 @@ function dfsTopology(
 
 /**
  * Analyzes the graph topology of a component tree to detect cycles, self-references, and orphans.
+ *
+ * @param components List of component definition objects forming the graph.
+ * @param refFieldsMap Mapping of reference property names per component type.
+ * @param options Topology evaluation options.
+ * @returns Set of all component identifiers visited during graph traversal.
+ * @throws {A2uiRecursionError} If a self-reference, circular dependency, or excessive depth is detected.
+ * @throws {A2uiIntegrityError} If unreachable orphan components exist when prohibited.
+ *
+ * @example
+ * ```ts
+ * const visitedIds = analyzeTopology(components, STANDARD_REF_MAP, { allowOrphanComponents: false });
+ * ```
  */
 export function analyzeTopology(
   components: Array<Record<string, any>>,

--- a/typescript/web_core/src/validating/validator.test.ts
+++ b/typescript/web_core/src/validating/validator.test.ts
@@ -254,5 +254,40 @@ describe('A2uiValidator & Integrity Verification', () => {
 
       assert.doesNotThrow(() => validator.validate(orphanPayload, undefined, RELAXED_VALIDATION));
     });
+
+    it('enforces missing root even when allowDanglingReferences is true', () => {
+      const components = [{id: 'c1', component: 'Text', text: 'No root'}];
+      assert.throws(
+        () =>
+          validateComponentIntegrity(
+            components,
+            {},
+            {allowDanglingReferences: true, allowMissingRoot: false},
+          ),
+        (err: any) =>
+          err instanceof A2uiIntegrityError && err.message.includes("No component has id='root'"),
+      );
+    });
+
+    it('validates components split across multiple stream messages', () => {
+      const splitPayload = [
+        {
+          version: 'v1.0',
+          updateComponents: {
+            surfaceId: 's1',
+            components: [{id: 'root', component: 'Column', children: ['c1']}],
+          },
+        },
+        {
+          version: 'v1.0',
+          updateComponents: {
+            surfaceId: 's1',
+            components: [{id: 'c1', component: 'Text', text: 'Child in second message'}],
+          },
+        },
+      ];
+
+      assert.doesNotThrow(() => validator.validate(splitPayload, undefined, STRICT_VALIDATION));
+    });
   });
 });

--- a/typescript/web_core/src/validating/validator.test.ts
+++ b/typescript/web_core/src/validating/validator.test.ts
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getComponentReferences,
+  validateComponentIntegrity,
+  validateRecursionAndPaths,
+} from './integrity-checker.js';
+import {analyzeTopology} from './topology-analyzer.js';
+import {A2uiValidator, RELAXED_VALIDATION, STRICT_VALIDATION} from './validator.js';
+import {A2uiIntegrityError, A2uiRecursionError, A2uiValidationError} from '../errors.js';
+
+describe('A2uiValidator & Integrity Verification', () => {
+  describe('getComponentReferences', () => {
+    it('extracts references from container components', () => {
+      const refMap = {
+        Container: [new Set(['singleChild', 'nestedObj']), new Set(['childrenList', 'tabs'])],
+      } as const;
+
+      const comp = {
+        id: 'c1',
+        component: {
+          Container: {
+            singleChild: 'child1',
+            childrenList: ['child2', 'child3'],
+            nestedObj: {componentId: 'child4'},
+            tabs: [{child: 'tab1'}, {child: 'tab2'}],
+          },
+        },
+      };
+
+      const refs = Array.from(getComponentReferences(comp, refMap as any));
+      const refIds = refs.map(([id]) => id);
+
+      assert.ok(refIds.includes('child1'));
+      assert.ok(refIds.includes('child2'));
+      assert.ok(refIds.includes('child3'));
+      assert.ok(refIds.includes('child4'));
+      assert.ok(refIds.includes('tab1'));
+      assert.ok(refIds.includes('tab2'));
+    });
+  });
+
+  describe('validateComponentIntegrity', () => {
+    it('passes for valid component tree', () => {
+      const refMap = {Box: [new Set(['child']), new Set()]} as const;
+      const components = [
+        {id: 'root', component: {Box: {child: 'c1'}}},
+        {id: 'c1', component: {Box: {}}},
+      ];
+      assert.doesNotThrow(() => validateComponentIntegrity(components, refMap as any));
+    });
+
+    it('throws on duplicate component ID', () => {
+      const components = [
+        {id: 'c1', component: 'Box'},
+        {id: 'c1', component: 'Text'},
+      ];
+      assert.throws(
+        () => validateComponentIntegrity(components, {}),
+        (err: any) =>
+          err instanceof A2uiIntegrityError && err.message.includes('Duplicate component ID: c1'),
+      );
+    });
+
+    it('throws on missing root component', () => {
+      const components = [{id: 'c1', component: 'Box'}];
+      assert.throws(
+        () => validateComponentIntegrity(components, {}),
+        (err: any) =>
+          err instanceof A2uiIntegrityError && err.message.includes("No component has id='root'"),
+      );
+    });
+
+    it('throws on dangling component reference', () => {
+      const refMap = {Box: [new Set(['child']), new Set()]} as const;
+      const components = [{id: 'root', component: {Box: {child: 'nonexistent'}}}];
+      assert.throws(
+        () => validateComponentIntegrity(components, refMap as any),
+        (err: any) =>
+          err instanceof A2uiIntegrityError &&
+          err.message.includes("references non-existent component 'nonexistent'"),
+      );
+    });
+  });
+
+  describe('validateRecursionAndPaths', () => {
+    it('passes valid path syntax', () => {
+      const data = {path: '/valid/path', nested: [{path: '/another'}]};
+      assert.doesNotThrow(() => validateRecursionAndPaths(data));
+    });
+
+    it('throws on unescaped invalid path syntax', () => {
+      const data = {path: 'invalid~path//double'};
+      assert.throws(
+        () => validateRecursionAndPaths(data),
+        (err: any) =>
+          err instanceof A2uiValidationError && err.message.includes('Invalid path syntax'),
+      );
+    });
+
+    it('throws when global recursion depth limit is exceeded', () => {
+      let deepList: any = [];
+      for (let i = 0; i < 52; i++) {
+        deepList = [deepList];
+      }
+      assert.throws(
+        () => validateRecursionAndPaths(deepList),
+        (err: any) =>
+          err instanceof A2uiRecursionError &&
+          err.message.includes('Global recursion limit exceeded'),
+      );
+    });
+
+    it('throws when function call recursion depth limit is exceeded', () => {
+      const deepCall: Record<string, any> = {};
+      let curr = deepCall;
+      for (let i = 0; i < 6; i++) {
+        curr.call = 'func';
+        curr.args = {};
+        curr = curr.args;
+      }
+      assert.throws(
+        () => validateRecursionAndPaths(deepCall),
+        (err: any) =>
+          err instanceof A2uiRecursionError && err.message.includes('Recursion limit exceeded'),
+      );
+    });
+  });
+
+  describe('analyzeTopology', () => {
+    it('passes for valid graph topology', () => {
+      const refMap = {Node: [new Set(['next']), new Set()]} as const;
+      const components = [
+        {id: 'root', component: {Node: {next: 'n1'}}},
+        {id: 'n1', component: {Node: {}}},
+      ];
+      const visited = analyzeTopology(components, refMap as any, {allowOrphanComponents: false});
+      assert.strictEqual(visited.size, 2);
+      assert.ok(visited.has('root'));
+      assert.ok(visited.has('n1'));
+    });
+
+    it('detects self-reference', () => {
+      const refMap = {Node: [new Set(['next']), new Set()]} as const;
+      const components = [{id: 'root', component: {Node: {next: 'root'}}}];
+      assert.throws(
+        () => analyzeTopology(components, refMap as any),
+        (err: any) =>
+          err instanceof A2uiRecursionError &&
+          err.message.includes("Component 'root' references itself"),
+      );
+    });
+
+    it('detects circular reference', () => {
+      const refMap = {Node: [new Set(['next']), new Set()]} as const;
+      const components = [
+        {id: 'root', component: {Node: {next: 'n1'}}},
+        {id: 'n1', component: {Node: {next: 'root'}}},
+      ];
+      assert.throws(
+        () => analyzeTopology(components, refMap as any),
+        (err: any) =>
+          err instanceof A2uiRecursionError && err.message.includes('Circular reference detected'),
+      );
+    });
+
+    it('detects orphan components when prohibited', () => {
+      const refMap = {Node: [new Set(['next']), new Set()]} as const;
+      const components = [
+        {id: 'root', component: {Node: {}}},
+        {id: 'orphan', component: {Node: {}}},
+      ];
+      assert.throws(
+        () => analyzeTopology(components, refMap as any, {allowOrphanComponents: false}),
+        (err: any) =>
+          err instanceof A2uiIntegrityError &&
+          err.message.includes("Component 'orphan' is not reachable"),
+      );
+    });
+  });
+
+  describe('A2uiValidator Full Pipeline', () => {
+    const validator = new A2uiValidator();
+
+    it('validates a valid message envelope stream', () => {
+      const payload = [
+        {
+          version: 'v1.0',
+          createSurface: {
+            surfaceId: 'main',
+            catalogId: 'https://a2ui.org/catalog',
+          },
+        },
+        {
+          version: 'v1.0',
+          updateComponents: {
+            surfaceId: 'main',
+            components: [
+              {
+                id: 'root',
+                component: 'Column',
+                children: ['c1'],
+              },
+              {
+                id: 'c1',
+                component: 'Text',
+                text: 'Hello World',
+              },
+            ],
+          },
+        },
+      ];
+
+      assert.doesNotThrow(() => validator.validate(payload));
+    });
+
+    it('respects relaxed validation config for dangling references & orphans', () => {
+      const orphanPayload = {
+        version: 'v1.0',
+        updateComponents: {
+          surfaceId: 's1',
+          components: [
+            {id: 'root', component: 'Column', children: ['c1']},
+            {id: 'c1', component: 'Text', text: 'Child'},
+            {id: 'orphan', component: 'Text', text: 'Unused'},
+          ],
+        },
+      };
+
+      assert.throws(
+        () => validator.validate(orphanPayload, undefined, STRICT_VALIDATION),
+        (err: any) => err instanceof A2uiIntegrityError && err.message.includes('not reachable'),
+      );
+
+      assert.doesNotThrow(() => validator.validate(orphanPayload, undefined, RELAXED_VALIDATION));
+    });
+  });
+});

--- a/typescript/web_core/src/validating/validator.test.ts
+++ b/typescript/web_core/src/validating/validator.test.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview Unit tests for A2uiValidator, integrity checks, path syntax validation, and graph topology analysis.
+ */
+
 import {describe, it} from 'node:test';
 import assert from 'node:assert/strict';
 import {

--- a/typescript/web_core/src/validating/validator.ts
+++ b/typescript/web_core/src/validating/validator.ts
@@ -131,13 +131,20 @@ export class A2uiValidator {
     const msgList = Array.isArray(messages) ? messages : [messages];
     this.validateProtocolEnvelope(msgList);
 
+    const accumulatedComponents: Array<Record<string, any>> = [];
     for (const msg of msgList) {
       validateRecursionAndPaths(msg);
 
       const updateComps = msg.updateComponents?.components;
       if (Array.isArray(updateComps)) {
-        this.validateComponents(updateComps, refFieldsMap, config, {skipRecursionCheck: true});
+        accumulatedComponents.push(...updateComps);
       }
+    }
+
+    if (accumulatedComponents.length > 0) {
+      this.validateComponents(accumulatedComponents, refFieldsMap, config, {
+        skipRecursionCheck: true,
+      });
     }
   }
 }

--- a/typescript/web_core/src/validating/validator.ts
+++ b/typescript/web_core/src/validating/validator.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {A2uiValidationError} from '../errors.js';
+import {AgentToRendererMessageSchema} from '../v1_0/schema/agent-to-renderer.js';
+import {
+  ComponentRefMap,
+  IntegrityOptions,
+  STANDARD_REF_MAP,
+  validateComponentIntegrity,
+  validateRecursionAndPaths,
+} from './integrity-checker.js';
+import {analyzeTopology, TopologyOptions} from './topology-analyzer.js';
+
+export interface ValidationConfig extends IntegrityOptions, TopologyOptions {}
+
+export const STRICT_VALIDATION: ValidationConfig = {
+  allowOrphanComponents: false,
+  allowDanglingReferences: false,
+  allowMissingRoot: false,
+};
+
+export const RELAXED_VALIDATION: ValidationConfig = {
+  allowOrphanComponents: true,
+  allowDanglingReferences: true,
+  allowMissingRoot: true,
+};
+
+/**
+ * High-level validator for auditing A2UI message streams, components, and graph topology.
+ */
+export class A2uiValidator {
+  /**
+   * Validates a list of protocol messages against Zod message envelope schemas.
+   */
+  public validateProtocolEnvelope(messages: Array<Record<string, any>>): void {
+    if (!Array.isArray(messages)) {
+      throw new A2uiValidationError('Message stream must be an array of objects');
+    }
+
+    for (let idx = 0; idx < messages.length; idx++) {
+      const msg = messages[idx];
+      if (typeof msg !== 'object' || msg === null) {
+        throw new A2uiValidationError(`Message must be an object at index ${idx}`);
+      }
+
+      const parseResult = AgentToRendererMessageSchema.safeParse(msg);
+      if (!parseResult.success) {
+        throw new A2uiValidationError(
+          `Validation failed for message at index ${idx}: ${parseResult.error.message}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Validates component list integrity and graph topology.
+   */
+  public validateComponents(
+    components: Array<Record<string, any>>,
+    refFieldsMap: ComponentRefMap = STANDARD_REF_MAP,
+    config: ValidationConfig = STRICT_VALIDATION,
+  ): void {
+    validateComponentIntegrity(components, refFieldsMap, config);
+    analyzeTopology(components, refFieldsMap, config);
+    validateRecursionAndPaths(components);
+  }
+
+  /**
+   * Validates an entire A2UI payload (envelope, components, topology, and path syntax).
+   */
+  public validate(
+    messages: Array<Record<string, any>> | Record<string, any>,
+    refFieldsMap: ComponentRefMap = STANDARD_REF_MAP,
+    config: ValidationConfig = STRICT_VALIDATION,
+  ): void {
+    const msgList = Array.isArray(messages) ? messages : [messages];
+    this.validateProtocolEnvelope(msgList);
+
+    for (const msg of msgList) {
+      validateRecursionAndPaths(msg);
+
+      const updateComps = msg.updateComponents?.components;
+      if (Array.isArray(updateComps)) {
+        this.validateComponents(updateComps, refFieldsMap, config);
+      }
+    }
+  }
+}

--- a/typescript/web_core/src/validating/validator.ts
+++ b/typescript/web_core/src/validating/validator.ts
@@ -39,6 +39,10 @@ export const RELAXED_VALIDATION: ValidationConfig = {
   allowMissingRoot: true,
 };
 
+export interface ValidateComponentsOptions {
+  skipRecursionCheck?: boolean;
+}
+
 /**
  * High-level validator for auditing A2UI message streams, components, and graph topology.
  */
@@ -73,10 +77,13 @@ export class A2uiValidator {
     components: Array<Record<string, any>>,
     refFieldsMap: ComponentRefMap = STANDARD_REF_MAP,
     config: ValidationConfig = STRICT_VALIDATION,
+    options: ValidateComponentsOptions = {},
   ): void {
     validateComponentIntegrity(components, refFieldsMap, config);
     analyzeTopology(components, refFieldsMap, config);
-    validateRecursionAndPaths(components);
+    if (!options.skipRecursionCheck) {
+      validateRecursionAndPaths(components);
+    }
   }
 
   /**
@@ -95,7 +102,7 @@ export class A2uiValidator {
 
       const updateComps = msg.updateComponents?.components;
       if (Array.isArray(updateComps)) {
-        this.validateComponents(updateComps, refFieldsMap, config);
+        this.validateComponents(updateComps, refFieldsMap, config, {skipRecursionCheck: true});
       }
     }
   }

--- a/typescript/web_core/src/validating/validator.ts
+++ b/typescript/web_core/src/validating/validator.ts
@@ -25,30 +25,44 @@ import {
 } from './integrity-checker.js';
 import {analyzeTopology, TopologyOptions} from './topology-analyzer.js';
 
+/** Combined configuration specifying integrity and topology rules. */
 export interface ValidationConfig extends IntegrityOptions, TopologyOptions {}
 
+/** Strict validation configuration requiring root node presence, no orphans, and valid references. */
 export const STRICT_VALIDATION: ValidationConfig = {
   allowOrphanComponents: false,
   allowDanglingReferences: false,
   allowMissingRoot: false,
 };
 
+/** Relaxed validation configuration permitting orphan components, missing root, and dangling references. */
 export const RELAXED_VALIDATION: ValidationConfig = {
   allowOrphanComponents: true,
   allowDanglingReferences: true,
   allowMissingRoot: true,
 };
 
+/** Options for fine-tuning component validation operations. */
 export interface ValidateComponentsOptions {
+  /** Whether to bypass path syntax and depth recursion checks on component objects. */
   skipRecursionCheck?: boolean;
 }
 
 /**
  * High-level validator for auditing A2UI message streams, components, and graph topology.
+ *
+ * @example
+ * ```ts
+ * const validator = new A2uiValidator();
+ * validator.validate(messages, STANDARD_REF_MAP, STRICT_VALIDATION);
+ * ```
  */
 export class A2uiValidator {
   /**
    * Validates a list of protocol messages against Zod message envelope schemas.
+   *
+   * @param messages Stream of raw message objects to audit.
+   * @throws {A2uiValidationError} If any message fails Zod envelope schema validation.
    */
   public validateProtocolEnvelope(messages: Array<Record<string, any>>): void {
     if (!Array.isArray(messages)) {
@@ -72,6 +86,14 @@ export class A2uiValidator {
 
   /**
    * Validates component list integrity and graph topology.
+   *
+   * @param components List of component definition objects.
+   * @param refFieldsMap Reference field definitions per component type.
+   * @param config Validation settings for integrity and topology.
+   * @param options Additional component validation options.
+   * @throws {A2uiIntegrityError} If integrity check or reachability check fails.
+   * @throws {A2uiRecursionError} If graph recursion or self-reference is found.
+   * @throws {A2uiValidationError} If invalid path syntax is encountered.
    */
   public validateComponents(
     components: Array<Record<string, any>>,
@@ -88,6 +110,18 @@ export class A2uiValidator {
 
   /**
    * Validates an entire A2UI payload (envelope, components, topology, and path syntax).
+   *
+   * @param messages Single message object or array of message objects to validate.
+   * @param refFieldsMap Component reference mapping.
+   * @param config Validation configuration options.
+   * @throws {A2uiValidationError} If envelope format or path syntax is invalid.
+   * @throws {A2uiIntegrityError} If component references or graph integrity are violated.
+   * @throws {A2uiRecursionError} If recursion limits or circular component links are detected.
+   *
+   * @example
+   * ```ts
+   * validator.validate(payloadMessage);
+   * ```
    */
   public validate(
     messages: Array<Record<string, any>> | Record<string, any>,


### PR DESCRIPTION
## Summary

This pull request implements Stage 3 (`Sauce-TS`) deliverables for the Web Core renderer package (`typescript/web_core`). It introduces the `RpcHandler` engine for handling bidirectional remote function calls between the client renderer and server agent, enforces execution boundaries (`callableFrom`) and user activation constraints (`requiresUserActivation`), exports structured RPC error codes and exceptions (`RpcError`, `RpcErrorCode`), registers the built-in `@index` function with array index resolution, and cleans up legacy `v0_9` re-export stubs.

---

## Stack Context

- 🥞 **PR 1 (Base of Stack)**: [#2257](https://github.com/a2ui-project/a2ui/pull/2257) (`v1_0_firing_ts`) — Core v1.0 Zod schemas, version adapters, `callableFrom` metadata, composition constraints, and data model path resolution.
- 🥞 **PR 2 (This PR)**: [#2264](https://github.com/a2ui-project/a2ui/pull/2264) (`v1_0_sauce_ts`) — Bidirectional RPC execution (`callRendererFunction`, `callAgentFunction`), dynamic `ValidationResult` handling, multi-catalog resolution engine, and `@index` loop function.

---

## Changes

### 1. Bidirectional RPC Engine (`typescript/web_core/src/v1_0/rpc/`)
- Implemented `RpcHandler` in `src/v1_0/rpc/rpc-handler.ts` to process incoming `callRendererFunction` messages and return `rendererFunctionResponse` payloads.
- Implemented outbound `callAgentFunction` request tracking and response resolution via incoming `agentFunctionResponse` messages matching `functionCallId`.
- Created structured `RpcErrorCode` enum (`INVALID_FUNCTION_CALL`, `EXECUTION_ERROR`, `TIMEOUT`, `CANCELLED`, `DISPOSED`, `DUPLICATE`, `NO_LISTENER`) and `RpcError` exception class with prototype restoration.
- Configured extensible `RpcHandlerOptions` options bag with backward-compatible array constructor overload.
- Added `isDisposed` lifecycle guards failing fast post-disposal, and `globalThis.crypto.randomUUID()` feature checks with non-secure context fallbacks.
- Enforced catalog execution boundary checks (`callableFrom`: `rendererOnly`, `agentOnly`, `rendererOrAgent`) and user activation context constraints (`requiresUserActivation`).

### 2. Basic Catalog `@index` Function & Property Merging
- Centralized `IndexApi` in `src/v0_9/basic_catalog/functions/basic_functions_api.ts` with `z.coerce.number().optional()` schema validation.
- Implemented `IndexImplementation` with strict `/^\d+$/` path segment regex matching to resolve loop indices for nested child contexts, supporting optional `offset` configuration.
- Updated `processUpdateComponentsOp` in `src/processing/message-processor.ts` to merge existing properties with incoming properties on partial updates.

### 3. Public Export & Modular Cleanup (`typescript/web_core/src/v1_0/`)
- Re-exported `RpcHandler`, `OutboundMessageListener`, `RpcHandlerOptions`, `RpcErrorCode`, and `RpcError` from `src/v1_0/index.ts`.
- Removed redundant `src/v0_9/` stub files across catalog, rendering, reactivity, and state directories.

---

## Impact & Risks

- **Impact**: Enables full bidirectional RPC execution between renderer components and server agents while supporting context-aware loop index functions in component trees.
- **Risks**: Low. Fully verified with dedicated RPC test suites and zero regression across existing protocol versions.

---

## Testing

- **Unit Tests**: Ran `npm run test` in `typescript/web_core` — **295/295 passing tests** (100%).
- **Conformance Suite**: Executed `node tests/conformance/conformance_test.mjs` — **216/216 passing test vectors** (100%).
- **Static Analysis & Linting**: Verified clean compilation with `yarn build` and zero ESLint errors with `yarn lint`.
