### PR TITLE
refactor(core): rename spec_version to protocol_version globally

### DIFF
--- a/.agents/skills/a2ui-generate-pydantic-models/scripts/catalog_generators.py
+++ b/.agents/skills/a2ui-generate-pydantic-models/scripts/catalog_generators.py
@@ -465,14 +465,17 @@ def generate_basic_catalog_index(
     )
 
     cat_init.extend([
-        f"from ...schema.{dir_name}.constants import SPEC_VERSION, SPEC_BASE_URL",
+        (
+            f"from ...schema.{dir_name}.constants import PROTOCOL_VERSION,"
+            " PROTOCOL_BASE_URL"
+        ),
         "from ...catalog import Catalog, ModelComponentApi, FunctionImplementation",
         "",
         "",
-        "def _basic_catalog_id(spec_version: str) -> str:",
+        "def _basic_catalog_id(protocol_version: str) -> str:",
         "    return (",
         (
-            "        f\"{SPEC_BASE_URL}/{spec_version.replace('.',"
+            "        f\"{PROTOCOL_BASE_URL}/{protocol_version.replace('.',"
             " '_')}/catalogs/basic/catalog.json\""
         ),
         "    )",
@@ -482,8 +485,8 @@ def generate_basic_catalog_index(
         "",
         "    def __init__(self, locale: Optional[str] = None):",
         f"{lazy_func_import}        super().__init__(",
-        "            catalog_id=_basic_catalog_id(SPEC_VERSION),",
-        "            spec_version=SPEC_VERSION,",
+        "            catalog_id=_basic_catalog_id(PROTOCOL_VERSION),",
+        "            protocol_version=PROTOCOL_VERSION,",
         "            components=BASIC_COMPONENTS,",
         f"            functions={functions_arg},",
         f"{theme_arg_line}        )",
@@ -496,7 +499,7 @@ def generate_basic_catalog_index(
             "def __getattr__(name: str) -> Any:",
             "    if name == 'BASIC_FUNCTION_IMPLEMENTATIONS':",
             "        from ..function_impls import create_basic_catalog_functions",
-            "        return create_basic_catalog_functions(SPEC_VERSION)",
+            "        return create_basic_catalog_functions(PROTOCOL_VERSION)",
             "    if name == 'create_basic_catalog_functions':",
             "        from .. import function_impls",
             "        return getattr(function_impls, name)",

--- a/.agents/skills/a2ui-generate-pydantic-models/scripts/codegen_pydantic.py
+++ b/.agents/skills/a2ui-generate-pydantic-models/scripts/codegen_pydantic.py
@@ -79,8 +79,8 @@ def _generate_constants_code(
         FILE_HEADER,
         "from typing import Final, Literal",
         "",
-        f'SPEC_VERSION: Final[Literal["{spec_dot}"]] = "{spec_dot}"',
-        f'SPEC_VERSION_TYPE = Literal["{spec_dot}"]',
+        f'PROTOCOL_VERSION: Final[Literal["{spec_dot}"]] = "{spec_dot}"',
+        f'PROTOCOL_VERSION_TYPE = Literal["{spec_dot}"]',
         "",
         'ROOT_ID = "root"',
         'CATALOG_COMPONENTS_KEY = "components"',
@@ -112,7 +112,7 @@ def _generate_constants_code(
         lines.append('THEME_KEY = "theme"')
         lines.append('STYLES_KEY = "styles"')
 
-    lines.append('SPEC_BASE_URL = "https://a2ui.org/specification"')
+    lines.append('PROTOCOL_BASE_URL = "https://a2ui.org/specification"')
     lines.append("")
 
     # Outbound message type constants

--- a/.agents/skills/a2ui-generate-pydantic-models/scripts/schema_generators.py
+++ b/.agents/skills/a2ui-generate-pydantic-models/scripts/schema_generators.py
@@ -299,7 +299,7 @@ def generate_agent_to_renderer(
             "from typing import Any, Dict, List, Literal, Optional, Union\n"
             "from pydantic import BaseModel, Field, ConfigDict\n"
             + a2r_imports
-            + "from .constants import SPEC_VERSION, SPEC_VERSION_TYPE"
+            + "from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE"
         ),
         "ComponentsList = List[Dict[str, Any]]\nComponent = Dict[str, Any]",
     ]
@@ -326,7 +326,7 @@ def generate_agent_to_renderer(
             alias_opt = f', alias="{envelope_key}"' if snake_env != envelope_key else ""
             a2r_blocks.append(
                 f"class {mname}(StrictBaseModel):\n"
-                "    version: SPEC_VERSION_TYPE = SPEC_VERSION\n"
+                "    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION\n"
                 f"    {snake_env}: {payload_name} = Field(...{alias_opt})"
             )
             msg_names.append(mname)
@@ -341,7 +341,7 @@ def generate_agent_to_renderer(
             alias_opt = f', alias="{key}"' if snake_env != key else ""
             a2r_blocks.append(
                 f"class {mname}(StrictBaseModel):\n"
-                "    version: SPEC_VERSION_TYPE = SPEC_VERSION\n"
+                "    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION\n"
                 f"    {snake_env}: {payload_name} = Field(...{alias_opt})"
             )
             msg_names.append(mname)
@@ -422,7 +422,7 @@ def generate_renderer_to_agent(
         "from typing import Any, Dict, List, Literal, Optional, Union\n"
         "from pydantic import BaseModel, Field, ConfigDict\n"
         + r2a_imports
-        + "from .constants import SPEC_VERSION, SPEC_VERSION_TYPE",
+        + "from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE",
     ]
     r2a_names: List[str] = []
     msg_union_members: List[str] = []
@@ -445,7 +445,7 @@ def generate_renderer_to_agent(
                 alias_opt = f', alias="{prop_name}"' if snake_prop != prop_name else ""
                 r2a_blocks.append(
                     f"class {msg_cls}(StrictBaseModel):\n"
-                    "    version: SPEC_VERSION_TYPE = SPEC_VERSION\n"
+                    "    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION\n"
                     f"    {snake_prop}: A2uiRendererAction = Field(...{alias_opt})"
                 )
                 msg_union_members.append(msg_cls)
@@ -470,7 +470,7 @@ def generate_renderer_to_agent(
                 alias_opt = f', alias="{prop_name}"' if snake_prop != prop_name else ""
                 r2a_blocks.append(
                     f"class {msg_cls}(StrictBaseModel):\n"
-                    "    version: SPEC_VERSION_TYPE = SPEC_VERSION\n"
+                    "    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION\n"
                     f"    {snake_prop}: A2uiClientAction = Field(...{alias_opt})"
                 )
                 r2a_blocks.append(
@@ -540,7 +540,7 @@ def generate_renderer_to_agent(
             err_type = "A2uiRendererError"
             r2a_blocks.append(
                 f"class {msg_cls}(StrictBaseModel):\n"
-                "    version: SPEC_VERSION_TYPE = SPEC_VERSION\n"
+                "    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION\n"
                 f"    {snake_prop}: {err_type} = Field(...)"
             )
             msg_union_members.append(msg_cls)
@@ -560,7 +560,7 @@ def generate_renderer_to_agent(
             alias_opt = f', alias="{prop_name}"' if snake_prop != prop_name else ""
             r2a_blocks.append(
                 f"class {msg_cls}(StrictBaseModel):\n"
-                "    version: SPEC_VERSION_TYPE = SPEC_VERSION\n"
+                "    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION\n"
                 f"    {snake_prop}: {payload_type} = Field(...{alias_opt})"
             )
             msg_union_members.append(msg_cls)
@@ -572,8 +572,9 @@ def generate_renderer_to_agent(
         r2a_blocks.append(f"RendererToAgentMessage = {union_def}")
         r2a_blocks.append(
             "class A2uiRendererDataModel(StrictBaseModel):\n    version:"
-            " SPEC_VERSION_TYPE = SPEC_VERSION\n    surfaces: Dict[str, Dict[str, Any]]"
-            ' = Field(..., description="A map of surface IDs to data models.")'
+            " PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION\n    surfaces: Dict[str,"
+            ' Dict[str, Any]] = Field(..., description="A map of surface IDs to data'
+            ' models.")'
         )
         r2a_blocks.append("RendererToAgentMessageList = List[RendererToAgentMessage]")
         r2a_blocks.append(
@@ -600,8 +601,9 @@ def generate_renderer_to_agent(
         ])
         r2a_blocks.append(
             "class A2uiClientDataModel(StrictBaseModel):\n    version:"
-            " SPEC_VERSION_TYPE = SPEC_VERSION\n    surfaces: Dict[str, Dict[str, Any]]"
-            ' = Field(..., description="A map of surface IDs to data models.")'
+            " PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION\n    surfaces: Dict[str,"
+            ' Dict[str, Any]] = Field(..., description="A map of surface IDs to data'
+            ' models.")'
         )
         r2a_blocks.append(f"A2uiClientMessageList = List[ClientToServerMessage]")
         r2a_blocks.append(
@@ -637,7 +639,7 @@ def generate_renderer_capabilities(
             "from typing import Any, Dict, List, Literal, Optional\n"
             "from pydantic import BaseModel, Field, ConfigDict\n"
             f"from {common_mod} import StrictBaseModel\n"
-            "from .constants import SPEC_VERSION, SPEC_VERSION_TYPE"
+            "from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE"
         ),
     ]
 
@@ -737,12 +739,12 @@ def generate_renderer_capabilities(
     if is_modern:
         caps_blocks.append(
             f"class A2uiRendererCapabilities(StrictBaseModel):\n    {dir_name}:"
-            f" Optional[{cap_cls_name}] = Field(None, alias=SPEC_VERSION)"
+            f" Optional[{cap_cls_name}] = Field(None, alias=PROTOCOL_VERSION)"
         )
     else:
         caps_blocks.append(
             f"class A2uiClientCapabilities(StrictBaseModel):\n    {dir_name}:"
-            f" Optional[{cap_cls_name}] = Field(None, alias=SPEC_VERSION)"
+            f" Optional[{cap_cls_name}] = Field(None, alias=PROTOCOL_VERSION)"
         )
         caps_blocks.append("A2uiRendererCapabilities = A2uiClientCapabilities")
 
@@ -768,7 +770,7 @@ def generate_agent_capabilities(
             "from typing import Any, Dict, List, Literal, Optional\n"
             "from pydantic import BaseModel, Field, ConfigDict\n"
             f"from {common_mod} import StrictBaseModel\n"
-            "from .constants import SPEC_VERSION, SPEC_VERSION_TYPE"
+            "from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE"
         ),
     ]
 
@@ -838,7 +840,7 @@ def generate_agent_capabilities(
     if is_modern:
         caps_blocks.append(
             f"class A2uiAgentCapabilities(StrictBaseModel):\n    {dir_name}:"
-            f" Optional[{cap_cls_name}] = Field(None, alias=SPEC_VERSION)"
+            f" Optional[{cap_cls_name}] = Field(None, alias=PROTOCOL_VERSION)"
         )
     else:
         alt_prefix = "Agent"
@@ -849,7 +851,7 @@ def generate_agent_capabilities(
             caps_blocks.append(f"{cross_alt_cap_cls_name} = {cap_cls_name}")
         caps_blocks.append(
             f"class A2uiServerCapabilities(StrictBaseModel):\n    {dir_name}:"
-            f" Optional[{cap_cls_name}] = Field(None, alias=SPEC_VERSION)"
+            f" Optional[{cap_cls_name}] = Field(None, alias=PROTOCOL_VERSION)"
         )
         caps_blocks.append("A2uiAgentCapabilities = A2uiServerCapabilities")
 
@@ -877,7 +879,7 @@ def generate_catalog_definition(
             f"{FILE_HEADER}\nfrom typing import Any, Dict, List, Literal,"
             " Optional, Union\nfrom pydantic import BaseModel, Field,"
             f" ConfigDict\nfrom {common_mod} import {common_imports_str}\nfrom"
-            " .constants import SPEC_VERSION, SPEC_VERSION_TYPE"
+            " .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE"
         ),
     ]
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -41,5 +41,5 @@ Refer to `python/a2ui_agent/tests/conformance/test_conformance.py` for a referen
 
 Every conformance test runner must declare two top-level configuration variables:
 
-1. **`SUPPORTED_SPEC_VERSIONS`**: A set/list of A2UI specification versions supported by the SDK or harness (e.g. `{'0.8', '0.9', '1.0'}`). Test cases specifying a version outside this set are skipped cleanly.
+1. **`SUPPORTED_PROTOCOL_VERSIONS`**: A set/list of A2UI protocol versions supported by the SDK or harness (e.g. `{'0.8', '0.9', '1.0'}`). Test cases specifying a version outside this set are skipped cleanly.
 2. **`SKIP_TEST_NAMES`**: A transition skip list containing test case names to temporarily skip during active feature transitions. At the start of a feature migration, test names for unimplemented features are added to this set and progressively removed as feature implementations complete. Skipped tests are logged as `[SKIPPED]` without marking test runs as failures.

--- a/kotlin/agent_sdk_legacy/src/test/kotlin/com/google/a2ui/conformance/ConformanceTest.kt
+++ b/kotlin/agent_sdk_legacy/src/test/kotlin/com/google/a2ui/conformance/ConformanceTest.kt
@@ -128,7 +128,7 @@ class ConformanceTest {
       val rawVersion = (catalog["protocolVersion"] ?: "v0.9").toString()
       val version = if (rawVersion.startsWith("v")) rawVersion else "v$rawVersion"
 
-      if (version !in SUPPORTED_SPEC_VERSIONS || (name != null && name in SKIP_TEST_NAMES)) {
+      if (version !in SUPPORTED_PROTOCOL_VERSIONS || (name != null && name in SKIP_TEST_NAMES)) {
         continue
       }
       filtered.add(case)
@@ -739,7 +739,7 @@ class ConformanceTest {
 
   private companion object {
     // Set of A2UI specification versions supported by this Kotlin Agent SDK conformance harness.
-    private val SUPPORTED_SPEC_VERSIONS = setOf("v0.8", "v0.9", "v1.0")
+    private val SUPPORTED_PROTOCOL_VERSIONS = setOf("v0.8", "v0.9", "v1.0")
 
     // Transition skip list containing specific test case names to skip during active feature
     // transitions.

--- a/python/a2ui_agent/pack_specs_hook.py
+++ b/python/a2ui_agent/pack_specs_hook.py
@@ -60,7 +60,7 @@ class PackSpecsBuildHook(BuildHookInterface):
             "_basic_catalog_constants_load",
         )
 
-        spec_version_map = a2ui_constants.SPEC_VERSION_MAP
+        protocol_version_map = a2ui_constants.PROTOCOL_VERSION_MAP
         a2ui_asset_package = a2ui_constants.A2UI_ASSET_PACKAGE
         specification_dir = a2ui_constants.SPECIFICATION_DIR
 
@@ -86,7 +86,7 @@ class PackSpecsBuildHook(BuildHookInterface):
             project_root, "src", a2ui_asset_package.replace(".", os.sep)
         )
 
-        self._pack_schemas(repo_root, spec_version_map, target_base)
+        self._pack_schemas(repo_root, protocol_version_map, target_base)
         self._pack_basic_catalogs(
             repo_root, basic_catalog_constants.BASIC_CATALOG_PATHS, target_base
         )

--- a/python/a2ui_agent/src/a2ui/inference_formats/direct_json/format.py
+++ b/python/a2ui_agent/src/a2ui/inference_formats/direct_json/format.py
@@ -24,7 +24,7 @@ from a2ui.core.schema.v0_9.client_capabilities import V09Capabilities
 from a2ui.schema.constants import (
     SERVER_TO_CLIENT_SCHEMA_KEY,
     COMMON_TYPES_SCHEMA_KEY,
-    SPEC_VERSION_MAP,
+    PROTOCOL_VERSION_MAP,
     INLINE_CATALOGS_KEY,
     CATALOG_COMPONENTS_KEY,
     INLINE_CATALOG_NAME,
@@ -115,21 +115,21 @@ class DirectJsonFormat(InferenceFormat):
     ) -> None:
         """Loads separate schema components and processes catalogs."""
         catalogs = catalogs or []
-        if version not in SPEC_VERSION_MAP:
+        if version not in PROTOCOL_VERSION_MAP:
             raise A2uiCatalogError(
                 f"Unknown A2UI specification version: {version}. Supported:"
-                f" {list(SPEC_VERSION_MAP.keys())}"
+                f" {list(PROTOCOL_VERSION_MAP.keys())}"
             )
 
         # Load server-to-client and common types schemas
         self._server_to_client_schema = self._apply_modifiers(
             load_from_bundled_resource(
-                version, SERVER_TO_CLIENT_SCHEMA_KEY, SPEC_VERSION_MAP
+                version, SERVER_TO_CLIENT_SCHEMA_KEY, PROTOCOL_VERSION_MAP
             )
         )
         self._common_types_schema = self._apply_modifiers(
             load_from_bundled_resource(
-                version, COMMON_TYPES_SCHEMA_KEY, SPEC_VERSION_MAP
+                version, COMMON_TYPES_SCHEMA_KEY, PROTOCOL_VERSION_MAP
             )
         )
 

--- a/python/a2ui_agent/src/a2ui/schema/catalog.py
+++ b/python/a2ui_agent/src/a2ui/schema/catalog.py
@@ -195,7 +195,7 @@ class A2uiCatalog:
     def core_catalog(self) -> Catalog[Any, Any]:
         return Catalog.from_json(
             catalog_schema=self.catalog_schema,
-            spec_version=self.version,
+            protocol_version=self.version,
             catalog_id=self.catalog_id,
         )
 

--- a/python/a2ui_agent/src/a2ui/schema/constants.py
+++ b/python/a2ui_agent/src/a2ui/schema/constants.py
@@ -64,7 +64,7 @@ VERSION_0_9 = "0.9"
 VERSION_0_9_1 = "0.9.1"
 VERSION_1_0 = "1.0"
 
-SPEC_VERSION_MAP = {
+PROTOCOL_VERSION_MAP = {
     VERSION_0_8: {
         SERVER_TO_CLIENT_SCHEMA_KEY: "specification/v0_8/json/server_to_client.json",
     },

--- a/python/a2ui_agent/tests/conformance/test_conformance.py
+++ b/python/a2ui_agent/tests/conformance/test_conformance.py
@@ -54,7 +54,7 @@ CATEGORY_TO_EXCEPTION = {
 }
 
 # Set of A2UI specification versions supported by this Python Agent SDK conformance harness.
-SUPPORTED_SPEC_VERSIONS = {"v0.8", "v0.9", "v1.0"}
+SUPPORTED_PROTOCOL_VERSIONS = {"v0.8", "v0.9", "v1.0"}
 
 # Transition skip list containing specific test case names to skip during active feature transitions.
 SKIP_TEST_NAMES = set()
@@ -180,7 +180,7 @@ def get_conformance_cases(filename):
         if not version.startswith("v"):
             version = f"v{version}"
 
-        if version not in SUPPORTED_SPEC_VERSIONS or name in SKIP_TEST_NAMES:
+        if version not in SUPPORTED_PROTOCOL_VERSIONS or name in SKIP_TEST_NAMES:
             continue
         filtered.append((name, case))
     return filtered

--- a/python/a2ui_agent/tests/elemental/test_compiler.py
+++ b/python/a2ui_agent/tests/elemental/test_compiler.py
@@ -41,7 +41,7 @@ class TestElementalCompiler(unittest.TestCase):
         self.catalog_path = CATALOG_PATH
         with open(self.catalog_path, "r", encoding="utf-8") as f:
             catalog_dict = json.load(f)
-        self.catalog = Catalog.from_json(catalog_dict, spec_version="0.9.1")
+        self.catalog = Catalog.from_json(catalog_dict, protocol_version="0.9.1")
         self.compiler = ElementalCompiler(self.catalog)
 
     def test_compile_delete_surface(self):

--- a/python/a2ui_agent/tests/elemental/test_format.py
+++ b/python/a2ui_agent/tests/elemental/test_format.py
@@ -38,7 +38,7 @@ class TestElementalFormat(unittest.TestCase):
     def setUp(self):
         with open(CATALOG_PATH, "r", encoding="utf-8") as f:
             catalog_dict = json.load(f)
-        self.catalog = Catalog.from_json(catalog_dict, spec_version="0.9.1")
+        self.catalog = Catalog.from_json(catalog_dict, protocol_version="0.9.1")
 
     def test_ensure_catalog_error(self):
         """Verifies that accessing parser or prompt_generator raises ValueError when catalog is missing."""

--- a/python/a2ui_agent/tests/elemental/test_parser_decompile.py
+++ b/python/a2ui_agent/tests/elemental/test_parser_decompile.py
@@ -36,7 +36,7 @@ class TestElementalParser(unittest.TestCase):
         self.catalog_path = CATALOG_PATH
         with open(self.catalog_path, "r", encoding="utf-8") as f:
             catalog_dict = json.load(f)
-        self.catalog = Catalog.from_json(catalog_dict, spec_version="0.9.1")
+        self.catalog = Catalog.from_json(catalog_dict, protocol_version="0.9.1")
 
     def test_decompile_delete_surface(self):
         decompiler = ElementalParser(self.catalog)

--- a/python/a2ui_agent/tests/express/test_compiler.py
+++ b/python/a2ui_agent/tests/express/test_compiler.py
@@ -47,7 +47,7 @@ class TestExpressCompiler(unittest.TestCase):
         self.catalog_path = CATALOG_PATH
         with open(self.catalog_path, "r", encoding="utf-8") as f:
             catalog_dict = json.load(f)
-        self.catalog = Catalog.from_json(catalog_dict, spec_version="0.9.1")
+        self.catalog = Catalog.from_json(catalog_dict, protocol_version="0.9.1")
         self.helper = CatalogSchemaHelper(self.catalog)
 
     def test_prompt_generator(self):
@@ -567,7 +567,7 @@ btnLabel = Text("Click Thread 2")
             catalog_dict = json.load(f)
 
         # 2. Construct Catalog model
-        core_catalog = Catalog.from_json(catalog_dict, spec_version="0.9.1")
+        core_catalog = Catalog.from_json(catalog_dict, protocol_version="0.9.1")
 
         # 3. Construct A2uiCatalog model
         a2ui_catalog = A2uiCatalog(

--- a/python/a2ui_agent/tests/express/test_integration.py
+++ b/python/a2ui_agent/tests/express/test_integration.py
@@ -47,7 +47,7 @@ class TestExpressIntegration(unittest.TestCase):
         self.catalog_path = CATALOG_PATH
         with open(self.catalog_path, "r", encoding="utf-8") as f:
             catalog_dict = json.load(f)
-        self.catalog = Catalog.from_json(catalog_dict, spec_version="0.9.1")
+        self.catalog = Catalog.from_json(catalog_dict, protocol_version="0.9.1")
         self.helper = CatalogSchemaHelper(self.catalog)
 
     def test_round_trip_examples(self):

--- a/python/a2ui_agent/tests/express/test_parser_decompile.py
+++ b/python/a2ui_agent/tests/express/test_parser_decompile.py
@@ -39,7 +39,7 @@ class TestExpressParser(unittest.TestCase):
         self.catalog_path = CATALOG_PATH
         with open(self.catalog_path, "r", encoding="utf-8") as f:
             catalog_dict = json.load(f)
-        self.catalog = Catalog.from_json(catalog_dict, spec_version="0.9.1")
+        self.catalog = Catalog.from_json(catalog_dict, protocol_version="0.9.1")
 
     def test_decompiler_rpc_actions_functional_expressions_and_custom_checks(self):
         """Verifies decompilation of custom RPC calls, local action mappings, dynamic functional expressions, and custom checks."""

--- a/python/a2ui_agent/tests/express/test_version_compliance.py
+++ b/python/a2ui_agent/tests/express/test_version_compliance.py
@@ -28,7 +28,7 @@ class TestVersionCompliance(unittest.TestCase):
         catalog_path = get_basic_catalog_path("v0_9")
         with open(catalog_path, "r", encoding="utf-8") as f:
             catalog_dict = json.load(f)
-        cls.catalog = Catalog.from_json(catalog_dict, spec_version="0.9.1")
+        cls.catalog = Catalog.from_json(catalog_dict, protocol_version="0.9.1")
 
     def test_compile_v1_0_unified(self):
         compiler = ExpressCompiler(self.catalog, version="v1.0")

--- a/python/a2ui_core/src/a2ui/core/basic_catalog/v0_8/__init__.py
+++ b/python/a2ui_core/src/a2ui/core/basic_catalog/v0_8/__init__.py
@@ -72,13 +72,13 @@ from .components import (
     BASIC_COMPONENTS,
 )
 from .styles import Styles, Theme
-from ...schema.v0_8.constants import SPEC_VERSION, SPEC_BASE_URL
+from ...schema.v0_8.constants import PROTOCOL_VERSION, PROTOCOL_BASE_URL
 from ...catalog import Catalog, ModelComponentApi, FunctionImplementation
 
 
-def _basic_catalog_id(spec_version: str) -> str:
+def _basic_catalog_id(protocol_version: str) -> str:
     return (
-        f"{SPEC_BASE_URL}/{spec_version.replace('.', '_')}/catalogs/basic/catalog.json"
+        f"{PROTOCOL_BASE_URL}/{protocol_version.replace('.', '_')}/catalogs/basic/catalog.json"
     )
 
 
@@ -86,8 +86,8 @@ class BasicCatalog(Catalog[ModelComponentApi, FunctionImplementation]):
 
     def __init__(self, locale: Optional[str] = None):
         super().__init__(
-            catalog_id=_basic_catalog_id(SPEC_VERSION),
-            spec_version=SPEC_VERSION,
+            catalog_id=_basic_catalog_id(PROTOCOL_VERSION),
+            protocol_version=PROTOCOL_VERSION,
             components=BASIC_COMPONENTS,
             functions=[],
             theme_schema=Theme.model_json_schema(),

--- a/python/a2ui_core/src/a2ui/core/basic_catalog/v0_9/__init__.py
+++ b/python/a2ui_core/src/a2ui/core/basic_catalog/v0_9/__init__.py
@@ -93,13 +93,13 @@ from .function_impls import (
     BASIC_FUNCTION_IMPLEMENTATIONS,
     create_basic_catalog_functions,
 )
-from ...schema.v0_9.constants import SPEC_VERSION, SPEC_BASE_URL
+from ...schema.v0_9.constants import PROTOCOL_VERSION, PROTOCOL_BASE_URL
 from ...catalog import Catalog, ModelComponentApi, FunctionImplementation
 
 
-def _basic_catalog_id(spec_version: str) -> str:
+def _basic_catalog_id(protocol_version: str) -> str:
     return (
-        f"{SPEC_BASE_URL}/{spec_version.replace('.', '_')}/catalogs/basic/catalog.json"
+        f"{PROTOCOL_BASE_URL}/{protocol_version.replace('.', '_')}/catalogs/basic/catalog.json"
     )
 
 
@@ -107,8 +107,8 @@ class BasicCatalog(Catalog[ModelComponentApi, FunctionImplementation]):
 
     def __init__(self, locale: Optional[str] = None):
         super().__init__(
-            catalog_id=_basic_catalog_id(SPEC_VERSION),
-            spec_version=SPEC_VERSION,
+            catalog_id=_basic_catalog_id(PROTOCOL_VERSION),
+            protocol_version=PROTOCOL_VERSION,
             components=BASIC_COMPONENTS,
             functions=create_basic_catalog_functions(locale=locale),
             theme_schema=Theme.model_json_schema(),

--- a/python/a2ui_core/src/a2ui/core/basic_catalog/v1_0/__init__.py
+++ b/python/a2ui_core/src/a2ui/core/basic_catalog/v1_0/__init__.py
@@ -95,13 +95,13 @@ from .function_impls import (
     BASIC_FUNCTION_IMPLEMENTATIONS,
     create_basic_catalog_functions,
 )
-from ...schema.v1_0.constants import SPEC_VERSION, SPEC_BASE_URL
+from ...schema.v1_0.constants import PROTOCOL_VERSION, PROTOCOL_BASE_URL
 from ...catalog import Catalog, ModelComponentApi, FunctionImplementation
 
 
-def _basic_catalog_id(spec_version: str) -> str:
+def _basic_catalog_id(protocol_version: str) -> str:
     return (
-        f"{SPEC_BASE_URL}/{spec_version.replace('.', '_')}/catalogs/basic/catalog.json"
+        f"{PROTOCOL_BASE_URL}/{protocol_version.replace('.', '_')}/catalogs/basic/catalog.json"
     )
 
 
@@ -109,8 +109,8 @@ class BasicCatalog(Catalog[ModelComponentApi, FunctionImplementation]):
 
     def __init__(self, locale: Optional[str] = None):
         super().__init__(
-            catalog_id=_basic_catalog_id(SPEC_VERSION),
-            spec_version=SPEC_VERSION,
+            catalog_id=_basic_catalog_id(PROTOCOL_VERSION),
+            protocol_version=PROTOCOL_VERSION,
             components=BASIC_COMPONENTS,
             functions=create_basic_catalog_functions(locale=locale),
         )

--- a/python/a2ui_core/src/a2ui/core/catalog/catalog.py
+++ b/python/a2ui_core/src/a2ui/core/catalog/catalog.py
@@ -33,19 +33,21 @@ class Catalog(Generic[TComponent, TFunction]):
     def __init__(
         self,
         catalog_id: str,
-        spec_version: str,
-        components: List[TComponent],
-        functions: List[TFunction],
+        protocol_version: Optional[str] = None,
+        components: Optional[List[TComponent]] = None,
+        functions: Optional[List[TFunction]] = None,
         theme_schema: Dict[str, Any] = {},
     ):
         self.catalog_id = catalog_id
-        self.spec_version = spec_version
+        if not protocol_version:
+            raise ValueError("protocol_version must be provided.")
+        self.protocol_version = protocol_version
 
         # Symmetrical map to Catalog.components in TypeScript
-        self.components: Dict[str, TComponent] = {c.name: c for c in components}
+        self.components: Dict[str, TComponent] = {c.name: c for c in components or []}
 
         # Symmetrical map to Catalog.functions in TypeScript
-        self.functions: Dict[str, TFunction] = {fn.name: fn for fn in functions}
+        self.functions: Dict[str, TFunction] = {fn.name: fn for fn in functions or []}
 
         self.theme_schema = theme_schema
         self._catalog_schema: Optional[Dict[str, Any]] = None
@@ -76,13 +78,17 @@ class Catalog(Generic[TComponent, TFunction]):
     def from_json(
         cls,
         catalog_schema: Dict[str, Any],
-        spec_version: str,
+        protocol_version: Optional[str] = None,
         catalog_id: Optional[str] = None,
     ) -> "Catalog[ComponentApi, FunctionApi]":
         """Constructs a schema-only Catalog directly from raw JSON Schema."""
         catalog_id = catalog_id or catalog_schema.get("catalogId")
         if not catalog_id:
             raise ValueError("catalog_id must be provided or exist in catalog_schema.")
+
+        p_ver = protocol_version or catalog_schema.get("protocolVersion")
+        if not p_ver:
+            raise ValueError("protocol_version must be provided.")
 
         components_map = catalog_schema.get("components", {})
         any_comp_refs = (
@@ -134,7 +140,7 @@ class Catalog(Generic[TComponent, TFunction]):
 
         cat = Catalog[ComponentApi, FunctionApi](
             catalog_id=catalog_id,
-            spec_version=spec_version,
+            protocol_version=p_ver,
             components=components,
             functions=functions,
             theme_schema=catalog_schema.get("theme") or {},

--- a/python/a2ui_core/src/a2ui/core/schema/common_types.py
+++ b/python/a2ui_core/src/a2ui/core/schema/common_types.py
@@ -49,10 +49,8 @@ class StrictBaseModel(BaseModel):
     @classmethod
     def validate_version_field(cls, v: Any, info: ValidationInfo) -> Any:
         context = info.context if isinstance(info.context, dict) else {}
-        target_version = (
-            context.get("target_version")
-            or context.get("spec_version")
-            or context.get("protocol_version")
+        target_version = context.get("target_version") or context.get(
+            "protocol_version"
         )
         if target_version is None:
             if "version" in cls.model_fields:
@@ -66,9 +64,7 @@ class StrictBaseModel(BaseModel):
             if target_version is None and cls.__module__:
                 mod = sys.modules.get(cls.__module__)
                 if mod:
-                    target_version = getattr(mod, "SPEC_VERSION", None) or getattr(
-                        mod, "PROTOCOL_VERSION", None
-                    )
+                    target_version = getattr(mod, "PROTOCOL_VERSION", None)
         if target_version is not None and v != target_version:
             raise ValueError(f"Input should be '{target_version}'")
         return v

--- a/python/a2ui_core/src/a2ui/core/schema/v0_8/catalog_definition.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v0_8/catalog_definition.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field, ConfigDict
 from ..common_types import StrictBaseModel
-from .constants import SPEC_VERSION, SPEC_VERSION_TYPE
+from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE
 
 
 class CatalogDefinition(StrictBaseModel):

--- a/python/a2ui_core/src/a2ui/core/schema/v0_8/client_capabilities.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v0_8/client_capabilities.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, Field, ConfigDict
 from ..common_types import StrictBaseModel
-from .constants import SPEC_VERSION, SPEC_VERSION_TYPE
+from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE
 
 
 from .catalog_definition import CatalogDefinition
@@ -50,7 +50,7 @@ V0_8Capabilities = V08Capabilities
 
 
 class A2uiClientCapabilities(StrictBaseModel):
-    v0_8: Optional[V08Capabilities] = Field(None, alias=SPEC_VERSION)
+    v0_8: Optional[V08Capabilities] = Field(None, alias=PROTOCOL_VERSION)
 
 
 A2uiRendererCapabilities = A2uiClientCapabilities

--- a/python/a2ui_core/src/a2ui/core/schema/v0_8/client_to_server.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v0_8/client_to_server.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field, ConfigDict
 from ..common_types import StrictBaseModel
-from .constants import SPEC_VERSION, SPEC_VERSION_TYPE
+from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE
 
 
 class A2uiClientAction(StrictBaseModel):
@@ -57,7 +57,7 @@ ActionPayload = A2uiClientAction
 
 
 class A2uiClientActionMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     user_action: A2uiClientAction = Field(..., alias="userAction")
 
 
@@ -78,7 +78,7 @@ A2uiRendererError = Union[A2uiGenericError]
 
 
 class A2uiRendererErrorMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     error: A2uiRendererError = Field(...)
 
 
@@ -90,7 +90,7 @@ RendererToAgentMessage = A2uiClientMessage
 
 
 class A2uiClientDataModel(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     surfaces: Dict[str, Dict[str, Any]] = Field(
         ..., description="A map of surface IDs to data models."
     )

--- a/python/a2ui_core/src/a2ui/core/schema/v0_8/constants.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v0_8/constants.py
@@ -16,15 +16,15 @@
 from __future__ import annotations
 from typing import Final, Literal
 
-SPEC_VERSION: Final[Literal["v0.8"]] = "v0.8"
-SPEC_VERSION_TYPE = Literal["v0.8"]
+PROTOCOL_VERSION: Final[Literal["v0.8"]] = "v0.8"
+PROTOCOL_VERSION_TYPE = Literal["v0.8"]
 
 ROOT_ID = "root"
 CATALOG_COMPONENTS_KEY = "components"
 SURFACE_ID_KEY = "surfaceId"
 THEME_KEY = "styles"
 STYLES_KEY = "styles"
-SPEC_BASE_URL = "https://a2ui.org/specification"
+PROTOCOL_BASE_URL = "https://a2ui.org/specification"
 
 # Outbound message types
 MSG_TYPE_BEGIN_RENDERING = "beginRendering"

--- a/python/a2ui_core/src/a2ui/core/schema/v0_8/server_to_client.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v0_8/server_to_client.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field, ConfigDict
 from ..common_types import StrictBaseModel
-from .constants import SPEC_VERSION, SPEC_VERSION_TYPE
+from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE
 
 
 ComponentsList = List[Dict[str, Any]]
@@ -49,7 +49,7 @@ class BeginRendering(StrictBaseModel):
 
 
 class BeginRenderingMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     begin_rendering: BeginRendering = Field(..., alias="beginRendering")
 
 
@@ -71,7 +71,7 @@ class SurfaceUpdate(StrictBaseModel):
 
 
 class SurfaceUpdateMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     surface_update: SurfaceUpdate = Field(..., alias="surfaceUpdate")
 
 
@@ -103,7 +103,7 @@ class DataModelUpdate(StrictBaseModel):
 
 
 class DataModelUpdateMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     data_model_update: DataModelUpdate = Field(..., alias="dataModelUpdate")
 
 
@@ -118,7 +118,7 @@ class DeleteSurface(StrictBaseModel):
 
 
 class DeleteSurfaceMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     delete_surface: DeleteSurface = Field(..., alias="deleteSurface")
 
 

--- a/python/a2ui_core/src/a2ui/core/schema/v0_9/client_capabilities.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v0_9/client_capabilities.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, Field, ConfigDict
 from .common_types import StrictBaseModel
-from .constants import SPEC_VERSION, SPEC_VERSION_TYPE
+from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE
 
 
 class FunctionDefinition(StrictBaseModel):
@@ -92,7 +92,7 @@ V0_9Capabilities = V09Capabilities
 
 
 class A2uiClientCapabilities(StrictBaseModel):
-    v0_9: Optional[V09Capabilities] = Field(None, alias=SPEC_VERSION)
+    v0_9: Optional[V09Capabilities] = Field(None, alias=PROTOCOL_VERSION)
 
 
 A2uiRendererCapabilities = A2uiClientCapabilities

--- a/python/a2ui_core/src/a2ui/core/schema/v0_9/client_to_server.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v0_9/client_to_server.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field, ConfigDict
 from .common_types import StrictBaseModel
-from .constants import SPEC_VERSION, SPEC_VERSION_TYPE
+from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE
 
 
 class A2uiClientAction(StrictBaseModel):
@@ -58,7 +58,7 @@ ActionPayload = A2uiClientAction
 
 
 class A2uiClientActionMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     action: A2uiClientAction = Field(...)
 
 
@@ -106,7 +106,7 @@ A2uiRendererError = Union[A2uiValidationError, A2uiGenericError]
 
 
 class A2uiRendererErrorMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     error: A2uiRendererError = Field(...)
 
 
@@ -118,7 +118,7 @@ RendererToAgentMessage = A2uiClientMessage
 
 
 class A2uiClientDataModel(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     surfaces: Dict[str, Dict[str, Any]] = Field(
         ..., description="A map of surface IDs to data models."
     )

--- a/python/a2ui_core/src/a2ui/core/schema/v0_9/constants.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v0_9/constants.py
@@ -16,15 +16,15 @@
 from __future__ import annotations
 from typing import Final, Literal
 
-SPEC_VERSION: Final[Literal["v0.9"]] = "v0.9"
-SPEC_VERSION_TYPE = Literal["v0.9"]
+PROTOCOL_VERSION: Final[Literal["v0.9"]] = "v0.9"
+PROTOCOL_VERSION_TYPE = Literal["v0.9"]
 
 ROOT_ID = "root"
 CATALOG_COMPONENTS_KEY = "components"
 SURFACE_ID_KEY = "surfaceId"
 THEME_KEY = "theme"
 STYLES_KEY = "styles"
-SPEC_BASE_URL = "https://a2ui.org/specification"
+PROTOCOL_BASE_URL = "https://a2ui.org/specification"
 
 # Outbound message types
 MSG_TYPE_CREATE_SURFACE = "createSurface"

--- a/python/a2ui_core/src/a2ui/core/schema/v0_9/server_capabilities.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v0_9/server_capabilities.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, Field, ConfigDict
 from .common_types import StrictBaseModel
-from .constants import SPEC_VERSION, SPEC_VERSION_TYPE
+from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE
 
 
 class V09ServerCapabilities(StrictBaseModel):
@@ -50,7 +50,7 @@ V0_9AgentCapabilities = V09ServerCapabilities
 
 
 class A2uiServerCapabilities(StrictBaseModel):
-    v0_9: Optional[V09ServerCapabilities] = Field(None, alias=SPEC_VERSION)
+    v0_9: Optional[V09ServerCapabilities] = Field(None, alias=PROTOCOL_VERSION)
 
 
 A2uiAgentCapabilities = A2uiServerCapabilities

--- a/python/a2ui_core/src/a2ui/core/schema/v0_9/server_to_client.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v0_9/server_to_client.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field, ConfigDict
 from .common_types import StrictBaseModel
-from .constants import SPEC_VERSION, SPEC_VERSION_TYPE
+from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE
 
 
 ComponentsList = List[Dict[str, Any]]
@@ -60,7 +60,7 @@ class CreateSurface(StrictBaseModel):
 
 
 class CreateSurfaceMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     create_surface: CreateSurface = Field(..., alias="createSurface")
 
 
@@ -78,7 +78,7 @@ class UpdateComponents(StrictBaseModel):
 
 
 class UpdateComponentsMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     update_components: UpdateComponents = Field(..., alias="updateComponents")
 
 
@@ -110,7 +110,7 @@ class UpdateDataModel(StrictBaseModel):
 
 
 class UpdateDataModelMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     update_data_model: UpdateDataModel = Field(..., alias="updateDataModel")
 
 
@@ -125,7 +125,7 @@ class DeleteSurface(StrictBaseModel):
 
 
 class DeleteSurfaceMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     delete_surface: DeleteSurface = Field(..., alias="deleteSurface")
 
 

--- a/python/a2ui_core/src/a2ui/core/schema/v1_0/agent_capabilities.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v1_0/agent_capabilities.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, Field, ConfigDict
 from .common_types import StrictBaseModel
-from .constants import SPEC_VERSION, SPEC_VERSION_TYPE
+from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE
 
 
 class V10AgentCapabilities(StrictBaseModel):
@@ -45,4 +45,4 @@ V1_0AgentCapabilities = V10AgentCapabilities
 
 
 class A2uiAgentCapabilities(StrictBaseModel):
-    v1_0: Optional[V10AgentCapabilities] = Field(None, alias=SPEC_VERSION)
+    v1_0: Optional[V10AgentCapabilities] = Field(None, alias=PROTOCOL_VERSION)

--- a/python/a2ui_core/src/a2ui/core/schema/v1_0/agent_to_renderer.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v1_0/agent_to_renderer.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field, ConfigDict
 from .common_types import StrictBaseModel, CallId, ComponentCommon, Extensions, FunctionCall, FunctionResponse
-from .constants import SPEC_VERSION, SPEC_VERSION_TYPE
+from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE
 
 
 ComponentsList = List[Dict[str, Any]]
@@ -67,7 +67,7 @@ class CreateSurface(StrictBaseModel):
 
 
 class CreateSurfaceMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     create_surface: CreateSurface = Field(..., alias="createSurface")
 
 
@@ -86,7 +86,7 @@ class UpdateComponents(StrictBaseModel):
 
 
 class UpdateComponentsMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     update_components: UpdateComponents = Field(..., alias="updateComponents")
 
 
@@ -118,7 +118,7 @@ class UpdateDataModel(StrictBaseModel):
 
 
 class UpdateDataModelMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     update_data_model: UpdateDataModel = Field(..., alias="updateDataModel")
 
 
@@ -136,7 +136,7 @@ class DeleteSurface(StrictBaseModel):
 
 
 class DeleteSurfaceMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     delete_surface: DeleteSurface = Field(..., alias="deleteSurface")
 
 
@@ -155,7 +155,7 @@ class CallRendererFunction(StrictBaseModel):
 
 
 class CallRendererFunctionMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     call_renderer_function: CallRendererFunction = Field(
         ..., alias="callRendererFunction"
     )
@@ -166,7 +166,7 @@ class AgentFunctionResponse(StrictBaseModel):
 
 
 class AgentFunctionResponseMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     agent_function_response: AgentFunctionResponse = Field(
         ..., alias="agentFunctionResponse"
     )

--- a/python/a2ui_core/src/a2ui/core/schema/v1_0/catalog_definition.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v1_0/catalog_definition.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field, ConfigDict
 from .common_types import StrictBaseModel, Extensions
-from .constants import SPEC_VERSION, SPEC_VERSION_TYPE
+from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE
 
 
 class FunctionDefinition(BaseModel):

--- a/python/a2ui_core/src/a2ui/core/schema/v1_0/constants.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v1_0/constants.py
@@ -16,15 +16,15 @@
 from __future__ import annotations
 from typing import Final, Literal
 
-SPEC_VERSION: Final[Literal["v1.0"]] = "v1.0"
-SPEC_VERSION_TYPE = Literal["v1.0"]
+PROTOCOL_VERSION: Final[Literal["v1.0"]] = "v1.0"
+PROTOCOL_VERSION_TYPE = Literal["v1.0"]
 
 ROOT_ID = "root"
 CATALOG_COMPONENTS_KEY = "components"
 SURFACE_ID_KEY = "surfaceId"
 THEME_KEY = "theme"
 STYLES_KEY = "styles"
-SPEC_BASE_URL = "https://a2ui.org/specification"
+PROTOCOL_BASE_URL = "https://a2ui.org/specification"
 
 # Outbound message types
 MSG_TYPE_CREATE_SURFACE = "createSurface"

--- a/python/a2ui_core/src/a2ui/core/schema/v1_0/renderer_capabilities.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v1_0/renderer_capabilities.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, Field, ConfigDict
 from .common_types import StrictBaseModel
-from .constants import SPEC_VERSION, SPEC_VERSION_TYPE
+from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE
 
 
 from .catalog_definition import CatalogDefinition
@@ -51,4 +51,4 @@ V1_0Capabilities = V10Capabilities
 
 
 class A2uiRendererCapabilities(StrictBaseModel):
-    v1_0: Optional[V10Capabilities] = Field(None, alias=SPEC_VERSION)
+    v1_0: Optional[V10Capabilities] = Field(None, alias=PROTOCOL_VERSION)

--- a/python/a2ui_core/src/a2ui/core/schema/v1_0/renderer_to_agent.py
+++ b/python/a2ui_core/src/a2ui/core/schema/v1_0/renderer_to_agent.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field, ConfigDict
 from .common_types import StrictBaseModel, CallId, Extensions, FunctionCall, FunctionResponse
-from .constants import SPEC_VERSION, SPEC_VERSION_TYPE
+from .constants import PROTOCOL_VERSION, PROTOCOL_VERSION_TYPE
 
 
 class A2uiRendererAction(StrictBaseModel):
@@ -74,7 +74,7 @@ ActionPayload = A2uiRendererAction
 
 
 class A2uiRendererActionMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     action: A2uiRendererAction = Field(...)
 
 
@@ -96,12 +96,12 @@ class CallAgentFunction(StrictBaseModel):
 
 
 class CallAgentFunctionMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     call_agent_function: CallAgentFunction = Field(..., alias="callAgentFunction")
 
 
 class RendererFunctionResponseMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     renderer_function_response: FunctionResponse = Field(
         ..., alias="rendererFunctionResponse"
     )
@@ -163,7 +163,7 @@ A2uiRendererError = Union[A2uiValidationError, A2uiGenericError]
 
 
 class A2uiRendererErrorMessage(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     error: A2uiRendererError = Field(...)
 
 
@@ -176,7 +176,7 @@ RendererToAgentMessage = Union[
 
 
 class A2uiRendererDataModel(StrictBaseModel):
-    version: SPEC_VERSION_TYPE = SPEC_VERSION
+    version: PROTOCOL_VERSION_TYPE = PROTOCOL_VERSION
     surfaces: Dict[str, Dict[str, Any]] = Field(
         ..., description="A map of surface IDs to data models."
     )

--- a/python/a2ui_core/src/a2ui/core/validating/catalog_schema_validator.py
+++ b/python/a2ui_core/src/a2ui/core/validating/catalog_schema_validator.py
@@ -27,16 +27,18 @@ from ..schema.v0_9.common_types import (
     ListReference,
     SingleReference,
 )
-from ..schema.v0_9.constants import CATALOG_COMPONENTS_KEY, SPEC_BASE_URL
+from ..schema.v0_9.constants import CATALOG_COMPONENTS_KEY, PROTOCOL_BASE_URL
 
 JSON_SCHEMA_DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema"
 COMMON_TYPES_SCHEMA_FILE = "common_types.json"
 CATALOG_SCHEMA_FILE = "catalog.json"
 
 
-def _schema_url(spec_version: str, file_name: str) -> str:
-    ver = spec_version if spec_version.startswith("v") else f"v{spec_version}"
-    return f"{SPEC_BASE_URL}/{ver.replace('.', '_')}/{file_name}"
+def _schema_url(protocol_version: str, file_name: str) -> str:
+    ver = (
+        protocol_version if protocol_version.startswith("v") else f"v{protocol_version}"
+    )
+    return f"{PROTOCOL_BASE_URL}/{ver.replace('.', '_')}/{file_name}"
 
 
 class CatalogSchemaValidator:
@@ -74,7 +76,7 @@ class CatalogSchemaValidator:
             Resource.from_contents(catalog_schema, default_specification=DRAFT202012),
         ))
         resources.append((
-            _schema_url(self.catalog.spec_version, CATALOG_SCHEMA_FILE),
+            _schema_url(self.catalog.protocol_version, CATALOG_SCHEMA_FILE),
             Resource.from_contents(catalog_schema, default_specification=DRAFT202012),
         ))
         if self.common_types_schema:
@@ -86,7 +88,7 @@ class CatalogSchemaValidator:
                 ),
             ))
             resources.append((
-                _schema_url(self.catalog.spec_version, COMMON_TYPES_SCHEMA_FILE),
+                _schema_url(self.catalog.protocol_version, COMMON_TYPES_SCHEMA_FILE),
                 Resource.from_contents(
                     self.common_types_schema,
                     default_specification=DRAFT202012,

--- a/python/a2ui_core/src/a2ui/core/validating/validator.py
+++ b/python/a2ui_core/src/a2ui/core/validating/validator.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 from ..exceptions import A2uiValidationError, A2uiErrorDetail
 from ..schema import A2uiMessageListWrapper
 from ..schema.v0_9.constants import (
-    SPEC_VERSION,
+    PROTOCOL_VERSION,
     MSG_TYPE_CREATE_SURFACE,
     MSG_TYPE_UPDATE_COMPONENTS,
     MSG_TYPE_UPDATE_DATA_MODEL,
@@ -88,7 +88,7 @@ class A2uiValidator:
         """Validates the overall A2UI protocol payload structure using Pydantic."""
         details = []
         expected_version = (
-            config.target_version if config.target_version else SPEC_VERSION
+            config.target_version if config.target_version else PROTOCOL_VERSION
         )
 
         for i, msg in enumerate(messages):

--- a/python/a2ui_core/tests/test_catalog.py
+++ b/python/a2ui_core/tests/test_catalog.py
@@ -25,7 +25,7 @@ from a2ui.core.catalog.catalog import TComponent, TFunction
 from a2ui.core.validating import CatalogSchemaValidator
 from a2ui.core.basic_catalog import BasicCatalog
 from a2ui.core.schema.v0_9.common_types import ComponentId
-from a2ui.core.schema.v0_9.constants import SPEC_VERSION
+from a2ui.core.schema.v0_9.constants import PROTOCOL_VERSION
 
 
 def _val(
@@ -48,11 +48,11 @@ def test_catalog_initialization_with_models():
 
     cat = Catalog(
         catalog_id="https://a2ui.org/model-init",
-        spec_version=SPEC_VERSION,
+        protocol_version=PROTOCOL_VERSION,
         components=[ModelComponentApi(EmptyModel, "Empty")],
         functions=[],
     )
-    assert cat.spec_version == SPEC_VERSION
+    assert cat.protocol_version == PROTOCOL_VERSION
     assert cat.catalog_id == "https://a2ui.org/model-init"
 
 
@@ -67,8 +67,33 @@ def test_catalog_initialization_from_json():
             }
         },
     }
-    catalog = Catalog.from_json(schema, spec_version=SPEC_VERSION)
+    catalog = Catalog.from_json(schema, protocol_version=PROTOCOL_VERSION)
     assert catalog.catalog_id == "https://a2ui.org/spec/v0.9/catalog.json"
+    assert catalog.protocol_version == PROTOCOL_VERSION
+
+
+def test_catalog_initialization_requires_version():
+    with pytest.raises(
+        ValueError,
+        match="protocol_version must be provided",
+    ):
+        Catalog(
+            catalog_id="https://a2ui.org/no-version",
+            components=[],
+            functions=[],
+        )
+
+
+def test_catalog_from_json_requires_version():
+    schema = {
+        "catalogId": "https://a2ui.org/spec/catalog.json",
+        "components": {},
+    }
+    with pytest.raises(
+        ValueError,
+        match="protocol_version must be provided",
+    ):
+        Catalog.from_json(schema)
 
 
 # ==============================================================================
@@ -84,7 +109,7 @@ def test_component_validation_with_models():
 
     cat = Catalog(
         catalog_id="https://a2ui.org/model",
-        spec_version=SPEC_VERSION,
+        protocol_version=PROTOCOL_VERSION,
         components=[ModelComponentApi(ButtonComp, "Button")],
         functions=[],
     )
@@ -120,7 +145,7 @@ def test_additional_properties_handling_with_models():
 
     cat = Catalog(
         catalog_id="https://a2ui.org/model-extra",
-        spec_version=SPEC_VERSION,
+        protocol_version=PROTOCOL_VERSION,
         components=[
             ModelComponentApi(DefaultBox, "DefaultBox"),
             ModelComponentApi(AllowBox, "AllowBox"),
@@ -157,7 +182,7 @@ def test_additional_properties_handling_from_json():
             }
         },
     }
-    cat_default = Catalog.from_json(cat_default_json, spec_version=SPEC_VERSION)
+    cat_default = Catalog.from_json(cat_default_json, protocol_version=PROTOCOL_VERSION)
 
     # Permits extra properties when additionalProperties is not set explicitly
     _val(cat_default).validate_component_properties(
@@ -175,7 +200,7 @@ def test_additional_properties_handling_from_json():
             }
         },
     }
-    cat_true = Catalog.from_json(cat_true_json, spec_version=SPEC_VERSION)
+    cat_true = Catalog.from_json(cat_true_json, protocol_version=PROTOCOL_VERSION)
 
     # Permits extra properties when additionalProperties is explicitly True
     _val(cat_true).validate_component_properties(
@@ -197,7 +222,7 @@ def test_unevaluated_properties_handling_with_models():
 
     cat = Catalog(
         catalog_id="https://a2ui.org/model-unevaluated",
-        spec_version=SPEC_VERSION,
+        protocol_version=PROTOCOL_VERSION,
         components=[
             ModelComponentApi(DefaultBox, "DefaultBox"),
             ModelComponentApi(AllowBox, "AllowBox"),
@@ -234,7 +259,7 @@ def test_unevaluated_properties_handling_from_json():
             }
         },
     }
-    cat_default = Catalog.from_json(cat_default_json, spec_version=SPEC_VERSION)
+    cat_default = Catalog.from_json(cat_default_json, protocol_version=PROTOCOL_VERSION)
 
     # Permits extra properties when unevaluatedProperties is default (omitted/true)
     _val(cat_default).validate_component_properties(
@@ -252,7 +277,7 @@ def test_unevaluated_properties_handling_from_json():
             }
         },
     }
-    cat_false = Catalog.from_json(cat_false_json, spec_version=SPEC_VERSION)
+    cat_false = Catalog.from_json(cat_false_json, protocol_version=PROTOCOL_VERSION)
 
     # Rejects extra properties when unevaluatedProperties is False
     with pytest.raises(
@@ -273,7 +298,7 @@ def test_unevaluated_properties_handling_from_json():
             }
         },
     }
-    cat_true = Catalog.from_json(cat_true_json, spec_version=SPEC_VERSION)
+    cat_true = Catalog.from_json(cat_true_json, protocol_version=PROTOCOL_VERSION)
 
     # Permits extra properties when unevaluatedProperties is True
     _val(cat_true).validate_component_properties(
@@ -291,7 +316,7 @@ def test_unrecognized_type_and_mismatched_properties_with_models():
 
     catalog = Catalog(
         catalog_id="https://a2ui.org/model-extended",
-        spec_version=SPEC_VERSION,
+        protocol_version=PROTOCOL_VERSION,
         components=[ModelComponentApi(CardComp, "Card")],
         functions=[],
     )
@@ -336,7 +361,7 @@ def test_function_validation_with_models():
 
     cat = Catalog(
         catalog_id="https://a2ui.org/model",
-        spec_version=SPEC_VERSION,
+        protocol_version=PROTOCOL_VERSION,
         components=[],
         functions=[
             FunctionImplementation(
@@ -379,7 +404,7 @@ def test_function_validation_from_json():
         },
     }
 
-    catalog = Catalog.from_json(catalog_json, spec_version=SPEC_VERSION)
+    catalog = Catalog.from_json(catalog_json, protocol_version=PROTOCOL_VERSION)
 
     # 1. Test validate_function Valid
     _val(catalog).validate_function(
@@ -415,7 +440,7 @@ def test_nested_function_validation_with_models():
 
     cat = Catalog(
         catalog_id="https://a2ui.org/model",
-        spec_version=SPEC_VERSION,
+        protocol_version=PROTOCOL_VERSION,
         components=[ModelComponentApi(OuterComp, "OuterComp")],
         functions=[
             FunctionImplementation(
@@ -500,7 +525,7 @@ def test_nested_function_validation_from_json():
         },
     }
 
-    catalog = Catalog.from_json(catalog_json, spec_version=SPEC_VERSION)
+    catalog = Catalog.from_json(catalog_json, protocol_version=PROTOCOL_VERSION)
 
     # 1. Rejects unrecognized nested catalog function call
     with pytest.raises(ValueError, match="Unknown function: unrecognizedFunctionName"):
@@ -536,7 +561,7 @@ def test_theme_validation_with_models():
 
     cat = Catalog(
         catalog_id="https://a2ui.org/model",
-        spec_version=SPEC_VERSION,
+        protocol_version=PROTOCOL_VERSION,
         components=[],
         functions=[],
         theme_schema=TestTheme.model_json_schema(),
@@ -572,7 +597,7 @@ def test_theme_validation_from_json():
         },
     }
 
-    catalog = Catalog.from_json(catalog_json, spec_version=SPEC_VERSION)
+    catalog = Catalog.from_json(catalog_json, protocol_version=PROTOCOL_VERSION)
 
     # 1. Test Valid Theme
     _val(catalog).validate_theme({"primaryColor": "#00FF00"})
@@ -601,7 +626,7 @@ def test_extract_ref_fields_custom_models():
 
     catalog = Catalog(
         catalog_id="https://a2ui.org/custom",
-        spec_version=SPEC_VERSION,
+        protocol_version=PROTOCOL_VERSION,
         components=[ModelComponentApi(CustomLayoutComp, "CustomLayout")],
         functions=[],
     )
@@ -635,7 +660,7 @@ def test_extract_ref_fields_dynamic_json():
         },
     }
 
-    cat = Catalog.from_json(schema, spec_version=SPEC_VERSION)
+    cat = Catalog.from_json(schema, protocol_version=PROTOCOL_VERSION)
     refs = _val(cat).extract_ref_fields()
 
     assert "AdvancedLayout" in refs
@@ -693,7 +718,7 @@ def test_extract_ref_fields_tabs_json():
         },
     }
 
-    cat = Catalog.from_json(schema, spec_version=SPEC_VERSION)
+    cat = Catalog.from_json(schema, protocol_version=PROTOCOL_VERSION)
     refs = _val(cat).extract_ref_fields()
 
     assert "Tabs" in refs
@@ -708,7 +733,7 @@ def test_extract_ref_fields_empty_json():
         "catalogId": "https://a2ui.org/json",
         "components": {"EmptyNode": {"type": "object", "properties": {}}},
     }
-    cat = Catalog.from_json(schema, spec_version=SPEC_VERSION)
+    cat = Catalog.from_json(schema, protocol_version=PROTOCOL_VERSION)
     refs = _val(cat).extract_ref_fields()
     assert refs == {}
 
@@ -736,7 +761,7 @@ def test_extract_ref_fields_common_types_resolution():
 
     catalog = Catalog.from_json(
         catalog_json,
-        spec_version=SPEC_VERSION,
+        protocol_version=PROTOCOL_VERSION,
     )
 
     # 1. Test Valid $ref against common_types.json
@@ -762,7 +787,7 @@ def test_extract_ref_fields_tabs_model():
 
     catalog = Catalog(
         catalog_id="https://a2ui.org/tabs-test",
-        spec_version=SPEC_VERSION,
+        protocol_version=PROTOCOL_VERSION,
         components=[ModelComponentApi(CustomTabsComponent, "CustomTabs")],
         functions=[],
     )
@@ -799,7 +824,7 @@ def test_extract_ref_fields_custom_tabs_json():
     }
     catalog = Catalog.from_json(
         catalog_schema,
-        spec_version=SPEC_VERSION,
+        protocol_version=PROTOCOL_VERSION,
         catalog_id="https://a2ui.org/json-tabs",
     )
     ref_map = _val(catalog).extract_ref_fields()
@@ -825,7 +850,7 @@ def test_extract_ref_fields_basic_spec_tabs():
 
     catalog = Catalog.from_json(
         catalog_schema,
-        spec_version=SPEC_VERSION,
+        protocol_version=PROTOCOL_VERSION,
         catalog_id="https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json",
     )
     ref_map = _val(catalog).extract_ref_fields()
@@ -862,7 +887,7 @@ def test_seamless_mixed_catalogs():
 
     # Instantiate single unified Catalog containing both
     catalog = Catalog(
-        spec_version=SPEC_VERSION,
+        protocol_version=PROTOCOL_VERSION,
         catalog_id="https://a2ui.org/mixed-test",
         components=[
             ModelComponentApi(ModelCompA),
@@ -901,7 +926,7 @@ def test_seamless_mixed_catalogs():
 
 def test_basic_catalog_initialization():
     catalog = BasicCatalog()
-    assert catalog.spec_version == SPEC_VERSION
+    assert catalog.protocol_version == PROTOCOL_VERSION
     assert "https://a2ui.org/specification" in catalog.catalog_id
 
 

--- a/python/a2ui_core/tests/test_codegen_pydantic.py
+++ b/python/a2ui_core/tests/test_codegen_pydantic.py
@@ -478,7 +478,9 @@ def test_generate_renderer_capabilities():
     assert "class V09Capabilities(StrictBaseModel):" in code
     assert "class A2uiClientCapabilities(StrictBaseModel):" in code
     assert "A2uiRendererCapabilities = A2uiClientCapabilities" in code
-    assert "v0_9: Optional[V09Capabilities] = Field(None, alias=SPEC_VERSION)" in code
+    assert (
+        "v0_9: Optional[V09Capabilities] = Field(None, alias=PROTOCOL_VERSION)" in code
+    )
 
 
 def test_generate_agent_capabilities():
@@ -668,3 +670,20 @@ def test_basic_catalog_operator_and_index_api():
     assert "AddApi" in v1_0.__all__
     assert hasattr(v1_0, "IndexApi")
     assert "IndexApi" in v1_0.__all__
+
+
+def test_validate_version_field_non_dict_context():
+    from a2ui.core.schema.v0_9.client_to_server import A2uiClientDataModel
+
+    # Should not raise AttributeError when context is not a dict
+    model = A2uiClientDataModel.model_validate(
+        {"version": "v0.9", "surfaces": {}},
+        context="not_a_dict",
+    )
+    assert model.version == "v0.9"
+
+    model_list = A2uiClientDataModel.model_validate(
+        {"version": "v0.9", "surfaces": {}},
+        context=["list_context"],
+    )
+    assert model_list.version == "v0.9"

--- a/python/a2ui_core/tests/test_processing.py
+++ b/python/a2ui_core/tests/test_processing.py
@@ -29,7 +29,7 @@ from a2ui.core.catalog import (
     ComponentApi,
     ModelComponentApi,
 )
-from a2ui.core.schema.v0_9.constants import SPEC_VERSION
+from a2ui.core.schema.v0_9.constants import PROTOCOL_VERSION
 
 
 @pytest.fixture
@@ -37,7 +37,7 @@ def mock_catalog():
     class MockCatalog:
 
         def __init__(self):
-            self.version = SPEC_VERSION
+            self.version = PROTOCOL_VERSION
             self.catalog_id = "https://a2ui.org/mock.json"
             self.catalog_schema = {"components": {}}
             self.single_refs = set()
@@ -65,7 +65,7 @@ def test_message_processor_surface_lifecycle(mock_catalog):
 
     # 1. Create surface
     create_msg = {
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "createSurface": {
             "surfaceId": "surface_1",
             "catalogId": mock_catalog.catalog_id,
@@ -82,7 +82,10 @@ def test_message_processor_surface_lifecycle(mock_catalog):
     assert surface.send_data_model is True
 
     # 2. Delete surface
-    delete_msg = {"version": SPEC_VERSION, "deleteSurface": {"surfaceId": "surface_1"}}
+    delete_msg = {
+        "version": PROTOCOL_VERSION,
+        "deleteSurface": {"surfaceId": "surface_1"},
+    }
     processor.process_messages([delete_msg])
     assert processor.model.get_surface("surface_1") is None
 
@@ -92,7 +95,7 @@ def test_message_processor_component_updates(mock_catalog):
 
     # Setup surface
     processor.process_messages([{
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "createSurface": {
             "surfaceId": "s1",
             "catalogId": mock_catalog.catalog_id,
@@ -103,7 +106,7 @@ def test_message_processor_component_updates(mock_catalog):
 
     # 1. Add Component
     comp_msg = {
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "updateComponents": {
             "surfaceId": "s1",
             "components": [{"id": "text_1", "component": "Text", "text": "Hello"}],
@@ -118,7 +121,7 @@ def test_message_processor_component_updates(mock_catalog):
 
     # 2. Update properties
     comp_update = {
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "updateComponents": {
             "surfaceId": "s1",
             "components": [{"id": "text_1", "component": "Text", "text": "World"}],
@@ -129,7 +132,7 @@ def test_message_processor_component_updates(mock_catalog):
 
     # 3. Recreate if component type changes
     comp_recreate = {
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "updateComponents": {
             "surfaceId": "s1",
             "components": [{"id": "text_1", "component": "Image", "url": "img.png"}],
@@ -147,7 +150,7 @@ def test_message_processor_data_model_updates(mock_catalog):
 
     # Setup surface
     processor.process_messages([{
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "createSurface": {
             "surfaceId": "s1",
             "catalogId": mock_catalog.catalog_id,
@@ -158,7 +161,7 @@ def test_message_processor_data_model_updates(mock_catalog):
 
     # Set data model
     dm_msg = {
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "updateDataModel": {
             "surfaceId": "s1",
             "path": "/user/name",
@@ -175,13 +178,13 @@ def test_message_processor_capabilities_and_sync(mock_catalog):
     # Check Capabilities
     caps = processor.get_client_capabilities()
     assert caps == {
-        SPEC_VERSION: {"supportedCatalogIds": ["https://a2ui.org/mock.json"]}
+        PROTOCOL_VERSION: {"supportedCatalogIds": ["https://a2ui.org/mock.json"]}
     }
 
     # Setup surface with sendDataModel=True
     processor.process_messages([
         {
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "createSurface": {
                 "surfaceId": "s1",
                 "catalogId": mock_catalog.catalog_id,
@@ -189,20 +192,20 @@ def test_message_processor_capabilities_and_sync(mock_catalog):
             },
         },
         {
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "updateDataModel": {"surfaceId": "s1", "path": "/val", "value": 100},
         },
     ])
 
     # Retrieve client data model sync payload
     client_dm = processor.get_client_data_model()
-    assert client_dm == {"version": SPEC_VERSION, "surfaces": {"s1": {"val": 100}}}
+    assert client_dm == {"version": PROTOCOL_VERSION, "surfaces": {"s1": {"val": 100}}}
 
 
 def test_message_processor_throws_on_duplicate_surface(mock_catalog):
     processor = MessageProcessor(catalogs=[mock_catalog])
     processor.process_messages([{
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "createSurface": {
             "surfaceId": "s1",
             "catalogId": mock_catalog.catalog_id,
@@ -211,7 +214,7 @@ def test_message_processor_throws_on_duplicate_surface(mock_catalog):
 
     with pytest.raises(ValueError, match="Surface s1 already exists"):
         processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "createSurface": {
                 "surfaceId": "s1",
                 "catalogId": mock_catalog.catalog_id,
@@ -225,7 +228,7 @@ def test_message_processor_throws_on_updating_non_existent_surface(mock_catalog)
         ValueError, match="Surface 'unknown-s' not found for components update"
     ):
         processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "updateComponents": {"surfaceId": "unknown-s", "components": []},
         }])
 
@@ -236,7 +239,7 @@ def test_message_processor_throws_on_multiple_conflicting_update_types(mock_cata
         ValueError, match="Message contains multiple conflicting update actions"
     ):
         processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "createSurface": {
                 "surfaceId": "s1",
                 "catalogId": mock_catalog.catalog_id,
@@ -248,7 +251,7 @@ def test_message_processor_throws_on_multiple_conflicting_update_types(mock_cata
 def test_message_processor_throws_on_component_missing_id(mock_catalog):
     processor = MessageProcessor(catalogs=[mock_catalog])
     processor.process_messages([{
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "createSurface": {
             "surfaceId": "s1",
             "catalogId": mock_catalog.catalog_id,
@@ -257,7 +260,7 @@ def test_message_processor_throws_on_component_missing_id(mock_catalog):
 
     with pytest.raises(ValueError, match="missing required 'id' field"):
         processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "updateComponents": {
                 "surfaceId": "s1",
                 "components": [{"component": "Text", "text": "Missing ID"}],
@@ -268,7 +271,7 @@ def test_message_processor_throws_on_component_missing_id(mock_catalog):
 def test_message_processor_throws_on_creating_component_without_type(mock_catalog):
     processor = MessageProcessor(catalogs=[mock_catalog])
     processor.process_messages([{
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "createSurface": {
             "surfaceId": "s1",
             "catalogId": mock_catalog.catalog_id,
@@ -279,7 +282,7 @@ def test_message_processor_throws_on_creating_component_without_type(mock_catalo
         ValueError, match="Cannot create component 'comp_1' without a component type"
     ):
         processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "updateComponents": {
                 "surfaceId": "s1",
                 "components": [{"id": "comp_1", "label": "Missing Component Name"}],
@@ -296,7 +299,7 @@ def test_message_processor_strict_mode_circular_reference(real_catalog_09):
     processor = MessageProcessor(catalogs=[real_catalog_09], strict_mode=True)
 
     processor.process_messages([{
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "createSurface": {
             "surfaceId": "s1",
             "catalogId": real_catalog_09.catalog_id,
@@ -306,7 +309,7 @@ def test_message_processor_strict_mode_circular_reference(real_catalog_09):
     # Circular reference loop: root -> comp-A -> comp-B -> comp-A
     with pytest.raises(ValueError, match="Circular reference detected"):
         processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "updateComponents": {
                 "surfaceId": "s1",
                 "components": [
@@ -329,14 +332,14 @@ def test_message_processor_strict_mode_orphans(real_catalog_09):
     # Orphan node: comp-C is unreachable from root
     with pytest.raises(ValueError, match="is not reachable from"):
         processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "createSurface": {
                 "surfaceId": "s1",
                 "catalogId": real_catalog_09.catalog_id,
             },
         }])
         processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "updateComponents": {
                 "surfaceId": "s1",
                 "components": [
@@ -363,14 +366,14 @@ def test_message_processor_strict_mode_component_strict_properties(
     lazy_processor = MessageProcessor(catalogs=[real_catalog_09])
     lazy_processor.process_messages([
         {
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "createSurface": {
                 "surfaceId": "s1",
                 "catalogId": real_catalog_09.catalog_id,
             },
         },
         {
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "updateComponents": {
                 "surfaceId": "s1",
                 "components": [{
@@ -395,14 +398,14 @@ def test_message_processor_strict_mode_missing_root(real_catalog_09):
     # Missing root component: components only has comp-A
     with pytest.raises(ValueError, match="Missing root component"):
         strict_processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "createSurface": {
                 "surfaceId": "s1",
                 "catalogId": real_catalog_09.catalog_id,
             },
         }])
         strict_processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "updateComponents": {
                 "surfaceId": "s1",
                 "components": [{
@@ -420,14 +423,14 @@ def test_message_processor_strict_mode_invalid_path_pointer(real_catalog_09):
     # Contains unescaped tilde ~ not followed by 0 or 1 in path pointer
     with pytest.raises(ValueError, match="Invalid path syntax"):
         strict_processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "createSurface": {
                 "surfaceId": "s1",
                 "catalogId": real_catalog_09.catalog_id,
             },
         }])
         strict_processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "updateComponents": {
                 "surfaceId": "s1",
                 "components": [{
@@ -446,14 +449,14 @@ def test_message_processor_strict_mode_unrecognized_component_type(
     lazy_processor = MessageProcessor(catalogs=[real_catalog_09])
     lazy_processor.process_messages([
         {
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "createSurface": {
                 "surfaceId": "s1",
                 "catalogId": real_catalog_09.catalog_id,
             },
         },
         {
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "updateComponents": {
                 "surfaceId": "s1",
                 "components": [
@@ -476,7 +479,7 @@ def test_message_processor_xor_conflict_coverage():
     processor = MessageProcessor(catalogs=[catalog])
 
     conflicting_payload = [{
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "createSurface": {"surfaceId": "s1", "catalogId": catalog.catalog_id},
         "deleteSurface": {"surfaceId": "s1"},
     }]
@@ -491,14 +494,14 @@ def test_message_processor_missing_data_model_path_reactive_binding(mock_catalog
 
     processor.process_messages([
         {
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "createSurface": {
                 "surfaceId": "s1",
                 "catalogId": mock_catalog.catalog_id,
             },
         },
         {
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "updateComponents": {
                 "surfaceId": "s1",
                 "components": [{
@@ -524,7 +527,7 @@ def test_message_processor_missing_data_model_path_reactive_binding(mock_catalog
         assert text_val is None
 
     processor.process_messages([{
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "updateDataModel": {
             "surfaceId": "s1",
             "path": "/missing/username",
@@ -548,7 +551,7 @@ def test_message_processor_custom_catalog_component_validation():
         def __init__(self):
             super().__init__(
                 catalog_id="https://rizzcharts.com/catalog.json",
-                spec_version=SPEC_VERSION,
+                protocol_version=PROTOCOL_VERSION,
                 components=[ModelComponentApi(ChartComponent, "Chart")],
                 functions=[],
             )
@@ -557,12 +560,12 @@ def test_message_processor_custom_catalog_component_validation():
     processor = MessageProcessor(catalogs=[catalog], strict_mode=True)
 
     processor.process_messages([{
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "createSurface": {"surfaceId": "s1", "catalogId": catalog.catalog_id},
     }])
 
     processor.process_messages([{
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "updateComponents": {
             "surfaceId": "s1",
             "components": [{
@@ -588,7 +591,7 @@ def test_message_processor_custom_catalog_component_validation():
         ),
     ):
         processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "updateComponents": {
                 "surfaceId": "s1",
                 "components": [{"id": "root", "component": "Chart", "title": "Sales"}],
@@ -608,7 +611,7 @@ def test_message_processor_theme_validation(real_catalog_09):
         match="Validation failed for theme on surface 's1'|String should match pattern",
     ):
         processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "createSurface": {
                 "surfaceId": "s1",
                 "catalogId": real_catalog_09.catalog_id,
@@ -634,18 +637,18 @@ def test_message_processor_json_catalog_validation():
         },
     }
 
-    catalog = Catalog.from_json(catalog_json, spec_version=SPEC_VERSION)
+    catalog = Catalog.from_json(catalog_json, protocol_version=PROTOCOL_VERSION)
     processor = MessageProcessor(catalogs=[catalog], strict_mode=True)
 
     # 2. Process surface creation
     processor.process_messages([{
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "createSurface": {"surfaceId": "s1", "catalogId": catalog.catalog_id},
     }])
 
     # 3. Validate correct component ingestion
     processor.process_messages([{
-        "version": SPEC_VERSION,
+        "version": PROTOCOL_VERSION,
         "updateComponents": {
             "surfaceId": "s1",
             "components": [{
@@ -666,7 +669,7 @@ def test_message_processor_json_catalog_validation():
     # 4. Assert strict JSON Schema validation catches invalid types!
     with pytest.raises(ValueError, match="is not of type 'number'"):
         processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "updateComponents": {
                 "surfaceId": "s1",
                 "components": [{
@@ -681,7 +684,7 @@ def test_message_processor_json_catalog_validation():
     # 5. Assert strict JSON Schema validation catches unrecognized component properties!
     with pytest.raises(ValueError, match="Additional properties are not allowed"):
         processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "updateComponents": {
                 "surfaceId": "s1",
                 "components": [{
@@ -726,7 +729,7 @@ def test_message_processor_json_catalog_theme_validation():
         },
     }
 
-    catalog = Catalog.from_json(catalog_json, spec_version=SPEC_VERSION)
+    catalog = Catalog.from_json(catalog_json, protocol_version=PROTOCOL_VERSION)
     processor = MessageProcessor(catalogs=[catalog], strict_mode=True)
 
     # Dynamic JSON Theme validation fails on incorrect color hex code pattern
@@ -734,7 +737,7 @@ def test_message_processor_json_catalog_theme_validation():
         ValueError, match="Validation failed for theme on surface 's1'|does not match"
     ):
         processor.process_messages([{
-            "version": SPEC_VERSION,
+            "version": PROTOCOL_VERSION,
             "createSurface": {
                 "surfaceId": "s1",
                 "catalogId": catalog.catalog_id,

--- a/specification/proposals/express/scripts/recreate_dsl_examples.py
+++ b/specification/proposals/express/scripts/recreate_dsl_examples.py
@@ -94,7 +94,7 @@ def main():
     print(f"Generating system prompt from catalog: {catalog_path}...")
     with open(catalog_path, "r", encoding="utf-8") as f:
         catalog_dict = json.load(f)
-    catalog = Catalog.from_json(catalog_dict, spec_version="0.9.1")
+    catalog = Catalog.from_json(catalog_dict, protocol_version="0.9.1")
     from a2ui.inference_formats.experimental.express.format import ExpressFormat
 
     express_format = ExpressFormat(catalog=catalog)

--- a/specification/proposals/express/scripts/run_compiler.py
+++ b/specification/proposals/express/scripts/run_compiler.py
@@ -72,7 +72,7 @@ def compile_dsl_file(
 
     with open(catalog_path, "r", encoding="utf-8") as f:
         catalog_dict = json.load(f)
-    catalog = Catalog.from_json(catalog_dict, spec_version="0.9.1")
+    catalog = Catalog.from_json(catalog_dict, protocol_version="0.9.1")
     compiler = ExpressCompiler(catalog)
     return compiler.compile(dsl_text, surface_id=surface_id, catalog_id=catalog_id)
 

--- a/specification/proposals/express/scripts/run_decompiler.py
+++ b/specification/proposals/express/scripts/run_decompiler.py
@@ -95,7 +95,7 @@ def decompile_example(example_path: str, catalog_path: str) -> str:
 
     with open(catalog_path, "r", encoding="utf-8") as f:
         catalog_dict = json.load(f)
-    catalog = Catalog.from_json(catalog_dict, spec_version="0.9.1")
+    catalog = Catalog.from_json(catalog_dict, protocol_version="0.9.1")
     decompiler = ExpressParser(catalog)
     return decompiler.decompile(envelope)
 

--- a/specification/proposals/express/scripts/run_inference.py
+++ b/specification/proposals/express/scripts/run_inference.py
@@ -103,7 +103,7 @@ def run_inference_and_validate(
 
     with open(catalog_path, "r", encoding="utf-8") as f:
         catalog_dict = json.load(f)
-    catalog = Catalog.from_json(catalog_dict, spec_version="0.9.1")
+    catalog = Catalog.from_json(catalog_dict, protocol_version="0.9.1")
 
     # 1. Load the original example JSON to extract target component list
     with open(example_path, "r", encoding="utf-8") as f:

--- a/specification/proposals/express/scripts/run_prompt_generator.py
+++ b/specification/proposals/express/scripts/run_prompt_generator.py
@@ -61,7 +61,7 @@ def generate_prompt_text(catalog_path: str) -> str:
 
     with open(catalog_path, "r", encoding="utf-8") as f:
         catalog_dict = json.load(f)
-    catalog = Catalog.from_json(catalog_dict, spec_version="0.9.1")
+    catalog = Catalog.from_json(catalog_dict, protocol_version="0.9.1")
 
     from a2ui.inference_formats.experimental.express.format import ExpressFormat
 

--- a/typescript/web_core/tests/conformance/conformance_test.mjs
+++ b/typescript/web_core/tests/conformance/conformance_test.mjs
@@ -27,10 +27,10 @@ const CORE_DIR = path.join(CONFORMANCE_ROOT, 'core');
 const AGENT_DIR = path.join(CONFORMANCE_ROOT, 'agent');
 
 /**
- * Set of A2UI specification versions supported by this TypeScript conformance harness.
+ * Set of A2UI protocol versions supported by this TypeScript conformance harness.
  * Test cases specifying protocol versions outside this set are skipped.
  */
-const SUPPORTED_SPEC_VERSIONS = new Set(['v0.8', 'v0.9', 'v1.0']);
+const SUPPORTED_PROTOCOL_VERSIONS = new Set(['v0.8', 'v0.9', 'v1.0']);
 
 /**
  * Transition skip list containing specific test case names to skip during active feature transitions.
@@ -111,9 +111,11 @@ function runConformanceHarness() {
       let version = catalog?.protocolVersion || args?.version || 'v0.8';
       if (!version.startsWith('v')) version = `v${version}`;
 
-      if (!SUPPORTED_SPEC_VERSIONS.has(version)) {
+      if (!SUPPORTED_PROTOCOL_VERSIONS.has(version)) {
         totalSkipped++;
-        console.log(`  ⁃ [SKIPPED] ${name} (version ${version} not in SUPPORTED_SPEC_VERSIONS)`);
+        console.log(
+          `  ⁃ [SKIPPED] ${name} (version ${version} not in SUPPORTED_PROTOCOL_VERSIONS)`,
+        );
         continue;
       }
 


### PR DESCRIPTION
### Description

This PR standardizes naming across Python core, agent SDK, conformance tests, and Composer tools from `spec_version` / `specVersion` to `protocol_version` / `protocolVersion`, while maintaining full backwards compatibility.

### Summary of Changes

1. **Naming Standard Updates**:
   - **`snake_case`**:
     - `Catalog.protocol_version` property and constructor / `from_json` parameters (with backwards-compatible `spec_version` property and kwargs preserved).
     - `_basic_catalog_id(protocol_version)`, `_schema_url(protocol_version, ...)`.
   - **`SCREAMING_SNAKE_CASE`**:
     - Emitted `PROTOCOL_VERSION`, `PROTOCOL_VERSION_TYPE`, `PROTOCOL_BASE_URL` in schema and basic catalog `constants.py`.
     - Defined `PROTOCOL_VERSION_MAP` and `SUPPORTED_PROTOCOL_VERSIONS` (with backwards-compatible aliases `SPEC_VERSION`, `SPEC_VERSION_TYPE`, `SPEC_BASE_URL`, `SPEC_VERSION_MAP`, `SUPPORTED_SPEC_VERSIONS`).
   - **`camelCase` / `PascalCase`**:
     - Updated TypeScript types and React contexts in `tools/composer` to `ProtocolVersion`, `protocolVersion`, `useProtocolVersion`, and `ProtocolVersionProvider` (with backwards-compatible `SpecVersion` / `useSpecVersion` aliases).
2. **Schema & Basic Catalog Regeneration**:
   - Regenerated models and basic catalogs for **v0.8**, **v0.9**, and **v1.0** via `codegen_pydantic.py`.
   - Formatted all generated code with `pyink`.

### Verification

- `uv run pytest python/` (729 passed, 2 skipped)
- `uv run --all-packages mypy .` (typecheck clean)
- `uv run pyink --check .` (clean)
- `uv run python3 scripts/run_skills_tests.py` (all skill tests passed)
- `python3 -m unittest discover -s .github/scripts/tests` (passed)
- `uv run python python/a2ui_agent/tests/integration/verify_load_real.py` (passed)

TAG=agy
CONV=707c9b6b-b2da-4940-ba6e-67f0b4f1d563