### PR TITLE
feat(swift): enforce single-action mutual exclusivity in message decoding

### DIFF
--- a/swift/core/Sources/A2UICore/Messages/ClientToServerMessage.swift
+++ b/swift/core/Sources/A2UICore/Messages/ClientToServerMessage.swift
@@ -49,10 +49,12 @@ public enum ClientToServerMessage: Equatable, Codable, Sendable {
     switch payloadKey {
     case .action:
       self = .action(try container.decode(ClientAction.self, forKey: .action))
-    case .error:
-      self = .error(try container.decode(ClientServerError.self, forKey: .error))
     case .version:
-      fatalError("Unreachable: filtered out version key")
+      let context = DecodingError.Context(
+        codingPath: container.codingPath,
+        debugDescription: "Internal error: version key was not filtered out"
+      )
+      throw DecodingError.dataCorrupted(context)
     }
   }
 

--- a/swift/core/Sources/A2UICore/Messages/ClientToServerMessage.swift
+++ b/swift/core/Sources/A2UICore/Messages/ClientToServerMessage.swift
@@ -36,23 +36,23 @@ public enum ClientToServerMessage: Equatable, Codable, Sendable {
       )
     }
 
-    if let action = try container.decodeIfPresent(
-      ClientAction.self,
-      forKey: .action
-    ) {
-      self = .action(action)
-    } else if let error = try container.decodeIfPresent(
-      ClientServerError.self,
-      forKey: .error
-    ) {
-      self = .error(error)
-    } else {
-      throw DecodingError.dataCorrupted(
-        DecodingError.Context(
-          codingPath: decoder.codingPath,
-          debugDescription: "Message must contain either 'action' or 'error'"
-        )
+    let payloadKeys = container.allKeys.filter { $0 != .version }
+    guard payloadKeys.count == 1, let payloadKey = payloadKeys.first else {
+      let context = DecodingError.Context(
+        codingPath: container.codingPath,
+        debugDescription:
+          "ClientToServerMessage must contain exactly one payload ('action' or 'error'), found \(payloadKeys.count)"
       )
+      throw DecodingError.dataCorrupted(context)
+    }
+
+    switch payloadKey {
+    case .action:
+      self = .action(try container.decode(ClientAction.self, forKey: .action))
+    case .error:
+      self = .error(try container.decode(ClientServerError.self, forKey: .error))
+    case .version:
+      fatalError("Unreachable: filtered out version key")
     }
   }
 

--- a/swift/core/Sources/A2UICore/Messages/ClientToServerMessage.swift
+++ b/swift/core/Sources/A2UICore/Messages/ClientToServerMessage.swift
@@ -49,6 +49,8 @@ public enum ClientToServerMessage: Equatable, Codable, Sendable {
     switch payloadKey {
     case .action:
       self = .action(try container.decode(ClientAction.self, forKey: .action))
+    case .error:
+      self = .error(try container.decode(ClientServerError.self, forKey: .error))
     case .version:
       let context = DecodingError.Context(
         codingPath: container.codingPath,

--- a/swift/core/Sources/A2UICore/Messages/ServerToClientMessage.swift
+++ b/swift/core/Sources/A2UICore/Messages/ServerToClientMessage.swift
@@ -62,6 +62,8 @@ public enum ServerToClientMessage: Codable, Sendable, Equatable {
     case .updateDataModel:
       self = .updateDataModel(
         try container.decode(UpdateDataModelMessage.self, forKey: .updateDataModel))
+    case .deleteSurface:
+      self = .deleteSurface(try container.decode(DeleteSurfaceMessage.self, forKey: .deleteSurface))
     case .version:
       let context = DecodingError.Context(
         codingPath: container.codingPath,

--- a/swift/core/Sources/A2UICore/Messages/ServerToClientMessage.swift
+++ b/swift/core/Sources/A2UICore/Messages/ServerToClientMessage.swift
@@ -43,35 +43,29 @@ public enum ServerToClientMessage: Codable, Sendable, Equatable {
       )
     }
 
-    if let createSurface = try container.decodeIfPresent(
-      CreateSurfaceMessage.self,
-      forKey: .createSurface
-    ) {
-      self = .createSurface(createSurface)
-    } else if let updateComponents = try container.decodeIfPresent(
-      UpdateComponentsMessage.self,
-      forKey: .updateComponents
-    ) {
-      self = .updateComponents(updateComponents)
-    } else if let updateDataModel = try container.decodeIfPresent(
-      UpdateDataModelMessage.self,
-      forKey: .updateDataModel
-    ) {
-      self = .updateDataModel(updateDataModel)
-    } else if let deleteSurface = try container.decodeIfPresent(
-      DeleteSurfaceMessage.self,
-      forKey: .deleteSurface
-    ) {
-      self = .deleteSurface(deleteSurface)
-    } else {
+    let actionKeys = container.allKeys.filter { $0 != .version }
+    guard actionKeys.count == 1, let actionKey = actionKeys.first else {
       let context = DecodingError.Context(
         codingPath: container.codingPath,
-        debugDescription: """
-          ServerToClientMessage must contain one of: 'createSurface', \
-          'updateComponents', 'updateDataModel', or 'deleteSurface'
-          """
+        debugDescription:
+          "ServerToClientMessage must contain exactly one action, found \(actionKeys.count)"
       )
       throw DecodingError.dataCorrupted(context)
+    }
+
+    switch actionKey {
+    case .createSurface:
+      self = .createSurface(try container.decode(CreateSurfaceMessage.self, forKey: .createSurface))
+    case .updateComponents:
+      self = .updateComponents(
+        try container.decode(UpdateComponentsMessage.self, forKey: .updateComponents))
+    case .updateDataModel:
+      self = .updateDataModel(
+        try container.decode(UpdateDataModelMessage.self, forKey: .updateDataModel))
+    case .deleteSurface:
+      self = .deleteSurface(try container.decode(DeleteSurfaceMessage.self, forKey: .deleteSurface))
+    case .version:
+      fatalError("Unreachable: filtered out version key")
     }
   }
 

--- a/swift/core/Sources/A2UICore/Messages/ServerToClientMessage.swift
+++ b/swift/core/Sources/A2UICore/Messages/ServerToClientMessage.swift
@@ -62,10 +62,12 @@ public enum ServerToClientMessage: Codable, Sendable, Equatable {
     case .updateDataModel:
       self = .updateDataModel(
         try container.decode(UpdateDataModelMessage.self, forKey: .updateDataModel))
-    case .deleteSurface:
-      self = .deleteSurface(try container.decode(DeleteSurfaceMessage.self, forKey: .deleteSurface))
     case .version:
-      fatalError("Unreachable: filtered out version key")
+      let context = DecodingError.Context(
+        codingPath: container.codingPath,
+        debugDescription: "Internal error: version key was not filtered out"
+      )
+      throw DecodingError.dataCorrupted(context)
     }
   }
 

--- a/swift/core/Tests/A2UICoreTests/ClientToServerMessageTests.swift
+++ b/swift/core/Tests/A2UICoreTests/ClientToServerMessageTests.swift
@@ -124,6 +124,31 @@ struct ClientToServerMessageTests {
     }
   }
 
+  @Test func decodeRejectsBothActionAndError() throws {
+    let json = try #require(
+      """
+      {
+        "version": "v0.9.1",
+        "action": {
+          "name": "submit",
+          "surfaceId": "main",
+          "sourceComponentId": "btn_submit",
+          "timestamp": "2023-10-27T10:00:00Z",
+          "context": {}
+        },
+        "error": {
+          "code": "VALIDATION_FAILED",
+          "surfaceId": "main",
+          "path": "/components/0",
+          "message": "Invalid input"
+        }
+      }
+      """.data(using: .utf8))
+    #expect(throws: DecodingError.self) {
+      try JSONDecoder().decode(ClientToServerMessage.self, from: json)
+    }
+  }
+
   @Test func decodeRejectsActionMissingRequiredField() throws {
     let json = try #require(
       """

--- a/swift/core/Tests/A2UICoreTests/ServerToClientMessageTests.swift
+++ b/swift/core/Tests/A2UICoreTests/ServerToClientMessageTests.swift
@@ -199,6 +199,74 @@ struct ServerToClientMessageTests {
     }
   }
 
+  @Test func decodeRejectsMultipleActionsCreateAndComponents() throws {
+    let json = try #require(
+      """
+      {
+        "version": "v0.9.1",
+        "createSurface": {
+          "surfaceId": "s1",
+          "catalogId": "default"
+        },
+        "updateComponents": {
+          "surfaceId": "s1",
+          "components": []
+        }
+      }
+      """.data(using: .utf8))
+    #expect(throws: DecodingError.self) {
+      try JSONDecoder().decode(ServerToClientMessage.self, from: json)
+    }
+  }
+
+  @Test func decodeRejectsMultipleActionsCreateAndDataModel() throws {
+    let json = try #require(
+      """
+      {
+        "version": "v0.9.1",
+        "createSurface": {
+          "surfaceId": "s1",
+          "catalogId": "default"
+        },
+        "updateDataModel": {
+          "surfaceId": "s1",
+          "value": "hello"
+        }
+      }
+      """.data(using: .utf8))
+    #expect(throws: DecodingError.self) {
+      try JSONDecoder().decode(ServerToClientMessage.self, from: json)
+    }
+  }
+
+  @Test func decodeRejectsMultipleActionsAllFour() throws {
+    let json = try #require(
+      """
+      {
+        "version": "v0.9.1",
+        "createSurface": {"surfaceId": "s1", "catalogId": "default"},
+        "updateComponents": {"surfaceId": "s1", "components": []},
+        "updateDataModel": {"surfaceId": "s1", "value": 1},
+        "deleteSurface": {"surfaceId": "s1"}
+      }
+      """.data(using: .utf8))
+    #expect(throws: DecodingError.self) {
+      try JSONDecoder().decode(ServerToClientMessage.self, from: json)
+    }
+  }
+
+  @Test func decodeRejectsZeroActions() throws {
+    let json = try #require(
+      """
+      {
+        "version": "v0.9.1"
+      }
+      """.data(using: .utf8))
+    #expect(throws: DecodingError.self) {
+      try JSONDecoder().decode(ServerToClientMessage.self, from: json)
+    }
+  }
+
   // MARK: - Encoding Round-Trip
 
   @Test func encodeDecodeRoundTripCreateSurface() throws {


### PR DESCRIPTION
## Summary

Enforces single-action and single-payload mutual exclusivity during decoding of `ServerToClientMessage` and `ClientToServerMessage` in `A2UICore`.

Previously, `ServerToClientMessage` and `ClientToServerMessage` used chained `if let ... else if let ...` decoding, silently accepting envelopes containing multiple action/payload keys and processing only the first.

This change uses `container.allKeys` to verify that exactly one action or payload is present in the message envelope, throwing `DecodingError.dataCorrupted` if multiple or zero actions are supplied, and performing an exhaustive single-case decode.

## Changes

* `ServerToClientMessage.swift`: Filters `container.allKeys` for non-version keys and verifies `actionKeys.count == 1` before decoding the specific action.
* `ClientToServerMessage.swift`: Filters `container.allKeys` for non-version keys and verifies `payloadKeys.count == 1` before decoding the specific payload.
* `ServerToClientMessageTests.swift`: Added test cases for envelopes containing multiple actions (`createSurface` + `updateComponents`, `createSurface` + `updateDataModel`, all four actions combined, and zero actions).
* `ClientToServerMessageTests.swift`: Added test case for envelopes containing both `action` and `error`.

## Testing

* `swift-format lint`: Passed with 0 errors.
* `swift test`: 389 unit tests pass across 41 test suites.
