### PR TITLE
ci: update workflow runners to use ubuntu-latest-extra-capacity

### DIFF
--- a/.github/workflows/community_code.yml
+++ b/.github/workflows/community_code.yml
@@ -30,7 +30,7 @@ on:
       - ".github/workflows/community_code.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/community_code.yml
+++ b/.github/workflows/community_code.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   web:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     defaults:
       run:
         working-directory: samples/community
@@ -68,7 +68,7 @@ jobs:
         run: yarn workspace custom-lit-components run build
 
   python:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   changes:
     if: github.repository == 'a2ui-project/a2ui'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     permissions:
       contents: read
     outputs:
@@ -67,7 +67,7 @@ jobs:
   build_and_deploy:
     needs: changes
     if: github.repository == 'a2ui-project/a2ui' && (github.event_name == 'push' || needs.changes.outputs.docs == 'true')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     # Requires write access to publish built documentation to gh-pages branch
     permissions:
       contents: write

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -26,7 +26,7 @@ jobs:
     # Do not run on forked branches,
     # because the test does not have access to secrets in forks.
     if: github.repository == 'a2ui-project/a2ui'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/flutter_packages_test.yaml
+++ b/.github/workflows/flutter_packages_test.yaml
@@ -26,7 +26,7 @@ on:
     - cron: "0 * * * *" # hourly
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/flutter_packages_test.yaml
+++ b/.github/workflows/flutter_packages_test.yaml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     outputs:
       matrix: ${{ steps.generate_matrix.outputs.matrix }}
       flutter_version: ${{ steps.generate_matrix.outputs.flutter_version }}
@@ -70,7 +70,7 @@ jobs:
           fi
 
   cycle-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/kotlin_agent_sdk_build_and_test.yml
+++ b/.github/workflows/kotlin_agent_sdk_build_and_test.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/presubmit-lint.yml
+++ b/.github/workflows/presubmit-lint.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   static-checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -66,7 +66,7 @@ jobs:
         run: ./scripts/fix_licenses.py --check
 
   format-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -83,7 +83,7 @@ jobs:
         run: ./scripts/fix_format.sh --check
 
   workspace-lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/presubmit-lint.yml
+++ b/.github/workflows/presubmit-lint.yml
@@ -20,7 +20,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -40,7 +40,7 @@ on:
       - ".github/actions/setup-python/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -48,7 +48,7 @@ permissions:
 
 jobs:
   python-ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/remediate_chatops.yml
+++ b/.github/workflows/remediate_chatops.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   run-remediation:
     name: Execute Automated Remediation Draft PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     timeout-minutes: 60
     if: >
       !github.event.issue.pull_request &&

--- a/.github/workflows/run_evals.yml
+++ b/.github/workflows/run_evals.yml
@@ -35,7 +35,7 @@ on:
     - cron: "0 0 * * *" # daily
 jobs:
   run-evals:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -62,7 +62,7 @@ permissions:
 jobs:
   triage:
     name: Execute Triage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     # Requires issue and PR write permissions for automated labeling and comment management
     permissions:
       contents: read

--- a/.github/workflows/validate_blueprints.yml
+++ b/.github/workflows/validate_blueprints.yml
@@ -26,7 +26,7 @@ on:
       - ".github/workflows/validate_blueprints.yml"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/validate_blueprints.yml
+++ b/.github/workflows/validate_blueprints.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   validate-blueprints:
     name: Validate Blueprints
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/validate_specifications.yml
+++ b/.github/workflows/validate_specifications.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   validate:
     name: Validate Specifications
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     permissions:
       contents: read
 

--- a/.github/workflows/web_ci.yml
+++ b/.github/workflows/web_ci.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     outputs:
       renderers: ${{ steps.filter.outputs.renderers }}
       tools: ${{ steps.filter.outputs.tools }}
@@ -81,7 +81,7 @@ jobs:
   ci-renderers:
     needs: changes
     if: ${{ needs.changes.outputs.renderers == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     # Healthy runs finish in ~20 min. Cap the job so a hung test fails fast
     # instead of running to the default 6h timeout (see issue #1637).
     timeout-minutes: 30
@@ -109,7 +109,7 @@ jobs:
   ci-tools:
     needs: changes
     if: ${{ needs.changes.outputs.tools == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -125,7 +125,7 @@ jobs:
   ci-samples:
     needs: changes
     if: ${{ needs.changes.outputs.samples == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -143,7 +143,7 @@ jobs:
   ci-scripts:
     needs: changes
     if: ${{ needs.changes.outputs.scripts == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -157,7 +157,7 @@ jobs:
   ci-other:
     needs: changes
     if: ${{ needs.changes.outputs.other == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/web_ci.yml
+++ b/.github/workflows/web_ci.yml
@@ -20,7 +20,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref_name || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   run-audit:
     name: Execute Antigravity Compliance Audit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-extra-capacity
     timeout-minutes: 60
     # Requires issue write permissions to create compliance audit reports
     permissions:


### PR DESCRIPTION
## Summary

Updates the `runs-on` target label across GitHub Actions workflows from standard `ubuntu-latest` to `ubuntu-latest-extra-capacity` to utilize provisioned higher-capacity runner pools, and fixes workflow concurrency expressions to ensure redundant in-progress runs auto-cancel on branch updates.

## Changes

- **Runner Pool Updates**: Updated `runs-on: ubuntu-latest` to `runs-on: ubuntu-latest-extra-capacity` across 14 workflow files in `.github/workflows/`:
  - [`.github/workflows/web_ci.yml`](file:///.github/workflows/web_ci.yml)
  - [`.github/workflows/presubmit-lint.yml`](file:///.github/workflows/presubmit-lint.yml)
  - [`.github/workflows/docs.yml`](file:///.github/workflows/docs.yml)
  - [`.github/workflows/community_code.yml`](file:///.github/workflows/community_code.yml)
  - [`.github/workflows/flutter_packages_test.yaml`](file:///.github/workflows/flutter_packages_test.yaml)
  - [`.github/workflows/python_ci.yml`](file:///.github/workflows/python_ci.yml)
  - [`.github/workflows/kotlin_agent_sdk_build_and_test.yml`](file:///.github/workflows/kotlin_agent_sdk_build_and_test.yml)
  - [`.github/workflows/e2e_test.yaml`](file:///.github/workflows/e2e_test.yaml)
  - [`.github/workflows/validate_blueprints.yml`](file:///.github/workflows/validate_blueprints.yml)
  - [`.github/workflows/validate_specifications.yml`](file:///.github/workflows/validate_specifications.yml)
  - [`.github/workflows/run_evals.yml`](file:///.github/workflows/run_evals.yml)
  - [`.github/workflows/remediate_chatops.yml`](file:///.github/workflows/remediate_chatops.yml)
  - [`.github/workflows/triage.yml`](file:///.github/workflows/triage.yml)
  - [`.github/workflows/weekly-audit.yml`](file:///.github/workflows/weekly-audit.yml)

- **Concurrency Auto-Cancellation Fix**: Replaced `group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}` with `group: ${{ github.workflow }}-${{ github.ref_name || github.ref }}` across primary CI workflows (`web_ci.yml`, `presubmit-lint.yml`, `python_ci.yml`, `flutter_packages_test.yaml`, `community_code.yml`, `validate_blueprints.yml`).
  - *Fix rationale*: `github.head_ref` is empty on `push` events, causing the expression to fall back to `github.run_id` (a unique ID per run). This broke `cancel-in-progress` for push events. Using `github.ref_name || github.ref` resolves the branch name for both push and pull request events, properly cancelling outdated queued builds.

## Impact & Risks

- **Impact**: Routes CI workflow executions to the higher-capacity `ubuntu-latest-extra-capacity` runner pool and automatically cancels obsolete queued builds on branch updates, eliminating runner queue backlogs.
- **Risks**: None. Requires the `ubuntu-latest-extra-capacity` runner group to be provisioned and accessible to the repository.

## Testing

1. Verified local YAML syntax and concurrency group resolution across modified workflow files.
2. Verified branch diffs and line replacements across all `.github/workflows/` files.
