### PR TITLE
fix(swift): resolve only top-level path and call objects as bindings

### DIFF
--- a/swift/core/Sources/A2UICore/State/DataContext.swift
+++ b/swift/core/Sources/A2UICore/State/DataContext.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import Foundation
-import OrderedCollections
 import OrderedJSON
 
 /// Transient object created on-demand during rendering to solve "scope"
@@ -46,6 +45,10 @@ public final class DataContext: @unchecked Sendable {
   }
 
   /// Resolves a dynamic value to its current literal `JSONValue`.
+  ///
+  /// Only a top-level `path` or `call` object is a binding; any other value,
+  /// including containers with nested `path`/`call` keys, passes through
+  /// unchanged.
   public func resolveDynamicValue(_ value: JSONValue) -> JSONValue {
     switch value {
     case .object(let dict):
@@ -72,14 +75,7 @@ public final class DataContext: @unchecked Sendable {
         }
       }
 
-      var resolvedDict = OrderedDictionary<String, JSONValue>()
-      for (k, v) in dict {
-        resolvedDict[k] = resolveDynamicValue(v)
-      }
-
-      return .object(resolvedDict)
-    case .array(let arr):
-      return .array(arr.map { resolveDynamicValue($0) })
+      return value
     default:
       return value
     }

--- a/swift/core/Tests/A2UICoreTests/DataContextTests.swift
+++ b/swift/core/Tests/A2UICoreTests/DataContextTests.swift
@@ -88,24 +88,23 @@ struct DataContextTests {
     #expect(result.stringValue == "Hello, World!")
   }
   
-  @Test func resolveDynamicValueRecursesIntoArraysAndDictionaries() {
+  @Test func resolveDynamicValuePassesThroughNonBindingContainers() {
     let mockHandler = MockFunctionHandler()
     let dataModel = DataModel()
     dataModel.set("/item", value: "apple")
     let context = DataContext(dataModel: dataModel, path: "/", functionHandler: mockHandler)
-    
-    let complexBinding: JSONValue = [
+
+    let literalObject: JSONValue = [
       "list": [
         "static",
-        ["path": "item"]
+        ["path": "item"],
       ]
     ]
-    
-    let result = context.resolveDynamicValue(complexBinding)
-    let list = result["list"]?.arrayValue
-    #expect(list?.count == 2)
-    #expect(list?[0].stringValue == "static")
-    #expect(list?[1].stringValue == "apple")
+    #expect(context.resolveDynamicValue(literalObject) == literalObject)
+
+    let literalWithCall: JSONValue = ["config": ["call": "concat"]]
+    #expect(context.resolveDynamicValue(literalWithCall) == literalWithCall)
+    #expect(mockHandler.lastRequestedName == nil)
   }
 }
 


### PR DESCRIPTION
`DataContext.resolveDynamicValue` recursed into every plain object and array, treating any nested `"path"` or `"call"` key as a binding. Two consequences for legal payloads:

- Inside a function-call argument (the one place the schema admits literal objects), an object that merely contains a `"path"` string key was rewritten by a data-model lookup: `{"icon": {"path": "M12 2L2 7"}}` resolved to `{"icon": null}`. Elements of literal arrays got the same treatment everywhere arrays are legal.
- A nested `"call"` key executed its catalog function during value resolution, so a function embedded in a literal ran on every tree rebuild, meaning on every data update, rather than when something invoked it.

`resolveDynamicValue` now treats only a top-level `"path"` or `"call"` object as a binding and passes every other value through unchanged. This is compliant with the schema, which restricts values to single `DynamicValue` types and "prevents arbitrary nesting."

## Pre-launch Checklist

One time:

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] I have built and run at least one [sample].

For this PR:

- [x] I have updated the relevant CHANGELOG.md file.
- [x] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [x] If my branch is on a fork, I have verified that [scripts/e2e_test.sh](https://github.com/a2ui-project/a2ui/blob/main/scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CLA]: https://cla.developers.google.com/
[Contributors Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md
[discussion board]: https://github.com/a2ui-project/a2ui/discussions
[Style Guide]: https://github.com/a2ui-project/a2ui/blob/main/CONTRIBUTING.md#coding-style
[sample]: https://github.com/a2ui-project/a2ui/blob/main/samples/README.md#samples
