### PR TITLE
refactor(conformance): convert conformance test properties to camelCase

### DIFF
--- a/agent_sdks/python/a2ui_agent/tests/conformance/test_a2a_integration.py
+++ b/agent_sdks/python/a2ui_agent/tests/conformance/test_a2a_integration.py
@@ -64,18 +64,19 @@ def test_a2a_integration_conformance(name, test_case):
         assert is_a2ui_part(part)
         expect = test_case["expect"]
         data_part = get_a2ui_datapart(part)
-        assert data_part.metadata.get("mimeType") == expect["mime_type"]
+        exp_mime = expect.get("mimeType")
+        assert data_part.metadata.get("mimeType") == exp_mime
 
     elif action == "is_a2ui_part":
-        mime_type = args["mime_type"]
+        mime_type = args.get("mimeType")
         part = Part(root=DataPart(data={}, metadata={"mimeType": mime_type}))
         result = is_a2ui_part(part)
         assert result == test_case["expect"]
 
     elif action == "get_extension":
         version = args["version"]
-        accepts_inline_catalogs = args.get("accepts_inline_catalogs")
-        supported_catalog_ids = args.get("supported_catalog_ids")
+        accepts_inline_catalogs = args.get("acceptsInlineCatalogs")
+        supported_catalog_ids = args.get("supportedCatalogIds")
 
         kwargs = {}
         if accepts_inline_catalogs is not None:

--- a/agent_sdks/python/a2ui_agent/tests/conformance/test_adk_extensions.py
+++ b/agent_sdks/python/a2ui_agent/tests/conformance/test_adk_extensions.py
@@ -54,7 +54,7 @@ def test_adk_extensions_conformance(name, test_case):
     args = test_case.get("args", {})
 
     if action == "execute_tool":
-        a2ui_json_str = args.get("a2ui_json")
+        a2ui_json_str = args.get("a2uiJson")
         tool_args = {"a2ui_json": a2ui_json_str} if a2ui_json_str else args
 
         catalog_mock = MagicMock(spec=A2uiCatalog)
@@ -82,12 +82,13 @@ def test_adk_extensions_conformance(name, test_case):
                 SendA2uiToClientToolset._SendA2uiJsonToClientTool.VALIDATED_A2UI_JSON_KEY
                 in result
             )
-            if expect.get("contains_validated_json"):
+            if expect.get("containsValidatedJson"):
                 validated_payload = result[
                     SendA2uiToClientToolset._SendA2uiJsonToClientTool.VALIDATED_A2UI_JSON_KEY
                 ]
                 assert "beginRendering" in json.dumps(validated_payload)
         else:
             assert "error" in result
-            if expect.get("error_contains"):
-                assert expect["error_contains"] in result["error"]
+            err_contains = expect.get("errorContains")
+            if err_contains:
+                assert err_contains in result["error"]

--- a/agent_sdks/python/a2ui_agent/tests/conformance/test_conformance.py
+++ b/agent_sdks/python/a2ui_agent/tests/conformance/test_conformance.py
@@ -127,25 +127,25 @@ def load_tests(filename):
 
 
 def setup_catalog(catalog_config):
-    version = str(catalog_config.get("protocol_version", "v0.9")).removeprefix("v")
+    version = str(catalog_config.get("protocolVersion", "v0.9")).removeprefix("v")
 
-    s2c_schema = catalog_config.get("s2c_schema")
+    s2c_schema = catalog_config.get("s2cSchema")
     if isinstance(s2c_schema, str):
         s2c_schema = load_json_file(s2c_schema)
 
-    catalog_schema = catalog_config.get("catalog_schema")
+    catalog_schema = catalog_config.get("catalogSchema")
     if isinstance(catalog_schema, str):
         catalog_schema = load_json_file(catalog_schema)
     elif catalog_schema is None:
         catalog_schema = {}
 
-    common_types_schema = catalog_config.get("common_types_schema")
+    common_types_schema = catalog_config.get("commonTypesSchema")
     if isinstance(common_types_schema, str):
         common_types_schema = load_json_file(common_types_schema)
     elif common_types_schema is None:
         common_types_schema = {}
 
-    custom_cuttable_keys = catalog_config.get("custom_cuttable_keys")
+    custom_cuttable_keys = catalog_config.get("customCuttableKeys")
     return A2uiCatalog(
         version=version,
         name=catalog_config.get("name", "test_catalog"),
@@ -190,8 +190,7 @@ def get_conformance_cases(filename):
         catalog = (
             case.get("catalog", {}) if isinstance(case.get("catalog"), dict) else {}
         )
-        args = case.get("args", {}) if isinstance(case.get("args"), dict) else {}
-        version = str(catalog.get("protocol_version") or args.get("version") or "v0.8")
+        version = str(catalog.get("protocolVersion", "v0.9"))
         if not version.startswith("v"):
             version = f"v{version}"
 
@@ -212,7 +211,7 @@ def test_parser_conformance(name, test_case):
     catalog_config = test_case["catalog"]
     catalog = setup_catalog(catalog_config)
     parser = DirectJsonStreamParser(catalog=catalog)
-    if test_case.get("disable_validation"):
+    if test_case.get("disableValidation"):
         parser._validator = None
 
     steps = test_case.get("steps")
@@ -223,7 +222,7 @@ def test_parser_conformance(name, test_case):
         steps = [test_case]
 
     for step in steps:
-        expect_error = step.get("expect_error") or test_case.get("expect_error")
+        expect_error = step.get("expectError") or test_case.get("expectError")
         if expect_error:
             with assert_raises(expect_error):
                 parser.process_chunk(step["input"])
@@ -249,8 +248,9 @@ def test_parser_non_streaming_conformance(name, test_case):
     content = test_case["input"]
 
     if action == "parse_full":
-        if "expect_error" in test_case:
-            with assert_raises(test_case["expect_error"]):
+        expect_error = test_case.get("expectError")
+        if expect_error:
+            with assert_raises(expect_error):
                 parse_response(content)
         else:
             parts = parse_response(content)
@@ -261,8 +261,9 @@ def test_parser_non_streaming_conformance(name, test_case):
                 assert actual.a2ui_json == exp.get("a2ui")
 
     elif action == "fix_payload":
-        if "expect_error" in test_case:
-            with assert_raises(test_case["expect_error"]):
+        expect_error = test_case.get("expectError")
+        if expect_error:
+            with assert_raises(expect_error):
                 parse_and_fix(content)
         else:
             result = parse_and_fix(content)
@@ -297,7 +298,7 @@ def test_validator_conformance(name, test_case):
     validator = A2uiValidator(catalog=catalog)
     for step in steps:
         step_messages = step["messages"]
-        expect_error = step.get("expect_error") or test_case.get("expect_error")
+        expect_error = step.get("expectError") or test_case.get("expectError")
         if expect_error:
             with assert_raises(expect_error):
                 validator.validate(step_messages)
@@ -319,21 +320,22 @@ def test_catalog_conformance(name, test_case):
     args = test_case.get("args", {})
 
     if action == "prune":
-        allowed_components = args.get("allowed_components", [])
-        allowed_messages = args.get("allowed_messages", [])
+        allowed_components = args.get("allowedComponents", [])
+        allowed_messages = args.get("allowedMessages", [])
         pruned = catalog.with_pruning(allowed_components, allowed_messages)
         expected = test_case["expect"]
         if isinstance(expected, dict):
-            if "catalog_schema" in expected:
-                assert pruned.catalog_schema == expected["catalog_schema"]
-            if "s2c_schema" in expected:
-                assert pruned.s2c_schema == expected["s2c_schema"]
-            if "common_types_schema" in expected:
-                assert pruned.common_types_schema == expected["common_types_schema"]
+            if "catalogSchema" in expected:
+                assert pruned.catalog_schema == expected["catalogSchema"]
+            if "s2cSchema" in expected:
+                assert pruned.s2c_schema == expected["s2cSchema"]
+            if "commonTypesSchema" in expected:
+                assert pruned.common_types_schema == expected["commonTypesSchema"]
 
     elif action == "render":
         output = catalog.render_as_llm_instructions()
-        assert output.strip() == test_case["expect_output"].strip()
+        expect_output = test_case["expectOutput"]
+        assert output.strip() == expect_output.strip()
 
     elif action == "load":
         path = args.get("path")
@@ -342,12 +344,14 @@ def test_catalog_conformance(name, test_case):
         else:
             full_path = None
         validate = args.get("validate", False)
-        if "expect_error" in test_case:
-            with assert_raises(test_case["expect_error"]):
+        expect_error = test_case.get("expectError")
+        if expect_error:
+            with assert_raises(expect_error):
                 catalog.load_examples(full_path, validate=validate)
         else:
             output = catalog.load_examples(full_path, validate=validate)
-            assert output.strip() == test_case["expect_output"].strip()
+            expect_output = test_case["expectOutput"]
+            assert output.strip() == expect_output.strip()
 
     elif action == "remove_strict_validation":
         schema = args["schema"]
@@ -355,7 +359,7 @@ def test_catalog_conformance(name, test_case):
         assert modified == test_case["expect"]["schema"]
 
     elif action == "verify_cuttable_keys":
-        expected = test_case["expect"]["custom_cuttable_keys"]
+        expected = test_case["expect"].get("customCuttableKeys")
         assert set(catalog.cuttable_keys) == set(expected)
 
 
@@ -373,9 +377,9 @@ def test_schema_manager_conformance(name, test_case):
     args = test_case.get("args", {})
 
     if action == "select_catalog":
-        supported_catalogs = args.get("supported_catalogs", [])
-        client_capabilities = args.get("client_capabilities", {})
-        accepts_inline_catalogs = args.get("accepts_inline_catalogs", False)
+        supported_catalogs = args.get("supportedCatalogs", [])
+        client_capabilities = args.get("clientCapabilities", {})
+        accepts_inline_catalogs = args.get("acceptsInlineCatalogs", False)
 
         configs = []
         for cat_def in supported_catalogs:
@@ -392,8 +396,9 @@ def test_schema_manager_conformance(name, test_case):
             accepts_inline_catalogs=accepts_inline_catalogs,
         )
 
-        if "expect_error" in test_case:
-            with assert_raises(test_case["expect_error"]):
+        expect_error = test_case.get("expectError")
+        if expect_error:
+            with assert_raises(expect_error):
                 direct_json_format.get_selected_catalog(client_capabilities)
         else:
             selected = direct_json_format.get_selected_catalog(client_capabilities)
@@ -401,11 +406,12 @@ def test_schema_manager_conformance(name, test_case):
                 expected = test_case["expect"]
                 if isinstance(expected, dict):
                     assert selected.catalog_schema == expected
-            if "expect_selected" in test_case:
-                assert selected.catalog_id == test_case["expect_selected"]
+            expect_selected = test_case.get("expectSelected")
+            if expect_selected:
+                assert selected.catalog_id == expect_selected
 
     elif action == "load_catalog":
-        catalog_configs = test_case.get("catalog_configs", [])
+        catalog_configs = test_case.get("catalogConfigs", [])
         modifiers = test_case.get("modifiers", [])
         schema_modifiers = []
         if "remove_strict_validation" in modifiers:
@@ -421,20 +427,21 @@ def test_schema_manager_conformance(name, test_case):
         )
         selected = direct_json_format.get_selected_catalog()
         expected = test_case["expect"]
-        if isinstance(expected, dict) and "supported_catalog_ids" in expected:
+        if isinstance(expected, dict) and "supportedCatalogIds" in expected:
+            exp_ids = expected["supportedCatalogIds"]
             assert [
                 c.catalog_id for c in direct_json_format._supported_catalogs
-            ] == expected["supported_catalog_ids"]
+            ] == exp_ids
         elif isinstance(expected, dict):
             assert selected.catalog_schema == expected
 
     elif action == "generate_prompt":
         version = args.get("version", VERSION_0_8)
-        role = args.get("role_description", "")
-        workflow = args.get("workflow_description", "")
-        ui_desc = args.get("ui_description", "")
+        role = args.get("roleDescription", "")
+        workflow = args.get("workflowDescription", "")
+        ui_desc = args.get("uiDescription", "")
 
-        examples_path = args.get("examples_path")
+        examples_path = args.get("examplesPath")
         if examples_path:
             examples_path = _get_conformance_path(examples_path)
 
@@ -446,26 +453,28 @@ def test_schema_manager_conformance(name, test_case):
                 examples_path=examples_path,
             )
 
+        accepts_inline = args.get("acceptsInlineCatalogs", False)
         direct_json_format = DirectJsonFormat(
             version=version,
             catalogs=[config],
-            accepts_inline_catalogs=args.get("accepts_inline_catalogs", False),
+            accepts_inline_catalogs=accepts_inline,
         )
 
         output = direct_json_format.generate_system_prompt(
             role_description=role,
             workflow_description=workflow,
             ui_description=ui_desc,
-            include_schema=args.get("include_schema", False),
-            include_examples=args.get("include_examples", False),
-            client_ui_capabilities=args.get("client_ui_capabilities"),
-            allowed_components=args.get("allowed_components"),
-            allowed_messages=args.get("allowed_messages"),
+            include_schema=args.get("includeSchema", False),
+            include_examples=args.get("includeExamples", False),
+            client_ui_capabilities=args.get("clientUiCapabilities"),
+            allowed_components=args.get("allowedComponents"),
+            allowed_messages=args.get("allowedMessages"),
         )
 
         output_normalized = re.sub(r"\s+", "", output.strip())
 
-        if "expect_contains" in test_case:
-            for expected in test_case["expect_contains"]:
+        expect_contains = test_case.get("expectContains")
+        if expect_contains:
+            for expected in expect_contains:
                 expected_normalized = re.sub(r"\s+", "", expected.strip())
                 assert expected_normalized in output_normalized

--- a/conformance/agent/inference_format.yaml
+++ b/conformance/agent/inference_format.yaml
@@ -18,58 +18,58 @@
   description: If supported_catalog_ids is not provided, return the first supported catalog.
   action: select_catalog
   args:
-    supported_catalogs:
+    supportedCatalogs:
       - catalogId: id_basic
         components: {}
       - catalogId: id_custom1
         components: {}
       - catalogId: id_custom2
         components: {}
-    client_capabilities: {}
-  expect_selected: id_basic
+    clientCapabilities: {}
+  expectSelected: id_basic
 
 - name: test_select_catalog_intersection
   description: Find the intersection, return any catalog that matches.
   action: select_catalog
   args:
-    supported_catalogs:
+    supportedCatalogs:
       - catalogId: id_basic
         components: {}
       - catalogId: id_custom1
         components: {}
       - catalogId: id_custom2
         components: {}
-    client_capabilities:
+    clientCapabilities:
       supportedCatalogIds: ["id_custom2", "id_custom1"]
-  expect_selected: id_custom2
+  expectSelected: id_custom2
 
 - name: test_select_catalog_priority
   description: Priority is determined by the order in supported_catalog_ids.
   action: select_catalog
   args:
-    supported_catalogs:
+    supportedCatalogs:
       - catalogId: id_basic
         components: {}
       - catalogId: id_custom1
         components: {}
       - catalogId: id_custom2
         components: {}
-    client_capabilities:
+    clientCapabilities:
       supportedCatalogIds: ["id_custom1", "id_custom2"]
-  expect_selected: id_custom1
+  expectSelected: id_custom1
 
 - name: test_select_catalog_no_match
   description: Raise error if supported list is non-empty but no match exists.
   action: select_catalog
   args:
-    supported_catalogs:
+    supportedCatalogs:
       - catalogId: id_basic
         components: {}
       - catalogId: id_custom1
         components: {}
-    client_capabilities:
+    clientCapabilities:
       supportedCatalogIds: ["id_not_exists"]
-  expect_error:
+  expectError:
     category: "CatalogError"
     message: "No client-supported catalog found"
 
@@ -77,12 +77,12 @@
   description: Inline catalog loading (merges onto base).
   action: select_catalog
   args:
-    accepts_inline_catalogs: true
-    supported_catalogs:
+    acceptsInlineCatalogs: true
+    supportedCatalogs:
       - catalogId: id_basic
         components:
           Text: {}
-    client_capabilities:
+    clientCapabilities:
       inlineCatalogs:
         - catalogId: id_inline
           components:
@@ -97,13 +97,13 @@
   description: Inline catalog loading should fail if not accepted.
   action: select_catalog
   args:
-    accepts_inline_catalogs: false
-    supported_catalogs:
+    acceptsInlineCatalogs: false
+    supportedCatalogs:
       - catalogId: id_basic
-    client_capabilities:
+    clientCapabilities:
       inlineCatalogs:
         - catalogId: id_inline
-  expect_error:
+  expectError:
     category: "CatalogError"
     message: "the agent does not accept inline catalogs"
 
@@ -111,12 +111,12 @@
   description: Tests that multiple inline catalogs are merged.
   action: select_catalog
   args:
-    accepts_inline_catalogs: true
-    supported_catalogs:
+    acceptsInlineCatalogs: true
+    supportedCatalogs:
       - catalogId: id_basic
         components:
           Text: {}
-    client_capabilities:
+    clientCapabilities:
       inlineCatalogs:
         - catalogId: id_basic
           components:
@@ -135,14 +135,14 @@
   description: Fallback to default catalog when no match in supported list but inline is present.
   action: select_catalog
   args:
-    accepts_inline_catalogs: true
-    supported_catalogs:
+    acceptsInlineCatalogs: true
+    supportedCatalogs:
       - catalogId: id_basic
         components:
           Text: {}
       - catalogId: id_custom1
         components: {}
-    client_capabilities:
+    clientCapabilities:
       supportedCatalogIds: ["id_not_exists"]
       inlineCatalogs:
         - catalogId: id_basic
@@ -158,7 +158,7 @@
 
 - name: test_manager_with_modifiers
   description: Tests that A2uiSchemaManager applies modifiers during loading.
-  catalog_configs:
+  catalogConfigs:
     - name: test_strict
       path: "test_data/load_examples/schema_with_strict/catalog.json"
   modifiers: ["remove_strict_validation"]
@@ -173,7 +173,7 @@
 
 - name: test_manager_no_modifiers
   description: Tests that A2uiSchemaManager works fine without modifiers.
-  catalog_configs:
+  catalogConfigs:
     - name: test_strict
       path: "test_data/load_examples/schema_with_strict/catalog.json"
   action: load_catalog
@@ -193,8 +193,8 @@
   action: generate_prompt
   args:
     version: "0.8"
-    role_description: "Just Role"
-  expect_contains:
+    roleDescription: "Just Role"
+  expectContains:
     - "Just Role"
     - "## Workflow Description:"
     - "The generated response MUST follow these rules:"
@@ -204,9 +204,9 @@
   action: generate_prompt
   args:
     version: "0.8"
-    role_description: "Role"
-    workflow_description: "Custom Rule Content"
-  expect_contains:
+    roleDescription: "Role"
+    workflowDescription: "Custom Rule Content"
+  expectContains:
     - "Role"
     - "## Workflow Description:"
     - "The generated response MUST follow these rules:"
@@ -217,10 +217,10 @@
   action: generate_prompt
   args:
     version: "0.8"
-    role_description: "Role"
-    workflow_description: "Workflow"
-    ui_description: "Render UI."
-  expect_contains:
+    roleDescription: "Role"
+    workflowDescription: "Workflow"
+    uiDescription: "Render UI."
+  expectContains:
     - "Role"
     - "## Workflow Description:"
     - "Workflow"
@@ -232,9 +232,9 @@
   action: generate_prompt
   args:
     version: "0.9"
-    role_description: "Role"
-    include_schema: true
-  expect_contains:
+    roleDescription: "Role"
+    includeSchema: true
+  expectContains:
     - "Role"
     - "---BEGIN A2UI JSON SCHEMA---"
     - "### Server To Client Schema:"
@@ -246,10 +246,10 @@
   action: generate_prompt
   args:
     version: "0.8"
-    role_description: "Role"
-    include_examples: true
-    examples_path: "test_data/load_examples/basic"
-  expect_contains:
+    roleDescription: "Role"
+    includeExamples: true
+    examplesPath: "test_data/load_examples/basic"
+  expectContains:
     - "Role"
     - "### Examples:"
     - "---BEGIN example1---"
@@ -262,15 +262,15 @@
   action: generate_prompt
   args:
     version: "0.8"
-    role_description: "Role"
-    include_schema: true
-    accepts_inline_catalogs: true
-    client_ui_capabilities:
+    roleDescription: "Role"
+    includeSchema: true
+    acceptsInlineCatalogs: true
+    clientUiCapabilities:
       inlineCatalogs:
         - catalogId: id_inline
           components:
             Button: {}
-  expect_contains:
+  expectContains:
     - "Role"
     - "---BEGIN A2UI JSON SCHEMA---"
     - "### Server To Client Schema:"
@@ -281,22 +281,22 @@
 - name: test_schema_manager_init_custom_catalog
   description: Tests that A2uiSchemaManager can load a custom catalog from path.
   action: load_catalog
-  catalog_configs:
+  catalogConfigs:
     - name: standard
       path: "test_data/schema_manager/catalog.json"
     - name: Custom
       path: "test_data/schema_manager/custom_catalog.json"
   expect:
-    supported_catalog_ids: ["basic", "Custom"]
+    supportedCatalogIds: ["basic", "Custom"]
 
 - name: test_generate_system_prompt_v0_9_common_types
   description: Tests v0.9 prompt generation with common types included.
   action: generate_prompt
   args:
     version: "0.9"
-    role_description: "Role"
-    include_schema: true
-  expect_contains:
+    roleDescription: "Role"
+    includeSchema: true
+  expectContains:
     - "Role"
     - "---BEGIN A2UI JSON SCHEMA---"
     - "### Server To Client Schema:"
@@ -309,13 +309,13 @@
   action: generate_prompt
   args:
     version: "0.8"
-    role_description: "Role"
-    include_schema: true
-    client_ui_capabilities:
+    roleDescription: "Role"
+    includeSchema: true
+    clientUiCapabilities:
       supportedCatalogIds: ["https://a2ui.org/specification/v0_8/standard_catalog_definition.json"]
 
-    allowed_components: ["Text"]
-  expect_contains:
+    allowedComponents: ["Text"]
+  expectContains:
     - "Role"
     - "---BEGIN A2UI JSON SCHEMA---"
     - "### Server To Client Schema:"
@@ -326,7 +326,7 @@
 - name: test_agent_v1_0_direct_json_envelope_parsing
   description: Verifies parsing Direct JSON v1.0 payload envelopes wrapped in <a2ui-json> sentinel tags.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: process_chunk
   steps:
     - input: |

--- a/conformance/agent/parser.yaml
+++ b/conformance/agent/parser.yaml
@@ -16,7 +16,7 @@
   description: Tests that empty response raises error.
   action: parse_full
   input: ""
-  expect_error:
+  expectError:
     category: "ParseError"
     message: "not found in response"
 
@@ -24,7 +24,7 @@
   description: Tests that response without tags raises error.
   action: parse_full
   input: "Only text, no tags."
-  expect_error:
+  expectError:
     category: "ParseError"
     message: "not found in response"
 
@@ -32,7 +32,7 @@
   description: Tests that empty tags raise error.
   action: parse_full
   input: "<a2ui-json></a2ui-json>"
-  expect_error:
+  expectError:
     category: "ParseError"
     message: "A2UI JSON part is empty"
 
@@ -84,7 +84,7 @@
   description: Tests that invalid JSON raises error.
   action: parse_full
   input: "<a2ui-json>\ninvalid_json\n</a2ui-json>"
-  expect_error:
+  expectError:
     category: "ParseError"
     message: "Failed to parse"
 

--- a/conformance/agent/streaming_parser.yaml
+++ b/conformance/agent/streaming_parser.yaml
@@ -15,9 +15,9 @@
 - name: test_incremental_yielding
   description: Tests that partial chunks are buffered and yielded correctly.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -36,9 +36,9 @@
 - name: test_waiting_for_root_component
   description: Tests that components are not yielded until reachable from root.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -77,9 +77,9 @@
 - name: test_complete_surface_ignore_orphan_component
   description: Tests that orphan components (not reachable from root) are ignored.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -103,9 +103,9 @@
 - name: test_circular_reference_detection
   description: Tests that circular references are detected during streaming.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Card:
@@ -117,16 +117,16 @@
     - input: '<a2ui-json>[{"beginRendering": {"root": "c1", "surfaceId": "s1"}},'
       expect: [{a2ui: [{beginRendering: {root: "c1", surfaceId: "s1"}}]}]
     - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "c1", "component": {"Card": {"child": "c2"}}}]}},{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "c2", "component": {"Card": {"child": "c1"}}}]}}]}} </a2ui-json>'
-      expect_error:
+      expectError:
         category: "RecursionError"
         message: "Circular reference detected"
 
 - name: test_self_reference_detection
   description: Tests that self-references are detected during streaming.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Card:
@@ -138,16 +138,16 @@
     - input: '<a2ui-json>[{"beginRendering": {"root": "c1", "surfaceId": "s1"}},'
       expect: [{a2ui: [{beginRendering: {root: "c1", surfaceId: "s1"}}]}]
     - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "c1", "component": {"Card": {"child": "c1"}}}]}}]}} </a2ui-json>'
-      expect_error:
+      expectError:
         category: "RecursionError"
         message: "Self-reference detected"
 
 - name: test_interleaved_conversational_text
   description: Tests that conversational text and A2UI content are interleaved correctly.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema: {catalogId: "test_catalog", components: {}}
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema: {catalogId: "test_catalog", components: {}}
   action: process_chunk
   steps:
     - input: "Hello! "
@@ -162,9 +162,9 @@
 - name: test_split_tag_handling_for_text
   description: Tests that the parser handles the opening tag split across chunks correctly.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema: {catalogId: "test_catalog", components: {}}
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema: {catalogId: "test_catalog", components: {}}
   action: process_chunk
   steps:
     - input: "Talking <a2u"
@@ -179,9 +179,9 @@
 - name: test_only_begin_rendering
   description: Tests that beginRendering is yielded only when complete.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components: {}
   action: process_chunk
@@ -217,9 +217,9 @@
 - name: test_multiple_a2ui_blocks
   description: Tests that multiple A2UI blocks are handled correctly with interleaved text.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: test_catalog
       components:
         Text:
@@ -249,9 +249,9 @@
 - name: test_partial_json_and_incremental_yielding
   description: Tests that partial JSON chunks are fixed and yielded incrementally.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -276,9 +276,9 @@
 - name: test_partial_single_child_string
   description: Tests that placeholders are yielded for missing children and resolved when they arrive.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -332,9 +332,9 @@
 - name: test_partial_template_componentId
   description: Tests that placeholders are yielded for missing template components and resolved when they arrive.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -394,9 +394,9 @@
 - name: test_partial_children_lists
   description: Tests that placeholders are yielded for all missing children in a list and resolved individually.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -468,9 +468,9 @@
 - name: test_data_model_before_components
   description: Tests that data model updates can be processed before components.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -506,9 +506,9 @@
 - name: test_data_model_after_components
   description: Tests that components can be processed before data model updates.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -544,9 +544,9 @@
 - name: test_partial_paths
   description: Tests that partial paths are buffered and not yielded until complete.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -580,9 +580,9 @@
 - name: test_url_placeholders_with_hints
   description: "Verifies that properties hinting at being images or links get specialized placeholders (Note: Python test actually expects full resolution as all components are provided in the chunk)."
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Container:
@@ -632,9 +632,9 @@
 - name: test_cut_atomic_id
   description: Tests that atomic keys are buffered and not yielded until complete.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -670,9 +670,9 @@
 - name: test_cut_cuttable_text
   description: Tests that cuttable text is yielded eagerly even if cut.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -712,9 +712,9 @@
 - name: test_message_ordering_buffering
   description: Tests that surfaceUpdate is buffered until beginRendering arrives.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -738,9 +738,9 @@
 - name: test_delete_surface_buffering
   description: Tests that deleteSurface before beginRendering is ignored.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema: {catalogId: "test_catalog", components: {}}
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema: {catalogId: "test_catalog", components: {}}
   action: process_chunk
   steps:
     - input: "<a2ui-json>["
@@ -753,9 +753,9 @@
 - name: test_cut_path
   description: Tests that non-cuttable keys like path are not yielded until complete.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -783,22 +783,22 @@
 - name: test_strict_begin_rendering_validation
   description: Tests that invalid messages fail validation.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema: {catalogId: "test_catalog", components: {}}
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema: {catalogId: "test_catalog", components: {}}
   action: process_chunk
   steps:
     - input: "<a2ui-json>["
       expect: []
     - input: '{"unknownMessage": "invalid"}]'
-      expect_error: "Validation failed"
+      expectError: "Validation failed"
 
 - name: test_yield_validation_failure
   description: Tests that invalid components fail validation.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -811,14 +811,14 @@
     - input: '<a2ui-json>[{"beginRendering": {"surfaceId": "s1", "root": "root"}}, '
       expect: [{a2ui: [{beginRendering: {surfaceId: "s1", root: "root"}}]}]
     - input: '{"surfaceUpdate": {"surfaceId": "s1", "components": [{"id": "root", "component": {"Text": {}}}]}}]'
-      expect_error: "Validation failed"
+      expectError: "Validation failed"
 
 - name: test_delta_streaming_correctness
   description: Verifies that the parser correctly assembles components from small deltas.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -862,9 +862,9 @@
 - name: test_multiple_re_yielding_scenarios
   description: Tests multiple re-yielding scenarios with data model updates.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -914,9 +914,9 @@
 - name: test_incremental_data_model_streaming
   description: Verifies that the parser yields surface updates as items arrive in a dataModelUpdate stream.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         List:
@@ -992,9 +992,9 @@
 - name: test_sniff_partial_invalid_datamodel_fails_gracefully
   description: Verifies that sniffing a partial DM update that would fail validation doesn't crash.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema: {catalogId: "test_catalog", components: {}}
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema: {catalogId: "test_catalog", components: {}}
   action: process_chunk
   steps:
     - input: '<a2ui-json>[ {"dataModelUpdate": {"surfaceId": "default", "contents": [{"key": "name", "valueString": "John"}, {"valueString": "incomplete"'
@@ -1009,9 +1009,9 @@
 - name: test_sniff_partial_datamodel_with_cut_key
   description: 'Verifies that an unclosed string like {"key or {"key": "val still yields previous valid entries.'
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema: {catalogId: "test_catalog", components: {}}
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema: {catalogId: "test_catalog", components: {}}
   action: process_chunk
   steps:
     - input: '<a2ui-json>[ {"dataModelUpdate": {"surfaceId": "default", "contents": [{"key": "infoLink", "valueString": "[More Info](x)"}, {"key'
@@ -1056,9 +1056,9 @@
 - name: test_sniff_partial_datamodel_cumulative_unmodified_keys
   description: Verifies that unchanged keys are retained in partial dataModelUpdates.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema: {catalogId: "test_catalog", components: {}}
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema: {catalogId: "test_catalog", components: {}}
   action: process_chunk
   steps:
     - input: '<a2ui-json>[ {"dataModelUpdate": {"surfaceId": "default", "contents": [{"key": "title", "valueString": "Top Restaurants"}, {"key": "items", "valueMap": ['
@@ -1087,9 +1087,9 @@
 - name: test_sniff_partial_datamodel_prunes_empty_keys
   description: Verifies that entries with only a key and no value are pruned from partial dataModelUpdates.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema: {catalogId: "test_catalog", components: {}}
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema: {catalogId: "test_catalog", components: {}}
   action: process_chunk
   steps:
     - input: '<a2ui-json>[ {"dataModelUpdate": {"surfaceId": "default", "contents": [{"key": "title", "valueString": "Top Restaurants"},{"key": "items", "valueMap": [{"key": "item1", "valueMap": [{"key": "name", "valueString": "Food"}, {"key": "detail", "valueString": "Spicy"}, {}, {"key": "imageUrl'
@@ -1112,9 +1112,9 @@
 - name: test_sniff_partial_datamodel_prunes_empty_trailing_dict
   description: Verifies that an incomplete trailing empty dictionary '{}' is dropped.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema: {catalogId: "test_catalog", components: {}}
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema: {catalogId: "test_catalog", components: {}}
   action: process_chunk
   steps:
     - input: '<a2ui-json>[ {"dataModelUpdate": {"surfaceId": "default", "contents": [{"key": "title", "valueString": "Top Restaurants"},{"key": "items", "valueMap": [{"key": "item2", "valueMap": [{"key": "name", "valueString": "Han Dynasty"}, {"key": "imageUrl", "valueString": "http://localhost:10002/static/mapotofu.jpeg"}, {}]}]} ]}] </a2ui-json>'
@@ -1137,9 +1137,9 @@
 - name: test_sniff_partial_component_discards_empty_children_dict
   description: Verifies that an incomplete component with an empty children dictionary is discarded until populated.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Column:
@@ -1185,9 +1185,9 @@
 - name: test_partial_empty_dict_discarded
   description: Tests that a component with an empty dictionary in a required field is discarded until populated.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Card:
@@ -1214,9 +1214,9 @@
 - name: test_sniff_partial_component_enforces_required_fields
   description: Tests that components missing required fields are not yielded during sniffing.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         AudioPlayer:
@@ -1245,9 +1245,9 @@
 - name: test_multiple_concurrent_surfaces
   description: Verifies that the parser can handle multiple surfaces simultaneously.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Card:
@@ -1310,10 +1310,10 @@
 - name: test_incremental_yielding_v09
   description: Tests that partial chunks are buffered and yielded correctly for v0.9.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Column:
@@ -1438,10 +1438,10 @@
 - name: test_waiting_for_root_component_v09
   description: Tests that components are not yielded until reachable from root for v0.9.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -1487,10 +1487,10 @@
 - name: test_complete_surface_ignore_orphan_component_v09
   description: Tests that orphan components (not reachable from root) are ignored for v0.9.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -1521,10 +1521,10 @@
 - name: test_circular_reference_detection_v09
   description: Tests that circular references are detected during streaming for v0.9.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Card:
@@ -1543,15 +1543,15 @@
       expect:
         [{a2ui: [{version: "v0.9", createSurface: {catalogId: "test_catalog", surfaceId: "s1"}}]}]
     - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Card", "child": "child"}]}},{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "child", "component": "Card", "child": "root"}]}}'
-      expect_error: "Circular reference detected"
+      expectError: "Circular reference detected"
 
 - name: test_self_reference_detection_v09
   description: Tests that self-references are detected during streaming for v0.9.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Card:
@@ -1570,15 +1570,15 @@
       expect:
         [{a2ui: [{version: "v0.9", createSurface: {catalogId: "test_catalog", surfaceId: "s1"}}]}]
     - input: '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "root", "component": "Card", "child": "root"}]}}'
-      expect_error: "Self-reference detected"
+      expectError: "Self-reference detected"
 
 - name: test_interleaved_conversational_text_v09
   description: Tests that conversational text and A2UI content are interleaved correctly for v0.9.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Dummy: {type: object}
@@ -1602,10 +1602,10 @@
 - name: test_split_tag_handling_for_text_v09
   description: Tests that the parser handles the opening tag split across chunks correctly for v0.9.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Dummy: {type: object}
@@ -1628,10 +1628,10 @@
 - name: test_create_surface_missing_catalog_id_v09
   description: Verifies that v0.9 createSurface fails when catalogId is missing.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components: {}
   action: process_chunk
@@ -1639,15 +1639,15 @@
     - input: "<a2ui-json>"
       expect: []
     - input: '[{"version": "v0.9", "createSurface": {"surfaceId": "s1"}}]'
-      expect_error: "required property"
+      expectError: "required property"
 
 - name: test_only_create_surface_v09
   description: Tests that createSurface is yielded only when complete for v0.9.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components: {}
   action: process_chunk
@@ -1684,10 +1684,10 @@
 - name: test_multiple_a2ui_blocks_v09
   description: Tests that multiple A2UI blocks are handled correctly with interleaved text for v0.9.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -1722,10 +1722,10 @@
 - name: test_partial_json_and_incremental_yielding_v09
   description: Tests that partial JSON yields incremental updates.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -1762,10 +1762,10 @@
 - name: test_partial_single_child_string_v09
   description: Tests that partial single child string yields placeholder.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -1815,10 +1815,10 @@
 - name: test_partial_template_componentId_v09
   description: Tests that partial template componentId yields placeholder after path is seen.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -1870,10 +1870,10 @@
 - name: test_partial_children_lists_v09
   description: Tests that partial children lists yield placeholders.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -1911,10 +1911,10 @@
 - name: test_data_model_before_components_v09
   description: Tests that data model before components works.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -1966,10 +1966,10 @@
 - name: test_data_model_after_components_v09
   description: Tests that data model after components works.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -2021,10 +2021,10 @@
 - name: test_partial_paths_v09
   description: Tests that partial paths are buffered.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -2069,10 +2069,10 @@
 - name: test_cut_atomic_id_v09
   description: Tests that atomic IDs are buffered when cut.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -2126,10 +2126,10 @@
 - name: test_cut_cuttable_text_v09
   description: Tests that cuttable text is yielded incrementally.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -2178,10 +2178,10 @@
 - name: test_message_ordering_buffering_v09
   description: Tests that updateComponents is buffered until createSurface arrives.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -2219,10 +2219,10 @@
 - name: test_delete_surface_buffering_v09
   description: Tests that deleteSurface before createSurface is ignored.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components: {}
   action: process_chunk
@@ -2242,10 +2242,10 @@
 - name: test_cut_path_v09
   description: Tests that cutting non-cuttable path buffers the component.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -2291,10 +2291,10 @@
 - name: test_strict_begin_rendering_validation_v09
   description: Tests that invalid message fails validation.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components: {}
   action: process_chunk
@@ -2302,15 +2302,15 @@
     - input: "<a2ui-json>["
       expect: []
     - input: '{"unknownMessage": "invalid"}]'
-      expect_error: "Validation failed"
+      expectError: "Validation failed"
 
 - name: test_yield_validation_failure_v09
   description: Tests that missing required fields fail validation.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -2336,15 +2336,15 @@
                 surfaceId: "s1"
                 catalogId: "test_catalog"
     - input: '{"updateComponents": {"components": []}}'
-      expect_error: "Validation failed"
+      expectError: "Validation failed"
 
 - name: test_delta_streaming_correctness_v09
   description: Tests that the parser correctly assembles components from small deltas.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -2399,10 +2399,10 @@
 - name: test_multiple_re_yielding_scenarios_v09
   description: Tests that updateDataModel yields expected updates.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Container:
@@ -2474,10 +2474,10 @@
 - name: test_incremental_data_model_streaming_v09
   description: Tests that the parser yields surface updates as items arrive in a updateDataModel stream.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         List:
@@ -2557,10 +2557,10 @@
 - name: test_sniff_partial_invalid_datamodel_fails_gracefully_v09
   description: Tests that sniffing a partial DM update that would fail validation doesn't crash.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components: {}
   action: process_chunk
@@ -2578,10 +2578,10 @@
 - name: test_sniff_partial_datamodel_with_cut_key_v09
   description: Tests that an unclosed string yields previous valid entries.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components: {}
   action: process_chunk
@@ -2614,10 +2614,10 @@
 - name: test_sniff_partial_datamodel_cumulative_unmodified_keys_v09
   description: Tests that unchanged keys are retained in partial updateDataModels.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components: {}
   action: process_chunk
@@ -2645,10 +2645,10 @@
 - name: test_sniff_partial_datamodel_prunes_empty_keys_v09
   description: Tests that entries with only a key and no value are pruned.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components: {}
   action: process_chunk
@@ -2669,10 +2669,10 @@
 - name: test_sniff_partial_datamodel_prunes_empty_trailing_dict_v09
   description: Tests that an incomplete trailing empty dictionary is dropped.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components: {}
   action: process_chunk
@@ -2693,10 +2693,10 @@
 - name: test_sniff_partial_component_discards_empty_children_dict_v09
   description: Tests that an incomplete component with an empty children dictionary is discarded.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Column:
@@ -2752,10 +2752,10 @@
 - name: test_partial_empty_dict_discarded_v09
   description: Tests that partial empty dict is discarded until populated.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Column:
@@ -2805,10 +2805,10 @@
 - name: test_sniff_partial_component_enforces_required_fields_v09
   description: Tests that partial component is discarded if it lacks required fields.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         AudioPlayer:
@@ -2849,10 +2849,10 @@
 - name: test_multiple_concurrent_surfaces_v09
   description: Tests that the parser can handle multiple surfaces simultaneously.
   catalog:
-    protocol_version: "v0.9"
-    common_types_schema: "test_data/simplified_common_types_v09.json"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    commonTypesSchema: "test_data/simplified_common_types_v09.json"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Card:
@@ -2943,20 +2943,20 @@
 - name: test_invalid_json_error
   description: Tests that completely invalid JSON inside A2UI tags raises an error.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema: {catalogId: "test_catalog", components: {}}
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema: {catalogId: "test_catalog", components: {}}
   action: process_chunk
   steps:
     - input: "<a2ui-json>invalid json</a2ui-json>"
-      expect_error: "Failed to parse JSON"
+      expectError: "Failed to parse JSON"
 
 - name: test_v08_path_heuristic_adds_slash
   description: Tests that the parser automatically adds a leading slash to paths in v0.8 if missing.
   catalog:
-    protocol_version: "v0.8"
-    s2c_schema: "test_data/simplified_s2c_v08.json"
-    catalog_schema:
+    protocolVersion: "v0.8"
+    s2cSchema: "test_data/simplified_s2c_v08.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -2984,9 +2984,9 @@
 - name: test_v09_path_heuristic_relative_path
   description: Tests that the parser does NOT add a leading slash to paths in v0.9.
   catalog:
-    protocol_version: "v0.9"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema:
+    protocolVersion: "v0.9"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema:
       catalogId: "test_catalog"
       components:
         Text:
@@ -3015,11 +3015,11 @@
 - name: test_custom_cuttable_keys
   description: Tests that the streaming parser respects custom cuttable_keys from catalog.
   catalog:
-    protocol_version: "v0.9"
-    s2c_schema: "test_data/simplified_s2c_v09.json"
-    catalog_schema: {catalogId: "c1"}
-    custom_cuttable_keys: ["customCuttable"]
-  disable_validation: true
+    protocolVersion: "v0.9"
+    s2cSchema: "test_data/simplified_s2c_v09.json"
+    catalogSchema: {catalogId: "c1"}
+    customCuttableKeys: ["customCuttable"]
+  disableValidation: true
   action: process_chunk
   steps:
     - input: '<a2ui-json>[{"version": "v0.9", "createSurface": {"surfaceId": "s1", "catalogId": "c1"}}]</a2ui-json>'

--- a/conformance/conformance_schema.json
+++ b/conformance/conformance_schema.json
@@ -53,10 +53,6 @@
           "type": "string",
           "description": "Optional description of what the test verifies."
         },
-        "protocol_version": {
-          "$ref": "#/$defs/ProtocolVersion",
-          "description": "Target A2UI protocol version."
-        },
         "protocolVersion": {
           "$ref": "#/$defs/ProtocolVersion",
           "description": "Target A2UI protocol version."
@@ -72,30 +68,22 @@
           },
           "description": "List of catalog objects for multi-catalog or processor tests."
         },
-        "catalog_paths": {
+        "catalogPaths": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "description": "List of file paths to catalog schema JSON files."
         },
-        "catalog_path": {
-          "type": "string",
-          "description": "File path to catalog schema JSON file."
-        },
         "catalogPath": {
           "type": "string",
           "description": "File path to catalog schema JSON file."
-        },
-        "catalog_id": {
-          "type": "string",
-          "description": "Target catalog identifier."
         },
         "catalogId": {
           "type": "string",
           "description": "Target catalog identifier."
         },
-        "catalog_configs": {
+        "catalogConfigs": {
           "type": "array",
           "items": {
             "$ref": "#/$defs/CatalogConfig"
@@ -129,11 +117,11 @@
           },
           "description": "Modifiers applied during test execution."
         },
-        "strict_mode": {
+        "strictMode": {
           "type": "boolean",
           "description": "Whether strict validation mode is enabled."
         },
-        "disable_validation": {
+        "disableValidation": {
           "type": "boolean",
           "description": "Whether validation is explicitly disabled for the test."
         },
@@ -147,17 +135,17 @@
         "expect": {
           "description": "Expected outcome of the test action (evaluated as a contains / subset match rather than an exact match)."
         },
-        "expect_error": {
+        "expectError": {
           "$ref": "#/$defs/ExpectError"
         },
-        "expect_contains": {
+        "expectContains": {
           "description": "Expected substrings or sub-objects in the output."
         },
-        "expect_empty": {
+        "expectEmpty": {
           "type": "boolean",
           "description": "Whether output is expected to be empty."
         },
-        "expect_selected": {
+        "expectSelected": {
           "type": "string",
           "description": "Expected selected catalog identifier."
         },
@@ -180,15 +168,7 @@
           "type": "string",
           "description": "Identifier of the catalog."
         },
-        "catalog_id": {
-          "type": "string",
-          "description": "Identifier of the catalog."
-        },
         "protocolVersion": {
-          "$ref": "#/$defs/ProtocolVersion",
-          "description": "Protocol version supported by this catalog."
-        },
-        "protocol_version": {
           "$ref": "#/$defs/ProtocolVersion",
           "description": "Protocol version supported by this catalog."
         },
@@ -226,16 +206,16 @@
           "type": "string",
           "description": "Legacy parser catalog version."
         },
-        "s2c_schema": {
+        "s2cSchema": {
           "description": "Legacy parser server-to-client schema path or object."
         },
-        "catalog_schema": {
+        "catalogSchema": {
           "description": "Legacy parser catalog schema path or object."
         },
-        "common_types_schema": {
+        "commonTypesSchema": {
           "description": "Legacy parser common types schema path or object."
         },
-        "custom_cuttable_keys": {
+        "customCuttableKeys": {
           "type": "array",
           "items": {
             "type": "string"
@@ -283,10 +263,10 @@
         "expect": {
           "description": "Expected output for this step (evaluated as a contains / subset match rather than an exact match)."
         },
-        "expect_error": {
+        "expectError": {
           "$ref": "#/$defs/ExpectError"
         },
-        "expect_contains": {
+        "expectContains": {
           "description": "Expected substrings or sub-objects for this step."
         }
       },
@@ -295,14 +275,14 @@
     "AccessibilityAssertions": {
       "type": "object",
       "properties": {
-        "axe_core": {
+        "axeCore": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "description": "List of axe-core rule IDs expected to pass."
         },
-        "accessibility_tree": {
+        "accessibilityTree": {
           "type": "object",
           "description": "Expected accessibility node tree structure."
         }

--- a/conformance/core/accessibility.yaml
+++ b/conformance/core/accessibility.yaml
@@ -14,8 +14,8 @@
 
 - name: test_accessibility_attributes_plumbing
   description: Verifies plumbing of AccessibilityAttributes (label, description, live, hidden) to accessibility node trees and axe-core rules.
-  protocol_version: "v1.0"
-  catalog_path: "specification/v1_0/catalogs/basic/catalog.json"
+  protocolVersion: "v1.0"
+  catalogPath: "specification/v1_0/catalogs/basic/catalog.json"
   action: accessibility_check
   surface:
     id: root
@@ -34,11 +34,11 @@
         accessibility:
           live: "polite"
   assertions:
-    axe_core:
+    axeCore:
       - "button-name"
       - "aria-valid-attr-value"
       - "aria-allowed-attr"
-    accessibility_tree:
+    accessibilityTree:
       btn1:
         label: "Mute Notifications"
         description: "Silences notifications about this conversation"
@@ -47,8 +47,8 @@
 
 - name: test_accessibility_live_region_assertive
   description: Verifies assertive live region announcement for critical alert banner updates.
-  protocol_version: "v1.0"
-  catalog_path: "specification/v1_0/catalogs/basic/catalog.json"
+  protocolVersion: "v1.0"
+  catalogPath: "specification/v1_0/catalogs/basic/catalog.json"
   action: accessibility_check
   surface:
     id: root
@@ -62,17 +62,17 @@
           label: "Critical Alert"
           live: "assertive"
   assertions:
-    axe_core:
+    axeCore:
       - "aria-valid-attr-value"
-    accessibility_tree:
+    accessibilityTree:
       alert_box:
         label: "Critical Alert"
         live: "assertive"
 
 - name: test_accessibility_hidden_subtree
   description: Verifies that setting hidden=true hides the component and its children from assistive technologies.
-  protocol_version: "v1.0"
-  catalog_path: "specification/v1_0/catalogs/basic/catalog.json"
+  protocolVersion: "v1.0"
+  catalogPath: "specification/v1_0/catalogs/basic/catalog.json"
   action: accessibility_check
   surface:
     id: root
@@ -88,16 +88,16 @@
         component: Icon
         name: "star"
   assertions:
-    axe_core:
+    axeCore:
       - "aria-hidden-focus"
-    accessibility_tree:
+    accessibilityTree:
       root:
         hidden: true
 
 - name: test_accessibility_implicit_label_inference
   description: Verifies default screen reader semantic inference from visible text properties when explicit accessibility attributes are omitted.
-  protocol_version: "v1.0"
-  catalog_path: "specification/v1_0/catalogs/basic/catalog.json"
+  protocolVersion: "v1.0"
+  catalogPath: "specification/v1_0/catalogs/basic/catalog.json"
   action: accessibility_check
   surface:
     id: root
@@ -108,8 +108,8 @@
         component: Button
         title: "Submit Form"
   assertions:
-    axe_core:
+    axeCore:
       - "button-name"
-    accessibility_tree:
+    accessibilityTree:
       submit_btn:
         label: "Submit Form"

--- a/conformance/core/catalog.yaml
+++ b/conformance/core/catalog.yaml
@@ -24,8 +24,8 @@
 - name: test_v08_catalog_from_json_basic
   description: Tests parsing a v0.8 catalog with styles, verifying backward-compatible mapping into theme and components.
   action: from_json
-  protocol_version: "v0.8"
-  catalog_id: "https://a2ui.org/catalogs/v08/basic"
+  protocolVersion: "v0.8"
+  catalogId: "https://a2ui.org/catalogs/v08/basic"
   catalog:
     components:
       Text:
@@ -43,7 +43,7 @@
         type: string
   expect:
     catalogId: "https://a2ui.org/catalogs/v08/basic"
-    protocol_version: "v0.8"
+    protocolVersion: "v0.8"
     components:
       Button:
         type: object
@@ -87,7 +87,7 @@
           amount: {type: number}
   expect:
     catalogId: "https://a2ui.org/catalogs/v09/basic"
-    protocol_version: "v0.9"
+    protocolVersion: "v0.9"
     theme:
       type: object
       properties:
@@ -128,7 +128,7 @@
         type: object
   expect:
     catalogId: "https://a2ui.org/catalogs/v09/filtered"
-    protocol_version: "v0.9"
+    protocolVersion: "v0.9"
     components:
       Button:
         type: object
@@ -151,7 +151,7 @@
         returnType: string
   expect:
     catalogId: "https://a2ui.org/catalogs/v09/func_filtered"
-    protocol_version: "v0.9"
+    protocolVersion: "v0.9"
     functions:
       validateEmail:
         returnType: boolean
@@ -179,7 +179,7 @@
             $ref: "#/$defs/BadgeType"
   expect:
     catalogId: "https://a2ui.org/catalogs/v09/defs"
-    protocol_version: "v0.9"
+    protocolVersion: "v0.9"
     components:
       CardWithBadge:
         type: object
@@ -217,7 +217,7 @@
             $ref: "#/$defs/OuterConfig"
   expect:
     catalogId: "https://a2ui.org/catalogs/v09/nested_defs"
-    protocol_version: "v0.9"
+    protocolVersion: "v0.9"
     components:
       StyledBox:
         type: object
@@ -246,7 +246,7 @@
         required: ["id", "binding"]
   expect:
     catalogId: "https://a2ui.org/catalogs/v09/with_common_types"
-    protocol_version: "v0.9"
+    protocolVersion: "v0.9"
     components:
       DataField:
         type: object
@@ -277,7 +277,7 @@
             $ref: "https://a2ui.org/specification/v0_9/common_types.json#/$defs/ChildList"
   expect:
     catalogId: "https://a2ui.org/catalogs/v09/container"
-    protocol_version: "v0.9"
+    protocolVersion: "v0.9"
     components:
       Container:
         type: object
@@ -305,7 +305,7 @@
   description: Tests parsing a v1.0 catalog without theme using protocolVersion in catalog schema.
   action: from_json
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
     catalogId: "https://a2ui.org/catalogs/v10/basic"
     components:
       Layout:
@@ -325,7 +325,7 @@
           rate: {type: number}
   expect:
     catalogId: "https://a2ui.org/catalogs/v10/basic"
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
     theme: {}
     components:
       ActionButton:
@@ -348,7 +348,7 @@
   description: Tests extracting function parameters and returnType from v1.0 catalog using protocolVersion in catalog schema.
   action: from_json
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
     catalogId: "https://a2ui.org/catalogs/v10/functions"
     functions:
       formatDate:
@@ -362,7 +362,7 @@
           value: {type: number}
   expect:
     catalogId: "https://a2ui.org/catalogs/v10/functions"
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
     functions:
       formatDate:
         returnType: string
@@ -380,21 +380,21 @@
   catalog:
     components:
       Text: {type: object}
-  expect_error:
+  expectError:
     category: "CatalogError"
     message: "catalog_id must be provided or exist in catalog_schema"
 
 - name: test_catalog_from_json_override_catalog_id
   description: Tests overriding catalogId during Catalog.from_json.
   action: from_json
-  catalog_id: "https://a2ui.org/catalogs/overridden"
+  catalogId: "https://a2ui.org/catalogs/overridden"
   catalog:
     catalogId: "https://a2ui.org/catalogs/original"
     components:
       Text: {type: object}
   expect:
     catalogId: "https://a2ui.org/catalogs/overridden"
-    protocol_version: "v0.9"
+    protocolVersion: "v0.9"
     components:
       Text:
         type: object
@@ -406,7 +406,7 @@
 - name: test_v08_catalog_schema_basic
   description: Tests serializing a v0.8 Catalog into JSON schema with styles and components.
   action: catalog_schema
-  protocol_version: "v0.8"
+  protocolVersion: "v0.8"
   catalog:
     components:
       Text:
@@ -420,7 +420,7 @@
     theme:
       primaryColor: {type: string}
   expect:
-    protocol_version: "v0.8"
+    protocolVersion: "v0.8"
     components:
       Button:
         type: object
@@ -468,7 +468,7 @@
         primaryColor: {type: string}
   expect:
     catalogId: "https://a2ui.org/catalogs/v09/basic"
-    protocol_version: "v0.9"
+    protocolVersion: "v0.9"
     components:
       Button:
         type: object
@@ -536,7 +536,7 @@
 - name: test_v10_catalog_schema_basic
   description: Tests serializing a v1.0 Catalog into JSON schema with protocolVersion and $defs.anyComponent.
   action: catalog_schema
-  protocol_version: "v1.0"
+  protocolVersion: "v1.0"
   catalog:
     catalogId: "https://a2ui.org/catalogs/v10/basic"
     components:

--- a/conformance/core/composition_constraints.yaml
+++ b/conformance/core/composition_constraints.yaml
@@ -15,7 +15,7 @@
 - name: test_composition_surface_implicit_parent_container
   description: Verifies root components treating Surface as canonical parent container when allowedParents includes Surface.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: validate
   steps:
     - payload:
@@ -44,8 +44,8 @@
 - name: test_composition_unallowed_parent_error
   description: Verifies validation error thrown when component is placed under an unallowed parent component type.
   catalog:
-    protocol_version: "v1.0"
-    catalog_schema:
+    protocolVersion: "v1.0"
+    catalogSchema:
       catalogId: "custom"
       components:
         ColumnHeader:
@@ -65,15 +65,15 @@
                 children: [invalid_header]
               - id: invalid_header
                 component: ColumnHeader
-  expect_error:
+  expectError:
     category: "ValidationError"
     message: "Component 'invalid_header' (ColumnHeader) cannot be placed under parent 'root' (Row). Allowed parents: ['Column']."
 
 - name: test_composition_unallowed_child_error
   description: Verifies validation error thrown when container contains an unallowed child component type.
   catalog:
-    protocol_version: "v1.0"
-    catalog_schema:
+    protocolVersion: "v1.0"
+    catalogSchema:
       catalogId: "custom"
       components:
         RestrictedBox:
@@ -93,6 +93,6 @@
                 children: [v1]
               - id: v1
                 component: Video
-  expect_error:
+  expectError:
     category: "ValidationError"
     message: "Container 'root' (RestrictedBox) cannot contain child 'v1' (Video). Allowed children: ['Text', 'Button']."

--- a/conformance/core/data_deletion.yaml
+++ b/conformance/core/data_deletion.yaml
@@ -15,7 +15,7 @@
 - name: test_data_deletion_value_null
   description: Verifies that updateDataModel with value=null deletes the specified JSON Pointer path.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: validate
   steps:
     - payload:
@@ -45,7 +45,7 @@
 - name: test_data_deletion_nested_pointer_sibling_preservation
   description: Verifies deleting a child property via value=null preserves sibling keys in parent object.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: validate
   steps:
     - payload:
@@ -77,7 +77,7 @@
 - name: test_data_deletion_top_level_key
   description: Verifies deleting a top-level JSON Pointer path via value=null.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: validate
   steps:
     - payload:
@@ -103,7 +103,7 @@
 - name: test_data_deletion_parent_object_recursive
   description: Verifies deleting an intermediate parent object key via value=null recursively removes all nested child properties.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: validate
   steps:
     - payload:

--- a/conformance/core/data_model_pointers.yaml
+++ b/conformance/core/data_model_pointers.yaml
@@ -15,7 +15,7 @@
 - name: test_pointer_escape_characters
   description: Verifies RFC 6901 JSON Pointer escape sequence resolution (~0 for ~ and ~1 for /).
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: validate
   steps:
     - payload:
@@ -44,7 +44,7 @@
 - name: test_pointer_array_indexing
   description: Verifies numeric array indexing in JSON Pointers (/items/0, /items/1).
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: validate
   steps:
     - payload:
@@ -69,7 +69,7 @@
 - name: test_pointer_auto_vivification
   description: Verifies automatic intermediate object creation when setting deep uncreated JSON Pointer paths.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: validate
   steps:
     - payload:

--- a/conformance/core/index_function.yaml
+++ b/conformance/core/index_function.yaml
@@ -15,7 +15,7 @@
 - name: test_index_function_in_collection_loop
   description: Verifies built-in @index function evaluation during collection template iteration.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: validate
   steps:
     - payload:
@@ -65,7 +65,7 @@
 - name: test_index_function_with_offset
   description: Verifies built-in @index function with offset argument (@index(1) for 1-based indexing).
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: validate
   steps:
     - payload:
@@ -98,7 +98,7 @@
 - name: test_index_function_nested_path
   description: Verifies built-in @index function evaluation inside a deeply nested child property path of a template list.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: validate
   steps:
     - payload:
@@ -140,7 +140,7 @@
 - name: test_index_function_outside_loop_error
   description: Verifies error thrown when @index function is called outside a collection iteration scope.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: validate
   steps:
     - payload:
@@ -154,6 +154,6 @@
                 text:
                   call: "@index"
                   args: {}
-      expect_error:
+      expectError:
         category: "ValidationError"
         message: "@index function can only be evaluated inside a collection template iteration scope."

--- a/conformance/core/message_processor.yaml
+++ b/conformance/core/message_processor.yaml
@@ -24,7 +24,7 @@
 - name: test_create_surface_basic
   description: Tests creating a surface with catalogId and theme, verifying sendDataModel defaults to false.
   action: process_messages
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
@@ -44,7 +44,7 @@
 - name: test_create_surface_send_data_model_enabled
   description: Tests creating a surface with sendDataModel explicitly enabled.
   action: process_messages
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
@@ -61,7 +61,7 @@
 - name: test_create_surface_duplicate_error
   description: Tests that creating a surface with an already existing surfaceId raises an IntegrityError.
   action: process_messages
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
@@ -72,28 +72,28 @@
       createSurface:
         surfaceId: "s1"
         catalogId: "test-catalog"
-  expect_error:
+  expectError:
     category: "IntegrityError"
     message: "Surface s1 already exists"
 
 - name: test_create_surface_unknown_catalog_error
   description: Tests that creating a surface referencing an unregistered catalogId raises a CatalogError.
   action: process_messages
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
       createSurface:
         surfaceId: "s1"
         catalogId: "unknown-catalog"
-  expect_error:
+  expectError:
     category: "CatalogError"
     message: "Catalog not found: unknown-catalog"
 
 - name: test_delete_surface_basic
   description: Tests deleting an active surface by surfaceId, cleanly removing it from state.
   action: process_messages
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
@@ -113,7 +113,7 @@
 - name: test_update_components_add_and_query
   description: Tests adding multiple components to an active surface and querying their properties.
   action: process_messages
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
@@ -144,7 +144,7 @@
 - name: test_update_components_modify_existing_properties
   description: Tests updating the properties of an existing component on a surface.
   action: process_messages
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
@@ -176,7 +176,7 @@
 - name: test_update_components_recreate_on_type_change
   description: Tests that changing a component's type recreates the component model and clears previous properties.
   action: process_messages
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
@@ -208,7 +208,7 @@
 - name: test_update_components_unknown_surface_error
   description: Tests that updating components on a non-existent surface raises an IntegrityError.
   action: process_messages
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
@@ -217,14 +217,14 @@
         components:
           - id: "c1"
             component: "Text"
-  expect_error:
+  expectError:
     category: "IntegrityError"
     message: "Surface not found for message: unknown-s"
 
 - name: test_update_components_missing_id_error
   description: Tests that component entries missing an 'id' property raise a validation error.
   action: process_messages
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
@@ -237,14 +237,14 @@
         components:
           - component: "Button"
             label: "Missing ID"
-  expect_error:
+  expectError:
     category: "ValidationError"
     message: "missing an 'id'"
 
 - name: test_update_components_create_without_type_error
   description: Tests that creating a brand new component without a component type name raises a validation error.
   action: process_messages
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
@@ -257,7 +257,7 @@
         components:
           - id: "comp1"
             label: "No Type"
-  expect_error:
+  expectError:
     category: "ValidationError"
     message: "Cannot create component comp1 without a type"
 
@@ -266,7 +266,7 @@
 - name: test_topology_missing_root_error
   description: Tests that component hierarchies missing a root component fail validation in strict mode.
   action: process_messages
-  strict_mode: true
+  strictMode: true
   catalogs:
     - catalogId: topo-cat
       components:
@@ -287,14 +287,14 @@
           - id: "c1"
             component: "Card"
             child: "c2"
-  expect_error:
+  expectError:
     category: "ValidationError"
     message: "Missing root component"
 
 - name: test_topology_direct_circular_reference_error
   description: Tests that direct circular component references (root -> c1 -> root) are detected and rejected.
   action: process_messages
-  strict_mode: true
+  strictMode: true
   catalogs:
     - catalogId: topo-cat
       components:
@@ -321,14 +321,14 @@
           - id: "c1"
             component: "Card"
             child: "root"
-  expect_error:
+  expectError:
     category: "ValidationError"
     message: "Circular reference detected"
 
 - name: test_topology_indirect_circular_reference_error
   description: Tests that indirect circular references (root -> c1 -> c2 -> root) are detected and rejected.
   action: process_messages
-  strict_mode: true
+  strictMode: true
   catalogs:
     - catalogId: topo-cat
       components:
@@ -358,14 +358,14 @@
           - id: "c2"
             component: "Card"
             child: "root"
-  expect_error:
+  expectError:
     category: "ValidationError"
     message: "Circular reference detected"
 
 - name: test_topology_self_reference_error
   description: Tests that self-referencing components (root -> root) are detected and rejected.
   action: process_messages
-  strict_mode: true
+  strictMode: true
   catalogs:
     - catalogId: topo-cat
       components:
@@ -389,14 +389,14 @@
           - id: "root"
             component: "Card"
             child: "root"
-  expect_error:
+  expectError:
     category: "ValidationError"
     message: "Circular reference detected"
 
 - name: test_topology_dangling_child_reference_error
   description: Tests that referencing a non-existent child component ID raises a validation error.
   action: process_messages
-  strict_mode: true
+  strictMode: true
   catalogs:
     - catalogId: topo-cat
       components:
@@ -420,14 +420,14 @@
           - id: "root"
             component: "Card"
             child: "missing_child_id"
-  expect_error:
+  expectError:
     category: "ValidationError"
     message: "Dangling reference"
 
 - name: test_topology_orphaned_component_error
   description: Tests that orphaned components unreachable from the root component fail validation in strict mode.
   action: process_messages
-  strict_mode: true
+  strictMode: true
   catalogs:
     - catalogId: topo-cat
       components:
@@ -462,7 +462,7 @@
           - id: "orphan_comp"
             component: "Text"
             text: "Unreachable"
-  expect_error:
+  expectError:
     category: "ValidationError"
     message: "Orphaned component"
 
@@ -471,7 +471,7 @@
 - name: test_update_components_strict_schema_validation_failure
   description: Tests that component properties violating catalog schema are rejected in strict mode.
   action: process_messages
-  strict_mode: true
+  strictMode: true
   catalogs:
     - catalogId: strict-cat
       components:
@@ -499,14 +499,14 @@
             component: "Chart"
             title: "Sales"
             value: "invalid-string-value"
-  expect_error:
+  expectError:
     category: "ValidationError"
     message: "Validation failed for component 'Chart'"
 
 - name: test_update_components_atomic_validation_rollback
   description: Tests that invalid components in a batch abort the entire update without applying partial mutations.
   action: process_messages
-  strict_mode: true
+  strictMode: true
   catalogs:
     - catalogId: strict-cat
       components:
@@ -533,14 +533,14 @@
           - id: "btn_invalid"
             component: "Button"
             label: 12345
-  expect_error:
+  expectError:
     category: "ValidationError"
     message: "Validation failed for component 'Button'"
 
 - name: test_create_surface_strict_theme_validation_failure
   description: Tests that creating a surface with theme properties violating the catalog theme schema raises a validation error in strict mode.
   action: process_messages
-  strict_mode: true
+  strictMode: true
   catalogs:
     - catalogId: theme-cat
       theme:
@@ -557,7 +557,7 @@
         catalogId: "theme-cat"
         theme:
           primaryColor: "not-a-hex-color"
-  expect_error:
+  expectError:
     category: "ValidationError"
     message: "Validation failed for theme on surface 's1'"
 
@@ -566,7 +566,7 @@
 - name: test_update_data_model_basic
   description: Tests updating the data model at root and nested JSON pointer paths.
   action: process_messages
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
@@ -588,7 +588,7 @@
 - name: test_update_data_model_unknown_surface_error
   description: Tests that updating data on a non-existent surface raises an IntegrityError.
   action: process_messages
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
@@ -596,14 +596,14 @@
         surfaceId: "unknown-s"
         path: "/foo"
         value: "bar"
-  expect_error:
+  expectError:
     category: "IntegrityError"
     message: "Surface not found for message: unknown-s"
 
 - name: test_get_renderer_data_model_filtering
   description: Tests that getRendererDataModel filters out surfaces where sendDataModel is false.
   action: get_renderer_data_model
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
@@ -637,7 +637,7 @@
 - name: test_get_renderer_data_model_empty_when_no_surfaces_enabled
   description: Tests that getRendererDataModel returns null/undefined when no active surfaces have sendDataModel enabled.
   action: get_renderer_data_model
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
@@ -661,7 +661,7 @@
   action: resolve_path
   args:
     path: "/foo"
-    context_path: "/bar"
+    contextPath: "/bar"
   expect: "/foo"
 
 - name: test_resolve_path_relative
@@ -669,7 +669,7 @@
   action: resolve_path
   args:
     path: "foo"
-    context_path: "/bar"
+    contextPath: "/bar"
   expect: "/bar/foo"
 
 - name: test_resolve_path_relative_trailing_slash
@@ -677,7 +677,7 @@
   action: resolve_path
   args:
     path: "foo"
-    context_path: "/bar/"
+    contextPath: "/bar/"
   expect: "/bar/foo"
 
 - name: test_resolve_path_relative_no_context
@@ -692,7 +692,7 @@
 - name: test_message_multiple_conflicting_update_types_error
   description: Tests that a message containing multiple conflicting update types raises a validation error.
   action: process_messages
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
@@ -701,14 +701,14 @@
         catalogId: "test-catalog"
       deleteSurface:
         surfaceId: "s1"
-  expect_error:
+  expectError:
     category: "ValidationError"
     message: "Message contains multiple conflicting update actions"
 
 - name: test_process_messages_wrapper_object
   description: "Tests processing messages wrapped inside a { messages: [...] } container object."
   action: process_messages
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     messages:
@@ -744,8 +744,8 @@
 - name: test_v08_begin_rendering_styles_mapping
   description: Tests that v0.8 VersionAdapter correctly extracts styles and root component from beginRendering.
   action: process_messages
-  protocol_version: "v0.8"
-  catalog_paths:
+  protocolVersion: "v0.8"
+  catalogPaths:
     - "specification/v0_8/json/standard_catalog_definition.json"
   messages:
     - beginRendering:
@@ -764,8 +764,8 @@
 - name: test_v08_surface_update_components
   description: Tests that v0.8 surfaceUpdate with nested component objects is properly adapted into ComponentModels.
   action: process_messages
-  protocol_version: "v0.8"
-  catalog_paths:
+  protocolVersion: "v0.8"
+  catalogPaths:
     - "specification/v0_8/json/standard_catalog_definition.json"
   messages:
     - beginRendering:
@@ -791,8 +791,8 @@
 - name: test_v08_data_model_update
   description: Tests that v0.8 dataModelUpdate with typed contents entries is properly adapted into the surface DataStore.
   action: process_messages
-  protocol_version: "v0.8"
-  catalog_paths:
+  protocolVersion: "v0.8"
+  catalogPaths:
     - "specification/v0_8/json/standard_catalog_definition.json"
   messages:
     - beginRendering:
@@ -817,7 +817,7 @@
     - catalogId: cat-v08
       protocolVersion: "v0.8"
   args:
-    include_inline_catalogs: false
+    includeInlineCatalogs: false
     version: "v0.8"
   expect:
     v0.8:
@@ -829,7 +829,7 @@
 - name: test_v09_create_surface_basic
   description: Tests v0.9 surface creation with standard theme object.
   action: process_messages
-  catalog_paths:
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   messages:
     - version: "v0.9"
@@ -852,7 +852,7 @@
     - catalogId: cat-1
     - catalogId: cat-2
   args:
-    include_inline_catalogs: false
+    includeInlineCatalogs: false
     version: "v0.9"
   expect:
     v0.9:
@@ -875,7 +875,7 @@
           required:
             - label
   args:
-    include_inline_catalogs: true
+    includeInlineCatalogs: true
     version: "v0.9"
   expect:
     v0.9:
@@ -910,7 +910,7 @@
               type: string
               description: "REF:common_types.json#/$defs/DynamicString|The title"
   args:
-    include_inline_catalogs: true
+    includeInlineCatalogs: true
     version: "v0.9"
   expect:
     v0.9:
@@ -962,7 +962,7 @@
             $ref: "common_types.json#/$defs/Color"
             description: The main color
   args:
-    include_inline_catalogs: true
+    includeInlineCatalogs: true
     version: "v0.9"
   expect:
     v0.9:
@@ -1014,7 +1014,7 @@
           color:
             type: string
   args:
-    include_inline_catalogs: true
+    includeInlineCatalogs: true
     version: "v0.9"
   expect:
     v0.9:
@@ -1042,8 +1042,8 @@
 - name: test_v10_create_surface_inline_initialization
   description: Tests v1.0 createSurface message with inline components and initial dataModel initialization.
   action: process_messages
-  protocol_version: "v1.0"
-  catalog_paths:
+  protocolVersion: "v1.0"
+  catalogPaths:
     - "specification/v1_0/catalogs/basic/catalog.json"
   messages:
     - version: "v1.0"
@@ -1078,8 +1078,8 @@
 - name: test_v10_create_surface_optional_catalog_id
   description: Tests that v1.0 createSurface permits omitting catalogId.
   action: process_messages
-  protocol_version: "v1.0"
-  catalog_paths:
+  protocolVersion: "v1.0"
+  catalogPaths:
     - "specification/v1_0/catalogs/basic/catalog.json"
   messages:
     - version: "v1.0"
@@ -1093,8 +1093,8 @@
 - name: test_v10_create_surface_with_metadata_extensions
   description: Tests v1.0 createSurface with metadata and extension descriptors.
   action: process_messages
-  protocol_version: "v1.0"
-  catalog_paths:
+  protocolVersion: "v1.0"
+  catalogPaths:
     - "specification/v1_0/catalogs/basic/catalog.json"
   messages:
     - version: "v1.0"
@@ -1149,8 +1149,8 @@
 - name: test_v10_update_data_model_deletion
   description: Tests that updating a path with value null deletes the key from the data model in v1.0.
   action: process_messages
-  protocol_version: "v1.0"
-  catalog_paths:
+  protocolVersion: "v1.0"
+  catalogPaths:
     - "specification/v1_0/catalogs/basic/catalog.json"
   messages:
     - version: "v1.0"
@@ -1180,7 +1180,7 @@
     - catalogId: cat-v10
       protocolVersion: "v1.0"
   args:
-    include_inline_catalogs: false
+    includeInlineCatalogs: false
     version: "v1.0"
   expect:
     v1.0:

--- a/conformance/core/multi_catalog.yaml
+++ b/conformance/core/multi_catalog.yaml
@@ -15,7 +15,7 @@
 - name: test_multi_catalog_explicit_catalog_id_resolution
   description: Verifies resolving component definition using explicit catalogId specified on component instance.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: select_catalog
   args:
     surface:
@@ -31,12 +31,12 @@
         component: LineChart
         catalogId: "chart_catalog"
         data: "/series/line1"
-  expect_selected: "chart_catalog"
+  expectSelected: "chart_catalog"
 
 - name: test_multi_catalog_surface_default_fallback
   description: Verifies component falling back to surface defaultCatalogId when catalogId is omitted.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: select_catalog
   args:
     surface:
@@ -47,12 +47,12 @@
       c1:
         component: Button
         title: "Click Me"
-  expect_selected: "basic"
+  expectSelected: "basic"
 
 - name: test_multi_catalog_unregistered_catalog_error
   description: Verifies error thrown when component specifies catalogId not listed in surface supportedCatalogIds.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: select_catalog
   args:
     surface:
@@ -63,14 +63,14 @@
       c1:
         component: CustomWidget
         catalogId: "unregistered_vendor_catalog"
-  expect_error:
+  expectError:
     category: "CatalogError"
     message: "Catalog 'unregistered_vendor_catalog' is not supported by surface 'main_surface'."
 
 - name: test_multi_catalog_version_mismatch_error
   description: Verifies error thrown when mixed catalogs specify conflicting protocol versions.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: select_catalog
   args:
     surface:
@@ -82,24 +82,24 @@
         protocolVersion: "v1.0"
       legacy_v0_9_catalog:
         protocolVersion: "v0.9"
-  expect_error:
+  expectError:
     category: "CatalogError"
     message: "Protocol version mismatch: cannot mix catalog 'legacy_v0_9_catalog' (v0.9) with surface version v1.0."
 
 - name: test_multi_catalog_function_resolution_precedence
   description: Verifies function calls with explicit catalogId resolve to the specified catalog.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: select_catalog
   args:
     surface:
       id: main_surface
       defaultCatalogId: "basic"
       supportedCatalogIds: ["basic", "custom_math_catalog"]
-    function_call:
+    functionCall:
       call: "add"
       catalogId: "custom_math_catalog"
       args:
-        a: 10
-        b: 20
-  expect_selected: "custom_math_catalog"
+        a: 5
+        b: 10
+  expectSelected: "custom_math_catalog"

--- a/conformance/core/rpc_functions.yaml
+++ b/conformance/core/rpc_functions.yaml
@@ -15,7 +15,7 @@
 - name: test_rpc_call_renderer_function_success
   description: Verifies agent-initiated callRendererFunction on a function with callableFrom=rendererOrAgent.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: handle_rpc
   args:
     message:
@@ -28,7 +28,7 @@
           args:
             mediaId: "video-789"
             autoplay: true
-    function_metadata:
+    functionMetadata:
       playMedia:
         callableFrom: "rendererOrAgent"
         requiresUserActivation: false
@@ -44,7 +44,7 @@
 - name: test_rpc_call_renderer_function_unauthorized_caller
   description: Verifies callRendererFunction fails with INVALID_FUNCTION_CALL when callableFrom is rendererOnly.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: handle_rpc
   args:
     message:
@@ -55,7 +55,7 @@
           call: "internalStateReset"
           catalogId: "system_catalog"
           args: {}
-    function_metadata:
+    functionMetadata:
       internalStateReset:
         callableFrom: "rendererOnly"
         requiresUserActivation: false
@@ -71,10 +71,10 @@
 - name: test_rpc_call_renderer_function_requires_user_activation
   description: Verifies callRendererFunction execution when requiresUserActivation is true and user gesture is present.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: handle_rpc
   args:
-    user_activation_present: true
+    userActivationPresent: true
     message:
       version: "v1.0"
       callRendererFunction:
@@ -84,7 +84,7 @@
           catalogId: "basic"
           args:
             url: "https://example.com/details"
-    function_metadata:
+    functionMetadata:
       openExternalUrl:
         callableFrom: "rendererOrAgent"
         requiresUserActivation: true
@@ -99,10 +99,10 @@
 - name: test_rpc_call_agent_function_dispatch
   description: Verifies renderer-initiated callAgentFunction message generation and response correlation via functionCallId.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: handle_rpc
   args:
-    outbound_call:
+    outboundCall:
       surfaceId: "main_surface"
       functionCallId: "agent-call-55"
       callFunction:
@@ -110,7 +110,7 @@
         catalogId: "store_catalog"
         args:
           sku: "ITEM-404"
-    inbound_response:
+    inboundResponse:
       version: "v1.0"
       agentFunctionResponse:
         functionCallId: "agent-call-55"
@@ -118,7 +118,7 @@
           inStock: 12
           price: "$29.99"
   expect:
-    correlated_call_id: "agent-call-55"
+    correlatedCallId: "agent-call-55"
     result:
       inStock: 12
       price: "$29.99"
@@ -126,10 +126,10 @@
 - name: test_rpc_call_renderer_function_user_activation_denied
   description: Verifies callRendererFunction fails with INVALID_FUNCTION_CALL when requiresUserActivation is true but user gesture context is absent.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: handle_rpc
   args:
-    user_activation_present: false
+    userActivationPresent: false
     message:
       version: "v1.0"
       callRendererFunction:
@@ -139,7 +139,7 @@
           catalogId: "basic"
           args:
             url: "https://example.com/details"
-    function_metadata:
+    functionMetadata:
       openExternalUrl:
         callableFrom: "rendererOrAgent"
         requiresUserActivation: true
@@ -155,7 +155,7 @@
 - name: test_rpc_call_renderer_function_execution_exception
   description: Verifies callRendererFunction handles runtime function execution exceptions and returns EXECUTION_ERROR.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: handle_rpc
   args:
     message:
@@ -166,7 +166,7 @@
           call: "failingFunction"
           catalogId: "basic"
           args: {}
-    function_metadata:
+    functionMetadata:
       failingFunction:
         callableFrom: "rendererOrAgent"
         requiresUserActivation: false
@@ -182,7 +182,7 @@
 - name: test_rpc_call_renderer_function_agent_only_boundary
   description: Verifies agent-initiated callRendererFunction on a function with callableFrom=agentOnly.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: handle_rpc
   args:
     message:
@@ -193,7 +193,7 @@
           call: "syncState"
           catalogId: "basic"
           args: {}
-    function_metadata:
+    functionMetadata:
       syncState:
         callableFrom: "agentOnly"
         requiresUserActivation: false

--- a/conformance/core/validation_result.yaml
+++ b/conformance/core/validation_result.yaml
@@ -15,7 +15,7 @@
 - name: test_validation_result_dynamic_object_return
   description: Verifies CheckRule evaluation capturing dynamic ValidationResult object returned from custom validation function.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: validate
   steps:
     - payload:
@@ -49,7 +49,7 @@
 - name: test_validation_result_boolean_fallback
   description: Verifies CheckRule evaluation when validation function returns primitive boolean, falling back to CheckRule message.
   catalog:
-    protocol_version: "v1.0"
+    protocolVersion: "v1.0"
   action: validate
   steps:
     - payload:

--- a/conformance/core/validator.yaml
+++ b/conformance/core/validator.yaml
@@ -28,8 +28,8 @@
 - name: test_validator_0_8
   description: Tests schema validation of v0.8 message envelopes against the standard v0.8 catalog schema.
   action: validate
-  protocol_version: "v0.8"
-  catalog_paths:
+  protocolVersion: "v0.8"
+  catalogPaths:
     - "specification/v0_8/json/standard_catalog_definition.json"
   steps:
     - messages:
@@ -42,24 +42,24 @@
         - beginRendering:
             surfaceId: 123
             root: root
-      expect_error: "123 is not of type 'string'"
+      expectError: "123 is not of type 'string'"
     - messages:
         - beginRendering:
             surfaceId: id
             root: root
             styles: not-an-object
-      expect_error: "'not-an-object' is not of type 'object'"
+      expectError: "'not-an-object' is not of type 'object'"
     - messages:
         - beginRendering:
             surfaceId: id
-      expect_error: "'root' is a required property"
+      expectError: "'root' is a required property"
 
 - name: test_custom_catalog_0_8
   description: Tests component property schema validation in v0.8 against custom catalog schema.
   action: validate
-  protocol_version: "v0.8"
+  protocolVersion: "v0.8"
   catalog:
-    catalog_id: "custom"
+    catalogId: "custom"
     components:
       Canvas:
         type: object
@@ -130,7 +130,7 @@
                     type: line
                     chartData:
                       path: /chart
-      expect_error: "'line' is not one of ['doughnut', 'pie']"
+      expectError: "'line' is not one of ['doughnut', 'pie']"
     - messages:
         - surfaceUpdate:
             surfaceId: s1
@@ -140,7 +140,7 @@
                   Canvas:
                     children:
                       explicitList: 123
-      expect_error: "123 is not of type 'array'"
+      expectError: "123 is not of type 'array'"
     - messages:
         - surfaceUpdate:
             surfaceId: s1
@@ -149,7 +149,7 @@
                 component:
                   Canvas:
                     children: {}
-      expect_error: "'explicitList' is a required property"
+      expectError: "'explicitList' is a required property"
     - messages:
         - surfaceUpdate:
             surfaceId: s1
@@ -160,7 +160,7 @@
                     children:
                       explicitList: []
                     extraProperty: should-fail
-      expect_error: "Additional properties are not allowed"
+      expectError: "Additional properties are not allowed"
     - messages:
         - surfaceUpdate:
             surfaceId: s1
@@ -169,7 +169,7 @@
                 component:
                   UnknownComponent:
                     foo: "bar"
-      expect_error: "'UnknownComponent' was unexpected"
+      expectError: "'UnknownComponent' was unexpected"
 
 # ==============================================================================
 # Part 2: Protocol v0.9 / v0.9.1 Schema Validation
@@ -178,8 +178,8 @@
 - name: test_validator_0_9
   description: Tests schema validation of v0.9 message envelopes against the basic v0.9 catalog schema.
   action: validate
-  protocol_version: "v0.9"
-  catalog_paths:
+  protocolVersion: "v0.9"
+  catalogPaths:
     - "specification/v0_9/catalogs/basic/catalog.json"
   steps:
     - messages:
@@ -194,7 +194,7 @@
         - createSurface:
             surfaceId: "123"
             catalogId: standard
-      expect_error:
+      expectError:
         category: "ValidationError"
         details:
           - path: "messages.0.version"
@@ -204,7 +204,7 @@
           createSurface:
             surfaceId: "123"
             catalogId: standard
-      expect_error:
+      expectError:
         category: "ValidationError"
         details:
           - path: "messages.0.version"
@@ -214,7 +214,7 @@
           createSurface:
             surfaceId: 123
             catalogId: standard
-      expect_error:
+      expectError:
         category: "ValidationError"
         details:
           - path: "messages.0.createSurface.surfaceId"
@@ -223,7 +223,7 @@
         - version: "v0.9"
           createSurface:
             surfaceId: "123"
-      expect_error:
+      expectError:
         category: "ValidationError"
         details:
           - path: "messages.0.createSurface.catalogId"
@@ -233,7 +233,7 @@
   description: Tests component property schema validation in v0.9 against custom catalog schema.
   action: validate
   catalog:
-    catalog_id: "custom"
+    catalogId: "custom"
     components:
       Canvas:
         type: object
@@ -292,7 +292,7 @@
                 component: Chart
                 chartType: line
                 title: Invalid Chart
-      expect_error:
+      expectError:
         category: "ValidationError"
         details:
           - path: "chartType"
@@ -305,7 +305,7 @@
               - id: c1
                 component: Canvas
                 children: 123
-      expect_error:
+      expectError:
         category: "ValidationError"
         details:
           - path: "children"
@@ -317,7 +317,7 @@
             components:
               - id: c1
                 component: Canvas
-      expect_error:
+      expectError:
         category: "ValidationError"
         details:
           - path: "children"
@@ -329,7 +329,7 @@
             components:
               - id: c1
                 component: UnknownComponent
-      expect_error:
+      expectError:
         category: "ValidationError"
         details:
           - path: "component"
@@ -342,8 +342,8 @@
 - name: test_validator_1_0
   description: Tests schema validation of v1.0 message envelopes (inline components, optional catalogId, data deletion) against the basic v1.0 catalog schema.
   action: validate
-  protocol_version: "v1.0"
-  catalog_paths:
+  protocolVersion: "v1.0"
+  catalogPaths:
     - "specification/v1_0/catalogs/basic/catalog.json"
   steps:
     - messages:
@@ -371,7 +371,7 @@
     - messages:
         - createSurface:
             surfaceId: "s1"
-      expect_error:
+      expectError:
         category: "ValidationError"
         details:
           - path: "messages.0.version"
@@ -380,7 +380,7 @@
         - version: "v0.9"
           createSurface:
             surfaceId: "s1"
-      expect_error:
+      expectError:
         category: "ValidationError"
         details:
           - path: "messages.0.version"
@@ -389,7 +389,7 @@
         - version: "v1.0"
           createSurface:
             surfaceId: 123
-      expect_error:
+      expectError:
         category: "ValidationError"
         details:
           - path: "messages.0.createSurface.surfaceId"
@@ -398,9 +398,9 @@
 - name: test_custom_catalog_1_0
   description: Tests component property schema validation in v1.0 against custom catalog schema.
   action: validate
-  protocol_version: "v1.0"
+  protocolVersion: "v1.0"
   catalog:
-    catalog_id: "custom"
+    catalogId: "custom"
     components:
       Canvas:
         type: object
@@ -449,7 +449,7 @@
               - id: c1
                 component: Chart
                 chartType: bar
-      expect_error:
+      expectError:
         category: "ValidationError"
         details:
           - path: "chartType"
@@ -461,7 +461,7 @@
             components:
               - id: c1
                 component: Canvas
-      expect_error:
+      expectError:
         category: "ValidationError"
         details:
           - path: "children"
@@ -473,7 +473,7 @@
             components:
               - id: c1
                 component: UnknownComponent
-      expect_error:
+      expectError:
         category: "ValidationError"
         details:
           - path: "component"
@@ -483,7 +483,7 @@
   description: Tests schema validation of surface theme properties against catalog theme schema.
   action: validate
   catalog:
-    catalog_id: "theme_cat"
+    catalogId: "theme_cat"
     theme:
       type: "object"
       properties:
@@ -507,5 +507,5 @@
             catalogId: "theme_cat"
             theme:
               primaryColor: "not-a-hex"
-      expect_error:
+      expectError:
         category: "ValidationError"

--- a/conformance/extensions/a2a/a2a_integration.yaml
+++ b/conformance/extensions/a2a/a2a_integration.yaml
@@ -18,19 +18,19 @@
     data: {"foo": "bar"}
     version: "0.9.1"
   expect:
-    mime_type: "application/a2ui+json"
+    mimeType: "application/a2ui+json"
 
 - name: test_create_a2ui_part_legacy_default
   action: create_a2ui_part
   args:
     data: {"foo": "bar"}
   expect:
-    mime_type: "application/json+a2ui"
+    mimeType: "application/json+a2ui"
 
 - name: test_is_a2ui_part
   action: is_a2ui_part
   args:
-    mime_type: "application/a2ui+json"
+    mimeType: "application/a2ui+json"
   expect: true
 
 - name: test_try_activate_extension_success
@@ -60,7 +60,7 @@
             a2uiClientCapabilities:
               supportedCatalogIds:
                 ["https://a2ui.org/specification/v0_8/standard_catalog_definition.json"]
-    runner_output: "Here is your chart:\n<a2ui-json>\n[\n  {\n    “beginRendering”: {\n      “surfaceId”: “sales-dashboard”\n    }\n  }\n]\n</a2ui-json>\nEnjoy!"
+    runnerOutput: "Here is your chart:\n<a2ui-json>\n[\n  {\n    “beginRendering”: {\n      “surfaceId”: “sales-dashboard”\n    }\n  }\n]\n</a2ui-json>\nEnjoy!"
   expect:
     parts:
       - kind: "text"
@@ -82,7 +82,7 @@
         message:
           contextId: "test-context"
           parts: []
-    runner_output: "This is a normal conversational turn."
+    runnerOutput: "This is a normal conversational turn."
   expect:
     parts:
       - kind: "text"
@@ -99,7 +99,7 @@
         message:
           contextId: "test-context"
           parts: []
-    runner_output: "Here is an invalid chart:\n<a2ui-json>\n[\n  {\n    “beginRendering”: {  MISSING CLOSING BRACKETS...\n</a2ui-json>\nOops."
+    runnerOutput: "Here is an invalid chart:\n<a2ui-json>\n[\n  {\n    “beginRendering”: {  MISSING CLOSING BRACKETS...\n</a2ui-json>\nOops."
   expect:
     parts:
       - kind: "text"
@@ -117,7 +117,7 @@
   action: get_extension
   args:
     version: "0.8"
-    accepts_inline_catalogs: true
+    acceptsInlineCatalogs: true
   expect:
     uri: "https://a2ui.org/a2a-extension/a2ui/v0.8"
     params:
@@ -127,7 +127,7 @@
   action: get_extension
   args:
     version: "0.8"
-    supported_catalog_ids: ["a", "b", "c"]
+    supportedCatalogIds: ["a", "b", "c"]
   expect:
     uri: "https://a2ui.org/a2a-extension/a2ui/v0.8"
     params:

--- a/conformance/extensions/adk/adk_extensions.yaml
+++ b/conformance/extensions/adk/adk_extensions.yaml
@@ -15,9 +15,9 @@
 - name: test_converter_emits_failed_event
   action: convert_event
   args:
-    error_code: "some_error"
-    error_message: "Server crash"
-    has_catalog: true
+    errorCode: "some_error"
+    errorMessage: "Server crash"
+    hasCatalog: true
   expect:
     type: TaskStatusUpdateEvent
     state: FAILED
@@ -26,8 +26,8 @@
 - name: test_converter_emits_working_event
   action: convert_event
   args:
-    content_text: "Regular text response"
-    has_catalog: true
+    contentText: "Regular text response"
+    hasCatalog: true
   expect:
     type: TaskStatusUpdateEvent
     state: WORKING
@@ -36,21 +36,21 @@
 - name: test_converter_returns_empty_when_no_catalog
   action: convert_event
   args:
-    has_catalog: false
-  expect_empty: true
+    hasCatalog: false
+  expectEmpty: true
 
 - name: test_toolset_execute_valid_payload
   action: execute_tool
   args:
-    a2ui_json: '{"beginRendering": {"surfaceId": "dummy-surface", "root": {"component": "TestComp", "id": "1"}}}'
+    a2uiJson: '{"beginRendering": {"surfaceId": "dummy-surface", "root": {"component": "TestComp", "id": "1"}}}'
   expect:
     success: true
-    contains_validated_json: true
+    containsValidatedJson: true
 
 - name: test_toolset_execute_invalid_payload
   action: execute_tool
   args:
-    wrong_arg: "b"
+    wrongArg: "b"
   expect:
     success: false
-    error_contains: "missing required arg a2ui_json"
+    errorContains: "missing required arg a2ui_json"

--- a/kotlin/agent_sdk_legacy/src/test/kotlin/com/google/a2ui/conformance/A2aConformanceTest.kt
+++ b/kotlin/agent_sdk_legacy/src/test/kotlin/com/google/a2ui/conformance/A2aConformanceTest.kt
@@ -89,13 +89,11 @@ class A2aConformanceTest {
             val part = A2uiA2a.createA2uiPart(jsonElement, version)
             assertTrue(part is DataPart)
             val expect = case[ConformanceTestHelper.KEY_EXPECT] as Map<*, *>
-            assertEquals(
-              expect["mime_type"] as String,
-              (part as DataPart).metadata?.get(A2uiA2a.MIME_TYPE_KEY),
-            )
+            val expMime = expect["mimeType"] as String
+            assertEquals(expMime, (part as DataPart).metadata?.get(A2uiA2a.MIME_TYPE_KEY))
           }
           "is_a2ui_part" -> {
-            val mimeType = args["mime_type"] as String
+            val mimeType = args["mimeType"] as String
             val part = mockk<DataPart>()
             every { part.metadata } returns mapOf(A2uiA2a.MIME_TYPE_KEY to mimeType)
 
@@ -122,9 +120,10 @@ class A2aConformanceTest {
           }
           "get_extension" -> {
             val version = args["version"] as String
-            val acceptsInlineCatalogs = args["accepts_inline_catalogs"] as? Boolean ?: false
+            val acceptsInlineCatalogs = args["acceptsInlineCatalogs"] as? Boolean ?: false
             @Suppress("UNCHECKED_CAST")
-            val supportedCatalogIds = args["supported_catalog_ids"] as? List<String> ?: emptyList()
+            val supportedCatalogIds =
+              (args["supportedCatalogIds"] as? List<*>)?.mapNotNull { it as? String } ?: emptyList()
 
             val ext =
               A2uiA2a.getA2uiAgentExtension(version, acceptsInlineCatalogs, supportedCatalogIds)
@@ -152,7 +151,7 @@ class A2aConformanceTest {
           }
           "handle_rpc" -> {
             val request = args["request"] as Map<*, *>
-            val runnerOutput = args["runner_output"] as String
+            val runnerOutput = args["runnerOutput"] as String
 
             val mockRunner = mockk<Runner>(relaxed = true)
             val mockSessionService = mockk<BaseSessionService>(relaxed = true)

--- a/kotlin/agent_sdk_legacy/src/test/kotlin/com/google/a2ui/conformance/AdkExtensionsConformanceTest.kt
+++ b/kotlin/agent_sdk_legacy/src/test/kotlin/com/google/a2ui/conformance/AdkExtensionsConformanceTest.kt
@@ -69,7 +69,7 @@ class AdkExtensionsConformanceTest {
       DynamicTest.dynamicTest(name) {
         when (action) {
           "convert_event" -> {
-            val hasCatalog = args["has_catalog"] as? Boolean ?: false
+            val hasCatalog = args["hasCatalog"] as? Boolean ?: false
             val session = mockk<Session>()
             val state = ConcurrentHashMap<String, Any>()
             if (hasCatalog) {
@@ -81,9 +81,9 @@ class AdkExtensionsConformanceTest {
             every { context.session() } returns session
 
             val mockEvent = mockk<Event>()
-            val errorCode = args["error_code"] as? String
-            val errorMessage = args["error_message"] as? String
-            val contentText = args["content_text"] as? String
+            val errorCode = args["errorCode"] as? String
+            val errorMessage = args["errorMessage"] as? String
+            val contentText = args["contentText"] as? String
 
             if (errorCode != null) {
               val finishReason = mockk<FinishReason>()
@@ -121,7 +121,7 @@ class AdkExtensionsConformanceTest {
             val converter = A2uiEventConverter()
             val results = converter.convert(mockEvent, context)
 
-            val expectEmpty = case["expect_empty"] as? Boolean ?: false
+            val expectEmpty = case["expectEmpty"] as? Boolean ?: false
             if (expectEmpty) {
               assertTrue(results.isEmpty())
             } else {
@@ -150,7 +150,7 @@ class AdkExtensionsConformanceTest {
             }
           }
           "execute_tool" -> {
-            val a2uiJsonStr = args["a2ui_json"] as? String
+            val a2uiJsonStr = args["a2uiJson"] as? String
             val toolArgs =
               if (a2uiJsonStr != null) mapOf("a2ui_json" to a2uiJsonStr)
               else args as Map<String, Any>
@@ -187,7 +187,7 @@ class AdkExtensionsConformanceTest {
 
             if (expectSuccess) {
               assertTrue(result.containsKey(SendA2uiToClientToolset.VALIDATED_A2UI_JSON_KEY))
-              val containsValidatedJson = expect["contains_validated_json"] as? Boolean ?: false
+              val containsValidatedJson = expect["containsValidatedJson"] as? Boolean ?: false
               if (containsValidatedJson) {
                 val validatedPayload =
                   result[SendA2uiToClientToolset.VALIDATED_A2UI_JSON_KEY].toString()
@@ -195,7 +195,7 @@ class AdkExtensionsConformanceTest {
               }
             } else {
               assertTrue(result.containsKey(SendA2uiToClientToolset.TOOL_ERROR_KEY))
-              val errorContains = expect["error_contains"] as? String
+              val errorContains = expect["errorContains"] as? String
               if (errorContains != null) {
                 val errorMsg = result[SendA2uiToClientToolset.TOOL_ERROR_KEY] as String
                 assertTrue(errorMsg.contains(errorContains))

--- a/kotlin/agent_sdk_legacy/src/test/kotlin/com/google/a2ui/conformance/ConformanceTest.kt
+++ b/kotlin/agent_sdk_legacy/src/test/kotlin/com/google/a2ui/conformance/ConformanceTest.kt
@@ -125,7 +125,7 @@ class ConformanceTest {
       val case = caseObj as Map<*, *>
       val name = case[ConformanceTestHelper.KEY_NAME] as? String
       val catalog = case[ConformanceTestHelper.KEY_CATALOG] as? Map<*, *> ?: emptyMap<Any, Any>()
-      val rawVersion = (catalog["protocol_version"] ?: "v0.9").toString()
+      val rawVersion = (catalog["protocolVersion"] ?: "v0.9").toString()
       val version = if (rawVersion.startsWith("v")) rawVersion else "v$rawVersion"
 
       if (version !in SUPPORTED_SPEC_VERSIONS || (name != null && name in SKIP_TEST_NAMES)) {
@@ -207,7 +207,7 @@ class ConformanceTest {
     conformanceDir: File,
     baseSchemaMappings: Map<String, String>,
   ): Pair<A2uiCatalog, Map<String, String>> {
-    val versionStr = (catalogMap["protocol_version"] ?: "v0.9") as String
+    val versionStr = (catalogMap["protocolVersion"] ?: "v0.9") as String
     val version =
       if (versionStr == VERSION_0_8_STR || versionStr == "v0.8") {
         A2uiVersion.VERSION_0_8
@@ -215,7 +215,7 @@ class ConformanceTest {
         A2uiVersion.VERSION_0_9
       }
 
-    val s2cSchemaObj = catalogMap["s2c_schema"]
+    val s2cSchemaObj = catalogMap["s2cSchema"]
     val s2cSchema =
       when (s2cSchemaObj) {
         is String -> loadJsonFile(File(conformanceDir, s2cSchemaObj))
@@ -226,7 +226,7 @@ class ConformanceTest {
         else -> JsonObject(emptyMap())
       }
 
-    val catalogSchemaObj = catalogMap["catalog_schema"]
+    val catalogSchemaObj = catalogMap["catalogSchema"]
     val schemaMappings = HashMap(baseSchemaMappings)
 
     val urlPrefix = if (version == A2uiVersion.VERSION_0_8) URL_PREFIX_V08 else URL_PREFIX_V09
@@ -251,11 +251,11 @@ class ConformanceTest {
         Json.parseToJsonElement(jsonStr) as JsonObject
       } else {
         throw IllegalArgumentException(
-          "catalog_schema is required in conformance test catalog config"
+          "catalogSchema is required in conformance test catalog config"
         )
       }
 
-    val commonTypesObj = catalogMap["common_types_schema"]
+    val commonTypesObj = catalogMap["commonTypesSchema"]
     val commonTypesSchema =
       when (commonTypesObj) {
         is String -> loadJsonFile(File(conformanceDir, commonTypesObj))
@@ -267,7 +267,7 @@ class ConformanceTest {
       }
 
     val customCuttableKeys =
-      (catalogMap["custom_cuttable_keys"] as? List<*>)?.mapNotNull { it as? String }?.toSet()
+      (catalogMap["customCuttableKeys"] as? List<*>)?.mapNotNull { it as? String }?.toSet()
 
     val catalog =
       A2uiCatalog(
@@ -339,19 +339,19 @@ class ConformanceTest {
         when (action) {
           "prune" -> {
             val allowedComponents = args[KEY_ALLOWED_COMPONENTS] as? List<String>
-            val allowedMessages = args["allowed_messages"] as? List<String>
+            val allowedMessages = args["allowedMessages"] as? List<String>
             val pruned = catalog!!.withPruning(allowedComponents, allowedMessages)
             val expect = case[ConformanceTestHelper.KEY_EXPECT] as Map<*, *>
             if (expect.containsKey(KEY_CATALOG_SCHEMA)) {
               val expectSchema = jsonMapper.writeValueAsString(expect[KEY_CATALOG_SCHEMA])
               assertEquals(Json.parseToJsonElement(expectSchema), pruned.catalogSchema)
             }
-            if (expect.containsKey("s2c_schema")) {
-              val expectSchema = jsonMapper.writeValueAsString(expect["s2c_schema"])
+            if (expect.containsKey("s2cSchema")) {
+              val expectSchema = jsonMapper.writeValueAsString(expect["s2cSchema"])
               assertEquals(Json.parseToJsonElement(expectSchema), pruned.serverToClientSchema)
             }
-            if (expect.containsKey("common_types_schema")) {
-              val expectSchema = jsonMapper.writeValueAsString(expect["common_types_schema"])
+            if (expect.containsKey("commonTypesSchema")) {
+              val expectSchema = jsonMapper.writeValueAsString(expect["commonTypesSchema"])
               assertEquals(Json.parseToJsonElement(expectSchema), pruned.commonTypesSchema)
             }
           }
@@ -368,7 +368,7 @@ class ConformanceTest {
               assertExceptionMatches(exception, expectError)
             } else {
               val output = catalog!!.loadExamples(fullPath, validate = validate)
-              val expectOutput = case["expect_output"] as String
+              val expectOutput = case["expectOutput"] as String
               assertEquals(expectOutput.trim(), output.trim())
             }
           }
@@ -385,12 +385,12 @@ class ConformanceTest {
           }
           "render" -> {
             val output = catalog!!.renderAsLlmInstructions()
-            val expectOutput = case["expect_output"] as String
+            val expectOutput = case["expectOutput"] as String
             assertEquals(expectOutput.trim(), output.trim())
           }
           "verify_cuttable_keys" -> {
             val expect = case[ConformanceTestHelper.KEY_EXPECT] as Map<*, *>
-            val expectCuttableKeys = expect["custom_cuttable_keys"] as List<String>
+            val expectCuttableKeys = expect["customCuttableKeys"] as List<String>
             assertEquals(expectCuttableKeys.toSet(), catalog!!.cuttableKeys)
           }
           else -> assert(false, { "Unknown action: $action" })
@@ -414,9 +414,9 @@ class ConformanceTest {
       DynamicTest.dynamicTest(name) {
         when (action) {
           "select_catalog" -> {
-            val supportedCatalogs = args["supported_catalogs"] as? List<*> ?: emptyList<Any>()
-            val clientCapabilities = args["client_capabilities"] as? Map<*, *>
-            val acceptsInlineCatalogs = args["accepts_inline_catalogs"] as? Boolean ?: false
+            val supportedCatalogs = args["supportedCatalogs"] as? List<*> ?: emptyList<Any>()
+            val clientCapabilities = args["clientCapabilities"] as? Map<*, *>
+            val acceptsInlineCatalogs = args["acceptsInlineCatalogs"] as? Boolean ?: false
 
             val configs =
               supportedCatalogs.map { catDefObj ->
@@ -434,8 +434,13 @@ class ConformanceTest {
                 acceptsInlineCatalogs = acceptsInlineCatalogs,
               )
 
-            val capsJsonStr = jsonMapper.writeValueAsString(clientCapabilities)
-            val capsJson = Json.parseToJsonElement(capsJsonStr) as JsonObject
+            val capsJson =
+              if (clientCapabilities != null) {
+                val capsJsonStr = jsonMapper.writeValueAsString(clientCapabilities)
+                Json.parseToJsonElement(capsJsonStr) as JsonObject
+              } else {
+                JsonObject(emptyMap())
+              }
 
             val expectErrorObj = case[ConformanceTestHelper.KEY_EXPECT_ERROR]
             if (expectErrorObj != null) {
@@ -450,18 +455,14 @@ class ConformanceTest {
                 val expectSchema = Json.parseToJsonElement(expectSchemaStr)
                 assertEquals(expectSchema, selected.catalogSchema)
               }
-              if (case.containsKey("expect_selected")) {
-                assertEquals(case["expect_selected"] as String, selected.catalogId)
-              }
-              if (case.containsKey("expect_catalog_schema")) {
-                val expectSchemaStr = jsonMapper.writeValueAsString(case["expect_catalog_schema"])
-                val expectSchema = Json.parseToJsonElement(expectSchemaStr)
-                assertEquals(expectSchema, selected.catalogSchema)
+              val expectSelected = case["expectSelected"]
+              if (expectSelected != null) {
+                assertEquals(expectSelected as String, selected.catalogId)
               }
             }
           }
           "load_catalog" -> {
-            val catalogConfigs = case["catalog_configs"] as? List<*> ?: emptyList<Any>()
+            val catalogConfigs = case["catalogConfigs"] as? List<*> ?: emptyList<Any>()
             val modifiers = case["modifiers"] as? List<String> ?: emptyList()
 
             val schemaModifiers = mutableListOf<(JsonObject) -> JsonObject>()
@@ -487,8 +488,9 @@ class ConformanceTest {
             val selected = manager.getSelectedCatalog()
             val expect = case[ConformanceTestHelper.KEY_EXPECT] as Map<*, *>
 
-            if (expect.containsKey("supported_catalog_ids")) {
-              val expectIds = expect["supported_catalog_ids"] as List<String>
+            val supportedIdsObj = expect["supportedCatalogIds"]
+            if (supportedIdsObj != null) {
+              val expectIds = supportedIdsObj as List<String>
               assertEquals(expectIds, manager.supportedCatalogIds)
             } else {
               val expectSchemaStr = jsonMapper.writeValueAsString(expect)
@@ -500,20 +502,20 @@ class ConformanceTest {
             val versionStr = args["version"] as? String ?: "0.8"
             val version =
               if (versionStr == "0.8") A2uiVersion.VERSION_0_8 else A2uiVersion.VERSION_0_9
-            val role = args["role_description"] as? String ?: ""
-            val workflow = args["workflow_description"] as? String ?: ""
-            val uiDesc = args["ui_description"] as? String ?: ""
-            val includeSchema = args["include_schema"] as? Boolean ?: false
-            val includeExamples = args["include_examples"] as? Boolean ?: false
-            val validateExamples = args["validate_examples"] as? Boolean ?: false
+            val role = args["roleDescription"] as? String ?: ""
+            val workflow = args["workflowDescription"] as? String ?: ""
+            val uiDesc = args["uiDescription"] as? String ?: ""
+            val includeSchema = args["includeSchema"] as? Boolean ?: false
+            val includeExamples = args["includeExamples"] as? Boolean ?: false
+            val validateExamples = args["validateExamples"] as? Boolean ?: false
 
-            val clientCapabilities = args["client_ui_capabilities"] as? Map<*, *>
+            val clientCapabilities = args["clientUiCapabilities"] as? Map<*, *>
             val capsJsonStr = jsonMapper.writeValueAsString(clientCapabilities)
             val capsJson = Json.parseToJsonElement(capsJsonStr) as? JsonObject
 
-            val allowedComponents = args["allowed_components"] as? List<String> ?: emptyList()
+            val allowedComponents = args["allowedComponents"] as? List<String> ?: emptyList()
 
-            val examplesPath = args["examples_path"] as? String
+            val examplesPath = args["examplesPath"] as? String
             val fullExamplesPath = examplesPath?.let { File(conformanceDir, it).absolutePath }
 
             val dummyCatalog =
@@ -528,11 +530,12 @@ class ConformanceTest {
                 examplesPath = fullExamplesPath,
               )
 
+            val acceptsInline = args["acceptsInlineCatalogs"] as? Boolean ?: false
             val manager =
               A2uiSchemaManager(
                 version = version,
                 catalogs = listOf(dummyConfig),
-                acceptsInlineCatalogs = args["accepts_inline_catalogs"] as? Boolean ?: false,
+                acceptsInlineCatalogs = acceptsInline,
               )
 
             val output =
@@ -549,8 +552,9 @@ class ConformanceTest {
 
             val outputNormalized = output.replace(Regex("\\s+"), "").trim()
 
-            if (case.containsKey(KEY_EXPECT_CONTAINS)) {
-              val expectContains = case[KEY_EXPECT_CONTAINS] as List<String>
+            val expectContainsObj = case[KEY_EXPECT_CONTAINS]
+            if (expectContainsObj != null) {
+              val expectContains = expectContainsObj as List<String>
               for (expected in expectContains) {
                 val expectedNormalized = expected.replace(Regex("\\s+"), "").trim()
                 assertTrue(
@@ -659,7 +663,7 @@ class ConformanceTest {
           catalogMap?.let { buildCatalog(it, conformanceDir, baseSchemaMappings) }
             ?: (null to emptyMap())
         val parser = StreamingParser.create(catalog, schemaMappings)
-        if (case["disable_validation"] as? Boolean == true) {
+        if (case["disableValidation"] as? Boolean == true) {
           parser.validator = null
         }
 
@@ -756,13 +760,13 @@ class ConformanceTest {
     private const val SCHEMA_MANAGER_YAML_FILE = "agent/inference_format.yaml"
     private const val PARSER_YAML_FILE = "agent/parser.yaml"
 
-    private const val KEY_EXPECT_CONTAINS = "expect_contains"
+    private const val KEY_EXPECT_CONTAINS = "expectContains"
     private const val KEY_INPUT = "input"
     private const val KEY_TEXT = "text"
     private const val KEY_A2UI = "a2ui"
     private const val KEY_PATH = "path"
-    private const val KEY_ALLOWED_COMPONENTS = "allowed_components"
-    private const val KEY_CATALOG_SCHEMA = "catalog_schema"
+    private const val KEY_ALLOWED_COMPONENTS = "allowedComponents"
+    private const val KEY_CATALOG_SCHEMA = "catalogSchema"
 
     private fun isSkipped(suitePath: String): Boolean {
       return suitePath in SKIP_TEST_SUITES || File(suitePath).name in SKIP_TEST_SUITES

--- a/kotlin/agent_sdk_legacy/src/test/kotlin/com/google/a2ui/conformance/ConformanceTestHelper.kt
+++ b/kotlin/agent_sdk_legacy/src/test/kotlin/com/google/a2ui/conformance/ConformanceTestHelper.kt
@@ -32,7 +32,7 @@ object ConformanceTestHelper {
   const val KEY_STEPS = "steps"
   const val KEY_MESSAGES = "messages"
   const val KEY_VALIDATE = "validate"
-  const val KEY_EXPECT_ERROR = "expect_error"
+  const val KEY_EXPECT_ERROR = "expectError"
   const val KEY_EXPECT = "expect"
 
   private fun findRepoRoot(): File {

--- a/renderers/web_core/tests/conformance/conformance_test.mjs
+++ b/renderers/web_core/tests/conformance/conformance_test.mjs
@@ -108,7 +108,7 @@ function runConformanceHarness() {
 
     for (const testCase of testCases) {
       const {name, action, catalog, args} = testCase;
-      let version = catalog?.protocol_version || args?.version || 'v0.8';
+      let version = catalog?.protocolVersion || args?.version || 'v0.8';
       if (!version.startsWith('v')) version = `v${version}`;
 
       if (!SUPPORTED_SPEC_VERSIONS.has(version)) {
@@ -189,12 +189,10 @@ function validateRpcTestCase(testCase) {
 }
 
 function validateSelectCatalogTestCase(testCase) {
-  const {args, expect, expect_selected, expect_catalog_schema, expect_error} = testCase;
+  const {args, expect, expectSelected, expectError} = testCase;
   if (!args) throw new Error('select_catalog test requires "args" object.');
-  if (!expect && !expect_selected && !expect_catalog_schema && !expect_error) {
-    throw new Error(
-      'select_catalog test requires "expect", "expect_selected", "expect_catalog_schema", or "expect_error".',
-    );
+  if (!expect && !expectSelected && !expectError) {
+    throw new Error('select_catalog test requires "expect", "expectSelected", or "expectError".');
   }
 }
 


### PR DESCRIPTION
### Summary

Stacked on top of #2277 (`refactor/conformance-modernization`).

Converts conformance test runner properties and schemas across all test suites to use `camelCase` consistently:

- **YAML Suites**: Converted all test runner directives (`protocolVersion`, `catalogPath`, `catalogPaths`, `catalogConfigs`, `catalogId`, `strictMode`, `disableValidation`, `expectError`, `expectContains`, `expectEmpty`, `expectSelected`, `expectParts`, `expectOutput`, `customCuttableKeys`, `supportedCatalogIds`, `allowedComponents`, `allowedMessages`, `roleDescription`, `workflowDescription`, `uiDescription`, `examplesPath`, `includeSchema`, `includeExamples`, `clientUiCapabilities`, `clientCapabilities`, `acceptsInlineCatalogs`, `supportedCatalogs`, `includeInlineCatalogs`, `contextPath`, `axeCore`, `accessibilityTree`, `a2uiJson`, `containsValidatedJson`, `contentText`, `errorCode`, `errorContains`, `errorMessage`, `hasCatalog`, `mimeType`, `runnerOutput`, `wrongArg`).
- **Schema**: Updated `conformance/conformance_schema.json` to define pure `camelCase` properties across all definitions.
- **Python Runners**: Updated `test_conformance.py`, `test_adk_extensions.py`, and `test_a2a_integration.py` to support `camelCase` property keys.
- **Kotlin Runners**: Updated `ConformanceTest.kt`, `A2aConformanceTest.kt`, and `AdkExtensionsConformanceTest.kt` for `camelCase` property key compatibility.

### Verification
- Validated all 9 YAML test suites against `conformance_schema.json`.
- All Python tests pass (`pytest` 756 passed, 2 skipped).
- All Kotlin tests pass (`./gradlew test` 157 passed).
- Reverted/ignored formatting changes in all Dart files.
