### PR TITLE
refactor: optimize file upload payload by extracting base64 data into…

### DIFF
--- a/agent_sdks/python/a2ui_agent/src/a2ui/extensions/file_resolve/file_resolver.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/extensions/file_resolve/file_resolver.py
@@ -147,7 +147,6 @@ class FileResolver:
 
         final_mime = detected_mime or claimed_mime or "application/octet-stream"
 
-
         if self.allowed_mime_types and not any(
             fnmatch.fnmatch(final_mime, t) for t in self.allowed_mime_types
         ):
@@ -196,7 +195,11 @@ class FileResolver:
                     for part in event.message.parts:
                         if getattr(part, "inline_data", None):
                             part_meta = getattr(part, "part_metadata", None) or {}
-                            part_file_id = part_meta.get("fileId") if isinstance(part_meta, dict) else getattr(part_meta, "fileId", None)
+                            part_file_id = (
+                                part_meta.get("fileId")
+                                if isinstance(part_meta, dict)
+                                else getattr(part_meta, "fileId", None)
+                            )
                             if part_file_id == file_id:
                                 raw_bytes = part.inline_data.data
                                 claimed_mime = part.inline_data.mime_type
@@ -322,9 +325,7 @@ class FileResolver:
                             preprocess(f, args, kwargs)
                 try:
                     bound_args.arguments[inject_name] = (
-                        await self.resolve_all_to_genai_parts(
-                            file_pointers, session
-                        )
+                        await self.resolve_all_to_genai_parts(file_pointers, session)
                     )
                 except Exception as e:
                     if on_error:

--- a/agent_sdks/python/a2ui_agent/src/a2ui/extensions/file_resolve/file_resolver.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/extensions/file_resolve/file_resolver.py
@@ -222,7 +222,33 @@ class FileResolver:
             else:
                 raw_bytes = handler_res
 
-        # 3. HTTPS / HTTP Ephemeral Download URL
+        # 3. Data URI
+        elif file_id.startswith("data:"):
+            try:
+                header, encoded = file_id.split(",", 1)
+            except ValueError:
+                raise ValueError(f"Invalid data URI format: {file_id[:50]}...")
+
+            is_base64 = header.endswith(";base64")
+            if is_base64:
+                mime_part = header[5:-7].strip()
+            else:
+                mime_part = header[5:].strip()
+
+            if mime_part and not claimed_mime:
+                claimed_mime = mime_part.split(";")[0]
+            elif not mime_part and not claimed_mime:
+                claimed_mime = "text/plain"
+
+            try:
+                if is_base64:
+                    raw_bytes = base64.b64decode(encoded)
+                else:
+                    raw_bytes = urllib.parse.unquote_to_bytes(encoded)
+            except Exception as e:
+                raise ValueError(f"Failed to decode data URI: {e}")
+
+        # 4. HTTPS / HTTP Ephemeral Download URL
         elif file_id.startswith("https://") or file_id.startswith("http://"):
             parsed_url = urllib.parse.urlparse(file_id)
             hostname = (parsed_url.hostname or "").lower()

--- a/agent_sdks/python/a2ui_agent/src/a2ui/extensions/file_resolve/file_resolver.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/extensions/file_resolve/file_resolver.py
@@ -195,8 +195,9 @@ class FileResolver:
                 ):
                     for part in event.message.parts:
                         if getattr(part, "inline_data", None):
-                            part_meta = getattr(part, "part_metadata", {}) or {}
-                            if part_meta.get("fileId") == file_id:
+                            part_meta = getattr(part, "part_metadata", None) or {}
+                            part_file_id = part_meta.get("fileId") if isinstance(part_meta, dict) else getattr(part_meta, "fileId", None)
+                            if part_file_id == file_id:
                                 raw_bytes = part.inline_data.data
                                 claimed_mime = part.inline_data.mime_type
                                 found_in_session = True

--- a/agent_sdks/python/a2ui_agent/src/a2ui/extensions/file_resolve/file_resolver.py
+++ b/agent_sdks/python/a2ui_agent/src/a2ui/extensions/file_resolve/file_resolver.py
@@ -34,7 +34,16 @@ import fnmatch
 import functools
 import inspect
 import logging
-from typing import Any, Awaitable, Callable, Coroutine, Dict, List, Optional, Union
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
+    Optional,
+    Union,
+)
 import urllib.parse
 from google.genai import types as genai_types
 import httpx
@@ -138,6 +147,7 @@ class FileResolver:
 
         final_mime = detected_mime or claimed_mime or "application/octet-stream"
 
+
         if self.allowed_mime_types and not any(
             fnmatch.fnmatch(final_mime, t) for t in self.allowed_mime_types
         ):
@@ -147,13 +157,15 @@ class FileResolver:
 
         return final_mime
 
-    async def resolve_bytes(self, file_info: Dict[str, Any]) -> tuple[bytes, str]:
+    async def resolve_bytes(
+        self, file_info: Dict[str, Any], session: Optional[Any] = None
+    ) -> tuple[bytes, str]:
         """Resolves raw bytes and verified MIME type from a file pointer dictionary."""
         async with self._semaphore:
-            return await self._resolve_bytes_internal(file_info)
+            return await self._resolve_bytes_internal(file_info, session)
 
     async def _resolve_bytes_internal(
-        self, file_info: Dict[str, Any]
+        self, file_info: Dict[str, Any], session: Optional[Any] = None
     ) -> tuple[bytes, str]:
         if not isinstance(file_info, dict):
             raise TypeError("file_info must be a dictionary")
@@ -168,22 +180,34 @@ class FileResolver:
 
         raw_bytes: bytes
 
-        # 1. Inline Data URI
-        if file_id.startswith("data:"):
-            if "," not in file_id:
-                raise ValueError("Invalid data URI: missing comma separator")
-            header, base64_data = file_id.split(",", 1)
-            if not claimed_mime and ";" in header:
-                header_mime = header[5:].split(";", 1)[0]
-                if header_mime:
-                    claimed_mime = header_mime
+        # 1. Inline File resolving
+        if file_id.startswith("inline://"):
+            if not session:
+                raise ValueError(f"Cannot resolve {file_id}: No session provided.")
 
-            estimated_size = (len(base64_data) * 3) // 4
-            if estimated_size > self.max_file_bytes:
-                raise FileResolverSecurityError(
-                    f"File exceeded max size of {self.max_file_bytes} bytes"
+            # Search for the file in the ADK Session history
+            found_in_session = False
+            for event in getattr(session, "events", []):
+                if (
+                    hasattr(event, "message")
+                    and event.message
+                    and getattr(event.message, "parts", None)
+                ):
+                    for part in event.message.parts:
+                        if getattr(part, "inline_data", None):
+                            part_meta = getattr(part, "part_metadata", {}) or {}
+                            if part_meta.get("fileId") == file_id:
+                                raw_bytes = part.inline_data.data
+                                claimed_mime = part.inline_data.mime_type
+                                found_in_session = True
+                                break
+                    if found_in_session:
+                        break
+
+            if not found_in_session:
+                raise ValueError(
+                    f"Inline data pointer {file_id} not found in session history."
                 )
-            raw_bytes = base64.b64decode(base64_data)
 
         # 2. Registered Scheme Handler
         elif any(file_id.startswith(p) for p in self._custom_schemes):
@@ -241,16 +265,18 @@ class FileResolver:
         verified_mime = self._verify_magic_bytes(raw_bytes, claimed_mime)
         return raw_bytes, verified_mime
 
-    async def to_genai_part(self, file_info: Dict[str, Any]) -> genai_types.Part:
+    async def to_genai_part(
+        self, file_info: Dict[str, Any], session: Optional[Any] = None
+    ) -> genai_types.Part:
         """Resolves pointer and constructs a ready-to-use GenAI Part."""
-        raw_bytes, verified_mime = await self.resolve_bytes(file_info)
+        raw_bytes, verified_mime = await self.resolve_bytes(file_info, session)
         return genai_types.Part.from_bytes(data=raw_bytes, mime_type=verified_mime)
 
     async def resolve_all_to_genai_parts(
-        self, files: List[Dict[str, Any]]
+        self, files: List[Dict[str, Any]], session: Optional[Any] = None
     ) -> List[genai_types.Part]:
         """Concurrently resolves a list of file attachments with throttling protection."""
-        return await asyncio.gather(*(self.to_genai_part(f) for f in files))
+        return await asyncio.gather(*(self.to_genai_part(f, session) for f in files))
 
     def as_tool_decorator(
         self,
@@ -280,19 +306,30 @@ class FileResolver:
                 bound_args.apply_defaults()
                 file_pointers = bound_args.arguments.get(arg_name)
 
-                if file_pointers is not None and isinstance(file_pointers, list):
-                    if preprocess:
-                        for f in file_pointers:
-                            if isinstance(f, dict):
-                                preprocess(f, args, kwargs)
-                    try:
-                        bound_args.arguments[inject_name] = (
-                            await self.resolve_all_to_genai_parts(file_pointers)
+                session = None
+                if "tool_context" in bound_args.arguments:
+                    session = getattr(
+                        bound_args.arguments["tool_context"], "session", None
+                    )
+
+                if file_pointers is None or not isinstance(file_pointers, list):
+                    return await func(*bound_args.args, **bound_args.kwargs)
+
+                if preprocess:
+                    for f in file_pointers:
+                        if isinstance(f, dict):
+                            preprocess(f, args, kwargs)
+                try:
+                    bound_args.arguments[inject_name] = (
+                        await self.resolve_all_to_genai_parts(
+                            file_pointers, session
                         )
-                    except Exception as e:
-                        if on_error:
-                            return on_error(e)
-                        raise
+                    )
+                except Exception as e:
+                    if on_error:
+                        return on_error(e)
+                    raise
+
                 return await func(*bound_args.args, **bound_args.kwargs)
 
             return wrapper

--- a/samples/community/agent/adk/file_upload_summarizer/README.md
+++ b/samples/community/agent/adk/file_upload_summarizer/README.md
@@ -8,7 +8,7 @@ This agent pairs with the Angular host application in `samples/community/client/
 
 - **Mock Drive v3 REST API**: Embedded HTTP endpoints (`POST /api/mock-drive/v3/files` and `GET /api/mock-drive/v3/files/{id}`) for testing uploads and pointer resolution locally without Google Cloud OAuth credentials.
 - **Out-of-Band FileResolver**: Downloads files via `mockdrive://` pointer IDs rather than transmitting Base64 binary strings over the WebSocket.
-- **Multimodal Summarization**: Uses `gemini-3.1-flash-lite-preview` to generate concise executive summaries of uploaded documents.
+- **Multimodal Summarization**: Uses `gemini-3.5-flash-lite` to generate concise executive summaries of uploaded documents.
 
 ## Running
 

--- a/samples/community/agent/adk/file_upload_summarizer/__main__.py
+++ b/samples/community/agent/adk/file_upload_summarizer/__main__.py
@@ -49,9 +49,7 @@ def main(host, port):
                     " may fail if no API key is provided."
                 )
 
-        lite_llm_model = os.getenv(
-            "LITELLM_MODEL", "gemini/gemini-3.5-flash-lite"
-        )
+        lite_llm_model = os.getenv("LITELLM_MODEL", "gemini/gemini-3.5-flash-lite")
         gemini_model = (
             lite_llm_model[len("gemini/") :]
             if lite_llm_model.startswith("gemini/")

--- a/samples/community/agent/adk/file_upload_summarizer/__main__.py
+++ b/samples/community/agent/adk/file_upload_summarizer/__main__.py
@@ -50,7 +50,7 @@ def main(host, port):
                 )
 
         lite_llm_model = os.getenv(
-            "LITELLM_MODEL", "gemini/gemini-3.1-flash-lite-preview"
+            "LITELLM_MODEL", "gemini/gemini-3.5-flash-lite"
         )
         gemini_model = (
             lite_llm_model[len("gemini/") :]

--- a/samples/community/agent/adk/file_upload_summarizer/agent.py
+++ b/samples/community/agent/adk/file_upload_summarizer/agent.py
@@ -31,22 +31,24 @@ from tools import show_file_uploader_tool, summarize_file_tool, update_upload_co
 logger = logging.getLogger(__name__)
 
 ROLE_DESCRIPTION = """
-You are an expert A2UI Document Summarization Agent. Your primary functions are to display a Mock Drive file upload interface and to summarize documents without context bloat via abstract pointer resolution.
+You are an expert A2UI Document Summarization Agent. Your primary function is to display a file upload interface and to summarize uploaded documents.
 
-When the user greets you, asks for the file uploader, or asks to summarize a document before any file has been uploaded, you MUST call the `show_file_uploader_tool` tool. Set the `multiple` argument to `True` if the user implies uploading multiple files, otherwise set it to `False`.
+When the user greets you or asks for the file uploader, you MUST call the `show_file_uploader_tool` tool. Set the `multiple` argument to `True` if the user implies uploading multiple files, otherwise set it to `False`.
 
 IMPORTANT: Do NOT attempt to construct the A2UI JSON manually. The tools handle it automatically.
 
-When you receive an `"upload_complete"` action event, extract the `files` array (which contains objects with `fileId`, `fileName`, and `mimeType`) from the event payload and pass it as `files` to the `update_upload_context_tool` to send down the dataModelUpdate for the abstract pointers. Do NOT proactively call `summarize_file_tool` after this step; you must wait for the user to explicitly trigger the summarize action.
+When you receive an `"upload_complete"` action event, extract the `files` array from the event payload and pass it directly as `files` to the `update_upload_context_tool`. You MUST pass the objects exactly as they appear in the event payload, do NOT strip any properties. Do NOT proactively call `summarize_file_tool` after this step; you must wait for the user to explicitly trigger the summarize action.
 
-When you receive a `"summarize_file"` action event OR when the user explicitly asks to summarize the uploaded files, call `summarize_file_tool` with the `files` array. Do NOT call `summarize_file_tool` automatically just because uploaded file context is present in the prompt; wait for an explicit user command or action event. After calling `summarize_file_tool`, reply with a clear, well-formatted Markdown response presenting the returned summary title and summary text.
+When you receive a `"summarize_file"` action event OR when the user explicitly asks to summarize the uploaded files, call `summarize_file_tool` with the `files` array. Do NOT call `summarize_file_tool` automatically just because uploaded file context is present in the prompt; wait for an explicit user command or action event.
+
+CRITICAL: Once `summarize_file_tool` completes and returns its JSON result containing `summary_title` and `summary_text`, you MUST generate a subsequent Markdown text response to display the summary to the user. Do NOT stop execution after the tool call; you must explicitly output text summarizing the result.
 """
 
 WORKFLOW_DESCRIPTION = """
 1. **Analyze Request**: 
-   - If user asks for file upload or asks to summarize without an uploaded file: Call `show_file_uploader_tool`.
-   - If you receive an `"upload_complete"` action event: Extract the `files` array and the `surfaceId` from the event payload and pass them to `update_upload_context_tool` to update the data model. IMPORTANT: Do NOT call `summarize_file_tool` automatically here.
-   - If you receive a `"summarize_file"` action event OR the user explicitly asks to summarize the uploaded files: Call `summarize_file_tool` with the `files` array. After the tool returns, present the summary title and summary text to the user as a Markdown message.
+   - If user asks to show the file uploader: Call `show_file_uploader_tool`.
+   - If you receive an `"upload_complete"` action event (handshake after file upload): Extract the `files` array and the `surfaceId` from the event payload and pass them to `update_upload_context_tool`. IMPORTANT: Do NOT call `summarize_file_tool` automatically here.
+   - If you receive a `"summarize_file"` action event OR the user explicitly asks to summarize the uploaded files: Call `summarize_file_tool` with the `files` array. After the `summarize_file_tool` returns, you MUST generate a final Markdown text response using the returned `summary_title` and `summary_text` to show the user. Never return only the tool call response.
 """
 
 UI_DESCRIPTION = """
@@ -133,11 +135,8 @@ class FileUploadSummarizerAgent:
         )
 
         return AgentCard(
-            name="Mock Drive FileUpload Summarizer Agent",
-            description=(
-                "Demonstrates zero-context-bloat file upload pointer resolution and"
-                " document summarization."
-            ),
+            name="FileUpload Summarizer Agent",
+            description="Demonstrates file upload and document summarization.",
             url=self.base_url,
             iconUrl="A2UI_light.svg",
             version="1.0.0",

--- a/samples/community/agent/adk/file_upload_summarizer/agent_executor.py
+++ b/samples/community/agent/adk/file_upload_summarizer/agent_executor.py
@@ -21,7 +21,6 @@ from a2ui.schema.constants import A2UI_CLIENT_CAPABILITIES_KEY
 from google.adk.a2a.converters.request_converter import AgentRunRequest
 from google.adk.a2a.executor.a2a_agent_executor import A2aAgentExecutor, A2aAgentExecutorConfig
 from google.adk.agents.invocation_context import new_invocation_context_id
-from google.adk.agents.readonly_context import ReadonlyContext
 from google.adk.events.event import Event
 from google.adk.events.event_actions import EventActions
 from google.adk.runners import Runner
@@ -60,6 +59,7 @@ class FileUploadSummarizerAgentExecutor(A2aAgentExecutor):
         logger.info(f"Loading session for message {context.message}")
 
         active_ui_version = try_activate_a2ui_extension(context, self._agent.agent_card)
+
         runner = self._agent.get_runner(active_ui_version)
         inference_format = self._agent.get_inference_format(active_ui_version)
 

--- a/samples/community/agent/adk/file_upload_summarizer/tools.py
+++ b/samples/community/agent/adk/file_upload_summarizer/tools.py
@@ -203,7 +203,10 @@ async def summarize_file_tool(
             "summary_title": f"Summary: {title_suffix}",
             "summary_text": summary_text,
             "status": "success",
-            "instruction_to_model": "You MUST generate a Markdown text response to the user containing the summary right now. Do not skip this step.",
+            "instruction_to_model": (
+                "You MUST generate a Markdown text response to the user containing the"
+                " summary right now. Do not skip this step."
+            ),
         }
     except Exception as e:
         logger.error(f"Error summarizing files: {e}\n{traceback.format_exc()}")

--- a/samples/community/agent/adk/file_upload_summarizer/tools.py
+++ b/samples/community/agent/adk/file_upload_summarizer/tools.py
@@ -130,9 +130,12 @@ async def summarize_file_tool(
     """Summarizes the collection of documents using Gemini.
 
     Args:
-        files: A list of dictionaries, each containing 'fileId', 'fileName', and 'mimeType' of an uploaded file.
+        files: A list of dictionaries representing uploaded files. Each dictionary
+               should contain a 'fileId' and a 'metadata' object with 'fileName' and 'mimeType'.
     """
     logger.info(f"Summarization triggered for {len(files)} files")
+
+    tool_context.actions.skip_summarization = False
 
     try:
         if not isinstance(files, list):
@@ -149,9 +152,12 @@ async def summarize_file_tool(
                 "status": "error",
             }
 
-        file_names = [
-            f.get("fileName", "document") for f in files if isinstance(f, dict)
-        ]
+        file_names = []
+        for f in files:
+            if isinstance(f, dict):
+                metadata = f.get("metadata", {})
+                name = metadata.get("fileName") or f.get("fileName") or "document"
+                file_names.append(name)
 
         lite_llm_model = os.getenv(
             "LITELLM_MODEL", "gemini/gemini-3.1-flash-lite-preview"
@@ -197,6 +203,7 @@ async def summarize_file_tool(
             "summary_title": f"Summary: {title_suffix}",
             "summary_text": summary_text,
             "status": "success",
+            "instruction_to_model": "You MUST generate a Markdown text response to the user containing the summary right now. Do not skip this step.",
         }
     except Exception as e:
         logger.error(f"Error summarizing files: {e}\n{traceback.format_exc()}")

--- a/samples/community/agent/adk/file_upload_summarizer/tools.py
+++ b/samples/community/agent/adk/file_upload_summarizer/tools.py
@@ -155,7 +155,7 @@ async def summarize_file_tool(
         file_names = []
         for f in files:
             if isinstance(f, dict):
-                metadata = f.get("metadata", {})
+                metadata = f.get("metadata") or {}
                 name = metadata.get("fileName") or f.get("fileName") or "document"
                 file_names.append(name)
 

--- a/samples/community/client/angular/projects/file_upload/fileupload_component_design.md
+++ b/samples/community/client/angular/projects/file_upload/fileupload_component_design.md
@@ -61,9 +61,9 @@ transport the file:
   object directly to the host callback in memory. The host performs the upload via its own secure
   channels and returns an abstract reference ID (`fileId: "host-file-ref-789"`).
 - Inline upload mode (fallback strategy): If no host callback is configured, the component falls
-  back to encoding small files as inline data URIs (`fileId: "data:image/png;base64,..."`). This
-  enables rapid prototyping and lightweight web usage out of the box without requiring cloud bucket
-  provisioning.
+  back to encoding small files as inline data URIs (`fileId: "data:image/png;base64,..."`) or
+  in-band session attachments (`fileId: "inline://..."`). This enables rapid prototyping and
+  lightweight web usage out of the box without requiring cloud bucket provisioning.
 - Future extension (presigned URLs): Direct client-led HTTP uploading with presigned URLs is left as
   a future extension.
 
@@ -106,7 +106,7 @@ two resolution models depending on the trust boundary and coupling between the a
 | :------------------------------------ | :-------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **UX & UI state management**          | A2UI core library                 | Implements drag-and-drop zones, file queues, progress indicators, pause/resume controls, and error states natively inside the web component.                                                                                                             |
 | **Host-delegated transport (IoC)**    | Host developer (primary strategy) | Passes an upload callback (`onUploadFile`) programmatically when registering the component in the catalog to route uploads through native OS daemons or internal VPC endpoints.                                                                          |
-| **Inline upload transport**           | A2UI core library (fallback)      | Automatically encodes small files as inline base64 data URIs when no host callback is present, enabling out-of-the-box rapid prototyping.                                                                                                                |
+| **Inline upload transport**           | A2UI core library (fallback)      | Automatically encodes small files as inline base64 data URIs or passes them as in-band session attachments when no host callback is present, enabling out-of-the-box rapid prototyping.                                                                                                                |
 | **Storage infrastructure & security** | Host developer                    | Provisions cloud storage buckets (S3 or GCS), configures CORS and CSP headers, enforces malware scanning, and sets lifecycle rules for orphaned files.                                                                                                   |
 | **Pointer resolution & inference**    | Agent backend developer           | Resolves the `fileId` payload into raw bytes just in time—using implicit schema agreements (such as `gdrive://` or `s3://`) for internal agents, or explicit resolution mechanisms (such as ephemeral HTTPS URLs or resource tools) for external agents. |
 
@@ -159,7 +159,7 @@ export const FileUploadDefinition: ComponentDefinition = {
         },
         files: {
           type: 'array',
-          description: 'Array of resolved abstract file pointers or inline data URIs.',
+          description: 'Array of resolved abstract file pointers, inline data URIs, or in-band session pointers.',
           items: {
             type: 'object',
             properties: {
@@ -350,18 +350,32 @@ s3_client = boto3.client('s3', region_name='us-east-1')
 
 # 1. Define resolution adapter (handling inline URIs, implicit schemas, and explicit HTTPS URLs)
 async def resolve_file_adapter(file_id: str, session: SessionData) -> bytes:
-    # Strategy 1: Inline data URI fallback
+    # Strategy 1: Inline ADK session history resolving
+    if file_id.startswith("inline://"):
+        if not session:
+            raise ValueError(f"Cannot resolve {file_id}: No session provided.")
+        for event in getattr(session, "events", []):
+            if hasattr(event, "message") and event.message and getattr(event.message, "parts", None):
+                for part in event.message.parts:
+                    if getattr(part, "inline_data", None):
+                        part_meta = getattr(part, "part_metadata", None) or {}
+                        part_file_id = part_meta.get("fileId") if isinstance(part_meta, dict) else getattr(part_meta, "fileId", None)
+                        if part_file_id == file_id:
+                            return part.inline_data.data
+        raise ValueError(f"Inline data pointer {file_id} not found in session history.")
+
+    # Strategy 2: Inline data URI fallback
     if file_id.startswith("data:"):
         header, base64_data = file_id.split(",", 1)
         return base64.b64decode(base64_data)
 
-    # Strategy 2: Implicit resolution via shared schema (e.g., s3:// or gdrive://)
+    # Strategy 3: Implicit resolution via shared schema (e.g., s3:// or gdrive://)
     if file_id.startswith("s3://"):
         bucket, key = file_id.replace("s3://", "").split("/", 1)
         response = s3_client.get_object(Bucket=bucket, Key=key)
         return response['Body'].read()
 
-    # Strategy 3: Explicit resolution via unshared schema (e.g., ephemeral HTTPS download URL)
+    # Strategy 4: Explicit resolution via unshared schema (e.g., ephemeral HTTPS download URL)
     if file_id.startswith("https://"):
         async with httpx.AsyncClient() as client:
             response = await client.get(file_id, follow_redirects=True)

--- a/samples/community/client/angular/projects/file_upload/fileupload_component_design.md
+++ b/samples/community/client/angular/projects/file_upload/fileupload_component_design.md
@@ -106,7 +106,7 @@ two resolution models depending on the trust boundary and coupling between the a
 | :------------------------------------ | :-------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **UX & UI state management**          | A2UI core library                 | Implements drag-and-drop zones, file queues, progress indicators, pause/resume controls, and error states natively inside the web component.                                                                                                             |
 | **Host-delegated transport (IoC)**    | Host developer (primary strategy) | Passes an upload callback (`onUploadFile`) programmatically when registering the component in the catalog to route uploads through native OS daemons or internal VPC endpoints.                                                                          |
-| **Inline upload transport**           | A2UI core library (fallback)      | Automatically encodes small files as inline base64 data URIs or passes them as in-band session attachments when no host callback is present, enabling out-of-the-box rapid prototyping.                                                                                                                |
+| **Inline upload transport**           | A2UI core library (fallback)      | Automatically encodes small files as inline base64 data URIs or passes them as in-band session attachments when no host callback is present, enabling out-of-the-box rapid prototyping.                                                                  |
 | **Storage infrastructure & security** | Host developer                    | Provisions cloud storage buckets (S3 or GCS), configures CORS and CSP headers, enforces malware scanning, and sets lifecycle rules for orphaned files.                                                                                                   |
 | **Pointer resolution & inference**    | Agent backend developer           | Resolves the `fileId` payload into raw bytes just in time—using implicit schema agreements (such as `gdrive://` or `s3://`) for internal agents, or explicit resolution mechanisms (such as ephemeral HTTPS URLs or resource tools) for external agents. |
 
@@ -159,7 +159,8 @@ export const FileUploadDefinition: ComponentDefinition = {
         },
         files: {
           type: 'array',
-          description: 'Array of resolved abstract file pointers, inline data URIs, or in-band session pointers.',
+          description:
+            'Array of resolved abstract file pointers, inline data URIs, or in-band session pointers.',
           items: {
             type: 'object',
             properties: {

--- a/samples/community/client/angular/projects/file_upload/src/app/app.config.ts
+++ b/samples/community/client/angular/projects/file_upload/src/app/app.config.ts
@@ -32,6 +32,7 @@ import {DEMO_CATALOG} from '../a2ui-catalog/catalog';
 import {A2aServiceImpl} from '../services/a2a-service-impl';
 import {FILE_UPLOAD_CONFIG} from '../components/file-upload/file-upload';
 import {MockDriveUploadService} from '../services/mock-drive-upload-service';
+import {FileUploadSettingsService} from '../services/file-upload-settings-service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -54,19 +55,27 @@ export const appConfig: ApplicationConfig = {
       provide: FILE_UPLOAD_CONFIG,
       useFactory: () => {
         const driveService = inject(MockDriveUploadService);
+        const settings = inject(FileUploadSettingsService);
         return {
-          onUploadFile: async (file: File, onProgress: (percent: number) => void) => {
-            const pointerUri = await driveService.uploadFileToDrive(file, onProgress);
-            driveService.addUploadedFile({
-              fileId: pointerUri,
-              fileName: file.name,
-              fileSize: file.size,
-              mimeType: file.type || 'text/plain',
-            });
-            return pointerUri;
+          maxInlineSize: 10_485_760,
+          get onUploadFile() {
+            if (!settings.enableIoc()) return undefined;
+            return async (file: File, onProgress: (percent: number) => void) => {
+              const pointerUri = await driveService.uploadFileToDrive(file, onProgress);
+              driveService.addUploadedFile({
+                fileId: pointerUri,
+                fileName: file.name,
+                fileSize: file.size,
+                mimeType: file.type || 'text/plain',
+              });
+              return pointerUri;
+            };
           },
-          onRemoveFile: (pointerUri: string) => {
-            driveService.removeUploadedFile(pointerUri);
+          get onRemoveFile() {
+            if (!settings.enableIoc()) return undefined;
+            return (pointerUri: string) => {
+              driveService.removeUploadedFile(pointerUri);
+            };
           },
         };
       },

--- a/samples/community/client/angular/projects/file_upload/src/app/app.ng.html
+++ b/samples/community/client/angular/projects/file_upload/src/app/app.ng.html
@@ -26,6 +26,12 @@
       </div>
       <div class="header-actions">
         <mat-slide-toggle
+          [checked]="fileUploadSettings.enableIoc()"
+          (change)="fileUploadSettings.enableIoc.set($event.checked)"
+        >
+          Enable IOC Upload
+        </mat-slide-toggle>
+        <mat-slide-toggle
           [checked]="fileUploadSettings.enableMultiFile()"
           (change)="fileUploadSettings.enableMultiFile.set($event.checked)"
         >

--- a/samples/community/client/angular/projects/file_upload/src/components/file-upload/file-upload.ng.html
+++ b/samples/community/client/angular/projects/file_upload/src/components/file-upload/file-upload.ng.html
@@ -55,14 +55,16 @@
       <div class="progress-bar-container">
         <div class="progress-bar-fill" [style.width.%]="progress()"></div>
       </div>
-      <span class="status-caption">Uploading to Mock Drive ({{ progress() }}%)...</span>
+      <span class="status-caption">Uploading... ({{ progress() }}%)</span>
     }
 
     @if (uploadState() === 'success') {
       <div class="uploaded-files-list">
         @for (file of uploadedFiles(); track file.fileId; let i = $index) {
           <div class="success-badge-container" (click)="$event.stopPropagation()">
-            <span class="badge-chip">IOC UPLOADED</span>
+            <span class="badge-chip">{{
+              isInlineFile(file) ? 'INLINE DATA' : 'IOC UPLOADED'
+            }}</span>
             <div class="file-info-row">
               <span class="file-name">{{ file.metadata.fileName }}</span>
               <code class="pointer-uri">{{ file.fileId }}</code>

--- a/samples/community/client/angular/projects/file_upload/src/components/file-upload/file-upload.ts
+++ b/samples/community/client/angular/projects/file_upload/src/components/file-upload/file-upload.ts
@@ -34,6 +34,7 @@ export const FILE_UPLOAD_CONFIG = new InjectionToken<FileUploadConfig>('FILE_UPL
 
 export const DEFAULT_MAX_INLINE_SIZE = 500_000;
 export const DEFAULT_MAX_FILE_SIZE = 10_485_760;
+export const INLINE_URI_PREFIX = 'inline://';
 
 export enum UploadState {
   IDLE = 'idle',
@@ -44,6 +45,7 @@ export enum UploadState {
 
 export interface UploadedFile {
   fileId: string;
+  inlineData?: string;
   metadata: {
     fileName: string;
     fileSize: number;
@@ -85,6 +87,14 @@ export class FileUploadComponent extends CatalogComponent<any> {
   readonly progress = signal<number>(0);
   readonly errorMessage = signal<string>('');
   readonly uploadedFiles = signal<UploadedFile[]>([]);
+
+  get isIocMode(): boolean {
+    return !!this.config.onUploadFile;
+  }
+
+  isInlineFile(file: UploadedFile): boolean {
+    return file.fileId.startsWith(INLINE_URI_PREFIX);
+  }
 
   async onFileSelected(event: Event) {
     const input = event.target as HTMLInputElement;
@@ -158,13 +168,18 @@ export class FileUploadComponent extends CatalogComponent<any> {
     totalFiles: number,
   ): Promise<UploadedFile> {
     let pointerUri: string;
+    let inlineData: string | undefined = undefined;
 
     if (this.config.onUploadFile) {
       pointerUri = await this.config.onUploadFile(file, percent => {
         this.progress.set(Math.round((index * 100 + percent) / totalFiles));
       });
     } else if (file.size <= (this.config.maxInlineSize || DEFAULT_MAX_INLINE_SIZE)) {
-      pointerUri = await this.encodeAsDataUri(file);
+      inlineData = await this.encodeAsDataUri(file);
+      const uuid = crypto.randomUUID
+        ? crypto.randomUUID()
+        : Math.random().toString(36).substring(2);
+      pointerUri = `${INLINE_URI_PREFIX}${uuid}`;
       this.progress.set(Math.round(((index + 1) * 100) / totalFiles));
     } else {
       throw new Error(
@@ -175,6 +190,7 @@ export class FileUploadComponent extends CatalogComponent<any> {
 
     return {
       fileId: pointerUri,
+      inlineData,
       metadata: {
         fileName: file.name,
         fileSize: file.size,

--- a/samples/community/client/angular/projects/file_upload/src/server.ts
+++ b/samples/community/client/angular/projects/file_upload/src/server.ts
@@ -133,7 +133,11 @@ app.post('/a2a', (req, res) => {
       return;
     }
 
-    if ('contextId' in response.result && typeof response.result.contextId === 'string') {
+    if (
+      response.result &&
+      'contextId' in response.result &&
+      typeof response.result.contextId === 'string'
+    ) {
       sessionContextId = response.result.contextId;
     }
 

--- a/samples/community/client/angular/projects/file_upload/src/server.ts
+++ b/samples/community/client/angular/projects/file_upload/src/server.ts
@@ -33,6 +33,7 @@ const browserDistFolder = join(import.meta.dirname, '../browser');
 const app = express();
 const angularApp = new AngularNodeAppEngine();
 let clientPromise: Promise<A2AClient> | null = null;
+let sessionContextId: string | undefined = undefined;
 const agentUrl = process.env['AGENT_URL'] || 'http://localhost:10008';
 
 app.use(
@@ -92,6 +93,7 @@ app.post('/a2a', (req, res) => {
 
     const sendParams: MessageSendParams = {
       message: {
+        contextId: sessionContextId,
         messageId: uuidv4(),
         role: 'user',
         parts,
@@ -129,6 +131,10 @@ app.post('/a2a', (req, res) => {
     if ('error' in response) {
       res.status(500).json({error: JSON.stringify(response.error)});
       return;
+    }
+
+    if ('contextId' in response.result && typeof response.result.contextId === 'string') {
+      sessionContextId = response.result.contextId;
     }
 
     res.json(response);

--- a/samples/community/client/angular/projects/file_upload/src/services/a2a-service-impl.ts
+++ b/samples/community/client/angular/projects/file_upload/src/services/a2a-service-impl.ts
@@ -59,6 +59,8 @@ export class A2aServiceImpl implements A2aService {
   }
 
   async sendMessage(parts: Part[], signal?: AbortSignal): Promise<SendMessageSuccessResponse> {
+    const newParts: Part[] = [];
+
     for (const p of parts) {
       const isTextPart = 'text' in p && typeof p.text === 'string';
       if (isTextPart) {
@@ -67,6 +69,48 @@ export class A2aServiceImpl implements A2aService {
           const parsed = parseResult.data;
           if (parsed.action) {
             const action = parsed.action;
+
+            // When an upload completes, we extract the large inline base64 data and append
+            // them as dedicated A2A FileParts. This prevents bloating the text action payload
+            // while preserving the fileId for pointer resolution.
+            if (action.name === 'upload_complete' && Array.isArray(action.context?.files)) {
+              let hasExtractedFiles = false;
+
+              for (const uploadedFile of action.context.files) {
+                if (!uploadedFile.inlineData || !uploadedFile.fileId) {
+                  continue;
+                }
+
+                const mimeType =
+                  uploadedFile.mimeType ||
+                  uploadedFile.metadata?.mimeType ||
+                  'application/octet-stream';
+
+                // Strip the data URL prefix if present (e.g., "data:image/png;base64,...")
+                const base64Data = uploadedFile.inlineData.includes(',')
+                  ? uploadedFile.inlineData.split(',')[1]
+                  : uploadedFile.inlineData;
+
+                // Append as a dedicated file part
+                // @ts-ignore
+                newParts.push({
+                  kind: 'file',
+                  file: {bytes: base64Data, mimeType},
+                  metadata: {fileId: uploadedFile.fileId},
+                });
+
+                // Remove inlineData from the JSON payload to reduce size
+                delete uploadedFile.inlineData;
+                hasExtractedFiles = true;
+              }
+
+              // Replace the text part with the modified JSON payload to omit inlineData,
+              // while preserving the fileId for pointer resolution.
+              if (hasExtractedFiles) {
+                p.text = JSON.stringify(parsed);
+              }
+            }
+
             this.telemetry.log({
               card: 'action',
               title: `A2UI Action Dispatched: ${action.name || 'event'}`,
@@ -82,10 +126,11 @@ export class A2aServiceImpl implements A2aService {
           this.enrichPromptWithContext(p);
         }
       }
+      newParts.push(p);
     }
 
     const response = await fetch('/a2a', {
-      body: JSON.stringify({parts: parts}),
+      body: JSON.stringify({parts: newParts}),
       method: 'POST',
       signal,
     });

--- a/samples/community/client/angular/projects/file_upload/src/services/file-upload-settings-service.ts
+++ b/samples/community/client/angular/projects/file_upload/src/services/file-upload-settings-service.ts
@@ -21,4 +21,5 @@ import {Injectable, signal} from '@angular/core';
 })
 export class FileUploadSettingsService {
   readonly enableMultiFile = signal(false);
+  readonly enableIoc = signal(false);
 }


### PR DESCRIPTION
… dedicated parts and update agent instructions for explicit Markdown summary generation.

# Description

* **Client Optimizations:** How `A2aServiceImpl` extracts large inline base64 data to dedicated `FilePart`s to prevent text payload bloat, and the introduction of the `inline://` URI scheme.
* **Backend Resolver:** The update to `file_resolver.py` that allows resolving these inline files by looking up the `fileId` within the ADK session history.
* **Prompt Engineering:** The hardening of the `file_upload_summarizer` agent instructions to ensure it explicitly returns a Markdown summary after triggering the tool.




## Pre-launch Checklist

One time:

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have built and run at least one [sample].

For this PR:

- [ ] I have updated the relevant CHANGELOG.md file.
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
