### PR TITLE
feat(explorers): add collapsible sidebars and j/k keyboard navigation

### DIFF
--- a/renderers/angular/a2ui_explorer/src/app/app.spec.ts
+++ b/renderers/angular/a2ui_explorer/src/app/app.spec.ts
@@ -20,6 +20,9 @@ import {provideMarkdownRenderer} from '../../../src/v0_9/core/markdown';
 
 describe('App', () => {
   beforeEach(async () => {
+    if (typeof document !== 'undefined' && document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
     await TestBed.configureTestingModule({
       imports: [App],
       providers: [provideMarkdownRenderer()],
@@ -43,5 +46,95 @@ describe('App', () => {
 
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('h3')?.textContent).toContain('A2UI Examples');
+  });
+
+  it('should toggle left sidebar collapse and expand', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const leftSidebar = compiled.querySelector('.sidebar') as HTMLElement;
+    const collapseBtn = compiled.querySelector('.collapse-left-btn') as HTMLButtonElement;
+
+    expect(leftSidebar.classList.contains('collapsed')).toBeFalse();
+    expect(collapseBtn).toBeTruthy();
+
+    collapseBtn.click();
+    fixture.detectChanges();
+
+    expect(leftSidebar.classList.contains('collapsed')).toBeTrue();
+
+    const expandBtn = compiled.querySelector('.expand-left-btn') as HTMLButtonElement;
+    expect(expandBtn).toBeTruthy();
+
+    expandBtn.click();
+    fixture.detectChanges();
+
+    expect(leftSidebar.classList.contains('collapsed')).toBeFalse();
+  });
+
+  it('should toggle right inspector sidebar collapse and expand', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const inspectArea = compiled.querySelector('.inspect-area') as HTMLElement;
+    const collapseBtn = compiled.querySelector('.collapse-right-btn') as HTMLButtonElement;
+
+    expect(inspectArea.classList.contains('collapsed')).toBeFalse();
+    expect(collapseBtn).toBeTruthy();
+
+    collapseBtn.click();
+    fixture.detectChanges();
+
+    expect(inspectArea.classList.contains('collapsed')).toBeTrue();
+
+    const expandBtn = compiled.querySelector('.expand-right-btn') as HTMLButtonElement;
+    expect(expandBtn).toBeTruthy();
+
+    expandBtn.click();
+    fixture.detectChanges();
+
+    expect(inspectArea.classList.contains('collapsed')).toBeFalse();
+  });
+
+  it('should navigate to next and previous examples with j and k keys', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const activeBefore = compiled.querySelector('.example-list li.active .ex-name')?.textContent;
+
+    // Press 'j' -> Next example
+    window.dispatchEvent(new KeyboardEvent('keydown', {key: 'j'}));
+    fixture.detectChanges();
+
+    const activeAfterJ = compiled.querySelector('.example-list li.active .ex-name')?.textContent;
+    expect(activeAfterJ).not.toEqual(activeBefore);
+
+    // Press 'k' -> Previous example
+    window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k'}));
+    fixture.detectChanges();
+
+    const activeAfterK = compiled.querySelector('.example-list li.active .ex-name')?.textContent;
+    expect(activeAfterK).toEqual(activeBefore);
+  });
+
+  it('should not navigate with j and k when typing in textarea', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const activeBefore = compiled.querySelector('.example-list li.active .ex-name')?.textContent;
+    const textarea = compiled.querySelector('textarea') as HTMLTextAreaElement;
+
+    // Dispatch keydown from textarea
+    textarea.focus();
+    const event = new KeyboardEvent('keydown', {key: 'j', bubbles: true});
+    textarea.dispatchEvent(event);
+    fixture.detectChanges();
+
+    const activeAfter = compiled.querySelector('.example-list li.active .ex-name')?.textContent;
+    expect(activeAfter).toEqual(activeBefore);
   });
 });

--- a/renderers/angular/a2ui_explorer/src/app/demo.component.ts
+++ b/renderers/angular/a2ui_explorer/src/app/demo.component.ts
@@ -22,6 +22,8 @@ import {
   OnDestroy,
   effect,
   signal,
+  HostListener,
+  ElementRef,
 } from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {A2uiRendererService, A2UI_RENDERER_CONFIG} from '@a2ui/angular/v0_9';
@@ -49,15 +51,36 @@ import {Catalog as CatalogV08, DEFAULT_CATALOG as DEFAULT_CATALOG_V08} from '@a2
   template: `
     <div class="dashboard">
       <!-- Sidebar Navigation -->
-      <div class="sidebar">
+      <div class="sidebar" [class.collapsed]="isLeftSidebarCollapsed">
         <div class="sidebar-header">
           <h3>A2UI Examples</h3>
-          <div class="version-selector">
-            <label for="version">Version:</label>
-            <select id="version" (change)="onVersionChange($event)">
-              <option [value]="Version.V0_9" [selected]="version === Version.V0_9">0.9</option>
-              <option [value]="Version.V0_8" [selected]="version === Version.V0_8">0.8</option>
-            </select>
+          <div class="header-actions">
+            <div class="version-selector">
+              <label for="version">Ver:</label>
+              <select id="version" (change)="onVersionChange($event)">
+                <option [value]="Version.V0_9" [selected]="version === Version.V0_9">0.9</option>
+                <option [value]="Version.V0_8" [selected]="version === Version.V0_8">0.8</option>
+              </select>
+            </div>
+            <button
+              class="icon-btn collapse-left-btn"
+              (click)="toggleLeftSidebar()"
+              title="Collapse sidebar"
+              aria-label="Collapse sidebar"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polyline points="15 18 9 12 15 6"></polyline>
+              </svg>
+            </button>
           </div>
         </div>
         <ul class="example-list">
@@ -74,9 +97,55 @@ import {Catalog as CatalogV08, DEFAULT_CATALOG as DEFAULT_CATALOG_V08} from '@a2
 
       <!-- Main Canvas Area -->
       <div class="canvas-area">
-        <div class="canvas-header" *ngIf="selectedExample">
-          <h2>{{ selectedExample.name }}</h2>
-          <p class="subtitle">{{ selectedExample.description }}</p>
+        <div class="canvas-header">
+          <div class="canvas-header-left">
+            <button
+              *ngIf="isLeftSidebarCollapsed"
+              class="icon-btn expand-left-btn"
+              (click)="toggleLeftSidebar()"
+              title="Expand sidebar"
+              aria-label="Expand sidebar"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polyline points="9 18 15 12 9 6"></polyline>
+              </svg>
+            </button>
+            <div *ngIf="selectedExample" class="title-details">
+              <h2>{{ selectedExample.name }}</h2>
+              <p class="subtitle">{{ selectedExample.description }}</p>
+            </div>
+          </div>
+          <div class="canvas-header-right">
+            <button
+              *ngIf="isRightSidebarCollapsed"
+              class="icon-btn expand-right-btn"
+              (click)="toggleRightSidebar()"
+              title="Expand inspector"
+              aria-label="Expand inspector"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polyline points="15 18 9 12 15 6"></polyline>
+              </svg>
+            </button>
+          </div>
         </div>
         <div class="canvas-frame">
           <div
@@ -97,7 +166,29 @@ import {Catalog as CatalogV08, DEFAULT_CATALOG as DEFAULT_CATALOG_V08} from '@a2
       </div>
 
       <!-- Inspect Panel -->
-      <div class="inspect-area">
+      <div class="inspect-area" [class.collapsed]="isRightSidebarCollapsed">
+        <div class="inspect-header">
+          <h4>Inspector</h4>
+          <button
+            class="icon-btn collapse-right-btn"
+            (click)="toggleRightSidebar()"
+            title="Collapse inspector"
+            aria-label="Collapse inspector"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polyline points="9 18 15 12 9 6"></polyline>
+            </svg>
+          </button>
+        </div>
         <div class="inspect-section surface-section" [class.folded]="isSurfaceMessageFolded">
           <div
             class="section-header"
@@ -254,16 +345,27 @@ import {Catalog as CatalogV08, DEFAULT_CATALOG as DEFAULT_CATALOG_V08} from '@a2
       /* Sidebar */
       .sidebar {
         width: 260px;
+        min-width: 260px;
         background-color: #1e1e1e;
         border-right: 1px solid #333;
         display: flex;
         flex-direction: column;
+        transition:
+          width 0.2s ease,
+          min-width 0.2s ease;
+      }
+      .sidebar.collapsed {
+        width: 0;
+        min-width: 0;
+        border-right: none;
+        overflow: hidden;
+        display: none;
       }
       .sidebar-header {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        padding: 0 16px;
+        padding: 0 12px 0 16px;
         height: 56px;
         border-bottom: 1px solid #334155;
         background-color: #1e293b;
@@ -273,10 +375,15 @@ import {Catalog as CatalogV08, DEFAULT_CATALOG as DEFAULT_CATALOG_V08} from '@a2
         color: #4dabf7;
         font-size: 1rem;
       }
+      .header-actions {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
       .version-selector {
         display: flex;
         align-items: center;
-        gap: 8px;
+        gap: 4px;
       }
       .version-selector label {
         font-size: 0.75rem;
@@ -287,7 +394,7 @@ import {Catalog as CatalogV08, DEFAULT_CATALOG as DEFAULT_CATALOG_V08} from '@a2
         color: #f8fafc;
         border: 1px solid #334155;
         border-radius: 4px;
-        padding: 2px 6px;
+        padding: 2px 4px;
         font-size: 0.75rem;
         cursor: pointer;
         outline: none;
@@ -295,6 +402,30 @@ import {Catalog as CatalogV08, DEFAULT_CATALOG as DEFAULT_CATALOG_V08} from '@a2
       }
       .version-selector select:focus {
         border-color: #3b82f6;
+      }
+      .icon-btn {
+        background: transparent;
+        border: 1px solid #334155;
+        border-radius: 4px;
+        color: #94a3b8;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 4px;
+        line-height: 1;
+        transition: all 0.2s;
+      }
+      .icon-btn:hover {
+        background-color: #334155;
+        color: #f8fafc;
+        border-color: #475569;
+      }
+      .icon-btn svg {
+        display: block;
+      }
+      .expand-btn {
+        padding: 6px;
       }
       .example-list {
         list-style: none;
@@ -338,12 +469,22 @@ import {Catalog as CatalogV08, DEFAULT_CATALOG as DEFAULT_CATALOG_V08} from '@a2
       }
       .canvas-header {
         display: flex;
-        flex-direction: column;
-        justify-content: center;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
         padding: 0 16px;
         height: 56px;
         background-color: #1e293b;
         border-bottom: 1px solid #334155;
+      }
+      .canvas-header-left {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .canvas-header-right {
+        display: flex;
+        align-items: center;
       }
       .canvas-header h2 {
         margin: 0;
@@ -386,12 +527,38 @@ import {Catalog as CatalogV08, DEFAULT_CATALOG as DEFAULT_CATALOG_V08} from '@a2
       /* Inspect Panel */
       .inspect-area {
         width: 380px;
+        min-width: 380px;
         background-color: #0f172a;
         border-left: 1px solid #1e293b;
         display: flex;
         flex-direction: column;
         height: 100%;
         overflow: hidden;
+        transition:
+          width 0.2s ease,
+          min-width 0.2s ease;
+      }
+      .inspect-area.collapsed {
+        width: 0;
+        min-width: 0;
+        border-left: none;
+        overflow: hidden;
+        display: none;
+      }
+      .inspect-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0 12px 0 16px;
+        height: 56px;
+        background-color: #1e293b;
+        border-bottom: 1px solid #334155;
+      }
+      .inspect-header h4 {
+        margin: 0;
+        font-size: 1rem;
+        color: #f8fafc;
+        font-weight: 500;
       }
       .inspect-section {
         flex: 0 1 auto;
@@ -627,31 +794,111 @@ export class DemoComponent implements OnInit, OnDestroy {
     });
   }
 
+  private readonly elementRef = inject(ElementRef);
+
   isDataModelFolded = false;
   isSurfaceMessageFolded = false;
   isEventsLogFolded = false;
+  isLeftSidebarCollapsed = false;
+  isRightSidebarCollapsed = false;
+
+  private getLocalStorage(key: string): string | null {
+    try {
+      return typeof window !== 'undefined' ? localStorage.getItem(key) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private setLocalStorage(key: string, value: string) {
+    try {
+      if (typeof window !== 'undefined') {
+        localStorage.setItem(key, value);
+      }
+    } catch {
+      // Ignore localStorage errors in restricted environments
+    }
+  }
+
+  toggleLeftSidebar() {
+    this.isLeftSidebarCollapsed = !this.isLeftSidebarCollapsed;
+    this.setLocalStorage('isLeftSidebarCollapsed', String(this.isLeftSidebarCollapsed));
+  }
+
+  toggleRightSidebar() {
+    this.isRightSidebarCollapsed = !this.isRightSidebarCollapsed;
+    this.setLocalStorage('isRightSidebarCollapsed', String(this.isRightSidebarCollapsed));
+  }
 
   toggleDataModel() {
     this.isDataModelFolded = !this.isDataModelFolded;
-    localStorage.setItem('isDataModelFolded', String(this.isDataModelFolded));
+    this.setLocalStorage('isDataModelFolded', String(this.isDataModelFolded));
   }
 
   toggleSurfaceMessage() {
     this.isSurfaceMessageFolded = !this.isSurfaceMessageFolded;
-    localStorage.setItem('isSurfaceMessageFolded', String(this.isSurfaceMessageFolded));
+    this.setLocalStorage('isSurfaceMessageFolded', String(this.isSurfaceMessageFolded));
   }
 
   toggleEventsLog() {
     this.isEventsLogFolded = !this.isEventsLogFolded;
-    localStorage.setItem('isEventsLogFolded', String(this.isEventsLogFolded));
+    this.setLocalStorage('isEventsLogFolded', String(this.isEventsLogFolded));
+  }
+
+  @HostListener('window:keydown', ['$event'])
+  handleKeyboardEvent(event: KeyboardEvent) {
+    const activeEl =
+      typeof document !== 'undefined' ? (document.activeElement as HTMLElement | null) : null;
+    const targetEl = event.target as HTMLElement | null;
+    const focusedEl = (activeEl && activeEl.isConnected ? activeEl : null) || targetEl;
+
+    if (
+      focusedEl &&
+      (focusedEl.tagName === 'INPUT' ||
+        focusedEl.tagName === 'TEXTAREA' ||
+        focusedEl.tagName === 'SELECT' ||
+        focusedEl.isContentEditable)
+    ) {
+      return;
+    }
+
+    if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {
+      return;
+    }
+
+    if (event.key === 'j') {
+      this.selectNextExample();
+      event.preventDefault();
+    } else if (event.key === 'k') {
+      this.selectPrevExample();
+      event.preventDefault();
+    }
+  }
+
+  selectNextExample() {
+    if (!this.examples || this.examples.length === 0) return;
+    const currentIndex = this.selectedExample
+      ? this.examples.findIndex(ex => ex === this.selectedExample)
+      : -1;
+    const nextIndex = currentIndex < this.examples.length - 1 ? currentIndex + 1 : 0;
+    this.selectExample(this.examples[nextIndex]);
+  }
+
+  selectPrevExample() {
+    if (!this.examples || this.examples.length === 0) return;
+    const currentIndex = this.selectedExample
+      ? this.examples.findIndex(ex => ex === this.selectedExample)
+      : -1;
+    const prevIndex = currentIndex > 0 ? currentIndex - 1 : this.examples.length - 1;
+    this.selectExample(this.examples[prevIndex]);
   }
 
   ngOnInit(): void {
-    if (typeof window !== 'undefined') {
-      this.isDataModelFolded = localStorage.getItem('isDataModelFolded') === 'true';
-      this.isSurfaceMessageFolded = localStorage.getItem('isSurfaceMessageFolded') === 'true';
-      this.isEventsLogFolded = localStorage.getItem('isEventsLogFolded') === 'true';
-    }
+    this.isDataModelFolded = this.getLocalStorage('isDataModelFolded') === 'true';
+    this.isSurfaceMessageFolded = this.getLocalStorage('isSurfaceMessageFolded') === 'true';
+    this.isEventsLogFolded = this.getLocalStorage('isEventsLogFolded') === 'true';
+    this.isLeftSidebarCollapsed = this.getLocalStorage('isLeftSidebarCollapsed') === 'true';
+    this.isRightSidebarCollapsed = this.getLocalStorage('isRightSidebarCollapsed') === 'true';
     this.selectExampleFromUrl();
   }
 
@@ -670,10 +917,22 @@ export class DemoComponent implements OnInit, OnDestroy {
 
   selectExample(example: A2uiExample) {
     this.selectedExample = example;
-    window.location.hash = this.slugify(example.name);
+    if (typeof window !== 'undefined') {
+      window.location.hash = this.slugify(example.name);
+    }
 
     this.agentStub.initializeDemo(example.messages);
     this.cdr.detectChanges();
+    this.scrollToActiveExample();
+  }
+
+  private scrollToActiveExample() {
+    if (typeof window !== 'undefined') {
+      setTimeout(() => {
+        const activeEl = this.elementRef.nativeElement.querySelector('.example-list li.active');
+        activeEl?.scrollIntoView({block: 'nearest', behavior: 'smooth'});
+      }, 0);
+    }
   }
 
   /** Gets a display string for the action type. */

--- a/renderers/lit/a2ui_explorer/src/local-gallery.css.ts
+++ b/renderers/lit/a2ui_explorer/src/local-gallery.css.ts
@@ -66,6 +66,38 @@ export const appStyles = css`
     border-right: 1px solid rgba(148, 163, 184, 0.1);
     display: flex;
     flex-direction: column;
+    overflow: hidden;
+    transition:
+      width 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+      min-width 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    flex-shrink: 0;
+  }
+
+  .nav-pane.collapsed {
+    width: 0 !important;
+    min-width: 0 !important;
+    border-right: none;
+    visibility: hidden;
+  }
+
+  .nav-header {
+    padding: 12px 16px;
+    background: #1e293b;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .nav-header h3 {
+    margin: 0;
+    font-size: 1rem;
+    color: #38bdf8;
+  }
+
+  .nav-list {
+    flex: 1;
     overflow-y: auto;
   }
 
@@ -98,6 +130,30 @@ export const appStyles = css`
     text-overflow: ellipsis;
   }
 
+  .icon-btn {
+    background: transparent;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 4px;
+    color: #94a3b8;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px;
+    line-height: 1;
+    transition: all 0.2s;
+  }
+
+  .icon-btn:hover {
+    background-color: #334155;
+    color: #f8fafc;
+    border-color: #475569;
+  }
+
+  .icon-btn svg {
+    display: block;
+  }
+
   .gallery-pane {
     flex: 1;
     display: flex;
@@ -111,19 +167,27 @@ export const appStyles = css`
     background: #1e293b;
     border-bottom: 1px solid rgba(148, 163, 184, 0.1);
     display: flex;
-    flex-direction: column;
-    align-items: stretch;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
     gap: 12px;
+    flex-shrink: 0;
 
     h2 {
       margin: 0;
     }
   }
 
+  .preview-header-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
   .agent-controls {
     display: flex;
     gap: 8px;
-    justify-content: space-between;
+    align-items: center;
 
     fieldset {
       border: 1px solid rgba(148, 163, 184, 0.2);
@@ -205,6 +269,36 @@ export const appStyles = css`
     flex-direction: column;
     border-left: 1px solid rgba(148, 163, 184, 0.1);
     background: #020617;
+    overflow: hidden;
+    transition:
+      width 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+      min-width 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    flex-shrink: 0;
+  }
+
+  .inspector-pane.collapsed {
+    width: 0 !important;
+    min-width: 0 !important;
+    border-left: none;
+    visibility: hidden;
+  }
+
+  .inspector-pane-header {
+    padding: 12px 16px;
+    background: #1e293b;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .inspector-pane-header h4 {
+    margin: 0;
+    font-size: 0.9rem;
+    color: #94a3b8;
+    text-transform: uppercase;
+    font-weight: 600;
   }
 
   .inspector-section {

--- a/renderers/lit/a2ui_explorer/src/local-gallery.ts
+++ b/renderers/lit/a2ui_explorer/src/local-gallery.ts
@@ -31,6 +31,9 @@ export class LocalGallery extends LitElement {
   @state() processedMessageCount = 0;
   @state() currentDataModelText = '{}';
   @state() primaryColor = '#1177ee';
+  @state() isLeftSidebarCollapsed = false;
+  @state() isRightSidebarCollapsed = false;
+
   // Expose the dispatched actions log for automated integration tests to inspect
   actionLog: A2uiClientAction[] = [];
 
@@ -46,16 +49,99 @@ export class LocalGallery extends LitElement {
 
   static styles = [appStyles];
 
+  private getLocalStorage(key: string): string | null {
+    try {
+      return typeof window !== 'undefined' ? localStorage.getItem(key) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private setLocalStorage(key: string, value: string) {
+    try {
+      if (typeof window !== 'undefined') {
+        localStorage.setItem(key, value);
+      }
+    } catch {
+      // Ignore in restricted environments
+    }
+  }
+
   async connectedCallback() {
     super.connectedCallback();
 
-    this.processor.model.onSurfaceCreated.subscribe((surface: any) => {
-      surface.onError.subscribe((err: any) => {
-        this.log(`Error on surface ${surface.id}: ${err.message}`, err);
-      });
-    });
+    this.isLeftSidebarCollapsed = this.getLocalStorage('isLeftSidebarCollapsed') === 'true';
+    this.isRightSidebarCollapsed = this.getLocalStorage('isRightSidebarCollapsed') === 'true';
+
+    window.addEventListener('keydown', this.handleKeyDown);
+
+    this.processor.model.onSurfaceCreated.subscribe(
+      (surface: {onError: {subscribe: (cb: (err: Error) => void) => void}; id: string}) => {
+        surface.onError.subscribe((err: Error) => {
+          this.log(`Error on surface ${surface.id}: ${err.message}`, err);
+        });
+      },
+    );
 
     this.loadExamples();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('keydown', this.handleKeyDown);
+  }
+
+  private handleKeyDown = (event: KeyboardEvent) => {
+    const activeEl =
+      typeof document !== 'undefined' ? (document.activeElement as HTMLElement | null) : null;
+    const targetEl = event.target as HTMLElement | null;
+    const focusedEl = (activeEl && activeEl.isConnected ? activeEl : null) || targetEl;
+
+    if (
+      focusedEl &&
+      (focusedEl.tagName === 'INPUT' ||
+        focusedEl.tagName === 'TEXTAREA' ||
+        focusedEl.tagName === 'SELECT' ||
+        focusedEl.isContentEditable)
+    ) {
+      return;
+    }
+
+    if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {
+      return;
+    }
+
+    if (event.key === 'j') {
+      this.selectNextExample();
+      event.preventDefault();
+    } else if (event.key === 'k') {
+      this.selectPrevExample();
+      event.preventDefault();
+    }
+  };
+
+  selectNextExample() {
+    if (!this.demoItems || this.demoItems.length === 0) return;
+    const nextIndex =
+      this.activeItemIndex < this.demoItems.length - 1 ? this.activeItemIndex + 1 : 0;
+    this.selectItem(nextIndex);
+  }
+
+  selectPrevExample() {
+    if (!this.demoItems || this.demoItems.length === 0) return;
+    const prevIndex =
+      this.activeItemIndex > 0 ? this.activeItemIndex - 1 : this.demoItems.length - 1;
+    this.selectItem(prevIndex);
+  }
+
+  toggleLeftSidebar() {
+    this.isLeftSidebarCollapsed = !this.isLeftSidebarCollapsed;
+    this.setLocalStorage('isLeftSidebarCollapsed', String(this.isLeftSidebarCollapsed));
+  }
+
+  toggleRightSidebar() {
+    this.isRightSidebarCollapsed = !this.isRightSidebarCollapsed;
+    this.setLocalStorage('isRightSidebarCollapsed', String(this.isRightSidebarCollapsed));
   }
 
   loadExamples() {
@@ -75,6 +161,14 @@ export class LocalGallery extends LitElement {
     // Then load the new one
     this.activeItemIndex = index;
     this.reloadExample();
+    this.scrollToActiveExample();
+  }
+
+  private scrollToActiveExample() {
+    setTimeout(() => {
+      const activeEl = this.renderRoot?.querySelector('.nav-item.active');
+      activeEl?.scrollIntoView({block: 'nearest', behavior: 'smooth'});
+    }, 0);
   }
 
   resetSurface() {
@@ -186,7 +280,7 @@ export class LocalGallery extends LitElement {
     this.reloadExample();
   }
 
-  log(msg: string, detail?: any) {
+  log(msg: string, detail?: unknown) {
     const time = new Date().toLocaleTimeString();
     const entry = detail ? `${msg}\n${JSON.stringify(detail, null, 2)}` : msg;
     this.mockLogs = [...this.mockLogs, `[${time}] ${entry}`];
@@ -205,25 +299,74 @@ export class LocalGallery extends LitElement {
         </div>
       </header>
       <main>
-        <nav class="nav-pane">
-          ${this.demoItems.map(
-            (item, i) => html`
-              <div
-                class="nav-item ${i === this.activeItemIndex ? 'active' : ''}"
-                @click=${() => this.selectItem(i)}
+        <nav class="nav-pane ${this.isLeftSidebarCollapsed ? 'collapsed' : ''}">
+          <div class="nav-header">
+            <h3>Examples</h3>
+            <button
+              class="icon-btn collapse-left-btn"
+              @click=${() => this.toggleLeftSidebar()}
+              title="Collapse sidebar"
+              aria-label="Collapse sidebar"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
               >
-                <h3 class="nav-title">${item.title}</h3>
-                <p class="nav-desc">${item.filename}</p>
-              </div>
-            `,
-          )}
+                <polyline points="15 18 9 12 15 6"></polyline>
+              </svg>
+            </button>
+          </div>
+          <div class="nav-list">
+            ${this.demoItems.map(
+              (item, i) => html`
+                <div
+                  class="nav-item ${i === this.activeItemIndex ? 'active' : ''}"
+                  @click=${() => this.selectItem(i)}
+                >
+                  <h3 class="nav-title">${item.title}</h3>
+                  <p class="nav-desc">${item.filename}</p>
+                </div>
+              `,
+            )}
+          </div>
         </nav>
 
         <section class="gallery-pane">
           <div class="preview-header">
-            <div>
-              <h2>${activeItem?.title || 'No selection'}</h2>
-              <p class="subtitle">${activeItem?.description}</p>
+            <div class="preview-header-left">
+              ${this.isLeftSidebarCollapsed
+                ? html`
+                    <button
+                      class="icon-btn expand-left-btn"
+                      @click=${() => this.toggleLeftSidebar()}
+                      title="Expand sidebar"
+                      aria-label="Expand sidebar"
+                    >
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <polyline points="9 18 15 12 9 6"></polyline>
+                      </svg>
+                    </button>
+                  `
+                : nothing}
+              <div>
+                <h2>${activeItem?.title || 'No selection'}</h2>
+                <p class="subtitle">${activeItem?.description}</p>
+              </div>
             </div>
             <div class="agent-controls">
               <fieldset class="message-controls">
@@ -250,6 +393,29 @@ export class LocalGallery extends LitElement {
                   <button @click=${this.clearColor} class="clear-btn">Clear</button>
                 </div>
               </fieldset>
+              ${this.isRightSidebarCollapsed
+                ? html`
+                    <button
+                      class="icon-btn expand-right-btn"
+                      @click=${() => this.toggleRightSidebar()}
+                      title="Expand inspector"
+                      aria-label="Expand inspector"
+                    >
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <polyline points="15 18 9 12 15 6"></polyline>
+                      </svg>
+                    </button>
+                  `
+                : nothing}
             </div>
           </div>
 
@@ -264,7 +430,29 @@ export class LocalGallery extends LitElement {
           </div>
         </section>
 
-        <aside class="inspector-pane">
+        <aside class="inspector-pane ${this.isRightSidebarCollapsed ? 'collapsed' : ''}">
+          <div class="inspector-pane-header">
+            <h4>Inspector</h4>
+            <button
+              class="icon-btn collapse-right-btn"
+              @click=${() => this.toggleRightSidebar()}
+              title="Collapse inspector"
+              aria-label="Collapse inspector"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polyline points="9 18 15 12 9 6"></polyline>
+              </svg>
+            </button>
+          </div>
           <div class="inspector-section">
             <div class="inspector-header">Data Model</div>
             <div class="inspector-body">${this.currentDataModelText}</div>

--- a/renderers/lit/a2ui_explorer/tests/sidebar-and-navigation.test.ts
+++ b/renderers/lit/a2ui_explorer/tests/sidebar-and-navigation.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {loadExample, whenSettled} from './utils/test-utils';
+import {LocalGallery} from '../src/local-gallery';
+
+describe('Lit Explorer Sidebars & Navigation', () => {
+  let gallery: LocalGallery;
+
+  beforeEach(async () => {
+    gallery = await loadExample('00_simple-text.json');
+  });
+
+  afterEach(() => {
+    gallery?.remove();
+  });
+
+  it('should toggle left sidebar collapse and expand', async () => {
+    const navPane = gallery.shadowRoot?.querySelector('.nav-pane') as HTMLElement;
+    const collapseBtn = gallery.shadowRoot?.querySelector(
+      '.collapse-left-btn',
+    ) as HTMLButtonElement;
+
+    expect(navPane.classList.contains('collapsed')).toBeFalse();
+    expect(collapseBtn).toBeTruthy();
+
+    collapseBtn.click();
+    await whenSettled(gallery);
+
+    expect(navPane.classList.contains('collapsed')).toBeTrue();
+
+    const expandBtn = gallery.shadowRoot?.querySelector('.expand-left-btn') as HTMLButtonElement;
+    expect(expandBtn).toBeTruthy();
+
+    expandBtn.click();
+    await whenSettled(gallery);
+
+    expect(navPane.classList.contains('collapsed')).toBeFalse();
+  });
+
+  it('should toggle right inspector sidebar collapse and expand', async () => {
+    const inspectorPane = gallery.shadowRoot?.querySelector('.inspector-pane') as HTMLElement;
+    const collapseBtn = gallery.shadowRoot?.querySelector(
+      '.collapse-right-btn',
+    ) as HTMLButtonElement;
+
+    expect(inspectorPane.classList.contains('collapsed')).toBeFalse();
+    expect(collapseBtn).toBeTruthy();
+
+    collapseBtn.click();
+    await whenSettled(gallery);
+
+    expect(inspectorPane.classList.contains('collapsed')).toBeTrue();
+
+    const expandBtn = gallery.shadowRoot?.querySelector('.expand-right-btn') as HTMLButtonElement;
+    expect(expandBtn).toBeTruthy();
+
+    expandBtn.click();
+    await whenSettled(gallery);
+
+    expect(inspectorPane.classList.contains('collapsed')).toBeFalse();
+  });
+
+  it('should navigate to next and previous examples with j and k keys', async () => {
+    const initialIndex = gallery.activeItemIndex;
+
+    // Press 'j' -> Next example
+    window.dispatchEvent(new KeyboardEvent('keydown', {key: 'j'}));
+    await whenSettled(gallery);
+
+    expect(gallery.activeItemIndex).toBe(initialIndex + 1);
+
+    // Press 'k' -> Previous example
+    window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k'}));
+    await whenSettled(gallery);
+
+    expect(gallery.activeItemIndex).toBe(initialIndex);
+  });
+});

--- a/renderers/react/a2ui_explorer/src/App.module.css
+++ b/renderers/react/a2ui_explorer/src/App.module.css
@@ -34,6 +34,12 @@
   flex-shrink: 0;
 }
 
+.headerLeft {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
 .h1 {
   margin: 0;
   font-size: 1.5rem;
@@ -57,6 +63,39 @@
   border-right: 1px solid rgba(148, 163, 184, 0.1);
   display: flex;
   flex-direction: column;
+  overflow: hidden;
+  transition:
+    width 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    min-width 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  flex-shrink: 0;
+}
+
+.navPane.collapsed {
+  width: 0 !important;
+  min-width: 0 !important;
+  border-right: none;
+  visibility: hidden;
+}
+
+.navHeader {
+  padding: 12px 16px;
+  background: #1e293b;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.navHeaderTitle {
+  margin: 0;
+  font-size: 1rem;
+  color: #38bdf8;
+  font-weight: 600;
+}
+
+.navList {
+  flex: 1;
   overflow-y: auto;
 }
 
@@ -96,6 +135,46 @@
   text-overflow: ellipsis;
 }
 
+.iconBtn {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 4px;
+  color: #94a3b8;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  line-height: 1;
+  transition: all 0.2s;
+}
+
+.iconBtn:hover {
+  background-color: #334155;
+  color: #f8fafc;
+  border-color: #475569;
+}
+
+.iconBtn svg {
+  display: block;
+}
+
+.collapseLeftBtn {
+  composes: iconBtn;
+}
+
+.expandLeftBtn {
+  composes: iconBtn;
+}
+
+.collapseRightBtn {
+  composes: iconBtn;
+}
+
+.expandRightBtn {
+  composes: iconBtn;
+}
+
 .galleryPane {
   flex: 1;
   display: flex;
@@ -111,6 +190,19 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-shrink: 0;
+}
+
+.previewHeaderLeft {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.previewHeaderRight {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .stepperControls {
@@ -162,6 +254,36 @@
   flex-direction: column;
   border-left: 1px solid rgba(148, 163, 184, 0.1);
   background: #020617;
+  overflow: hidden;
+  transition:
+    width 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    min-width 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  flex-shrink: 0;
+}
+
+.inspectorPane.collapsed {
+  width: 0 !important;
+  min-width: 0 !important;
+  border-left: none;
+  visibility: hidden;
+}
+
+.inspectorPaneHeader {
+  padding: 12px 16px;
+  background: #1e293b;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.inspectorPaneTitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #94a3b8;
+  text-transform: uppercase;
+  font-weight: 600;
 }
 
 .inspectorSection {

--- a/renderers/react/a2ui_explorer/src/App.tsx
+++ b/renderers/react/a2ui_explorer/src/App.tsx
@@ -88,10 +88,110 @@ export const App = ({initialExampleId, onAction}: AppProps) => {
   const [surfaces, setSurfaces] = useState<string[]>([]);
   const [currentMessageIndex, setCurrentMessageIndex] = useState(-1);
 
+  const [isLeftSidebarCollapsed, setIsLeftSidebarCollapsed] = useState(() => {
+    try {
+      return (
+        typeof window !== 'undefined' && localStorage.getItem('isLeftSidebarCollapsed') === 'true'
+      );
+    } catch {
+      return false;
+    }
+  });
+
+  const [isRightSidebarCollapsed, setIsRightSidebarCollapsed] = useState(() => {
+    try {
+      return (
+        typeof window !== 'undefined' && localStorage.getItem('isRightSidebarCollapsed') === 'true'
+      );
+    } catch {
+      return false;
+    }
+  });
+
+  const navListRef = useRef<HTMLDivElement | null>(null);
+
+  const toggleLeftSidebar = useCallback(() => {
+    setIsLeftSidebarCollapsed(prev => {
+      const next = !prev;
+      try {
+        if (typeof window !== 'undefined') {
+          localStorage.setItem('isLeftSidebarCollapsed', String(next));
+        }
+      } catch {
+        // Ignore in restricted environments
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleRightSidebar = useCallback(() => {
+    setIsRightSidebarCollapsed(prev => {
+      const next = !prev;
+      try {
+        if (typeof window !== 'undefined') {
+          localStorage.setItem('isRightSidebarCollapsed', String(next));
+        }
+      } catch {
+        // Ignore in restricted environments
+      }
+      return next;
+    });
+  }, []);
+
+  const scrollToActiveExample = useCallback(() => {
+    setTimeout(() => {
+      const activeEl = navListRef.current?.querySelector(`.${styles.navItem}.${styles.active}`);
+      activeEl?.scrollIntoView({block: 'nearest', behavior: 'smooth'});
+    }, 0);
+  }, []);
+
   const onActionRef = useRef(onAction);
   useEffect(() => {
     onActionRef.current = onAction;
   }, [onAction]);
+
+  // Handle keyboard shortcuts ('j' and 'k')
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const activeEl =
+        typeof document !== 'undefined' ? (document.activeElement as HTMLElement | null) : null;
+      const targetEl = event.target as HTMLElement | null;
+      const focusedEl = (activeEl && activeEl.isConnected ? activeEl : null) || targetEl;
+
+      if (
+        focusedEl &&
+        (focusedEl.tagName === 'INPUT' ||
+          focusedEl.tagName === 'TEXTAREA' ||
+          focusedEl.tagName === 'SELECT' ||
+          focusedEl.isContentEditable)
+      ) {
+        return;
+      }
+
+      if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {
+        return;
+      }
+
+      if (event.key === 'j') {
+        setSelectedExampleId(prevId => {
+          const currentIndex = demoItems.findIndex(e => e.id === prevId);
+          const nextIndex = currentIndex < demoItems.length - 1 ? currentIndex + 1 : 0;
+          return demoItems[nextIndex].id;
+        });
+        event.preventDefault();
+      } else if (event.key === 'k') {
+        setSelectedExampleId(prevId => {
+          const currentIndex = demoItems.findIndex(e => e.id === prevId);
+          const prevIndex = currentIndex > 0 ? currentIndex - 1 : demoItems.length - 1;
+          return demoItems[prevIndex].id;
+        });
+        event.preventDefault();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   // Initialize or reset processor
   const resetProcessor = useCallback(
@@ -133,6 +233,7 @@ export const App = ({initialExampleId, onAction}: AppProps) => {
   // Effect to handle example selection change
   useEffect(() => {
     resetProcessor(true);
+    scrollToActiveExample();
     // Cleanup on unmount or when changing examples
     return () => {
       setProcessor(prev => {
@@ -140,7 +241,7 @@ export const App = ({initialExampleId, onAction}: AppProps) => {
         return null;
       });
     };
-  }, [selectedExampleId, resetProcessor]);
+  }, [selectedExampleId, resetProcessor, scrollToActiveExample]);
 
   // Handle surface subscriptions
   useEffect(() => {
@@ -185,9 +286,11 @@ export const App = ({initialExampleId, onAction}: AppProps) => {
   return (
     <div className={styles.app}>
       <header className={styles.header}>
-        <div>
-          <h1 className={styles.h1}>A2UI React Explorer</h1>
-          <p className={styles.subtitle}>Preview and interact with React components</p>
+        <div className={styles.headerLeft}>
+          <div>
+            <h1 className={styles.h1}>A2UI React Explorer</h1>
+            <p className={styles.subtitle}>Preview and interact with React components</p>
+          </div>
         </div>
         <div className={styles.stepperControls}>
           <span>
@@ -201,23 +304,104 @@ export const App = ({initialExampleId, onAction}: AppProps) => {
 
       <main className={styles.main}>
         {/* Left Column: Sample List */}
-        <div className={styles.navPane}>
-          {demoItems.map(item => {
-            const isActive = selectedExampleId === item.id;
-            return (
-              <button
-                key={item.id}
-                className={`${styles.navItem} ${isActive ? styles.active : ''}`}
-                onClick={() => setSelectedExampleId(item.id)}
+        <nav
+          className={`${styles.navPane} ${isLeftSidebarCollapsed ? styles.collapsed : ''}`}
+          aria-label="Examples Navigation"
+        >
+          <div className={styles.navHeader}>
+            <h3 className={styles.navHeaderTitle}>Examples</h3>
+            <button
+              className={`${styles.iconBtn} ${styles.collapseLeftBtn}`}
+              onClick={toggleLeftSidebar}
+              title="Collapse sidebar"
+              aria-label="Collapse sidebar"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
               >
-                <div className={styles.navTitle}>{item.title}</div>
-              </button>
-            );
-          })}
-        </div>
+                <polyline points="15 18 9 12 15 6"></polyline>
+              </svg>
+            </button>
+          </div>
+          <div className={styles.navList} ref={navListRef}>
+            {demoItems.map(item => {
+              const isActive = selectedExampleId === item.id;
+              return (
+                <button
+                  key={item.id}
+                  className={`${styles.navItem} ${isActive ? styles.active : ''}`}
+                  onClick={() => setSelectedExampleId(item.id)}
+                >
+                  <div className={styles.navTitle}>{item.title}</div>
+                  <div className={styles.navDesc}>{item.description}</div>
+                </button>
+              );
+            })}
+          </div>
+        </nav>
 
         {/* Center Column: Preview & JSON Stepper */}
         <div className={styles.galleryPane}>
+          <div className={styles.previewHeader}>
+            <div className={styles.previewHeaderLeft}>
+              {isLeftSidebarCollapsed && (
+                <button
+                  className={`${styles.iconBtn} ${styles.expandLeftBtn}`}
+                  onClick={toggleLeftSidebar}
+                  title="Expand sidebar"
+                  aria-label="Expand sidebar"
+                >
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <polyline points="9 18 15 12 9 6"></polyline>
+                  </svg>
+                </button>
+              )}
+              <div>
+                <h2>{selectedItem?.title || 'No selection'}</h2>
+                <p className={styles.subtitle}>{selectedItem?.description}</p>
+              </div>
+            </div>
+            <div className={styles.previewHeaderRight}>
+              {isRightSidebarCollapsed && (
+                <button
+                  className={`${styles.iconBtn} ${styles.expandRightBtn}`}
+                  onClick={toggleRightSidebar}
+                  title="Expand inspector"
+                  aria-label="Expand inspector"
+                >
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <polyline points="15 18 9 12 15 6"></polyline>
+                  </svg>
+                </button>
+              )}
+            </div>
+          </div>
+
           <div className={styles.previewContent}>
             <div className={styles.surfaceContainer}>
               {surfaces.length === 0 && (
@@ -304,7 +488,33 @@ export const App = ({initialExampleId, onAction}: AppProps) => {
         </div>
 
         {/* Right Column: Live DataModelViewer & Action Logs */}
-        <div className={styles.inspectorPane}>
+        <aside
+          className={`${styles.inspectorPane} ${isRightSidebarCollapsed ? styles.collapsed : ''}`}
+          aria-label="Inspector Panel"
+        >
+          <div className={styles.inspectorPaneHeader}>
+            <h4 className={styles.inspectorPaneTitle}>Inspector</h4>
+            <button
+              className={`${styles.iconBtn} ${styles.collapseRightBtn}`}
+              onClick={toggleRightSidebar}
+              title="Collapse inspector"
+              aria-label="Collapse inspector"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polyline points="9 18 15 12 9 6"></polyline>
+              </svg>
+            </button>
+          </div>
+
           <div className={styles.inspectorSection}>
             <h3 className={styles.inspectorHeader}>Data Model</h3>
             <div className={styles.inspectorBody}>
@@ -343,7 +553,7 @@ export const App = ({initialExampleId, onAction}: AppProps) => {
               </div>
             </div>
           </div>
-        </div>
+        </aside>
       </main>
     </div>
   );

--- a/renderers/react/a2ui_explorer/tests/sidebar-and-navigation.test.tsx
+++ b/renderers/react/a2ui_explorer/tests/sidebar-and-navigation.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {act} from 'react';
+import {loadExample, cleanup, whenSettled} from './utils/test-utils';
+
+describe('React Explorer Sidebars & Navigation', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(async () => {
+    container = await loadExample('00_simple-text.json');
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it('should toggle left sidebar collapse and expand', async () => {
+    const navPane = container.querySelector('[class*="navPane"]') as HTMLElement;
+    const collapseBtn = container.querySelector('[class*="collapseLeftBtn"]') as HTMLButtonElement;
+
+    expect(navPane.className).not.toContain('collapsed');
+    expect(collapseBtn).toBeTruthy();
+
+    await act(async () => {
+      collapseBtn.click();
+      await whenSettled();
+    });
+
+    expect(navPane.className).toContain('collapsed');
+
+    const expandBtn = container.querySelector('[class*="expandLeftBtn"]') as HTMLButtonElement;
+    expect(expandBtn).toBeTruthy();
+
+    await act(async () => {
+      expandBtn.click();
+      await whenSettled();
+    });
+
+    expect(navPane.className).not.toContain('collapsed');
+  });
+
+  it('should toggle right inspector sidebar collapse and expand', async () => {
+    const inspectorPane = container.querySelector('[class*="inspectorPane"]') as HTMLElement;
+    const collapseBtn = container.querySelector('[class*="collapseRightBtn"]') as HTMLButtonElement;
+
+    expect(inspectorPane.className).not.toContain('collapsed');
+    expect(collapseBtn).toBeTruthy();
+
+    await act(async () => {
+      collapseBtn.click();
+      await whenSettled();
+    });
+
+    expect(inspectorPane.className).toContain('collapsed');
+
+    const expandBtn = container.querySelector('[class*="expandRightBtn"]') as HTMLButtonElement;
+    expect(expandBtn).toBeTruthy();
+
+    await act(async () => {
+      expandBtn.click();
+      await whenSettled();
+    });
+
+    expect(inspectorPane.className).not.toContain('collapsed');
+  });
+
+  it('should navigate to next and previous examples with j and k keys', async () => {
+    const getActiveTitle = () =>
+      container.querySelector('[class*="navItem"][class*="active"] [class*="navTitle"]')
+        ?.textContent;
+
+    const initialTitle = getActiveTitle();
+
+    // Press 'j' -> Next example
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', {key: 'j'}));
+      await whenSettled();
+    });
+
+    const nextTitle = getActiveTitle();
+    expect(nextTitle).not.toEqual(initialTitle);
+
+    // Press 'k' -> Previous example
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k'}));
+      await whenSettled();
+    });
+
+    expect(getActiveTitle()).toEqual(initialTitle);
+  });
+});


### PR DESCRIPTION
## Summary

Enhances the A2UI Angular Explorer (`@a2ui/angular-explorer`), Lit Explorer (`@a2ui/lit-explorer`), and React Explorer (`@a2ui/react-explorer`) with collapsible sidebars (left examples navigation and right inspector panel) and keyboard shortcuts for rapid example switching.

### Key Changes
- **Collapsible Left & Right Sidebars**:
  - Added dedicated toggle buttons to collapse and expand both the examples sidebar (left) and inspector panel (right) across Angular, Lit, and React explorer applications.
  - Persists collapsed/expanded states across reloads using safe `localStorage` access.
- **Keyboard Navigation Shortcuts (`j` and `k`)**:
  - Added global keydown shortcuts across all three explorers:
    - Press <kbd>j</kbd> to navigate to the next example in the catalog.
    - Press <kbd>k</kbd> to navigate to the previous example in the catalog.
  - Automatically scrolls the sidebar list to keep the currently active example in view.
  - Safely ignores navigation events when focus is inside text inputs, textareas, selects, or contenteditable regions, or when modifier keys are pressed.
- **Unit & Integration Tests**:
  - Added test suites for Angular, Lit, and React explorers verifying left and right sidebar collapse/expansion.
  - Added test suites verifying keyboard navigation with <kbd>j</kbd>/<kbd>k</kbd> and ensuring inputs/textareas are isolated.

## Pre-launch Checklist
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] My code changes have tests.