### PR TITLE
fix(renderers): loosen client-side component validation to allow unknown properties

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -92,7 +92,13 @@ let package = Package(
     ),
     .testTarget(
       name: "A2UISwiftUITests",
-      dependencies: ["A2UISwiftUI", "A2UICore"],
+      dependencies: [
+        "A2UISwiftUI",
+        "A2UICore",
+        "A2UIJSON",
+        .product(name: "JSONSchema", package: "swift-json-schema"),
+        .product(name: "OrderedJSON", package: "swift-json-schema"),
+      ],
       path: "swift/swiftui/Tests/A2UISwiftUITests"
     ),
     .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -103,7 +103,13 @@ let package = Package(
     ),
     .testTarget(
       name: "BasicCatalogTests",
-      dependencies: ["BasicCatalog"],
+      dependencies: [
+        "BasicCatalog",
+        "A2UICore",
+        "A2UIJSON",
+        .product(name: "JSONSchema", package: "swift-json-schema"),
+        .product(name: "OrderedJSON", package: "swift-json-schema"),
+      ],
       path: "swift/core/Tests/BasicCatalogTests"
     ),
   ]

--- a/renderers/angular/CHANGELOG.md
+++ b/renderers/angular/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- (v0_9) Support unrecognized and legacy component properties during dynamic component binding and rendering without errors.
 - (v0_9) Implement `createComponentImplementation` helper and deprecate `extraComponents` and `functions` in `BasicCatalogOptions` to align with the core API. [#2060](https://github.com/a2ui-project/a2ui/pull/2060)
 
 ## 0.10.5

--- a/renderers/angular/src/v0_9/catalog/basic/button.component.spec.ts
+++ b/renderers/angular/src/v0_9/catalog/basic/button.component.spec.ts
@@ -167,4 +167,17 @@ describe('ButtonComponent', () => {
 
     expect(computedStyle.backgroundColor).toBe('rgb(255, 0, 0)'); // 'red' is evaluated to rgb in computed style
   });
+
+  it('should render smoothly and ignore unrecognized properties', () => {
+    setComponentProps(fixture, {
+      ...defaultProps,
+      unknownColor: createBoundProperty('primary'),
+      extraData: createBoundProperty({custom: true}),
+    } as any);
+
+    fixture.detectChanges();
+    const button = fixture.debugElement.query(By.css('button'));
+    expect(button).toBeTruthy();
+    expect(button.nativeElement.classList).toContain('primary');
+  });
 });

--- a/renderers/angular/src/v0_9/core/component-binder.service.spec.ts
+++ b/renderers/angular/src/v0_9/core/component-binder.service.spec.ts
@@ -85,6 +85,24 @@ describe('ComponentBinder', () => {
       expect(bound['text'].raw).toBe('Hello World');
     });
 
+    it('should bind unknown/unrecognized properties without failing', () => {
+      const {context} = createComponentContext({
+        properties: {
+          label: 'Submit',
+          unknownColor: 'primary',
+          extraConfig: {custom: true},
+          legacyNumber: 99,
+        },
+      });
+
+      const bound = binder.bind(context);
+
+      expect(bound['label'].value()).toBe('Submit');
+      expect(bound['unknownColor'].value()).toBe('primary');
+      expect(bound['extraConfig'].value()).toEqual({custom: true});
+      expect(bound['legacyNumber'].value()).toBe(99);
+    });
+
     it('should bind path-based properties and setup onUpdate (two-way binding)', () => {
       const {context, surface} = createComponentContext({
         properties: {value: {path: '/data/text'}},

--- a/renderers/angular/src/v0_9/v0_9_integration.spec.ts
+++ b/renderers/angular/src/v0_9/v0_9_integration.spec.ts
@@ -402,4 +402,56 @@ describe('v0.9.1 Angular Renderer Integration', () => {
     expect(textEl).toBeTruthy();
     expect(textEl.textContent).toContain('Click Me');
   });
+
+  it('safely renders surfaces with unrecognized component types without throwing', async () => {
+    const consoleErrorSpy = spyOn(console, 'error');
+    const messagesWithUnknownComponent: A2uiMessage[] = [
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'unknown-comp-surface',
+          catalogId: basicCatalog.id,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'unknown-comp-surface',
+          components: [
+            {
+              id: 'root',
+              component: 'Column',
+              children: ['known-txt', 'unknown-gizmo'],
+            },
+            {
+              id: 'known-txt',
+              component: 'Text',
+              text: 'Known Visible Text',
+            },
+            {
+              id: 'unknown-gizmo',
+              component: 'FutureGizmo',
+              someData: 'test',
+            } as any,
+          ],
+        },
+      },
+    ];
+
+    rendererService.processMessages(messagesWithUnknownComponent);
+    fixture.componentInstance.surfaceId = 'unknown-comp-surface';
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // Verify known text component rendered
+    const textEl = fixture.nativeElement.querySelector('a2ui-v09-text');
+    expect(textEl).toBeTruthy();
+    expect(textEl.textContent).toContain('Known Visible Text');
+
+    // Verify console.error was logged for the unknown component type
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      `Component type "FutureGizmo" not found in catalog "${basicCatalog.id}"`,
+    );
+  });
 });

--- a/renderers/angular/src/v0_9/v0_9_integration.spec.ts
+++ b/renderers/angular/src/v0_9/v0_9_integration.spec.ts
@@ -455,4 +455,54 @@ describe('v0.9.1 Angular Renderer Integration', () => {
       `Component type "FutureGizmo" not found in catalog "${catalogId}"`,
     );
   });
+
+  it('safely renders surfaces with unrecognized function calls in dynamic values without throwing', async () => {
+    const catalogId = 'https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json';
+    const messagesWithUnknownFunc: A2uiMessage[] = [
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'unknown-func-surface',
+          catalogId,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'unknown-func-surface',
+          components: [
+            {
+              id: 'root',
+              component: 'Column',
+              children: ['known-txt', 'func-txt'],
+            },
+            {
+              id: 'known-txt',
+              component: 'Text',
+              text: 'Known Visible Text',
+            },
+            {
+              id: 'func-txt',
+              component: 'Text',
+              text: {
+                call: 'nonExistentFunction',
+                args: {x: 1},
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    rendererService.processMessages(messagesWithUnknownFunc);
+    fixture.componentInstance.surfaceId = 'unknown-func-surface';
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // Verify known text component rendered
+    const textEls = fixture.nativeElement.querySelectorAll('a2ui-v09-text');
+    expect(textEls.length).toBe(2);
+    expect(textEls[0].textContent).toContain('Known Visible Text');
+  });
 });

--- a/renderers/angular/src/v0_9/v0_9_integration.spec.ts
+++ b/renderers/angular/src/v0_9/v0_9_integration.spec.ts
@@ -353,4 +353,53 @@ describe('v0.9.1 Angular Renderer Integration', () => {
     expect(textEl).toBeTruthy();
     expect(textEl.textContent).toContain('Hello from v0.9.1!');
   });
+
+  it('should process and render surfaces containing components with unrecognized properties', async () => {
+    const messagesWithExtraProps: A2uiMessage[] = [
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'extra-props-surface',
+          catalogId: 'https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json',
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'extra-props-surface',
+          components: [
+            {
+              id: 'root',
+              component: 'Button',
+              variant: 'primary',
+              child: 'btn-text',
+              unknownColor: 'primary',
+              legacyExtraField: {custom: true},
+            } as any,
+            {
+              id: 'btn-text',
+              component: 'Text',
+              text: 'Click Me',
+              unknownAttribute: 12345,
+            } as any,
+          ],
+        },
+      },
+    ];
+
+    rendererService.processMessages(messagesWithExtraProps);
+    fixture.componentInstance.surfaceId = 'extra-props-surface';
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const buttonEl = fixture.nativeElement.querySelector('a2ui-v09-button');
+    expect(buttonEl).toBeTruthy();
+    const btnNative = buttonEl.querySelector('button');
+    expect(btnNative.classList).toContain('primary');
+
+    const textEl = fixture.nativeElement.querySelector('a2ui-v09-text');
+    expect(textEl).toBeTruthy();
+    expect(textEl.textContent).toContain('Click Me');
+  });
 });

--- a/renderers/angular/src/v0_9/v0_9_integration.spec.ts
+++ b/renderers/angular/src/v0_9/v0_9_integration.spec.ts
@@ -405,12 +405,13 @@ describe('v0.9.1 Angular Renderer Integration', () => {
 
   it('safely renders surfaces with unrecognized component types without throwing', async () => {
     const consoleErrorSpy = spyOn(console, 'error');
+    const catalogId = 'https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json';
     const messagesWithUnknownComponent: A2uiMessage[] = [
       {
         version: 'v0.9',
         createSurface: {
           surfaceId: 'unknown-comp-surface',
-          catalogId: basicCatalog.id,
+          catalogId,
         },
       },
       {
@@ -451,7 +452,7 @@ describe('v0.9.1 Angular Renderer Integration', () => {
 
     // Verify console.error was logged for the unknown component type
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      `Component type "FutureGizmo" not found in catalog "${basicCatalog.id}"`,
+      `Component type "FutureGizmo" not found in catalog "${catalogId}"`,
     );
   });
 });

--- a/renderers/lit/CHANGELOG.md
+++ b/renderers/lit/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- (v0_9) Support unrecognized and legacy component properties in `A2uiController` and Lit components without throwing or interrupting component lifecycle.
+
 ## 0.10.3
 
 - Enable `inlineSources` in `tsconfig.json` to populate `sourcesContent` in sourcemaps.

--- a/renderers/lit/src/v0_9/tests/a2ui-controller.test.ts
+++ b/renderers/lit/src/v0_9/tests/a2ui-controller.test.ts
@@ -234,4 +234,35 @@ describe('A2uiController', () => {
     // requestUpdate shouldn't be called again
     assert.strictEqual((mockHost.requestUpdate as any).mock.calls.length, initialCalls);
   });
+
+  it('should tolerate and pass through unrecognized properties without error', async () => {
+    await asyncUpdate(processor, p =>
+      p.processMessages([
+        {
+          version: 'v0.9',
+          updateComponents: {
+            surfaceId: 'test-surface',
+            components: [
+              {
+                id: 'test-comp',
+                component: 'Text',
+                text: 'Hello World',
+                unknownColor: 'primary',
+                extraMetadata: {custom: 123},
+              } as any,
+            ],
+          },
+        },
+      ]),
+    );
+
+    const mockHost = await createMockHost(context);
+    const controller = mockHost.testController;
+
+    assert.strictEqual(controller.props.text, 'Hello World');
+    assert.strictEqual((controller.props as any).unknownColor, 'primary');
+    assert.deepStrictEqual((controller.props as any).extraMetadata, {custom: 123});
+
+    controller.dispose();
+  });
 });

--- a/renderers/lit/src/v0_9/tests/a2ui-surface.test.ts
+++ b/renderers/lit/src/v0_9/tests/a2ui-surface.test.ts
@@ -127,4 +127,63 @@ describe('A2uiSurface', () => {
 
     document.body.removeChild(el);
   });
+
+  it('should tolerate unrecognized component types in surface without throwing', async () => {
+    const el = document.createElement('a2ui-surface') as unknown as A2uiSurface;
+    document.body.appendChild(el);
+
+    await asyncUpdate(el, e => {
+      e.surface = surfaceModel;
+    });
+
+    // Add root Column containing a valid Text and an unrecognized component
+    await asyncUpdate(el, () => {
+      processor.processMessages([
+        {
+          version: 'v0.9',
+          updateComponents: {
+            surfaceId: 'test-surface',
+            components: [
+              {
+                id: 'root',
+                component: 'Column',
+                children: ['txt1', 'unknown1'],
+              },
+              {
+                id: 'txt1',
+                component: 'Text',
+                text: 'Known Text Component',
+              },
+              {
+                id: 'unknown1',
+                component: 'UnregisteredFutureComponent',
+                customProperty: 42,
+              } as any,
+            ],
+          },
+        },
+      ]);
+    });
+
+    await el.updateComplete;
+
+    const columnEl = el.shadowRoot?.querySelector('a2ui-basic-column') as any;
+    if (columnEl && columnEl.updateComplete) {
+      await columnEl.updateComplete;
+    }
+
+    const textEl = columnEl?.shadowRoot?.querySelector('a2ui-basic-text') as any;
+    if (textEl && textEl.updateComplete) {
+      await textEl.updateComplete;
+    }
+
+    const textHtml = textEl?.shadowRoot?.innerHTML;
+    assert.ok(textHtml?.includes('Known Text Component'), 'Valid text component should render');
+
+    // Verify unregistered component does not crash or create invalid elements
+    const unknownEl = columnEl?.shadowRoot?.querySelector('unregistered-future-component');
+    assert.strictEqual(unknownEl, null);
+
+    document.body.removeChild(el);
+  });
 });

--- a/renderers/lit/src/v0_9/tests/a2ui-surface.test.ts
+++ b/renderers/lit/src/v0_9/tests/a2ui-surface.test.ts
@@ -186,4 +186,62 @@ describe('A2uiSurface', () => {
 
     document.body.removeChild(el);
   });
+
+  it('should tolerate unrecognized function calls in dynamic values without crashing', async () => {
+    const el = document.createElement('a2ui-surface') as unknown as A2uiSurface;
+    document.body.appendChild(el);
+
+    await asyncUpdate(el, e => {
+      e.surface = surfaceModel;
+    });
+
+    await asyncUpdate(el, () => {
+      processor.processMessages([
+        {
+          version: 'v0.9',
+          updateComponents: {
+            surfaceId: 'test-surface',
+            components: [
+              {
+                id: 'root',
+                component: 'Column',
+                children: ['txtValid', 'txtFunc'],
+              },
+              {
+                id: 'txtValid',
+                component: 'Text',
+                text: 'Known Visible Text',
+              },
+              {
+                id: 'txtFunc',
+                component: 'Text',
+                text: {
+                  call: 'unrecognizedFunction',
+                  args: {foo: 'bar'},
+                },
+              },
+            ],
+          },
+        },
+      ]);
+    });
+
+    await el.updateComplete;
+
+    const columnEl = el.shadowRoot?.querySelector('a2ui-basic-column') as any;
+    if (columnEl && columnEl.updateComplete) {
+      await columnEl.updateComplete;
+    }
+
+    const textEls = columnEl?.shadowRoot?.querySelectorAll('a2ui-basic-text');
+    assert.ok(textEls && textEls.length === 2, 'Both text elements should be present in DOM');
+
+    const validTextEl = textEls[0] as any;
+    if (validTextEl && validTextEl.updateComplete) {
+      await validTextEl.updateComplete;
+    }
+    assert.ok(validTextEl?.shadowRoot?.innerHTML?.includes('Known Visible Text'));
+
+    document.body.removeChild(el);
+  });
 });

--- a/renderers/react/CHANGELOG.md
+++ b/renderers/react/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - (v0_9) Add `A2uiNodeSurface`, a surface renderer driven by `NodeResolver` from `@a2ui/web_core`; component implementations gain an optional node-driven `view` (see `NodeViewProps` and `useSignalValue`) ([#2077](https://github.com/a2ui-project/a2ui/pull/2077)).
+- (v0_9) Support unrecognized and legacy component properties in React catalog components without rendering or runtime errors.
 
 ## 0.10.2
 

--- a/renderers/react/tests/v0_9/catalog-components.test.tsx
+++ b/renderers/react/tests/v0_9/catalog-components.test.tsx
@@ -399,5 +399,24 @@ describe('Basic Catalog Components', () => {
       fireEvent.change(screen.getByLabelText('When'), {target: {value: '2026-03-20'}});
       expect(surface.dataModel.get('/date')).toBe('2026-03-20');
     });
+
+    it('ignores unrecognized properties when rendering basic components', () => {
+      // Pass unknown/legacy fields to basic components
+      renderA2uiComponent(Button, 'btn1', {
+        child: 't1',
+        variant: 'primary',
+        color: 'primary',
+        unknownCustomField: 'ignored',
+        extraMetadata: {legacy: true},
+      } as any);
+
+      renderA2uiComponent(Text, 't1', {
+        text: 'Click Me',
+        unknownProperty: 123,
+      } as any);
+
+      expect(screen.getByRole('button')).toBeDefined();
+      expect(screen.getByText('Click Me')).toBeDefined();
+    });
   });
 });

--- a/renderers/react/tests/v0_9/integration-scenarios.test.tsx
+++ b/renderers/react/tests/v0_9/integration-scenarios.test.tsx
@@ -80,4 +80,51 @@ describe('Gallery Integration Tests', () => {
 
     expect(surface!.dataModel.get('/email')).toBe('alice@example.com');
   });
+
+  it('safely renders surfaces containing unrecognized component types without crashing', async () => {
+    const processor = new MessageProcessor([basicCatalog as any], async () => {});
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {surfaceId: 'surface-unrecognized', catalogId: basicCatalog.id},
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'surface-unrecognized',
+          components: [
+            {
+              id: 'root',
+              component: 'Column',
+              children: ['valid-text', 'unrecognized-widget'],
+            },
+            {
+              id: 'valid-text',
+              component: 'Text',
+              text: 'Valid Visible Text',
+            },
+            {
+              id: 'unrecognized-widget',
+              component: 'FutureAIGizmo',
+              customProps: {foo: 'bar'},
+            } as any,
+          ],
+        },
+      },
+    ]);
+
+    const surface = processor.model.getSurface('surface-unrecognized');
+    expect(surface).toBeDefined();
+
+    render(
+      <React.StrictMode>
+        <A2uiSurface surface={surface as any} />
+      </React.StrictMode>,
+    );
+
+    // Valid sibling renders correctly
+    expect(screen.getByText('Valid Visible Text')).toBeInTheDocument();
+    // Unrecognized component renders fallback indicator without crashing
+    expect(screen.getByText('Unknown component: FutureAIGizmo')).toBeInTheDocument();
+  });
 });

--- a/renderers/react/tests/v0_9/integration-scenarios.test.tsx
+++ b/renderers/react/tests/v0_9/integration-scenarios.test.tsx
@@ -127,4 +127,52 @@ describe('Gallery Integration Tests', () => {
     // Unrecognized component renders fallback indicator without crashing
     expect(screen.getByText('Unknown component: FutureAIGizmo')).toBeInTheDocument();
   });
+
+  it('safely renders surfaces containing unrecognized function calls in bindings without crashing', async () => {
+    const processor = new MessageProcessor([basicCatalog as any], async () => {});
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {surfaceId: 'surface-unrecognized-func', catalogId: basicCatalog.id},
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'surface-unrecognized-func',
+          components: [
+            {
+              id: 'root',
+              component: 'Column',
+              children: ['valid-text', 'unrecognized-func-text'],
+            },
+            {
+              id: 'valid-text',
+              component: 'Text',
+              text: 'Valid Visible Text',
+            },
+            {
+              id: 'unrecognized-func-text',
+              component: 'Text',
+              text: {
+                call: 'unrecognizedCustomFunction',
+                args: {param: 123},
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const surface = processor.model.getSurface('surface-unrecognized-func');
+    expect(surface).toBeDefined();
+
+    render(
+      <React.StrictMode>
+        <A2uiSurface surface={surface as any} />
+      </React.StrictMode>,
+    );
+
+    // Valid sibling renders correctly without crashing
+    expect(screen.getByText('Valid Visible Text')).toBeInTheDocument();
+  });
 });

--- a/renderers/web_core/CHANGELOG.md
+++ b/renderers/web_core/CHANGELOG.md
@@ -4,6 +4,8 @@
 - (v0_9) Emit `$ref` in inline-catalog capabilities for the basic catalog's child-reference properties even when a per-usage description is set; new `componentId()`/`childList()` helpers compose custom descriptions without losing the `$ref` ([#2077](https://github.com/a2ui-project/a2ui/pull/2077)).
 - (v0_9) `GenericBinder` reuses action closures across identical component resends, so action-valued props keep reference identity and downstream equality checks see them as unchanged ([#2077](https://github.com/a2ui-project/a2ui/pull/2077)).
 - (v0_9) `Catalog` and `SurfaceModel` accept a function-kind type parameter (defaulting to `FunctionImplementation`); invoking a catalog function that has no implementation now throws `A2uiExpressionError` ([#2077](https://github.com/a2ui-project/a2ui/pull/2077)).
+- (v0_9) Loosen client-side component validation: remove `.strict()` from basic component schemas and ignore `unrecognized_keys` validation issues in `MessageProcessor` (`additionalProperties: true`).
+- (v0_9) Update `GenericBinder` to safely pass through unrecognized component properties as static values into reactive snapshots.
 
 ## 0.10.6
 

--- a/renderers/web_core/src/v0_9/basic_catalog/components/basic_components.test.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/basic_components.test.ts
@@ -48,7 +48,7 @@ describe('Basic Components Schema', () => {
   });
 
   describe('SliderApi', () => {
-    it('should reject non-spec step property', () => {
+    it('should allow non-spec additional properties', () => {
       const validSlider = {
         max: 100,
         value: 50,
@@ -60,12 +60,7 @@ describe('Basic Components Schema', () => {
         step: 5,
       });
 
-      assert.strictEqual(result.success, false);
-      assert.ok(
-        result.error.issues.some(
-          issue => issue.code === 'unrecognized_keys' && issue.keys.includes('step'),
-        ),
-      );
+      assert.strictEqual(result.success, true);
     });
   });
 });

--- a/renderers/web_core/src/v0_9/basic_catalog/components/basic_components.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/basic_components.ts
@@ -40,44 +40,40 @@ const CommonProps = {
 
 export const TextApi = {
   name: 'Text',
-  schema: z
-    .object({
-      ...CommonProps,
-      'text': DynamicStringSchema.describe(
-        'The text content to display. While simple Markdown formatting is supported (i.e. without HTML, images, or links), utilizing dedicated UI components is generally preferred for a richer and more structured presentation.',
-      ),
-      'variant': z
-        .enum(['h1', 'h2', 'h3', 'h4', 'h5', 'caption', 'body'])
-        .default('body')
-        .describe('A hint for the base text style.')
-        .optional(),
-    })
-    .strict(),
+  schema: z.object({
+    ...CommonProps,
+    'text': DynamicStringSchema.describe(
+      'The text content to display. While simple Markdown formatting is supported (i.e. without HTML, images, or links), utilizing dedicated UI components is generally preferred for a richer and more structured presentation.',
+    ),
+    'variant': z
+      .enum(['h1', 'h2', 'h3', 'h4', 'h5', 'caption', 'body'])
+      .default('body')
+      .describe('A hint for the base text style.')
+      .optional(),
+  }),
 } satisfies ComponentApi;
 
 export const ImageApi = {
   name: 'Image',
-  schema: z
-    .object({
-      ...CommonProps,
-      'url': DynamicStringSchema.describe('The URL of the image to display.'),
-      'description': DynamicStringSchema.describe(
-        'The accessibility description of the image.',
-      ).optional(),
-      'fit': z
-        .enum(['contain', 'cover', 'fill', 'none', 'scaleDown'])
-        .default('fill')
-        .describe(
-          "Specifies how the image should be resized to fit its container. This corresponds to the CSS 'object-fit' property.",
-        )
-        .optional(),
-      'variant': z
-        .enum(['icon', 'avatar', 'smallFeature', 'mediumFeature', 'largeFeature', 'header'])
-        .default('mediumFeature')
-        .describe('A hint for the image size and style.')
-        .optional(),
-    })
-    .strict(),
+  schema: z.object({
+    ...CommonProps,
+    'url': DynamicStringSchema.describe('The URL of the image to display.'),
+    'description': DynamicStringSchema.describe(
+      'The accessibility description of the image.',
+    ).optional(),
+    'fit': z
+      .enum(['contain', 'cover', 'fill', 'none', 'scaleDown'])
+      .default('fill')
+      .describe(
+        "Specifies how the image should be resized to fit its container. This corresponds to the CSS 'object-fit' property.",
+      )
+      .optional(),
+    'variant': z
+      .enum(['icon', 'avatar', 'smallFeature', 'mediumFeature', 'largeFeature', 'header'])
+      .default('mediumFeature')
+      .describe('A hint for the image size and style.')
+      .optional(),
+  }),
 } satisfies ComponentApi;
 
 const ICON_NAMES = [
@@ -144,49 +140,39 @@ const ICON_NAMES = [
 
 export const IconApi = {
   name: 'Icon',
-  schema: z
-    .object({
-      ...CommonProps,
-      name: z
-        .union([
-          z.enum(ICON_NAMES),
-          z
-            .object({
-              svgPath: z.string().describe('Custom SVG path data'),
-            })
-            .strict(),
-          z
-            .object({
-              path: z.string(),
-            })
-            .strict(),
-        ])
-        .describe('The name of the icon to display.'),
-    })
-    .strict(),
+  schema: z.object({
+    ...CommonProps,
+    name: z
+      .union([
+        z.enum(ICON_NAMES),
+        z.object({
+          svgPath: z.string().describe('Custom SVG path data'),
+        }),
+        z.object({
+          path: z.string(),
+        }),
+      ])
+      .describe('The name of the icon to display.'),
+  }),
 } satisfies ComponentApi;
 
 export const VideoApi = {
   name: 'Video',
-  schema: z
-    .object({
-      ...CommonProps,
-      url: DynamicStringSchema.describe('The URL of the video to display.'),
-    })
-    .strict(),
+  schema: z.object({
+    ...CommonProps,
+    url: DynamicStringSchema.describe('The URL of the video to display.'),
+  }),
 } satisfies ComponentApi;
 
 export const AudioPlayerApi = {
   name: 'AudioPlayer',
-  schema: z
-    .object({
-      ...CommonProps,
-      url: DynamicStringSchema.describe('The URL of the audio to be played.'),
-      description: DynamicStringSchema.describe(
-        'A description of the audio, such as a title or summary.',
-      ).optional(),
-    })
-    .strict(),
+  schema: z.object({
+    ...CommonProps,
+    url: DynamicStringSchema.describe('The URL of the audio to be played.'),
+    description: DynamicStringSchema.describe(
+      'A description of the audio, such as a title or summary.',
+    ).optional(),
+  }),
 } satisfies ComponentApi;
 
 export const RowApi = {
@@ -213,7 +199,6 @@ export const RowApi = {
         )
         .optional(),
     })
-    .strict()
     .describe(
       'A layout component that arranges its children horizontally. To create a grid layout, nest Columns within this Row.',
     ),
@@ -243,7 +228,6 @@ export const ColumnApi = {
         )
         .optional(),
     })
-    .strict()
     .describe(
       'A layout component that arranges its children vertically. To create a grid layout, nest Rows within this Column.',
     ),
@@ -251,33 +235,32 @@ export const ColumnApi = {
 
 export const ListApi = {
   name: 'List',
-  schema: z
-    .object({
-      ...CommonProps,
-      'children': childList({
-        description:
-          'Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list.',
-      }),
-      'direction': z
-        .enum(['vertical', 'horizontal'])
-        .default('vertical')
-        .describe('The direction in which the list items are laid out.')
-        .optional(),
-      'align': z
-        .enum(['start', 'center', 'end', 'stretch'])
-        .default('stretch')
-        .describe('Defines the alignment of children along the cross axis.')
-        .optional(),
-      'listStyle': z
-        .enum(['ordered', 'unordered', 'none'])
-        .describe('The style of the list (ordered, unordered, or none).')
-        .optional(),
-    })
-    .strict(),
+  schema: z.object({
+    ...CommonProps,
+    'children': childList({
+      description:
+        'Defines the children. Use an array of strings for a fixed set of children, or a template object to generate children from a data list.',
+    }),
+    'direction': z
+      .enum(['vertical', 'horizontal'])
+      .default('vertical')
+      .describe('The direction in which the list items are laid out.')
+      .optional(),
+    'align': z
+      .enum(['start', 'center', 'end', 'stretch'])
+      .default('stretch')
+      .describe('Defines the alignment of children along the cross axis.')
+      .optional(),
+    'listStyle': z
+      .enum(['ordered', 'unordered', 'none'])
+      .describe('The style of the list (ordered, unordered, or none).')
+      .optional(),
+  }),
 } satisfies ComponentApi;
 
 export const CardApi = {
   name: 'Card',
+<<<<<<< HEAD
   schema: z
     .object({
       ...CommonProps,
@@ -287,10 +270,19 @@ export const CardApi = {
       }),
     })
     .strict(),
+=======
+  schema: z.object({
+    ...CommonProps,
+    'child': ComponentIdSchema.describe(
+      "The ID of the single child component to be rendered inside the card. To display multiple elements, you MUST wrap them in a layout component (like Column or Row) and pass that container's ID here. Do NOT pass multiple IDs or a non-existent ID. Do NOT define the child component inline.",
+    ),
+  }),
+>>>>>>> fb475a77 (fix(renderers): loosen client-side component validation to allow unknown properties)
 } satisfies ComponentApi;
 
 export const TabsApi = {
   name: 'Tabs',
+<<<<<<< HEAD
   schema: z
     .object({
       ...CommonProps,
@@ -311,10 +303,29 @@ export const TabsApi = {
         ),
     })
     .strict(),
+=======
+  schema: z.object({
+    ...CommonProps,
+    'tabs': z
+      .array(
+        z.object({
+          'title': DynamicStringSchema.describe('The tab title.'),
+          'child': ComponentIdSchema.describe(
+            'The ID of the child component. Do NOT define the component inline.',
+          ),
+        }),
+      )
+      .min(1)
+      .describe(
+        'An array of objects, where each object defines a tab with a title and a child component.',
+      ),
+  }),
+>>>>>>> fb475a77 (fix(renderers): loosen client-side component validation to allow unknown properties)
 } satisfies ComponentApi;
 
 export const ModalApi = {
   name: 'Modal',
+<<<<<<< HEAD
   schema: z
     .object({
       ...CommonProps,
@@ -328,24 +339,34 @@ export const ModalApi = {
       }),
     })
     .strict(),
+=======
+  schema: z.object({
+    ...CommonProps,
+    'trigger': ComponentIdSchema.describe(
+      'The ID of the component that opens the modal when interacted with (e.g., a button). Do NOT define the component inline.',
+    ),
+    'content': ComponentIdSchema.describe(
+      'The ID of the component to be displayed inside the modal. Do NOT define the component inline.',
+    ),
+  }),
+>>>>>>> fb475a77 (fix(renderers): loosen client-side component validation to allow unknown properties)
 } satisfies ComponentApi;
 
 export const DividerApi = {
   name: 'Divider',
-  schema: z
-    .object({
-      ...CommonProps,
-      'axis': z
-        .enum(['horizontal', 'vertical'])
-        .default('horizontal')
-        .describe('The orientation of the divider.')
-        .optional(),
-    })
-    .strict(),
+  schema: z.object({
+    ...CommonProps,
+    'axis': z
+      .enum(['horizontal', 'vertical'])
+      .default('horizontal')
+      .describe('The orientation of the divider.')
+      .optional(),
+  }),
 } satisfies ComponentApi;
 
 export const ButtonApi = {
   name: 'Button',
+<<<<<<< HEAD
   schema: z
     .object({
       ...CommonProps,
@@ -364,41 +385,54 @@ export const ButtonApi = {
       ...CheckableSchema.shape,
     })
     .strict(),
+=======
+  schema: z.object({
+    ...CommonProps,
+    'child': ComponentIdSchema.describe(
+      "The ID of the child component. Use a 'Text' component for a labeled button. Only use an 'Icon' if the requirements explicitly ask for an icon-only button. Do NOT define the child component inline.",
+    ),
+    'variant': z
+      .enum(['default', 'primary', 'borderless'])
+      .default('default')
+      .describe(
+        "A hint for the button style. If omitted, a default button style is used. 'primary' indicates this is the main call-to-action button. 'borderless' means the button has no visual border or background, making its child content appear like a clickable link.",
+      )
+      .optional(),
+    'action': ActionSchema.optional(),
+    ...CheckableSchema.shape,
+  }),
+>>>>>>> fb475a77 (fix(renderers): loosen client-side component validation to allow unknown properties)
 } satisfies ComponentApi;
 
 export const TextFieldApi = {
   name: 'TextField',
-  schema: z
-    .object({
-      ...CommonProps,
-      'label': DynamicStringSchema.describe('The text label for the input field.'),
-      'value': DynamicStringSchema.describe('The value of the text field.').optional(),
-      'variant': z
-        .enum(['longText', 'number', 'shortText', 'obscured'])
-        .default('shortText')
-        .describe('The type of input field to display.')
-        .optional(),
-      'validationRegexp': z
-        .string()
-        .describe('A regular expression used for client-side validation of the input.')
-        .optional(),
-      ...CheckableSchema.shape,
-    })
-    .strict(),
+  schema: z.object({
+    ...CommonProps,
+    'label': DynamicStringSchema.describe('The text label for the input field.'),
+    'value': DynamicStringSchema.describe('The value of the text field.').optional(),
+    'variant': z
+      .enum(['longText', 'number', 'shortText', 'obscured'])
+      .default('shortText')
+      .describe('The type of input field to display.')
+      .optional(),
+    'validationRegexp': z
+      .string()
+      .describe('A regular expression used for client-side validation of the input.')
+      .optional(),
+    ...CheckableSchema.shape,
+  }),
 } satisfies ComponentApi;
 
 export const CheckBoxApi = {
   name: 'CheckBox',
-  schema: z
-    .object({
-      ...CommonProps,
-      'label': DynamicStringSchema.describe('The text to display next to the checkbox.'),
-      'value': DynamicBooleanSchema.describe(
-        'The current state of the checkbox (true for checked, false for unchecked).',
-      ),
-      ...CheckableSchema.shape,
-    })
-    .strict(),
+  schema: z.object({
+    ...CommonProps,
+    'label': DynamicStringSchema.describe('The text to display next to the checkbox.'),
+    'value': DynamicBooleanSchema.describe(
+      'The current state of the checkbox (true for checked, false for unchecked).',
+    ),
+    ...CheckableSchema.shape,
+  }),
 } satisfies ComponentApi;
 
 export const ChoicePickerApi = {
@@ -414,12 +448,10 @@ export const ChoicePickerApi = {
         .optional(),
       'options': z
         .array(
-          z
-            .object({
-              'label': DynamicStringSchema.describe('The text to display for this option.'),
-              'value': z.string().describe('The stable value associated with this option.'),
-            })
-            .strict(),
+          z.object({
+            'label': DynamicStringSchema.describe('The text to display for this option.'),
+            'value': z.string().describe('The stable value associated with this option.'),
+          }),
         )
         .describe('The list of available options to choose from.'),
       'value': DynamicStringListSchema.describe(
@@ -437,54 +469,49 @@ export const ChoicePickerApi = {
         .optional(),
       ...CheckableSchema.shape,
     })
-    .strict()
     .describe('A component that allows selecting one or more options from a list.'),
 } satisfies ComponentApi;
 
 export const SliderApi = {
   name: 'Slider',
-  schema: z
-    .object({
-      ...CommonProps,
-      'label': DynamicStringSchema.describe('The label for the slider.').optional(),
-      'min': z.number().default(0).describe('The minimum value of the slider.').optional(),
-      'max': z.number().describe('The maximum value of the slider.'),
-      'value': DynamicNumberSchema.describe('The current value of the slider.'),
-      ...CheckableSchema.shape,
-    })
-    .strict(),
+  schema: z.object({
+    ...CommonProps,
+    'label': DynamicStringSchema.describe('The label for the slider.').optional(),
+    'min': z.number().default(0).describe('The minimum value of the slider.').optional(),
+    'max': z.number().describe('The maximum value of the slider.'),
+    'value': DynamicNumberSchema.describe('The current value of the slider.'),
+    ...CheckableSchema.shape,
+  }),
 } satisfies ComponentApi;
 
 export const DateTimeInputApi = {
   name: 'DateTimeInput',
-  schema: z
-    .object({
-      ...CommonProps,
-      'value': DynamicStringSchema.describe(
-        'The selected date and/or time value in ISO 8601 format. If not yet set, initialize with an empty string.',
-      ),
-      'enableDate': z
-        .boolean()
-        .default(false)
-        .describe('If true, allows the user to select a date.')
-        .optional(),
-      'enableTime': z
-        .boolean()
-        .default(false)
-        .describe('If true, allows the user to select a time.')
-        .optional(),
-      'min': z
-        .union([DynamicStringSchema, z.string().date(), z.string().time(), z.string().datetime()])
-        .describe('The minimum allowed date/time in ISO 8601 format.')
-        .optional(),
-      'max': z
-        .union([DynamicStringSchema, z.string().date(), z.string().time(), z.string().datetime()])
-        .describe('The maximum allowed date/time in ISO 8601 format.')
-        .optional(),
-      'label': DynamicStringSchema.describe('The text label for the input field.').optional(),
-      ...CheckableSchema.shape,
-    })
-    .strict(),
+  schema: z.object({
+    ...CommonProps,
+    'value': DynamicStringSchema.describe(
+      'The selected date and/or time value in ISO 8601 format. If not yet set, initialize with an empty string.',
+    ),
+    'enableDate': z
+      .boolean()
+      .default(false)
+      .describe('If true, allows the user to select a date.')
+      .optional(),
+    'enableTime': z
+      .boolean()
+      .default(false)
+      .describe('If true, allows the user to select a time.')
+      .optional(),
+    'min': z
+      .union([DynamicStringSchema, z.string().date(), z.string().time(), z.string().datetime()])
+      .describe('The minimum allowed date/time in ISO 8601 format.')
+      .optional(),
+    'max': z
+      .union([DynamicStringSchema, z.string().date(), z.string().time(), z.string().datetime()])
+      .describe('The maximum allowed date/time in ISO 8601 format.')
+      .optional(),
+    'label': DynamicStringSchema.describe('The text label for the input field.').optional(),
+    ...CheckableSchema.shape,
+  }),
 } satisfies ComponentApi;
 
 export const BASIC_COMPONENTS: ComponentApi[] = [

--- a/renderers/web_core/src/v0_9/basic_catalog/components/basic_components.ts
+++ b/renderers/web_core/src/v0_9/basic_catalog/components/basic_components.ts
@@ -260,59 +260,26 @@ export const ListApi = {
 
 export const CardApi = {
   name: 'Card',
-<<<<<<< HEAD
-  schema: z
-    .object({
-      ...CommonProps,
-      'child': componentId({
-        description:
-          "The ID of the single child component to be rendered inside the card. To display multiple elements, you MUST wrap them in a layout component (like Column or Row) and pass that container's ID here. Do NOT pass multiple IDs or a non-existent ID. Do NOT define the child component inline.",
-      }),
-    })
-    .strict(),
-=======
   schema: z.object({
     ...CommonProps,
-    'child': ComponentIdSchema.describe(
-      "The ID of the single child component to be rendered inside the card. To display multiple elements, you MUST wrap them in a layout component (like Column or Row) and pass that container's ID here. Do NOT pass multiple IDs or a non-existent ID. Do NOT define the child component inline.",
-    ),
+    'child': componentId({
+      description:
+        "The ID of the single child component to be rendered inside the card. To display multiple elements, you MUST wrap them in a layout component (like Column or Row) and pass that container's ID here. Do NOT pass multiple IDs or a non-existent ID. Do NOT define the child component inline.",
+    }),
   }),
->>>>>>> fb475a77 (fix(renderers): loosen client-side component validation to allow unknown properties)
 } satisfies ComponentApi;
 
 export const TabsApi = {
   name: 'Tabs',
-<<<<<<< HEAD
-  schema: z
-    .object({
-      ...CommonProps,
-      'tabs': z
-        .array(
-          z
-            .object({
-              'title': DynamicStringSchema.describe('The tab title.'),
-              'child': componentId({
-                description: 'The ID of the child component. Do NOT define the component inline.',
-              }),
-            })
-            .strict(),
-        )
-        .min(1)
-        .describe(
-          'An array of objects, where each object defines a tab with a title and a child component.',
-        ),
-    })
-    .strict(),
-=======
   schema: z.object({
     ...CommonProps,
     'tabs': z
       .array(
         z.object({
           'title': DynamicStringSchema.describe('The tab title.'),
-          'child': ComponentIdSchema.describe(
-            'The ID of the child component. Do NOT define the component inline.',
-          ),
+          'child': componentId({
+            description: 'The ID of the child component. Do NOT define the component inline.',
+          }),
         }),
       )
       .min(1)
@@ -320,36 +287,21 @@ export const TabsApi = {
         'An array of objects, where each object defines a tab with a title and a child component.',
       ),
   }),
->>>>>>> fb475a77 (fix(renderers): loosen client-side component validation to allow unknown properties)
 } satisfies ComponentApi;
 
 export const ModalApi = {
   name: 'Modal',
-<<<<<<< HEAD
-  schema: z
-    .object({
-      ...CommonProps,
-      'trigger': componentId({
-        description:
-          'The ID of the component that opens the modal when interacted with (e.g., a button). Do NOT define the component inline.',
-      }),
-      'content': componentId({
-        description:
-          'The ID of the component to be displayed inside the modal. Do NOT define the component inline.',
-      }),
-    })
-    .strict(),
-=======
   schema: z.object({
     ...CommonProps,
-    'trigger': ComponentIdSchema.describe(
-      'The ID of the component that opens the modal when interacted with (e.g., a button). Do NOT define the component inline.',
-    ),
-    'content': ComponentIdSchema.describe(
-      'The ID of the component to be displayed inside the modal. Do NOT define the component inline.',
-    ),
+    'trigger': componentId({
+      description:
+        'The ID of the component that opens the modal when interacted with (e.g., a button). Do NOT define the component inline.',
+    }),
+    'content': componentId({
+      description:
+        'The ID of the component to be displayed inside the modal. Do NOT define the component inline.',
+    }),
   }),
->>>>>>> fb475a77 (fix(renderers): loosen client-side component validation to allow unknown properties)
 } satisfies ComponentApi;
 
 export const DividerApi = {
@@ -366,31 +318,12 @@ export const DividerApi = {
 
 export const ButtonApi = {
   name: 'Button',
-<<<<<<< HEAD
-  schema: z
-    .object({
-      ...CommonProps,
-      'child': componentId({
-        description:
-          "The ID of the child component. Use a 'Text' component for a labeled button. Only use an 'Icon' if the requirements explicitly ask for an icon-only button. Do NOT define the child component inline.",
-      }),
-      'variant': z
-        .enum(['default', 'primary', 'borderless'])
-        .default('default')
-        .describe(
-          "A hint for the button style. If omitted, a default button style is used. 'primary' indicates this is the main call-to-action button. 'borderless' means the button has no visual border or background, making its child content appear like a clickable link.",
-        )
-        .optional(),
-      'action': ActionSchema.optional(),
-      ...CheckableSchema.shape,
-    })
-    .strict(),
-=======
   schema: z.object({
     ...CommonProps,
-    'child': ComponentIdSchema.describe(
-      "The ID of the child component. Use a 'Text' component for a labeled button. Only use an 'Icon' if the requirements explicitly ask for an icon-only button. Do NOT define the child component inline.",
-    ),
+    'child': componentId({
+      description:
+        "The ID of the child component. Use a 'Text' component for a labeled button. Only use an 'Icon' if the requirements explicitly ask for an icon-only button. Do NOT define the child component inline.",
+    }),
     'variant': z
       .enum(['default', 'primary', 'borderless'])
       .default('default')
@@ -401,7 +334,6 @@ export const ButtonApi = {
     'action': ActionSchema.optional(),
     ...CheckableSchema.shape,
   }),
->>>>>>> fb475a77 (fix(renderers): loosen client-side component validation to allow unknown properties)
 } satisfies ComponentApi;
 
 export const TextFieldApi = {

--- a/renderers/web_core/src/v0_9/processing/message-processor.test.ts
+++ b/renderers/web_core/src/v0_9/processing/message-processor.test.ts
@@ -1005,5 +1005,58 @@ describe('MessageProcessor', () => {
         },
       );
     });
+
+    it('accepts unrecognized component types without throwing validation errors', () => {
+      const knownButtonApi: ComponentApi = {
+        name: 'KnownButton',
+        schema: z.object({
+          label: z.string(),
+        }),
+      };
+
+      const proc = new MessageProcessor([new Catalog('cat-partial', [knownButtonApi])]);
+      proc.processMessages([
+        {
+          version: 'v0.9',
+          createSurface: {surfaceId: 's1', catalogId: 'cat-partial'},
+        },
+      ]);
+
+      // Process message containing both known and unknown component types
+      proc.processMessages([
+        {
+          version: 'v0.9',
+          updateComponents: {
+            surfaceId: 's1',
+            components: [
+              {
+                id: 'btn1',
+                component: 'KnownButton',
+                label: 'Save',
+              },
+              {
+                id: 'custom1',
+                component: 'UnknownGizmo',
+                arbitraryProp: 'someValue',
+                nested: {foo: 123},
+              } as any,
+            ],
+          },
+        },
+      ]);
+
+      const surface = proc.model.getSurface('s1');
+      assert.ok(surface);
+
+      const knownComp = surface.componentsModel.get('btn1');
+      assert.ok(knownComp);
+      assert.strictEqual(knownComp.type, 'KnownButton');
+      assert.strictEqual(knownComp.properties.label, 'Save');
+
+      const unknownComp = surface.componentsModel.get('custom1');
+      assert.ok(unknownComp);
+      assert.strictEqual(unknownComp.type, 'UnknownGizmo');
+      assert.strictEqual((unknownComp.properties as any).arbitraryProp, 'someValue');
+    });
   });
 });

--- a/renderers/web_core/src/v0_9/processing/message-processor.test.ts
+++ b/renderers/web_core/src/v0_9/processing/message-processor.test.ts
@@ -805,7 +805,49 @@ describe('MessageProcessor', () => {
       assert.strictEqual(formatZodIssue(issue), 'label: Expected string, received number');
     });
 
-    it('surfaces unrecognized property validation error and details when processing component updates', () => {
+    it('accepts and ignores unrecognized properties on components during processing (additionalProperties: true)', () => {
+      const strictButtonApi: ComponentApi = {
+        name: 'MaterialButton',
+        schema: z
+          .object({
+            label: z.string(),
+          })
+          .strict(),
+      };
+      const proc = new MessageProcessor([new Catalog('cat-m3', [strictButtonApi])]);
+      proc.processMessages([
+        {
+          version: 'v0.9',
+          createSurface: {surfaceId: 's1', catalogId: 'cat-m3'},
+        },
+      ]);
+
+      // Should succeed and not throw despite 'color' being an unrecognized property
+      proc.processMessages([
+        {
+          version: 'v0.9',
+          updateComponents: {
+            surfaceId: 's1',
+            components: [
+              {
+                id: 'btn1',
+                component: 'MaterialButton',
+                label: 'Submit',
+                color: 'primary',
+              } as any,
+            ],
+          },
+        },
+      ]);
+
+      const surface = proc.model.getSurface('s1');
+      const comp = surface?.componentsModel.get('btn1');
+      assert.ok(comp);
+      assert.strictEqual(comp.properties.label, 'Submit');
+      assert.strictEqual((comp.properties as any).color, 'primary');
+    });
+
+    it('still rejects invalid property types on components during processing', () => {
       const strictButtonApi: ComponentApi = {
         name: 'MaterialButton',
         schema: z
@@ -833,8 +875,8 @@ describe('MessageProcessor', () => {
                   {
                     id: 'btn1',
                     component: 'MaterialButton',
-                    label: 'Submit',
-                    color: 'primary',
+                    label: 123, // Invalid type
+                    color: 'primary', // Unrecognized property
                   } as any,
                 ],
               },
@@ -843,12 +885,9 @@ describe('MessageProcessor', () => {
         },
         (err: any) => {
           assert.ok(err instanceof A2uiValidationError);
-          assert.strictEqual(
-            err.message,
-            "Validation failed for component 'MaterialButton' (btn1): root: Unrecognized key(s) in object: 'color'",
-          );
-          assert.ok(Array.isArray(err.details));
-          assert.strictEqual(err.details[0].code, 'unrecognized_keys');
+          assert.ok(err.message.includes('Expected string, received number'));
+          assert.strictEqual(err.details.length, 1);
+          assert.strictEqual(err.details[0].code, 'invalid_type');
           return true;
         },
       );

--- a/renderers/web_core/src/v0_9/processing/message-processor.test.ts
+++ b/renderers/web_core/src/v0_9/processing/message-processor.test.ts
@@ -892,5 +892,118 @@ describe('MessageProcessor', () => {
         },
       );
     });
+
+    it('accepts unrecognized properties on component schemas with z.union of strict objects', () => {
+      const unionComponentApi: ComponentApi = {
+        name: 'VariantCard',
+        schema: z.union([
+          z
+            .object({
+              type: z.literal('simple'),
+              title: z.string(),
+            })
+            .strict(),
+          z
+            .object({
+              type: z.literal('advanced'),
+              title: z.string(),
+              rating: z.number(),
+            })
+            .strict(),
+        ]),
+      };
+
+      const proc = new MessageProcessor([new Catalog('cat-union', [unionComponentApi])]);
+      proc.processMessages([
+        {
+          version: 'v0.9',
+          createSurface: {surfaceId: 's1', catalogId: 'cat-union'},
+        },
+      ]);
+
+      // Simple variant with extra unrecognized properties
+      proc.processMessages([
+        {
+          version: 'v0.9',
+          updateComponents: {
+            surfaceId: 's1',
+            components: [
+              {
+                id: 'card1',
+                component: 'VariantCard',
+                type: 'simple',
+                title: 'Card 1',
+                extraProperty: 'should-be-ignored',
+                nestedInfo: {foo: 'bar'},
+              } as any,
+            ],
+          },
+        },
+      ]);
+
+      const surface = proc.model.getSurface('s1');
+      const comp = surface?.componentsModel.get('card1');
+      assert.ok(comp);
+      assert.strictEqual(comp.properties.type, 'simple');
+      assert.strictEqual(comp.properties.title, 'Card 1');
+      assert.strictEqual((comp.properties as any).extraProperty, 'should-be-ignored');
+    });
+
+    it('still rejects invalid union types when neither branch matches on valid properties', () => {
+      const unionComponentApi: ComponentApi = {
+        name: 'VariantCard',
+        schema: z.union([
+          z
+            .object({
+              type: z.literal('simple'),
+              title: z.string(),
+            })
+            .strict(),
+          z
+            .object({
+              type: z.literal('advanced'),
+              title: z.string(),
+              rating: z.number(),
+            })
+            .strict(),
+        ]),
+      };
+
+      const proc = new MessageProcessor([new Catalog('cat-union', [unionComponentApi])]);
+      proc.processMessages([
+        {
+          version: 'v0.9',
+          createSurface: {surfaceId: 's1', catalogId: 'cat-union'},
+        },
+      ]);
+
+      assert.throws(
+        () => {
+          proc.processMessages([
+            {
+              version: 'v0.9',
+              updateComponents: {
+                surfaceId: 's1',
+                components: [
+                  {
+                    id: 'card1',
+                    component: 'VariantCard',
+                    type: 'advanced',
+                    title: 12345, // Invalid type
+                    rating: 'not-a-number', // Invalid type
+                    extraProp: 'ignored',
+                  } as any,
+                ],
+              },
+            },
+          ]);
+        },
+        (err: any) => {
+          assert.ok(err instanceof A2uiValidationError);
+          assert.ok(err.message.includes("Validation failed for component 'VariantCard'"));
+          return true;
+        },
+      );
+    });
   });
 });

--- a/renderers/web_core/src/v0_9/processing/message-processor.test.ts
+++ b/renderers/web_core/src/v0_9/processing/message-processor.test.ts
@@ -16,7 +16,7 @@
 
 import * as assert from 'node:assert';
 import {describe, it, beforeEach} from 'node:test';
-import {MessageProcessor, formatZodIssue} from './message-processor.js';
+import {MessageProcessor, formatZodIssue, extractUnrecognizedKeys} from './message-processor.js';
 import {Catalog, ComponentApi} from '../catalog/types.js';
 import {CardApi, RowApi, TabsApi} from '../basic_catalog/components/basic_components.js';
 import {ButtonApi} from '../basic_catalog/index.js';
@@ -1057,6 +1057,37 @@ describe('MessageProcessor', () => {
       assert.ok(unknownComp);
       assert.strictEqual(unknownComp.type, 'UnknownGizmo');
       assert.strictEqual((unknownComp.properties as any).arbitraryProp, 'someValue');
+    });
+
+    it('extracts unrecognized keys recursively from direct schemas and invalid_union branches', () => {
+      // 1. Direct strict schema
+      const directStrict = z
+        .object({
+          name: z.string(),
+        })
+        .strict();
+      const directResult = directStrict.safeParse({name: 'Alice', extraA: 1, extraB: 2});
+      assert.strictEqual(directResult.success, false);
+      if (!directResult.success) {
+        const keys = extractUnrecognizedKeys(directResult.error.issues);
+        assert.deepStrictEqual(keys.sort(), ['extraA', 'extraB']);
+      }
+
+      // 2. Union with strict schema branch
+      const unionSchema = z.union([
+        z.string(),
+        z
+          .object({
+            path: z.string(),
+          })
+          .strict(),
+      ]);
+      const unionResult = unionSchema.safeParse({path: '/user/name', unexpectedProp: 'foo'});
+      assert.strictEqual(unionResult.success, false);
+      if (!unionResult.success) {
+        const keys = extractUnrecognizedKeys(unionResult.error.issues);
+        assert.deepStrictEqual(keys, ['unexpectedProp']);
+      }
     });
   });
 });

--- a/renderers/web_core/src/v0_9/processing/message-processor.ts
+++ b/renderers/web_core/src/v0_9/processing/message-processor.ts
@@ -92,6 +92,38 @@ export function formatZodIssue(err: z.ZodIssue): string {
 }
 
 /**
+ * Recursively filters out Zod validation issues that are solely caused by unrecognized keys
+ * (including inside z.union / discriminated union branches where extra keys on strict schemas cause invalid_union).
+ */
+export function filterZodRealIssues(issues: z.ZodIssue[]): z.ZodIssue[] {
+  return issues.filter(issue => {
+    // 1. Direct unrecognized_keys issues are ignored on the client
+    if (issue.code === 'unrecognized_keys') {
+      return false;
+    }
+
+    // 2. If a union failed, check whether at least one branch would have succeeded
+    //    if not for unrecognized keys.
+    if (
+      issue.code === 'invalid_union' &&
+      'unionErrors' in issue &&
+      Array.isArray((issue as any).unionErrors)
+    ) {
+      const unionErrors = (issue as any).unionErrors as z.ZodError[];
+      const hasMatchingBranch = unionErrors.some(branchError => {
+        const branchRealIssues = filterZodRealIssues(branchError.issues);
+        return branchRealIssues.length === 0;
+      });
+      if (hasMatchingBranch) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+/**
  * The central processor for A2UI messages.
  * @template T The concrete type of the ComponentApi.
  */
@@ -363,10 +395,8 @@ export class MessageProcessor<T extends ComponentApi> {
         if (componentApi) {
           const validationResult = componentApi.schema.safeParse(properties);
           if (!validationResult.success) {
-            // Client-side validation ignores unrecognized keys
-            const realIssues = validationResult.error.issues.filter(
-              issue => issue.code !== 'unrecognized_keys',
-            );
+            // Client-side validation ignores unrecognized keys (including inside z.union)
+            const realIssues = filterZodRealIssues(validationResult.error.issues);
             if (realIssues.length > 0) {
               const formattedErrors = realIssues.map(formatZodIssue).join(', ');
               console.error(

--- a/renderers/web_core/src/v0_9/processing/message-processor.ts
+++ b/renderers/web_core/src/v0_9/processing/message-processor.ts
@@ -124,6 +124,36 @@ export function filterZodRealIssues(issues: z.ZodIssue[]): z.ZodIssue[] {
 }
 
 /**
+ * Recursively extracts all unrecognized property keys from Zod issues,
+ * including those nested inside invalid_union branches.
+ */
+export function extractUnrecognizedKeys(issues: z.ZodIssue[]): string[] {
+  const keys: string[] = [];
+  for (const issue of issues) {
+    if (
+      issue.code === 'unrecognized_keys' &&
+      'keys' in issue &&
+      Array.isArray((issue as any).keys)
+    ) {
+      keys.push(...(issue as any).keys);
+    } else if (
+      issue.code === 'invalid_union' &&
+      'unionErrors' in issue &&
+      Array.isArray((issue as any).unionErrors)
+    ) {
+      const unionErrors = (issue as any).unionErrors as z.ZodError[];
+      // Find the branches where all failures were solely due to unrecognized keys
+      for (const branchError of unionErrors) {
+        if (filterZodRealIssues(branchError.issues).length === 0) {
+          keys.push(...extractUnrecognizedKeys(branchError.issues));
+        }
+      }
+    }
+  }
+  return Array.from(new Set(keys));
+}
+
+/**
  * The central processor for A2UI messages.
  * @template T The concrete type of the ComponentApi.
  */
@@ -392,9 +422,21 @@ export class MessageProcessor<T extends ComponentApi> {
       const componentType = component || existing?.type;
       if (componentType) {
         const componentApi = surface.catalog.components.get(componentType);
-        if (componentApi) {
+        if (!componentApi) {
+          console.warn(
+            `[A2UI] Unrecognized component type '${componentType}' (${id}) on surface '${payload.surfaceId}'.`,
+          );
+        } else {
           const validationResult = componentApi.schema.safeParse(properties);
           if (!validationResult.success) {
+            // Log warning for ignored unrecognized keys (including inside z.union)
+            const unrecognizedKeys = extractUnrecognizedKeys(validationResult.error.issues);
+            if (unrecognizedKeys.length > 0) {
+              console.warn(
+                `[A2UI] Ignored unrecognized property keys on component '${componentType}' (${id}): ${unrecognizedKeys.join(', ')}`,
+              );
+            }
+
             // Client-side validation ignores unrecognized keys (including inside z.union)
             const realIssues = filterZodRealIssues(validationResult.error.issues);
             if (realIssues.length > 0) {

--- a/renderers/web_core/src/v0_9/processing/message-processor.ts
+++ b/renderers/web_core/src/v0_9/processing/message-processor.ts
@@ -363,18 +363,24 @@ export class MessageProcessor<T extends ComponentApi> {
         if (componentApi) {
           const validationResult = componentApi.schema.safeParse(properties);
           if (!validationResult.success) {
-            const formattedErrors = validationResult.error.errors.map(formatZodIssue).join(', ');
-            console.error(
-              "[A2UI Validation Error] Component '" + componentType + "' (" + id + '):',
-              {
-                propertyKeys: Object.keys(properties),
-                issues: validationResult.error.issues,
-              },
+            // Client-side validation ignores unrecognized keys
+            const realIssues = validationResult.error.issues.filter(
+              issue => issue.code !== 'unrecognized_keys',
             );
-            throw new A2uiValidationError(
-              `Validation failed for component '${componentType}' (${id}): ${formattedErrors}`,
-              validationResult.error.issues,
-            );
+            if (realIssues.length > 0) {
+              const formattedErrors = realIssues.map(formatZodIssue).join(', ');
+              console.error(
+                "[A2UI Validation Error] Component '" + componentType + "' (" + id + '):',
+                {
+                  propertyKeys: Object.keys(properties),
+                  issues: realIssues,
+                },
+              );
+              throw new A2uiValidationError(
+                `Validation failed for component '${componentType}' (${id}): ${formattedErrors}`,
+                realIssues,
+              );
+            }
           }
         }
       }

--- a/renderers/web_core/src/v0_9/rendering/data-context.test.ts
+++ b/renderers/web_core/src/v0_9/rendering/data-context.test.ts
@@ -541,5 +541,31 @@ describe('DataContext', () => {
       assert.strictEqual((dispatchedError as any).code, 'EXPRESSION_ERROR');
       assert.strictEqual((dispatchedError as any).message, 'Generic inner failure');
     });
+
+    it('gracefully handles unrecognized function call by dispatching EXPRESSION_ERROR and returning undefined', () => {
+      let dispatchedError: any = null;
+      const catalogId = 'test-catalog';
+      const invoker = (name: string) => {
+        throw new A2uiExpressionError(
+          `Function not found in catalog '${catalogId}': ${name}`,
+          name,
+        );
+      };
+      const ctx = createTestDataContext(model, '/', invoker, err => {
+        dispatchedError = err;
+      });
+
+      const result = ctx.resolveDynamicValue({
+        call: 'nonExistentHelper',
+        args: {a: 1},
+        returnType: 'string',
+      });
+
+      assert.strictEqual(result, undefined);
+      assert.ok(dispatchedError);
+      assert.strictEqual(dispatchedError.code, 'EXPRESSION_ERROR');
+      assert.strictEqual(dispatchedError.expression, 'nonExistentHelper');
+      assert.ok(dispatchedError.message.includes("Function not found in catalog 'test-catalog'"));
+    });
   });
 });

--- a/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
+++ b/renderers/web_core/src/v0_9/rendering/generic-binder.test.ts
@@ -317,4 +317,27 @@ describe('GenericBinder Checkable Trait', () => {
     };
     assert.strictEqual(notificationCount, 1);
   });
+
+  it('should pass through unrecognized properties as static values into snapshot', () => {
+    const {surface} = setupSurfaceAndMocks();
+    const schema = z.object({
+      label: CommonSchemas.DynamicString,
+    });
+
+    const compModel = new ComponentModel('c9', 'Test', {
+      label: 'Submit',
+      unrecognizedString: 'foo',
+      unrecognizedObject: {nested: 'bar'},
+      unrecognizedNumber: 42,
+    });
+    surface.componentsModel.addComponent(compModel);
+
+    const context = new ComponentContext(surface, 'c9');
+    const binder = new GenericBinder<any>(context, schema);
+
+    assert.strictEqual(binder.snapshot.label, 'Submit');
+    assert.strictEqual(binder.snapshot.unrecognizedString, 'foo');
+    assert.deepStrictEqual(binder.snapshot.unrecognizedObject, {nested: 'bar'});
+    assert.strictEqual(binder.snapshot.unrecognizedNumber, 42);
+  });
 });

--- a/swift/core/Sources/A2UICore/Processing/MessageProcessor.swift
+++ b/swift/core/Sources/A2UICore/Processing/MessageProcessor.swift
@@ -407,38 +407,58 @@ public final class MessageProcessor: ObservableObject {
 
       let componentCatalogID = componentDict["catalogId"]?.stringValue ?? surface.defaultCatalogID
       let targetCatalog = surface.getCatalog(id: componentCatalogID)
-      guard let schema = targetCatalog?.components[type]?.schema else {
-        let error = ClientServerError.validationFailed(
-          ValidationFailedError(
-            surfaceID: surfaceID,
-            path: "/component",
-            message: "Unknown component type '\(type)' not registered in catalog"
+      let componentAPI = targetCatalog?.components[type]
+
+      if let schema = componentAPI?.schema {
+        let instance: JSONValue = .object(
+          OrderedDictionary(
+            uniqueKeysWithValues: componentDict.map { ($0.key, $0.value) }
           )
         )
-        actionHandler?.handle(error: error, from: surfaceID)
-        return
+        let result = schema.validate(instance)
+        guard result.isValid else {
+          let specificError = result.errors?.first.map(mostSpecificError(from:))
+          let errorMessage = specificError?.message ?? "Validation failed"
+          let errorPath = specificError?.instanceLocation.jsonPointerString ?? "/"
+          let error = ClientServerError.validationFailed(
+            ValidationFailedError(
+              surfaceID: surfaceID,
+              path: errorPath.isEmpty ? "/" : errorPath,
+              message: errorMessage
+            )
+          )
+          actionHandler?.handle(error: error, from: surfaceID)
+          return
+        }
+      } else {
+        print("[A2UI] Warning: Unrecognized component type '\(type)' (\(id)) on surface '\(surfaceID)'.")
       }
 
-      let instance: JSONValue = .object(
-        OrderedDictionary(
-          uniqueKeysWithValues: componentDict.map { ($0.key, $0.value) }
-        )
-      )
-      let result = schema.validate(instance)
-      guard result.isValid else {
-        let specificError = result.errors?.first.map(mostSpecificError(from:))
-        let errorMessage = specificError?.message ?? "Validation failed"
-        let errorPath = specificError?.instanceLocation.jsonPointerString ?? "/"
-        let error = ClientServerError.validationFailed(
-          ValidationFailedError(
-            surfaceID: surfaceID,
-            path: errorPath.isEmpty ? "/" : errorPath,
-            message: errorMessage
-          )
-        )
-        actionHandler?.handle(error: error, from: surfaceID)
-        return
+      var props: [String: JSONValue] = [:]
+      for (key, val) in componentDict
+      where key != "id" && key != "component" && key != "catalogId" {
+        props[key] = val
       }
+
+      if let componentAPI {
+        if let schemaJSON = schemaToJSONValue(componentAPI.schema),
+          let knownProps = schemaJSON["properties"]?.objectValue {
+          let unrecognizedKeys = props.keys.filter { !knownProps.keys.contains($0) }
+          if !unrecognizedKeys.isEmpty {
+            print(
+              "[A2UI] Warning: Ignored unrecognized property keys on component '\(type)' (\(id)): \(unrecognizedKeys.joined(separator: ", "))"
+            )
+          }
+        }
+      }
+
+      let existing = surface.componentsModel.get(id)
+      if let existing, existing.type != type {
+        surface.componentsModel.removeComponent(id)
+      }
+      surface.componentsModel.addComponent(
+        ComponentModel(id: id, type: type, catalogID: componentCatalogID, properties: props)
+      )
     }
 
     // Pass 2: Mutation Pass

--- a/swift/core/Sources/A2UICore/Processing/MessageProcessor.swift
+++ b/swift/core/Sources/A2UICore/Processing/MessageProcessor.swift
@@ -451,14 +451,6 @@ public final class MessageProcessor: ObservableObject {
           }
         }
       }
-
-      let existing = surface.componentsModel.get(id)
-      if let existing, existing.type != type {
-        surface.componentsModel.removeComponent(id)
-      }
-      surface.componentsModel.addComponent(
-        ComponentModel(id: id, type: type, catalogID: componentCatalogID, properties: props)
-      )
     }
 
     // Pass 2: Mutation Pass

--- a/swift/core/Tests/A2UICoreTests/DataContextTests.swift
+++ b/swift/core/Tests/A2UICoreTests/DataContextTests.swift
@@ -106,6 +106,24 @@ struct DataContextTests {
     #expect(context.resolveDynamicValue(literalWithCall) == literalWithCall)
     #expect(mockHandler.lastRequestedName == nil)
   }
+
+  @Test func resolveDynamicValueToleratesUnrecognizedFunctionReturnsNull() {
+    let mockHandler = MockFunctionHandler()
+    mockHandler.functionToReturn = nil
+    let dataModel = DataModel()
+    let context = DataContext(dataModel: dataModel, path: "/", functionHandler: mockHandler)
+
+    let functionBinding: JSONValue = [
+      "call": "unrecognizedFunction",
+      "args": [
+        "a": "Hello"
+      ]
+    ]
+
+    let result = context.resolveDynamicValue(functionBinding)
+    #expect(mockHandler.lastRequestedName == "unrecognizedFunction")
+    #expect(result == .null)
+  }
 }
 
 private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {

--- a/swift/core/Tests/A2UICoreTests/MessageProcessorTests.swift
+++ b/swift/core/Tests/A2UICoreTests/MessageProcessorTests.swift
@@ -341,6 +341,56 @@ struct MessageProcessorTests {
     #expect(comp?.properties["customMetadata"]?.intValue == 123)
   }
 
+  @Test func processUpdateComponentsWithUnrecognizedComponentType() throws {
+    let (processor, handler) = try makeProcessor()
+    processor.process(
+      message: try parse(
+        """
+        {
+          "version": "v0.9.1",
+          "createSurface": {
+            "surfaceId": "s1",
+            "catalogId": "default"
+          }
+        }
+        """))
+    processor.process(
+      message: try parse(
+        """
+        {
+          "version": "v0.9.1",
+          "updateComponents": {
+            "surfaceId": "s1",
+            "components": [
+              {
+                "id": "known1",
+                "component": "text",
+                "text": "Known Text"
+              },
+              {
+                "id": "unknown1",
+                "component": "FutureUnregisteredGizmo",
+                "customData": "abc",
+                "count": 42
+              }
+            ]
+          }
+        }
+        """))
+    #expect(handler.capturedErrors.isEmpty)
+    let vm = processor.surfaceGroupModel.surfacesMap["s1"]
+    let knownComp = vm?.componentsModel.components["known1"]
+    #expect(knownComp != nil)
+    #expect(knownComp?.type == "text")
+    #expect(knownComp?.properties["text"]?.stringValue == "Known Text")
+
+    let unknownComp = vm?.componentsModel.components["unknown1"]
+    #expect(unknownComp != nil)
+    #expect(unknownComp?.type == "FutureUnregisteredGizmo")
+    #expect(unknownComp?.properties["customData"]?.stringValue == "abc")
+    #expect(unknownComp?.properties["count"]?.intValue == 42)
+  }
+
   @Test func processUpdateComponentsValidBatch() throws {
     let (processor, handler) = try makeProcessor()
     processor.process(

--- a/swift/core/Tests/A2UICoreTests/MessageProcessorTests.swift
+++ b/swift/core/Tests/A2UICoreTests/MessageProcessorTests.swift
@@ -300,6 +300,47 @@ struct MessageProcessorTests {
     #expect(components?["root"] != nil)
   }
 
+  @Test func processUpdateComponentsWithUnrecognizedPropertiesSucceeds() throws {
+    let (processor, handler) = try makeProcessor()
+    processor.process(
+      message: try parse(
+        """
+        {
+          "version": "v0.9.1",
+          "createSurface": {
+            "surfaceId": "s1",
+            "catalogId": "default"
+          }
+        }
+        """))
+    processor.process(
+      message: try parse(
+        """
+        {
+          "version": "v0.9.1",
+          "updateComponents": {
+            "surfaceId": "s1",
+            "components": [
+              {
+                "id": "root",
+                "component": "text",
+                "text": "Hello",
+                "unknownField": "ignoredValue",
+                "customMetadata": 123
+              }
+            ]
+          }
+        }
+        """))
+    #expect(handler.capturedErrors.isEmpty)
+    let vm = processor.surfaceGroupModel.surfacesMap["s1"]
+    let comp = vm?.componentsModel.components["root"]
+    #expect(comp != nil)
+    #expect(comp?.properties["text"]?.stringValue == "Hello")
+    #expect(comp?.properties["unknownField"]?.stringValue == "ignoredValue")
+    #expect(comp?.properties["customMetadata"]?.intValue == 123)
+  }
+
   @Test func processUpdateComponentsValidBatch() throws {
     let (processor, handler) = try makeProcessor()
     processor.process(

--- a/swift/core/Tests/A2UICoreTests/SurfaceViewModelTests.swift
+++ b/swift/core/Tests/A2UICoreTests/SurfaceViewModelTests.swift
@@ -443,6 +443,26 @@ struct SurfaceViewModelTests {
     #expect(funcCallJSON["call"]?.stringValue == "submit")
   }
 
+  @Test func resolvePropertyWithUnrecognizedFunctionDoesNotCrash() throws {
+    let (processor, surface, _) = try makeProcessor()
+    processor.updateComponents(
+      surfaceID: surface.surfaceID,
+      components: [
+        [
+          "id": "root",
+          "component": "button",
+          "label": [
+            "call": "unrecognizedFunction",
+            "args": ["param": "val"],
+          ],
+        ]
+      ]
+    )
+    let node = surface.resolveNode(instanceID: "root")
+    #expect(node != nil)
+    #expect(node?.type == "button")
+  }
+
   // MARK: - Child List Resolution (Static)
 
   @Test func childListResolvesStaticArray() throws {

--- a/swift/core/Tests/A2UICoreTests/SurfaceViewModelTests.swift
+++ b/swift/core/Tests/A2UICoreTests/SurfaceViewModelTests.swift
@@ -443,7 +443,7 @@ struct SurfaceViewModelTests {
     #expect(funcCallJSON["call"]?.stringValue == "submit")
   }
 
-  @Test func resolvePropertyWithUnrecognizedFunctionDoesNotCrash() throws {
+  @Test func resolvePropertyWithUnrecognizedFunctionDoesNotCrash() async throws {
     let (processor, surface, _) = try makeProcessor()
     processor.updateComponents(
       surfaceID: surface.surfaceID,
@@ -458,7 +458,8 @@ struct SurfaceViewModelTests {
         ]
       ]
     )
-    let node = surface.resolveNode(instanceID: "root")
+    await Task.yield()
+    let node = surface.rootNode
     #expect(node != nil)
     #expect(node?.type == "button")
   }

--- a/swift/core/Tests/A2UICoreTests/SurfaceViewModelTests.swift
+++ b/swift/core/Tests/A2UICoreTests/SurfaceViewModelTests.swift
@@ -569,7 +569,7 @@ struct SurfaceViewModelTests {
     // by updateComponents would have infinite-looped without the guard.
     // rootNode resolves from "root" — but we only have "a" and "b", so
     // it will be nil. The key assertion is that we didn't hang.
-    #expect(true)
+    #expect(Bool(true))
   }
 
   @Test func legitimateDataDrivenRecursionResolves() throws {
@@ -608,7 +608,7 @@ struct SurfaceViewModelTests {
     // If we get here without hanging, the guard correctly allowed
     // legitimate recursion. Each nested "card" gets a unique
     // instanceID (card_0, card_0_0, etc.) so the guard never triggers.
-    #expect(true)
+    #expect(Bool(true))
   }
 }
 

--- a/swift/core/Tests/A2UICoreTests/SurfaceViewModelTests.swift
+++ b/swift/core/Tests/A2UICoreTests/SurfaceViewModelTests.swift
@@ -155,15 +155,16 @@ struct SurfaceViewModelTests {
     }
   }
 
-  @Test func updateComponentsRejectsUnknownType() throws {
-    let (processor, _, handler) = try makeProcessor()
+  @Test func updateComponentsToleratesUnknownType() throws {
+    let (processor, surface, handler) = try makeProcessor()
     processor.updateComponents(
       surfaceID: "test-surface",
       components: [
         ["id": "root", "component": "unknown_type"]
       ]
     )
-    #expect(handler.capturedErrors.count == 1)
+    #expect(handler.capturedErrors.isEmpty)
+    #expect(surface.componentsModel.get("root")?.type == "unknown_type")
   }
 
   @Test func updateComponentsRecreatesOnTypeChange() throws {
@@ -183,9 +184,7 @@ struct SurfaceViewModelTests {
         ["id": "root", "component": "text"]
       ]
     )
-    // The component should not be stored since "text" isn't in the catalog
-    // but the key point is that the old "button" component should be removed
-    // before attempting to store the new one (matching web_core behavior).
+    #expect(surface.componentsModel.get("root")?.type == "text")
   }
 
   // MARK: - Data Model Updates

--- a/swift/swiftui/Tests/A2UISwiftUITests/A2UISwiftUITests.swift
+++ b/swift/swiftui/Tests/A2UISwiftUITests/A2UISwiftUITests.swift
@@ -288,10 +288,7 @@ struct CatalogImplementationTests {
   }
 
   @Test func renderUnrecognizedComponentReturnsNil() {
-    let catalogImplementation = CatalogImplementation(
-      catalogID: "default",
-      components: []
-    )
+    let catalogImplementation = CatalogImplementation()
     let node = Node(
       id: "unknown1",
       type: "unrecognizedFutureWidget",
@@ -299,8 +296,7 @@ struct CatalogImplementationTests {
       properties: [:]
     )
     let renderedView = Surface.render(node: node, using: catalogImplementation)
-    let isNil = (renderedView == nil)
-    #expect(isNil)
+    #expect(renderedView == nil)
   }
 
   @Test func catalogImplementationEnvironmentDefaultsToNil() {

--- a/swift/swiftui/Tests/A2UISwiftUITests/A2UISwiftUITests.swift
+++ b/swift/swiftui/Tests/A2UISwiftUITests/A2UISwiftUITests.swift
@@ -296,7 +296,8 @@ struct CatalogImplementationTests {
       properties: [:]
     )
     let renderedView = Surface.render(node: node, using: catalogImplementation)
-    #expect(renderedView == nil)
+    let isNil = (renderedView == nil)
+    #expect(isNil)
   }
 
   @Test func catalogImplementationEnvironmentDefaultsToNil() {

--- a/swift/swiftui/Tests/A2UISwiftUITests/A2UISwiftUITests.swift
+++ b/swift/swiftui/Tests/A2UISwiftUITests/A2UISwiftUITests.swift
@@ -289,6 +289,12 @@ struct CatalogImplementationTests {
 
   @Test func renderUnrecognizedComponentReturnsNil() {
     let catalogImplementation = CatalogImplementation()
+    let builder = catalogImplementation.builder(
+      catalogID: "default",
+      type: "unrecognizedFutureWidget"
+    )
+    #expect(builder == nil)
+
     let node = Node(
       id: "unknown1",
       type: "unrecognizedFutureWidget",
@@ -296,8 +302,11 @@ struct CatalogImplementationTests {
       properties: [:]
     )
     let renderedView = Surface.render(node: node, using: catalogImplementation)
-    let isNil = (renderedView == nil)
-    #expect(isNil)
+    if case .none = renderedView {
+      #expect(Bool(true))
+    } else {
+      #expect(Bool(false))
+    }
   }
 
   @Test func catalogImplementationEnvironmentDefaultsToNil() {

--- a/swift/swiftui/Tests/A2UISwiftUITests/A2UISwiftUITests.swift
+++ b/swift/swiftui/Tests/A2UISwiftUITests/A2UISwiftUITests.swift
@@ -299,7 +299,8 @@ struct CatalogImplementationTests {
       properties: [:]
     )
     let renderedView = Surface.render(node: node, using: catalogImplementation)
-    #expect(renderedView == nil)
+    let isNil = (renderedView == nil)
+    #expect(isNil)
   }
 
   @Test func catalogImplementationEnvironmentDefaultsToNil() {

--- a/swift/swiftui/Tests/A2UISwiftUITests/A2UISwiftUITests.swift
+++ b/swift/swiftui/Tests/A2UISwiftUITests/A2UISwiftUITests.swift
@@ -287,6 +287,21 @@ struct CatalogImplementationTests {
     #expect(builderCalled)
   }
 
+  @Test func renderUnrecognizedComponentReturnsNil() {
+    let catalogImplementation = CatalogImplementation(
+      catalogID: "default",
+      components: []
+    )
+    let node = Node(
+      id: "unknown1",
+      type: "unrecognizedFutureWidget",
+      catalogID: "default",
+      properties: [:]
+    )
+    let renderedView = Surface.render(node: node, using: catalogImplementation)
+    #expect(renderedView == nil)
+  }
+
   @Test func catalogImplementationEnvironmentDefaultsToNil() {
     let environment = EnvironmentValues()
     #expect(environment.a2uiCatalogImplementation == nil)


### PR DESCRIPTION
## Summary

Loosens client-side component schema validation across renderers so that messages containing unrecognized properties (such as older conversation history or forward-compatible properties) render without throwing validation errors. Agent-side payload validation remains strict (`additionalProperties: false`).

## Changes

- **`@a2ui/web_core`**:
  - Removed `.strict()` from all basic component Zod schemas (`TextApi`, `ButtonApi`, `TextFieldApi`, `SliderApi`, etc.).
  - Updated `MessageProcessor.processUpdateComponentsMessage` to filter out `unrecognized_keys` Zod validation issues while continuing to reject invalid property types.
  - Verified `GenericBinder` treats unrecognized properties as static values in reactive snapshots.
- **Renderers & Framework Adapters**:
  - Verified and tested that `@a2ui/react`, `@a2ui/lit`, `@a2ui/angular`, and `A2UISwiftUI` tolerate unrecognized component properties without rendering or lifecycle issues.
- **Tests**:
  - Added unit and integration tests across `@a2ui/web_core`, `@a2ui/react`, `@a2ui/lit`, `@a2ui/angular`, and `swift/core`.
- **Documentation**:
  - Updated `CHANGELOG.md` files for `@a2ui/web_core`, `@a2ui/angular`, `@a2ui/lit`, and `@a2ui/react`.

## Verification

- `yarn test:all`: All workspace test suites passed.
- `yarn lint:all`: Linters passed.
- `yarn format:check:all`: Formatting checks passed.