### PR TITLE
fix(swift): implement atomic two-pass component validation in MessageProcessor

### DIFF
--- a/swift/core/Sources/A2UICore/Processing/MessageProcessor.swift
+++ b/swift/core/Sources/A2UICore/Processing/MessageProcessor.swift
@@ -361,6 +361,7 @@ public final class MessageProcessor: ObservableObject {
       return
     }
 
+    // Pass 1: Validation Pass
     for componentDict in components {
       guard let type = componentDict["component"]?.stringValue else {
         let error = ClientServerError.validationFailed(
@@ -371,7 +372,7 @@ public final class MessageProcessor: ObservableObject {
           )
         )
         actionHandler?.handle(error: error, from: surfaceID)
-        continue
+        return
       }
 
       guard let id = componentDict["id"]?.stringValue else {
@@ -383,7 +384,7 @@ public final class MessageProcessor: ObservableObject {
           )
         )
         actionHandler?.handle(error: error, from: surfaceID)
-        continue
+        return
       }
 
       let componentCatalogID = componentDict["catalogId"]?.stringValue ?? surface.defaultCatalogID
@@ -397,7 +398,7 @@ public final class MessageProcessor: ObservableObject {
           )
         )
         actionHandler?.handle(error: error, from: surfaceID)
-        continue
+        return
       }
 
       let instance: JSONValue = .object(
@@ -406,22 +407,7 @@ public final class MessageProcessor: ObservableObject {
         )
       )
       let result = schema.validate(instance)
-
-      if result.isValid {
-        var props: [String: JSONValue] = [:]
-        for (key, val) in componentDict
-        where key != "id" && key != "component" && key != "catalogId" {
-          props[key] = val
-        }
-
-        let existing = surface.componentsModel.get(id)
-        if let existing, existing.type != type {
-          surface.componentsModel.removeComponent(id)
-        }
-        surface.componentsModel.addComponent(
-          ComponentModel(id: id, type: type, catalogID: componentCatalogID, properties: props)
-        )
-      } else {
+      guard result.isValid else {
         let errorMessage = result.errors?.first?.message ?? "Validation failed"
         let errorPath = result.errors?.first?.instanceLocation.jsonPointerString ?? "/"
         let error = ClientServerError.validationFailed(
@@ -432,7 +418,32 @@ public final class MessageProcessor: ObservableObject {
           )
         )
         actionHandler?.handle(error: error, from: surfaceID)
+        return
       }
+    }
+
+    // Pass 2: Mutation Pass
+    for componentDict in components {
+      guard let type = componentDict["component"]?.stringValue,
+        let id = componentDict["id"]?.stringValue
+      else {
+        continue
+      }
+      let componentCatalogID = componentDict["catalogId"]?.stringValue ?? surface.defaultCatalogID
+
+      var props: [String: JSONValue] = [:]
+      for (key, val) in componentDict
+      where key != "id" && key != "component" && key != "catalogId" {
+        props[key] = val
+      }
+
+      let existing = surface.componentsModel.get(id)
+      if let existing, existing.type != type {
+        surface.componentsModel.removeComponent(id)
+      }
+      surface.componentsModel.addComponent(
+        ComponentModel(id: id, type: type, catalogID: componentCatalogID, properties: props)
+      )
     }
   }
 

--- a/swift/core/Tests/A2UICoreTests/MessageProcessorTests.swift
+++ b/swift/core/Tests/A2UICoreTests/MessageProcessorTests.swift
@@ -199,6 +199,87 @@ struct MessageProcessorTests {
     #expect(components?["root"] != nil)
   }
 
+  @Test func processUpdateComponentsValidBatch() throws {
+    let (processor, handler) = try makeProcessor()
+    try processor.process(
+      line: """
+        {
+          "version": "v0.9.1",
+          "createSurface": {
+            "surfaceId": "s1",
+            "catalogId": "default"
+          }
+        }
+        """)
+    try processor.process(
+      line: """
+        {
+          "version": "v0.9.1",
+          "updateComponents": {
+            "surfaceId": "s1",
+            "components": [
+              {
+                "id": "c1",
+                "component": "text",
+                "text": "First"
+              },
+              {
+                "id": "c2",
+                "component": "text",
+                "text": "Second"
+              }
+            ]
+          }
+        }
+        """)
+    let vm = processor.surfaceGroupModel.surfacesMap["s1"]
+    let components = vm?.componentsModel.components
+    #expect(components?.count == 2)
+    #expect(components?["c1"]?.properties["text"]?.stringValue == "First")
+    #expect(components?["c2"]?.properties["text"]?.stringValue == "Second")
+    #expect(handler.capturedErrors.isEmpty)
+  }
+
+  @Test func processUpdateComponentsAtomicFailure() throws {
+    let (processor, handler) = try makeProcessor()
+    try processor.process(
+      line: """
+        {
+          "version": "v0.9.1",
+          "createSurface": {
+            "surfaceId": "s1",
+            "catalogId": "default"
+          }
+        }
+        """)
+    try processor.process(
+      line: """
+        {
+          "version": "v0.9.1",
+          "updateComponents": {
+            "surfaceId": "s1",
+            "components": [
+              {
+                "id": "c1",
+                "component": "text",
+                "text": "First"
+              },
+              {
+                "id": "c2",
+                "component": "text",
+                "text": 12345
+              }
+            ]
+          }
+        }
+        """)
+    let vm = processor.surfaceGroupModel.surfacesMap["s1"]
+    let components = vm?.componentsModel.components
+    #expect(components?.isEmpty == true)
+    #expect(components?["c1"] == nil)
+    #expect(handler.capturedErrors.count == 1)
+  }
+
   @Test func processUpdateComponentsForMissingSurfaceThrows() throws {
     let (processor, handler) = try makeProcessor()
     #expect(throws: GenericError.self) {


### PR DESCRIPTION
## Summary

Implements atomic two-pass component validation in `MessageProcessor.updateComponents`.

Previously, `MessageProcessor` validated and applied components sequentially in a single pass. If an update payload contained a valid component followed by an invalid component, the valid component was committed to `SurfaceComponentsModel` before the error occurred, resulting in partial state mutations.

This change separates component processing into two distinct passes:
1. Validation pass: Iterates over all components in the batch, checking required keys (`component`, `id`) and validating each component instance against its catalog schema if present. If any component fails validation, the error is dispatched to `actionHandler` and the entire update aborts without modifying surface state.
2. Mutation pass: Runs only after all components in the batch pass validation, applying additions, property updates, and type replacements atomically.

## Changes

* `MessageProcessor.swift`: Refactored `updateComponents` into a pre-mutation validation pass followed by a mutation pass.
* `MessageProcessorTests.swift`: Added `processUpdateComponentsValidBatch` and `processUpdateComponentsAtomicFailure` unit tests to verify atomic commit and rollback behavior.

## Testing

* `swift test`: 386 unit tests pass across 41 test suites.
