### PR TITLE
Fix pong

### DIFF
--- a/samples/community/agent/adk/mcp_app_proxy/pong_mcp_bridge.js
+++ b/samples/community/agent/adk/mcp_app_proxy/pong_mcp_bridge.js
@@ -91,22 +91,22 @@ window.addEventListener('message', event => {
 
       // Automatically restart if scores reset to 0
       if (localPlayerScore === 0 && localCpuScore === 0) {
-        if (typeof isPaused !== 'undefined') {
+        if (typeof isPaused !== 'undefined' && isPaused) {
           isPaused = false;
+          if (typeof hideOverlay === 'function') {
+            hideOverlay();
+          }
+          if (typeof resetBall === 'function') {
+            resetBall();
+          }
+          sendRequest('tools/call', {
+            name: 'commentate_pong',
+            arguments: {
+              game_event: 'Match started! Current Score: Player 0 - CPU 0.',
+              silent: true,
+            },
+          }).catch(e => console.error('Failed to request commentary:', e));
         }
-        if (typeof hideOverlay === 'function') {
-          hideOverlay();
-        }
-        if (typeof resetBall === 'function') {
-          resetBall();
-        }
-        sendRequest('tools/call', {
-          name: 'commentate_pong',
-          arguments: {
-            game_event: 'Match started! Current Score: Player 0 - CPU 0.',
-            silent: true,
-          },
-        }).catch(e => console.error('Failed to request commentary:', e));
       }
     }
   }

--- a/samples/community/web/pong/pong_web_frame_bridge.js
+++ b/samples/community/web/pong/pong_web_frame_bridge.js
@@ -183,19 +183,19 @@ function handleDataModelUpdate(data) {
 
     // Automatically restart if scores reset to 0
     if (localPlayerScore === 0 && localCpuScore === 0) {
-      if (typeof isPaused !== 'undefined') {
+      if (typeof isPaused !== 'undefined' && isPaused) {
         isPaused = false;
+        if (typeof hideOverlay === 'function') {
+          hideOverlay();
+        }
+        if (typeof resetBall === 'function') {
+          resetBall();
+        }
+        dispatchAction('commentate_pong', {
+          game_event: 'Match started! Current Score: Player 0 - CPU 0.',
+          silent: true,
+        });
       }
-      if (typeof hideOverlay === 'function') {
-        hideOverlay();
-      }
-      if (typeof resetBall === 'function') {
-        resetBall();
-      }
-      dispatchAction('commentate_pong', {
-        game_event: 'Match started! Current Score: Player 0 - CPU 0.',
-        silent: true,
-      });
     }
   }
 }


### PR DESCRIPTION
# Description

Fixes an issue in the Pong sample bridges where game restart and unpause logic triggered indiscriminately on data model updates during active gameplay, rather than strictly when the match was paused after scores reset to 0.

## Changes
- **`pong_mcp_bridge.js`**:
  - Added an explicit `isPaused` check (`typeof isPaused !== 'undefined' && isPaused`) before executing overlay hiding, ball resetting, and match restart commentary upon score resets.
- **`pong_web_frame_bridge.js`**:
  - Applied the corresponding `isPaused` guard to the client web frame bridge implementation to prevent premature restarts during live gameplay.


## Pre-launch Checklist

One time:

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have built and run at least one [sample].

For this PR:

- [ ] I have updated the relevant CHANGELOG.md file.
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
