### PR TITLE
fix(swift): store data model updates before notifying subscribers

### DIFF
--- a/swift/core/Sources/A2UICore/Models/SurfaceViewModel.swift
+++ b/swift/core/Sources/A2UICore/Models/SurfaceViewModel.swift
@@ -334,8 +334,7 @@ public final class SurfaceViewModel: @unchecked Sendable, ObservableObject {
   /// Resolves a dynamic value to its current literal `JSONValue`.
   private func evaluateDynamicValue(
     _ value: JSONValue,
-    basePath: String?,
-    data: JSONValue
+    basePath: String?
   ) -> JSONValue {
     let context = DataContext(dataModel: dataModel, path: basePath ?? "", functionHandler: self)
     return context.resolveDynamicValue(value)
@@ -359,7 +358,7 @@ public final class SurfaceViewModel: @unchecked Sendable, ObservableObject {
         }
       )
     }
-    let resolvedValue = evaluateDynamicValue(value, basePath: basePath, data: data).boolValue
+    let resolvedValue = evaluateDynamicValue(value, basePath: basePath).boolValue
     return DataBinding<Bool>(
       identity: .literal(value),
       value: resolvedValue,
@@ -383,7 +382,7 @@ public final class SurfaceViewModel: @unchecked Sendable, ObservableObject {
         }
       )
     }
-    let resolvedValue = evaluateDynamicValue(value, basePath: basePath, data: data).stringValue
+    let resolvedValue = evaluateDynamicValue(value, basePath: basePath).stringValue
     return DataBinding<String>(
       identity: .literal(value),
       value: resolvedValue,
@@ -407,7 +406,7 @@ public final class SurfaceViewModel: @unchecked Sendable, ObservableObject {
         }
       )
     }
-    let resolvedValue = evaluateDynamicValue(value, basePath: basePath, data: data).doubleValue
+    let resolvedValue = evaluateDynamicValue(value, basePath: basePath).doubleValue
     return DataBinding<Double>(
       identity: .literal(value),
       value: resolvedValue,
@@ -431,7 +430,7 @@ public final class SurfaceViewModel: @unchecked Sendable, ObservableObject {
         }
       )
     }
-    let resolvedValue = evaluateDynamicValue(value, basePath: basePath, data: data)
+    let resolvedValue = evaluateDynamicValue(value, basePath: basePath)
     return DataBinding<JSONValue>(
       identity: .literal(value),
       value: resolvedValue,
@@ -465,11 +464,7 @@ public final class SurfaceViewModel: @unchecked Sendable, ObservableObject {
           var resolvedContext: [String: JSONValue] = [:]
           if let contextDict {
             for (key, val) in contextDict {
-              resolvedContext[key] = self.evaluateDynamicValue(
-                val,
-                basePath: basePath,
-                data: self.dataModel.data
-              )
+              resolvedContext[key] = self.evaluateDynamicValue(val, basePath: basePath)
             }
           }
 
@@ -497,11 +492,7 @@ public final class SurfaceViewModel: @unchecked Sendable, ObservableObject {
           var resolvedArgs: [String: JSONValue] = [:]
           if let argsDict {
             for (argKey, argVal) in argsDict {
-              resolvedArgs[argKey] = self.evaluateDynamicValue(
-                argVal,
-                basePath: basePath,
-                data: self.dataModel.data
-              )
+              resolvedArgs[argKey] = self.evaluateDynamicValue(argVal, basePath: basePath)
             }
           }
 

--- a/swift/core/Sources/A2UICore/Models/SurfaceViewModel.swift
+++ b/swift/core/Sources/A2UICore/Models/SurfaceViewModel.swift
@@ -127,7 +127,7 @@ public final class SurfaceViewModel: @unchecked Sendable, ObservableObject {
   }
 
   private func setUpSubscriptions() {
-    Publishers.CombineLatest(componentsModel.$components, dataModel.$data)
+    Publishers.CombineLatest(componentsModel.$components, dataModel.dataPublisher)
       .sink { [weak self] components, data in
         self?.rebuildTree(components: components, data: data)
       }

--- a/swift/core/Sources/A2UICore/State/DataModel.swift
+++ b/swift/core/Sources/A2UICore/State/DataModel.swift
@@ -25,16 +25,34 @@ import OrderedJSON
 public final class DataModel: @unchecked Sendable, ObservableObject {
 
   private let lock = NSRecursiveLock()
-  @Published public private(set) var data: JSONValue = .object([:])
+  private var storage: JSONValue
+  private let dataSubject: CurrentValueSubject<JSONValue, Never>
+
+  /// The current data tree.
+  public var data: JSONValue {
+    lock.withLock { storage }
+  }
+
+  /// Emits the data tree after each update is stored, and replays the
+  /// current value on subscription. Deliberately not `@Published`, which
+  /// emits during `willSet`: subscribers reading back through the model
+  /// would get the previous tree.
+  public var dataPublisher: AnyPublisher<JSONValue, Never> {
+    dataSubject.eraseToAnyPublisher()
+  }
 
   /// Creates an empty data model.
-  public init() {}
+  public init() {
+    self.storage = .object([:])
+    self.dataSubject = CurrentValueSubject(.object([:]))
+  }
 
   /// Creates a data model with an initial value.
   ///
   /// - Parameter initial: The initial JSON value for the root.
   public init(initial: JSONValue) {
-    self.data = initial
+    self.storage = initial
+    self.dataSubject = CurrentValueSubject(initial)
   }
 
   /// Resolves a JSON Pointer path to a value.
@@ -42,7 +60,7 @@ public final class DataModel: @unchecked Sendable, ObservableObject {
   /// - Parameter path: The path (e.g., `/user/name`).
   /// - Returns: The value at the path, or `nil` if not found.
   public func get(_ path: String) -> JSONValue? {
-    lock.withLock { data[path] }
+    lock.withLock { storage[path] }
   }
 
   /// Sets a value at the given JSON Pointer path.
@@ -54,7 +72,9 @@ public final class DataModel: @unchecked Sendable, ObservableObject {
   ///   - value: The value to set, or `nil` to remove.
   public func set(_ path: String, value: JSONValue?) {
     lock.withLock {
-      data[path] = value
+      objectWillChange.send()
+      storage[path] = value
+      dataSubject.send(storage)
     }
   }
 }

--- a/swift/core/Sources/A2UICore/State/DataModel.swift
+++ b/swift/core/Sources/A2UICore/State/DataModel.swift
@@ -14,6 +14,7 @@
 
 import Combine
 import Foundation
+import OrderedCollections
 import OrderedJSON
 
 /// A dedicated store for application data, supporting JSON Pointer
@@ -25,12 +26,11 @@ import OrderedJSON
 public final class DataModel: @unchecked Sendable, ObservableObject {
 
   private let lock = NSRecursiveLock()
-  private var storage: JSONValue
   private let dataSubject: CurrentValueSubject<JSONValue, Never>
 
   /// The current data tree.
   public var data: JSONValue {
-    lock.withLock { storage }
+    lock.withLock { dataSubject.value }
   }
 
   /// Emits the data tree after each update is stored, and replays the
@@ -41,17 +41,11 @@ public final class DataModel: @unchecked Sendable, ObservableObject {
     dataSubject.eraseToAnyPublisher()
   }
 
-  /// Creates an empty data model.
-  public init() {
-    self.storage = .object([:])
-    self.dataSubject = CurrentValueSubject(.object([:]))
-  }
-
-  /// Creates a data model with an initial value.
+  /// Creates a data model.
   ///
-  /// - Parameter initial: The initial JSON value for the root.
-  public init(initial: JSONValue) {
-    self.storage = initial
+  /// - Parameter initial: The initial JSON value for the root, defaulting to
+  ///   an empty object.
+  public init(initial: JSONValue = .object([:])) {
     self.dataSubject = CurrentValueSubject(initial)
   }
 
@@ -60,7 +54,7 @@ public final class DataModel: @unchecked Sendable, ObservableObject {
   /// - Parameter path: The path (e.g., `/user/name`).
   /// - Returns: The value at the path, or `nil` if not found.
   public func get(_ path: String) -> JSONValue? {
-    lock.withLock { storage[path] }
+    lock.withLock { dataSubject.value[path] }
   }
 
   /// Sets a value at the given JSON Pointer path.
@@ -73,8 +67,9 @@ public final class DataModel: @unchecked Sendable, ObservableObject {
   public func set(_ path: String, value: JSONValue?) {
     lock.withLock {
       objectWillChange.send()
-      storage[path] = value
-      dataSubject.send(storage)
+      var current = dataSubject.value
+      current[path] = value
+      dataSubject.send(current)
     }
   }
 }

--- a/swift/core/Tests/A2UICoreTests/SurfaceViewModelTests.swift
+++ b/swift/core/Tests/A2UICoreTests/SurfaceViewModelTests.swift
@@ -14,6 +14,7 @@
 
 import A2UICore
 import A2UIJSON
+import Combine
 import Foundation
 import JSONSchema
 import OrderedJSON
@@ -303,6 +304,42 @@ struct SurfaceViewModelTests {
     await Task.yield()
     let binding = try #require(surface.rootNode?.properties["label"] as? DataBinding<String>)
     #expect(binding.value == "Hello, World!")
+  }
+
+  /// A property bound through a function call must reflect a data update as
+  /// soon as the update is delivered, exactly like a plain path binding to
+  /// the same data.
+  @Test func functionCallBindingReflectsDataUpdate() async throws {
+    let (processor, surface, _) = try makeProcessor()
+    processor.updateDataModel(surfaceID: surface.surfaceID, path: "/user/first", value: "Alice")
+    processor.updateComponents(
+      surfaceID: surface.surfaceID,
+      components: [
+        [
+          "id": "root",
+          "component": "button",
+          "label": [
+            "call": "concat",
+            "args": ["a": ["path": "/user/first"], "b": "!"],
+          ],
+          "details": ["path": "/user/first"],
+        ]
+      ]
+    )
+    await Task.yield()
+    let initial = try #require(surface.rootNode?.properties["label"] as? DataBinding<String>)
+    #expect(initial.value == "Alice!")
+
+    processor.updateDataModel(surfaceID: surface.surfaceID, path: "/user/first", value: "Bob")
+    await Task.yield()
+
+    // Both bindings read the same path; both must see the new value.
+    let plainPath = try #require(
+      surface.rootNode?.properties["details"] as? DataBinding<JSONValue>)
+    let throughCall = try #require(
+      surface.rootNode?.properties["label"] as? DataBinding<String>)
+    #expect(plainPath.value?.stringValue == "Bob")
+    #expect(throughCall.value == "Bob!")
   }
 
   @Test func dynamicBooleanResolvesLiteralAndPathOnRootNode() async throws {
@@ -701,6 +738,21 @@ struct DataModelTests {
   @Test func initializesWithValue() {
     let model = DataModel(initial: ["name": "Bob"])
     #expect(model.get("/name")?.stringValue == "Bob")
+  }
+
+  @Test func subscriberReadingBackThroughModelSeesStoredValue() {
+    let model = DataModel()
+    var announced: [JSONValue] = []
+    var readBack: [JSONValue?] = []
+    let cancellable = model.dataPublisher.sink { value in
+      announced.append(value)
+      readBack.append(model.get("/user/name"))
+    }
+    model.set("/user/name", value: "Alice")
+    cancellable.cancel()
+    #expect(announced.count == 2)
+    #expect(announced[1]["/user/name"]?.stringValue == "Alice")
+    #expect(readBack[1]?.stringValue == "Alice")
   }
 }
 

--- a/swift/sample/Sources/A2UISampleClient/ViewModels/GalleryViewModel.swift
+++ b/swift/sample/Sources/A2UISampleClient/ViewModels/GalleryViewModel.swift
@@ -166,7 +166,7 @@ public final class GalleryViewModel: @unchecked Sendable, ObservableObject {
       activeSurfaceViewModel = firstSurface
       firstSurface.actionHandler = self.handler
 
-      surfaceSubscription = firstSurface.dataModel.$data
+      surfaceSubscription = firstSurface.dataModel.dataPublisher
         .sink { [weak self] newJSON in
           Task { @MainActor in
             self?.updateDataModelString(from: newJSON)


### PR DESCRIPTION
## Issue
`DataModel.data` was `@Published`, and `@Published` emits during `willSet`: subscribers run before the new value is stored. `SurfaceViewModel` rebuilds the tree synchronously inside that emission, so any resolution that read back through `dataModel.get` saw the previous tree. This means that every property whose value is a `FunctionCall` object rendered one data update behind, while plain path bindings (resolved from the emitted value, not the model) stayed fresh, so one surface could show two generations of the same data in the same frame.

## Change
`DataModel` now stores the update first and then emits, through a new `dataPublisher`. Subscribers that read back through the model get the value they were notified about, which makes `DataContext`'s `dataModel.get` reads correct without touching them.

Tests that fail on the main branch are included.

### API change

`dataModel.$data` is replaced by `dataModel.dataPublisher`. Migration is one line at each subscription site (two existed in this repo, both updated).

- Emission still happens synchronously under the model's lock, as before; only the order of storing and notifying changed.
- `objectWillChange` still fires before mutation, so SwiftUI observation of `DataModel` is unaffected.
- Reads of `data` now take the model's lock; the old `@Published` stored-property read was unsynchronized against locked writes.


## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have built and run at least one [sample].

For this PR:

~~- [ ] I have updated the relevant CHANGELOG.md file.~~
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [x] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
