### PR TITLE
ci: scope format presubmit to changed files (#2232)

### DIFF
--- a/.github/workflows/presubmit-lint.yml
+++ b/.github/workflows/presubmit-lint.yml
@@ -83,10 +83,14 @@ jobs:
       # runs and narrows its own work below.
       - name: Determine formatting scope
         id: scope
+        # Passed through env rather than interpolated into the script body:
+        # `${{ }}` expansion inside `run:` is a template-injection vector.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$BASE_SHA" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ] && [ -n "${BASE_SHA:-}" ]; then
             SCOPE_ARGS="--changed --base $BASE_SHA"
           else
             # Post-submit on main sweeps the whole repo, so drift can never
@@ -119,7 +123,11 @@ jobs:
         with:
           sdk: "3.12.2"
       - name: Run enforce-formatting check
-        run: ./scripts/fix_format.sh --check ${{ steps.scope.outputs.args }}
+        env:
+          SCOPE_ARGS: ${{ steps.scope.outputs.args }}
+        # SCOPE_ARGS is intentionally unquoted: it is either empty or the two
+        # words "--changed --base <sha>", and must word-split.
+        run: ./scripts/fix_format.sh --check $SCOPE_ARGS
 
   workspace-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/presubmit-lint.yml
+++ b/.github/workflows/presubmit-lint.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Run fix_licenses unit tests
         run: python3 -m unittest scripts.test_fix_licenses
 
+      - name: Run fix_format scoping unit tests
+        run: python3 -m unittest scripts.test_fix_format
+
       - name: Check license headers
         run: ./scripts/fix_licenses.py --check
 
@@ -71,16 +74,52 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          # Needed so that --changed can find the merge base with the PR base.
+          fetch-depth: 0
+
+      # This job deliberately has no workflow-level `paths:` filter. It is a
+      # required check, and a filtered-out required check never reports a
+      # conclusion, which leaves PRs stuck pending. Instead the job always
+      # runs and narrows its own work below.
+      - name: Determine formatting scope
+        id: scope
+        run: |
+          set -euo pipefail
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$BASE_SHA" ]; then
+            SCOPE_ARGS="--changed --base $BASE_SHA"
+          else
+            # Post-submit on main sweeps the whole repo, so drift can never
+            # accumulate behind the per-PR scoping.
+            SCOPE_ARGS=""
+          fi
+          echo "args=$SCOPE_ARGS" >> "$GITHUB_OUTPUT"
+
+          # --plan resolves the changed set without needing any language
+          # toolchain, so it can decide which toolchains are worth installing.
+          PLAN="$(./scripts/fix_format.sh --plan $SCOPE_ARGS)"
+          echo "$PLAN"
+
+          needs() {
+            echo "$PLAN" | grep -qE "^$1: (all|[1-9])"
+          }
+          for tool in prettier pyink dart; do
+            if needs "$tool"; then echo "$tool=true" >> "$GITHUB_OUTPUT"; else echo "$tool=false" >> "$GITHUB_OUTPUT"; fi
+          done
+
       - uses: ./.github/actions/setup-node
+        if: steps.scope.outputs.prettier == 'true'
         with:
           install: false
       - uses: ./.github/actions/setup-python
+        if: steps.scope.outputs.pyink == 'true'
       - name: Set up Dart (Lightweight)
+        if: steps.scope.outputs.dart == 'true'
         uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: "3.12.2"
       - name: Run enforce-formatting check
-        run: ./scripts/fix_format.sh --check
+        run: ./scripts/fix_format.sh --check ${{ steps.scope.outputs.args }}
 
   workspace-lint:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,21 @@ You can use the provided script to format the entire repo or check formatting:
 ./scripts/fix_format.sh --check
 ```
 
+To format only what your branch changed — which is what presubmit does on a
+pull request — add `--changed`. Formatters whose languages you did not touch
+are skipped entirely, so you are never asked to fix unrelated formatting drift
+just to get your change through:
+
+```bash
+./scripts/fix_format.sh --changed              # compares against origin/main
+./scripts/fix_format.sh --check --changed
+./scripts/fix_format.sh --changed --base upstream/main
+./scripts/fix_format.sh --plan --changed       # show what would run, and skip
+```
+
+`--plan` needs no language toolchains installed, so it is a quick way to see
+whether your change will pull in the Dart, Swift, or Kotlin formatters.
+
 ### IDE Recommendations (VS Code)
 
 We recommend using [VS Code](https://code.visualstudio.com/) for development. To help enforce formatting, please install the following extensions:

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -25,10 +25,76 @@ failure() {
 }
 trap 'failure' ERR
 
+usage() {
+  cat <<'EOF'
+Usage: fix_format.sh [--check] [--changed] [--base <ref>] [--plan]
+
+Formats (or checks) the repository with Prettier, Pyink, dart format,
+swift-format, and ktfmt.
+
+Options:
+  --check        Report formatting problems instead of rewriting files.
+  --changed      Only consider files that differ from the base ref. Formatters
+                 whose languages are untouched are skipped entirely, so a
+                 TypeScript-only change is never blocked by, say, unrelated
+                 Dart formatting drift.
+  --base <ref>   Base ref used by --changed. Defaults to the first of
+                 origin/main, upstream/main, or main that exists locally.
+                 Implies --changed.
+  --plan         Print which formatters would run, and over how many files,
+                 then exit without invoking any formatter. Requires no
+                 language toolchains, so it is safe to run anywhere.
+  -h, --help     Show this message.
+
+With no options the whole repository is formatted, which remains the correct
+behaviour for scheduled and post-submit runs.
+EOF
+}
+
 CHECK_ONLY=false
-if [[ "${1:-}" == "--check" ]]; then
-  CHECK_ONLY=true
-fi
+CHANGED_ONLY=false
+PLAN_ONLY=false
+BASE_REF=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      CHECK_ONLY=true
+      shift
+      ;;
+    --changed)
+      CHANGED_ONLY=true
+      shift
+      ;;
+    --base)
+      if [[ $# -lt 2 ]]; then
+        echo "❌ --base requires a git ref argument." >&2
+        exit 2
+      fi
+      BASE_REF="$2"
+      CHANGED_ONLY=true
+      shift 2
+      ;;
+    --base=*)
+      BASE_REF="${1#--base=}"
+      CHANGED_ONLY=true
+      shift
+      ;;
+    --plan)
+      PLAN_ONLY=true
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "❌ Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
 
 # Get repo root
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -39,85 +105,325 @@ if command -v corepack >/dev/null 2>&1; then
   YARN_CMD=(corepack yarn)
 fi
 
-echo "Running Prettier formatting for Node/Web assets..."
-if [ -f ".yarn/install-state.gz" ]; then
-  # Local Node environment already installed; invoke standard script targets
-  if [ "$CHECK_ONLY" = true ]; then
-    "${YARN_CMD[@]}" format:check:all
-  else
-    "${YARN_CMD[@]}" format:all | sed '/ (unchanged)$/d'
+# ---------------------------------------------------------------------------
+# Changed-file discovery
+# ---------------------------------------------------------------------------
+
+# Picks the base ref to diff against when the caller did not name one.
+detect_base_ref() {
+  local candidate
+  for candidate in origin/main upstream/main main; do
+    if git rev-parse --verify --quiet "$candidate" >/dev/null 2>&1; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Emits the repo-relative path of every file that differs from the base ref,
+# including staged, unstaged, and untracked work so that local runs match what
+# CI will see. Deleted paths are dropped: there is nothing left to format.
+collect_changed_files() {
+  local base="$1"
+  local diff_point
+
+  # Comparing against the merge base rather than the branch tip keeps unrelated
+  # commits that landed on main out of the changed set.
+  if ! diff_point="$(git merge-base HEAD "$base" 2>/dev/null)"; then
+    diff_point="$base"
   fi
-else
-  # Non-Node contributor or CI; run standalone Prettier via dlx without full monorepo install
-  if [ "$CHECK_ONLY" = true ]; then
-    "${YARN_CMD[@]}" dlx prettier@3.8.4 --config .prettierrc --check .
-  else
-    "${YARN_CMD[@]}" dlx prettier@3.8.4 --config .prettierrc --write . | sed '/ (unchanged)$/d'
+
+  {
+    git diff --name-only --diff-filter=ACMRT "$diff_point" --
+    git diff --name-only --diff-filter=ACMRT --
+    git diff --cached --name-only --diff-filter=ACMRT --
+    git ls-files --others --exclude-standard
+  } | sort -u | while IFS= read -r path; do
+    [[ -n "$path" && -f "$path" ]] && echo "$path"
+  done
+}
+
+CHANGED_FILES=""
+if [ "$CHANGED_ONLY" = true ]; then
+  if [ -z "$BASE_REF" ]; then
+    if ! BASE_REF="$(detect_base_ref)"; then
+      echo "❌ --changed could not find a base ref (tried origin/main, upstream/main, main)." >&2
+      echo "   Pass one explicitly, e.g. --base origin/main." >&2
+      exit 2
+    fi
+  fi
+  if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null 2>&1; then
+    echo "❌ --base ref '$BASE_REF' does not exist locally." >&2
+    exit 2
+  fi
+  echo "Scoping to files changed against '$BASE_REF'."
+  CHANGED_FILES="$(collect_changed_files "$BASE_REF")"
+  if [ -z "$CHANGED_FILES" ]; then
+    echo "No changed files detected; nothing to format."
   fi
 fi
 
-echo "Running Pyink for Python files..."
-if [ "$CHECK_ONLY" = true ]; then
-  uv run pyink --check .
-else
-  uv run pyink .
+# Filters the changed set by an extended regex. In whole-repo mode this yields
+# nothing, and callers fall back to their existing directory-wide invocation.
+select_changed() {
+  local pattern="$1"
+  [ -n "$CHANGED_FILES" ] || return 0
+  printf '%s\n' "$CHANGED_FILES" | grep -E "$pattern" || true
+}
+
+# True when a formatter has no work to do and should be skipped outright.
+should_skip() {
+  local label="$1" selected="$2"
+  if [ "$CHANGED_ONLY" = true ] && [ -z "$selected" ]; then
+    echo "Skipping $label: no matching files changed."
+    return 0
+  fi
+  return 1
+}
+
+count_lines() {
+  local value="$1"
+  [ -n "$value" ] || {
+    echo 0
+    return 0
+  }
+  printf '%s\n' "$value" | wc -l | tr -d ' '
+}
+
+# Splits a newline-delimited string into the global array SELECTED_TARGETS.
+# Written the long way rather than with mapfile so the script keeps working on
+# the bash 3.2 that ships with macOS.
+split_into_targets() {
+  local line
+  SELECTED_TARGETS=()
+  while IFS= read -r line; do
+    [ -n "$line" ] && SELECTED_TARGETS+=("$line")
+  done <<<"$1"
+}
+
+# ---------------------------------------------------------------------------
+# Per-language file selection
+#
+# Each selector mirrors the directory scope used by the corresponding
+# whole-repo run below, so --changed can never widen what a formatter touches.
+# ---------------------------------------------------------------------------
+
+# Prettier's built-in parsers. Matching on extension rather than handing over
+# the whole changed set is what lets a Swift-only or Dart-only change report
+# "prettier: 0" and skip installing Node altogether. Anything Prettier gains a
+# parser for through a plugin would need adding here; until then the
+# whole-repo post-submit run remains the backstop.
+PRETTIER_EXTENSIONS='\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|json|jsonc|json5|css|scss|less|html|htm|vue|md|markdown|mdx|ya?ml|graphql|gql|hbs|handlebars)$'
+PRETTIER_FILES="$(select_changed "$PRETTIER_EXTENSIONS|(^|/)\.(prettierrc|babelrc)$")"
+# pyink's extend-exclude in pyproject.toml is not applied to explicitly listed
+# files, only to directory walks, so /generated/ is filtered out here to keep
+# both modes consistent.
+PYTHON_FILES="$(select_changed '\.py$' | { grep -vE '(^|/)generated/' || true; })"
+DART_FILES="$(select_changed '^(samples/client/flutter|renderers/flutter)/.*\.dart$')"
+SWIFT_FILES="$(select_changed '^(Package\.swift$|swift/.*\.swift$)')"
+KOTLIN_FILES="$(select_changed '\.(kt|kts)$')"
+
+# Maps changed Kotlin sources onto the Gradle modules that own them. ktfmt is a
+# Gradle task rather than a file-level binary, so the finest granularity
+# available is "run only the modules that actually changed".
+kotlin_modules_for_files() {
+  local file dir
+  local modules=""
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    dir="$(dirname "$file")"
+    while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
+      if [ -f "$dir/build.gradle.kts" ] && grep -q "ktfmt" "$dir/build.gradle.kts" 2>/dev/null; then
+        modules+="$dir"$'\n'
+        break
+      fi
+      dir="$(dirname "$dir")"
+    done
+  done <<<"$1"
+  printf '%s' "$modules" | sort -u | { grep -v '^$' || true; }
+}
+
+KOTLIN_MODULES=""
+if [ -n "$KOTLIN_FILES" ]; then
+  KOTLIN_MODULES="$(kotlin_modules_for_files "$KOTLIN_FILES")"
 fi
 
-echo "Running Dart format..."
-cd "$REPO_ROOT"
-# Check if dart is available before running
-if command -v dart >/dev/null 2>&1; then
-
-  # Run "dart pub get" silently, to resolve Dart dependencies. This will resolve
-  # the analysis_options.yaml includes if the person running this script hasn't
-  # run dart or flutter "pub get" yet.
-  #
-  # Running "dart pub get" is not a NECESSARY thing for the formatting to work
-  # (dart format is entirely AST-based), but if someone runs the formatting
-  # script locally, then we don't want confusion about the warnings if they
-  # haven't run "dart pub get" (which is equivalent to "flutter pub get" if the
-  # dart executable is in a Flutter SDK directory).
-  #
-  # In CI, we want to be able to only install the lightweight Dart image, not
-  # the much heavier Flutter image, which quadruples the time it takes to run
-  # the formatting check. In that case, since the dart executable isn't part of
-  # a Flutter SDK directory, "dart pub get" will give errors about the monorepo
-  # depending on Flutter and not running "flutter pub get", so we want to
-  # suppress that failure here so it doesn't cause the fix_format.sh script to
-  # exit. The dart format run will still have warnings because pub get wasn't
-  # run, but it won't affect the CI build outcome.
-  if [ ! -f ".dart_tool/package_config.json" ]; then
-    dart pub get >/dev/null 2>&1 || true
-  fi
-
-  if [ "$CHECK_ONLY" = true ]; then
-    dart format --output=none --set-exit-if-changed samples/client/flutter renderers/flutter
+if [ "$PLAN_ONLY" = true ]; then
+  echo "--- formatting plan ---"
+  if [ "$CHANGED_ONLY" = true ]; then
+    echo "mode: changed (base: $BASE_REF)"
   else
-    dart format samples/client/flutter renderers/flutter
+    echo "mode: all"
   fi
-else
-  echo "Warning: dart command not found. Skipping Dart formatting."
-fi
-
-echo "Running swift-format..."
-if command -v swift-format >/dev/null 2>&1; then
-  if [ "$CHECK_ONLY" = true ]; then
-    echo "Linting Swift files..."
-    swift-format lint -r Package.swift swift/
+  if [ "$CHANGED_ONLY" = true ]; then
+    echo "prettier: $(count_lines "$PRETTIER_FILES") file(s)"
+    echo "pyink: $(count_lines "$PYTHON_FILES") file(s)"
+    echo "dart: $(count_lines "$DART_FILES") file(s)"
+    echo "swift: $(count_lines "$SWIFT_FILES") file(s)"
+    echo "ktfmt: $(count_lines "$KOTLIN_MODULES") module(s)"
   else
-    echo "Formatting Swift files..."
-    swift-format format -i -r Package.swift swift/
+    echo "prettier: all"
+    echo "pyink: all"
+    echo "dart: all"
+    echo "swift: all"
+    echo "ktfmt: all"
   fi
-else
-  echo "Warning: swift-format command not found. Skipping Swift formatting."
+  exit 0
 fi
 
-echo "Running ktfmt for Kotlin files..."
-cd "$REPO_ROOT"
-if command -v java >/dev/null 2>&1; then
-  while IFS= read -r -d '' build_file; do
-    dir="$(dirname "$build_file")"
-    if grep -q "ktfmt" "$build_file" 2>/dev/null; then
+# ---------------------------------------------------------------------------
+# Prettier
+# ---------------------------------------------------------------------------
+
+if should_skip "Prettier" "$PRETTIER_FILES"; then
+  :
+else
+  echo "Running Prettier formatting for Node/Web assets..."
+
+  prettier_targets=(.)
+  prettier_extra=()
+  if [ "$CHANGED_ONLY" = true ]; then
+    split_into_targets "$PRETTIER_FILES"
+    prettier_targets=("${SELECTED_TARGETS[@]}")
+    # Explicit paths may include extensions Prettier has no parser for; skip
+    # them instead of failing the run. .prettierignore still applies.
+    prettier_extra=(--ignore-unknown)
+  fi
+
+  if [ -f ".yarn/install-state.gz" ]; then
+    # Local Node environment already installed; invoke standard script targets
+    if [ "$CHANGED_ONLY" = false ]; then
+      if [ "$CHECK_ONLY" = true ]; then
+        "${YARN_CMD[@]}" format:check:all
+      else
+        "${YARN_CMD[@]}" format:all | sed '/ (unchanged)$/d'
+      fi
+    else
+      if [ "$CHECK_ONLY" = true ]; then
+        "${YARN_CMD[@]}" prettier --config .prettierrc "${prettier_extra[@]}" --check "${prettier_targets[@]}"
+      else
+        "${YARN_CMD[@]}" prettier --config .prettierrc "${prettier_extra[@]}" --write "${prettier_targets[@]}" | sed '/ (unchanged)$/d'
+      fi
+    fi
+  else
+    # Non-Node contributor or CI; run standalone Prettier via dlx without full monorepo install
+    if [ "$CHECK_ONLY" = true ]; then
+      "${YARN_CMD[@]}" dlx prettier@3.8.4 --config .prettierrc ${prettier_extra[@]+"${prettier_extra[@]}"} --check "${prettier_targets[@]}"
+    else
+      "${YARN_CMD[@]}" dlx prettier@3.8.4 --config .prettierrc ${prettier_extra[@]+"${prettier_extra[@]}"} --write "${prettier_targets[@]}" | sed '/ (unchanged)$/d'
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Pyink
+# ---------------------------------------------------------------------------
+
+if should_skip "Pyink" "$PYTHON_FILES"; then
+  :
+else
+  echo "Running Pyink for Python files..."
+  pyink_targets=(.)
+  if [ "$CHANGED_ONLY" = true ]; then
+    split_into_targets "$PYTHON_FILES"
+    pyink_targets=("${SELECTED_TARGETS[@]}")
+  fi
+  if [ "$CHECK_ONLY" = true ]; then
+    uv run pyink --check "${pyink_targets[@]}"
+  else
+    uv run pyink "${pyink_targets[@]}"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Dart
+# ---------------------------------------------------------------------------
+
+if should_skip "Dart format" "$DART_FILES"; then
+  :
+else
+  echo "Running Dart format..."
+  cd "$REPO_ROOT"
+  # Check if dart is available before running
+  if command -v dart >/dev/null 2>&1; then
+
+    # Run "dart pub get" silently, to resolve Dart dependencies. This will resolve
+    # the analysis_options.yaml includes if the person running this script hasn't
+    # run dart or flutter "pub get" yet.
+    #
+    # Running "dart pub get" is not a NECESSARY thing for the formatting to work
+    # (dart format is entirely AST-based), but if someone runs the formatting
+    # script locally, then we don't want confusion about the warnings if they
+    # haven't run "dart pub get" (which is equivalent to "flutter pub get" if the
+    # dart executable is in a Flutter SDK directory).
+    #
+    # In CI, we want to be able to only install the lightweight Dart image, not
+    # the much heavier Flutter image, which quadruples the time it takes to run
+    # the formatting check. In that case, since the dart executable isn't part of
+    # a Flutter SDK directory, "dart pub get" will give errors about the monorepo
+    # depending on Flutter and not running "flutter pub get", so we want to
+    # suppress that failure here so it doesn't cause the fix_format.sh script to
+    # exit. The dart format run will still have warnings because pub get wasn't
+    # run, but it won't affect the CI build outcome.
+    if [ ! -f ".dart_tool/package_config.json" ]; then
+      dart pub get >/dev/null 2>&1 || true
+    fi
+
+    dart_targets=(samples/client/flutter renderers/flutter)
+    if [ "$CHANGED_ONLY" = true ]; then
+      split_into_targets "$DART_FILES"
+      dart_targets=("${SELECTED_TARGETS[@]}")
+    fi
+
+    if [ "$CHECK_ONLY" = true ]; then
+      dart format --output=none --set-exit-if-changed "${dart_targets[@]}"
+    else
+      dart format "${dart_targets[@]}"
+    fi
+  else
+    echo "Warning: dart command not found. Skipping Dart formatting."
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# swift-format
+# ---------------------------------------------------------------------------
+
+if should_skip "swift-format" "$SWIFT_FILES"; then
+  :
+else
+  echo "Running swift-format..."
+  if command -v swift-format >/dev/null 2>&1; then
+    swift_targets=(-r Package.swift swift/)
+    if [ "$CHANGED_ONLY" = true ]; then
+      split_into_targets "$SWIFT_FILES"
+      swift_targets=("${SELECTED_TARGETS[@]}")
+    fi
+    if [ "$CHECK_ONLY" = true ]; then
+      echo "Linting Swift files..."
+      swift-format lint "${swift_targets[@]}"
+    else
+      echo "Formatting Swift files..."
+      swift-format format -i "${swift_targets[@]}"
+    fi
+  else
+    echo "Warning: swift-format command not found. Skipping Swift formatting."
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# ktfmt
+# ---------------------------------------------------------------------------
+
+if [ "$CHANGED_ONLY" = true ] && [ -z "$KOTLIN_MODULES" ]; then
+  echo "Skipping ktfmt: no matching files changed."
+else
+  echo "Running ktfmt for Kotlin files..."
+  cd "$REPO_ROOT"
+  if command -v java >/dev/null 2>&1; then
+    run_ktfmt_in_dir() {
+      local dir="$1"
       (
         cd "$dir"
         if [ -x "./gradlew" ]; then
@@ -135,10 +441,24 @@ if command -v java >/dev/null 2>&1; then
           "${GRADLE_CMD[@]}" -q ktfmtFormat
         fi
       )
+    }
+
+    if [ "$CHANGED_ONLY" = true ]; then
+      while IFS= read -r module_dir; do
+        [ -n "$module_dir" ] || continue
+        run_ktfmt_in_dir "$module_dir"
+      done <<<"$KOTLIN_MODULES"
+    else
+      while IFS= read -r -d '' build_file; do
+        dir="$(dirname "$build_file")"
+        if grep -q "ktfmt" "$build_file" 2>/dev/null; then
+          run_ktfmt_in_dir "$dir"
+        fi
+      done < <(find "$REPO_ROOT" \( -name build -o -name .gradle -o -name node_modules -o -name .git -o -name .yarn -o -name .dart_tool \) -prune -o -name "build.gradle.kts" -print0)
     fi
-  done < <(find "$REPO_ROOT" \( -name build -o -name .gradle -o -name node_modules -o -name .git -o -name .yarn -o -name .dart_tool \) -prune -o -name "build.gradle.kts" -print0)
-else
-  echo "Warning: java command not found. Skipping Kotlin formatting."
+  else
+    echo "Warning: java command not found. Skipping Kotlin formatting."
+  fi
 fi
 
 echo "Done."

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -135,12 +135,14 @@ collect_changed_files() {
   fi
 
   {
+    # Diffing a commit against the working tree (rather than against HEAD)
+    # already covers committed, staged, and unstaged changes in one pass.
     git diff --name-only --diff-filter=ACMRT "$diff_point" --
-    git diff --name-only --diff-filter=ACMRT --
-    git diff --cached --name-only --diff-filter=ACMRT --
     git ls-files --others --exclude-standard
   } | sort -u | while IFS= read -r path; do
-    [[ -n "$path" && -f "$path" ]] && echo "$path"
+    # printf rather than echo: a path such as "-n" would be swallowed as an
+    # option by echo.
+    [[ -n "$path" && -f "$path" ]] && printf '%s\n' "$path"
   done
 }
 

--- a/scripts/test_fix_format.py
+++ b/scripts/test_fix_format.py
@@ -178,6 +178,12 @@ class FixFormatScopingTest(unittest.TestCase):
             self.write(f"{module}/src/main/kotlin/Thing.kt", "val a = 1\n")
         self.assertEqual(self.counts()["ktfmt"], 2)
 
+    def test_staged_changes_are_included(self):
+        """Diffing a commit against the working tree already covers the index."""
+        self.write("swift/Sources/A2UI/Staged.swift", "let a = 1\n")
+        self._git("add", "swift/Sources/A2UI/Staged.swift")
+        self.assertEqual(self.counts()["swift"], 1)
+
     def test_untracked_files_are_included(self):
         self.write("renderers/flutter/lib/new_file.dart", "void main() {}\n")
         # Deliberately not staged or committed.

--- a/scripts/test_fix_format.py
+++ b/scripts/test_fix_format.py
@@ -1,0 +1,257 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests the changed-file scoping in fix_format.sh.
+
+These exercise `fix_format.sh --plan`, which resolves the changed set and
+reports which formatters would run without invoking any of them. That keeps the
+suite runnable on machines that have no Dart, Swift, or Kotlin toolchain.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from typing import Dict, Optional
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+FIX_FORMAT = os.path.join(SCRIPT_DIR, "fix_format.sh")
+
+# Any build file mentioning ktfmt marks its directory as a formattable module.
+KTFMT_BUILD_FILE = 'plugins { id("com.ncorti.ktfmt.gradle") }\n'
+
+
+class FixFormatScopingTest(unittest.TestCase):
+
+    def setUp(self):
+        self.repo = tempfile.mkdtemp()
+        os.makedirs(os.path.join(self.repo, "scripts"))
+        shutil.copy(FIX_FORMAT, os.path.join(self.repo, "scripts", "fix_format.sh"))
+        self._git("init", "-b", "main")
+        self._git("config", "user.email", "test@example.com")
+        self._git("config", "user.name", "Test")
+        # A baseline commit so that `main` exists as a diff target.
+        self.write("README.md", "# baseline\n")
+        self._git("add", "-A")
+        self._git("commit", "-m", "baseline")
+
+    def tearDown(self):
+        shutil.rmtree(self.repo, ignore_errors=True)
+
+    # -- helpers ------------------------------------------------------------
+
+    def _git(self, *args: str) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+
+    def write(self, rel_path: str, content: str = "x\n") -> None:
+        full = os.path.join(self.repo, rel_path)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "w", encoding="utf-8") as handle:
+            handle.write(content)
+
+    def plan(self, base: Optional[str] = "main") -> Dict[str, str]:
+        """Runs `--plan` and parses the reported per-formatter workload."""
+        cmd = [os.path.join(self.repo, "scripts", "fix_format.sh"), "--plan"]
+        if base is not None:
+            cmd += ["--base", base]
+        result = subprocess.run(
+            cmd, cwd=self.repo, check=True, capture_output=True, text=True
+        )
+        plan = {}
+        for line in result.stdout.splitlines():
+            match = re.match(r"^(mode|prettier|pyink|dart|swift|ktfmt):\s*(.+)$", line)
+            if match:
+                plan[match.group(1)] = match.group(2).strip()
+        return plan
+
+    def counts(self, base: Optional[str] = "main") -> Dict[str, int]:
+        """Same as plan(), reduced to integer counts per formatter."""
+        plan = self.plan(base)
+        return {
+            key: int(re.match(r"^(\d+)", value).group(1))
+            for key, value in plan.items()
+            if key != "mode"
+        }
+
+    # -- tests --------------------------------------------------------------
+
+    def test_no_flags_plans_whole_repo(self):
+        plan = self.plan(base=None)
+        self.assertEqual(plan["mode"], "all")
+        for formatter in ("prettier", "pyink", "dart", "swift", "ktfmt"):
+            self.assertEqual(plan[formatter], "all")
+
+    def test_clean_tree_schedules_nothing(self):
+        self.assertEqual(
+            self.counts(),
+            {"prettier": 0, "pyink": 0, "dart": 0, "swift": 0, "ktfmt": 0},
+        )
+
+    def test_swift_only_change_skips_other_formatters(self):
+        """The scenario from the issue: a Swift PR must not run dart format."""
+        self.write("swift/Sources/A2UI/Surface.swift", "let a = 1\n")
+        counts = self.counts()
+        self.assertEqual(counts["swift"], 1)
+        self.assertEqual(counts["dart"], 0)
+        self.assertEqual(counts["pyink"], 0)
+        self.assertEqual(counts["ktfmt"], 0)
+        # Also zero, so CI can skip installing Node for this PR.
+        self.assertEqual(counts["prettier"], 0)
+
+    def test_files_prettier_cannot_parse_do_not_schedule_it(self):
+        self.write("scripts/helper.sh", "echo hi\n")
+        self.write("docs/diagram.png", "notreallyapng\n")
+        self.assertEqual(self.counts()["prettier"], 0)
+
+    def test_prettier_covers_markdown_yaml_and_json(self):
+        self.write("docs/public/guide.md", "# hi\n")
+        self.write(".github/workflows/thing.yaml", "on: push\n")
+        self.write("renderers/web_core/tsconfig.json", "{}\n")
+        self.assertEqual(self.counts()["prettier"], 3)
+
+    def test_root_package_swift_is_in_scope(self):
+        self.write("Package.swift", "// swift-tools-version:5.9\n")
+        self.assertEqual(self.counts()["swift"], 1)
+
+    def test_typescript_change_only_runs_prettier(self):
+        self.write("renderers/web_core/src/index.ts", "export const a = 1;\n")
+        counts = self.counts()
+        self.assertEqual(counts["prettier"], 1)
+        self.assertEqual(counts["pyink"], 0)
+        self.assertEqual(counts["dart"], 0)
+        self.assertEqual(counts["swift"], 0)
+        self.assertEqual(counts["ktfmt"], 0)
+
+    def test_python_change_is_picked_up(self):
+        self.write("agent_sdks/python/a2ui_agent/src/a2ui/thing.py", "x = 1\n")
+        self.assertEqual(self.counts()["pyink"], 1)
+
+    def test_generated_python_is_excluded(self):
+        """pyproject's extend-exclude does not apply to explicit file args."""
+        self.write("agent_sdks/python/generated/models.py", "x = 1\n")
+        self.assertEqual(self.counts()["pyink"], 0)
+
+    def test_dart_outside_formatted_roots_is_ignored(self):
+        """Whole-repo mode only formats two Dart roots; --changed must match."""
+        self.write("tools/scratch/thing.dart", "void main() {}\n")
+        self.assertEqual(self.counts()["dart"], 0)
+
+    def test_dart_inside_formatted_roots_is_scheduled(self):
+        self.write("renderers/flutter/lib/a2ui.dart", "void main() {}\n")
+        self.write("samples/client/flutter/lib/main.dart", "void main() {}\n")
+        self.assertEqual(self.counts()["dart"], 2)
+
+    def test_kotlin_maps_to_owning_gradle_module(self):
+        self.write("kotlin/agent_sdk/build.gradle.kts", KTFMT_BUILD_FILE)
+        self.write("kotlin/agent_sdk/src/main/kotlin/Agent.kt", "val a = 1\n")
+        self.write("kotlin/agent_sdk/src/main/kotlin/Other.kt", "val b = 2\n")
+        # Two files, one owning module.
+        self.assertEqual(self.counts()["ktfmt"], 1)
+
+    def test_kotlin_module_without_ktfmt_is_skipped(self):
+        self.write("kotlin/no_fmt/build.gradle.kts", "plugins { java }\n")
+        self.write("kotlin/no_fmt/src/main/kotlin/Thing.kt", "val a = 1\n")
+        self.assertEqual(self.counts()["ktfmt"], 0)
+
+    def test_separate_kotlin_modules_are_counted_separately(self):
+        for module in ("kotlin/one", "kotlin/two"):
+            self.write(f"{module}/build.gradle.kts", KTFMT_BUILD_FILE)
+            self.write(f"{module}/src/main/kotlin/Thing.kt", "val a = 1\n")
+        self.assertEqual(self.counts()["ktfmt"], 2)
+
+    def test_untracked_files_are_included(self):
+        self.write("renderers/flutter/lib/new_file.dart", "void main() {}\n")
+        # Deliberately not staged or committed.
+        self.assertEqual(self.counts()["dart"], 1)
+
+    def test_deleted_files_are_not_scheduled(self):
+        self.write("renderers/flutter/lib/gone.dart", "void main() {}\n")
+        self._git("add", "-A")
+        self._git("commit", "-m", "add dart file")
+        os.remove(os.path.join(self.repo, "renderers/flutter/lib/gone.dart"))
+        self._git("add", "-A")
+        self.assertEqual(self.counts()["dart"], 0)
+
+    def test_committed_and_working_tree_changes_are_unioned(self):
+        self._git("checkout", "-b", "feature")
+        self.write("swift/Sources/A2UI/Committed.swift", "let a = 1\n")
+        self._git("add", "-A")
+        self._git("commit", "-m", "committed swift change")
+        self.write("swift/Sources/A2UI/Dirty.swift", "let b = 2\n")
+        self.assertEqual(self.counts()["swift"], 2)
+
+    def test_on_base_branch_committed_work_is_not_rescheduled(self):
+        """On main itself the merge base is HEAD, so only dirty files remain.
+
+        Post-submit runs on main are expected to use whole-repo mode; this
+        documents why --changed must not be used there.
+        """
+        self.write("swift/Sources/A2UI/Committed.swift", "let a = 1\n")
+        self._git("add", "-A")
+        self._git("commit", "-m", "committed swift change")
+        self.assertEqual(self.counts()["swift"], 0)
+
+    def test_unrelated_commits_on_base_are_excluded(self):
+        """Diffing against the merge base, not the branch tip."""
+        self._git("checkout", "-b", "feature")
+        self.write("swift/Sources/A2UI/Feature.swift", "let a = 1\n")
+        self._git("add", "-A")
+        self._git("commit", "-m", "feature work")
+
+        self._git("checkout", "main")
+        self.write("renderers/flutter/lib/unrelated.dart", "void main() {}\n")
+        self._git("add", "-A")
+        self._git("commit", "-m", "unrelated dart work on main")
+
+        self._git("checkout", "feature")
+        counts = self.counts()
+        self.assertEqual(counts["swift"], 1)
+        self.assertEqual(counts["dart"], 0)
+
+    def test_missing_base_ref_is_a_clear_error(self):
+        result = subprocess.run(
+            [
+                os.path.join(self.repo, "scripts", "fix_format.sh"),
+                "--plan",
+                "--base",
+                "does/not/exist",
+            ],
+            cwd=self.repo,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("does not exist locally", result.stderr)
+
+    def test_unknown_option_is_rejected(self):
+        result = subprocess.run(
+            [os.path.join(self.repo, "scripts", "fix_format.sh"), "--bogus"],
+            cwd=self.repo,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("Unknown option", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #2232

## Problem

`scripts/fix_format.sh` runs Prettier, Pyink, `dart format`, `swift-format`, and ktfmt across the entire workspace on every PR. A contributor touching only Swift can be blocked by unrelated Dart formatting drift, as happened in [this run](https://github.com/a2ui-project/a2ui/actions/runs/31609384280/job/94168489841). Their choices are to pull unrelated formatting churn into their PR or to wait for someone else to fix it. As the monorepo grows this gets worse.

## Approach

The obvious fix — adding `paths:` filters to the `presubmit-lint` workflow — is a trap. `format-check` is a required check, and a required check that is filtered out never reports a conclusion, so PRs that skip it sit pending forever. So the job still always runs; it narrows its own work instead.

`fix_format.sh` gains a `--changed` mode that resolves the changed set from git and hands each formatter only its own files, skipping formatters whose languages the branch never touched. Default behaviour (whole repo) is unchanged, and post-submit on `main` still sweeps everything, so scoping can never let drift accumulate.

## Changes

**`scripts/fix_format.sh`**

- New flags: `--changed`, `--base <ref>`, `--plan`, `--help`. Existing invocations (`fix_format.sh`, `fix_format.sh --check`) behave exactly as before.
- Changed-set discovery unions committed, staged, unstaged, and untracked files, and drops deletions. It diffs against the **merge base**, not the branch tip, so commits that landed on `main` after the branch point are not dragged in.
- Per-language selection mirrors each formatter's existing whole-repo scope, so `--changed` can never widen what a formatter touches:
  - Dart is still limited to `samples/client/flutter` and `renderers/flutter`.
  - Swift is still limited to `Package.swift` and `swift/`.
  - Python filters out `/generated/` explicitly, because pyink's `extend-exclude` in `pyproject.toml` applies to directory walks but **not** to explicitly listed files. Without this, scoped runs would have formatted generated code that whole-repo runs skip.
  - ktfmt is a Gradle task rather than a file-level binary, so changed Kotlin sources are mapped to their owning Gradle module and only those modules run.
- `--plan` prints which formatters would run and over how many files, then exits. It needs no language toolchains.

**`.github/workflows/presubmit-lint.yml`**

- `format-check` computes its scope from `github.event.pull_request.base.sha` on PRs, and stays in whole-repo mode for pushes to `main`.
- The scope step drives toolchain installation off `--plan` output: Node, Python, and Dart setup are each skipped when that formatter has no work. A Swift-only PR now installs none of the three.
- `fetch-depth: 0` so the merge base is reachable.
- The new unit tests run in the `static-checks` job.

**`scripts/test_fix_format.py`** — 21 tests covering the scoping logic.

**`CONTRIBUTING.md`** — documents `--changed`, `--base`, and `--plan`.

## Verification

The issue's exact scenario, run against this repo with a single added Swift file:

```
$ ./scripts/fix_format.sh --plan --base upstream/main
--- formatting plan ---
mode: changed (base: upstream/main)
prettier: 0 file(s)
pyink: 0 file(s)
dart: 0 file(s)
swift: 1 file(s)
ktfmt: 0 module(s)
```

Feeding that through the workflow's gating logic:

```
prettier=false (SKIP setup)
pyink=false   (SKIP setup)
dart=false    (SKIP setup)
```

Dart formatting can no longer block a Swift-only PR, and the job stops installing three toolchains it will not use.

Scoped mode on this PR's own diff:

```
$ ./scripts/fix_format.sh --check --changed --base upstream/main
Running Prettier formatting for Node/Web assets...   All matched files use Prettier code style!
Running Pyink for Python files...                    1 file would be left unchanged.
Skipping Dart format: no matching files changed.
Skipping swift-format: no matching files changed.
Skipping ktfmt: no matching files changed.
Done.                                                # exit 0
```

Correct failure behaviour — a deliberately malformed TS file is caught, and only that file is checked:

```
[warn] renderers/web_core/src/__scope_probe.ts
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
# exit 1
```

Backwards compatibility — the default whole-repo path is unchanged and still passes:

```
$ ./scripts/fix_format.sh --check
Running Prettier formatting for Node/Web assets...  All matched files use Prettier code style!
Running Pyink for Python files...                   320 files would be left unchanged.
```

Unit tests:

```
$ python3 -m unittest scripts.test_fix_format
Ran 21 tests in 0.7s
OK
```

They cover: Swift-only / TypeScript-only / Dart-only isolation, `Package.swift` at the root, generated-Python exclusion, Dart outside the two formatted roots, Kotlin→Gradle-module mapping (including modules without ktfmt), untracked files, deleted files, unioning committed and working-tree changes, merge-base isolation from unrelated `main` commits, whole-repo mode, and the two error paths.

## Notes for reviewers

- **Prettier file selection is an extension allowlist** (`PRETTIER_EXTENSIONS`). Handing Prettier the raw changed set with `--ignore-unknown` was simpler, but then any changed file at all — a `.sh`, a `.png` — marks Prettier as needed and forces a Node install. The allowlist covers Prettier's built-in parsers; a Prettier *plugin* adding a new language would need a line here. The whole-repo post-submit run is the backstop if that is ever missed.
- **`mapfile` is deliberately avoided** so the script keeps running on the bash 3.2 that ships with macOS.
- **Out of scope, happy to follow up:** `workspace-lint` still runs `yarn build:all` + `lint:all` for every PR, and `static-checks` still checks license headers repo-wide. Both have the same "unrelated work blocks your PR" shape, but scoping them means reasoning about the Yarn workspace/wireit graph, which felt like a separate change rather than something to bundle here.
