### PR TITLE
feat(web_core): implement Stage 3 Sauce-TS bidirectional RPC and @index function

### DIFF
--- a/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -452,8 +452,7 @@ export const OpenUrlImplementation = createFunctionImplementation(OpenUrlApi, ar
  * Returns the loop index offset from context.
  */
 export const IndexImplementation = createFunctionImplementation(IndexApi, (args, context) => {
-  const offset =
-    typeof args.offset === 'number' && Number.isFinite(args.offset) ? args.offset : 0;
+  const offset = typeof args.offset === 'number' && Number.isFinite(args.offset) ? args.offset : 0;
   let index = 0;
   if (typeof (context as any)?.getIndex === 'function') {
     index = (context as any).getIndex();

--- a/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -452,16 +452,16 @@ export const OpenUrlImplementation = createFunctionImplementation(OpenUrlApi, ar
  * Returns the loop index offset from context.
  */
 export const IndexImplementation = createFunctionImplementation(IndexApi, (args, context) => {
-  const offset = typeof args.offset === 'number' ? args.offset : 0;
+  const offset =
+    typeof args.offset === 'number' && Number.isFinite(args.offset) ? args.offset : 0;
   let index = 0;
   if (typeof (context as any)?.getIndex === 'function') {
     index = (context as any).getIndex();
   } else if (context?.path) {
     const parts = context.path.split('/').filter(Boolean);
     for (let i = parts.length - 1; i >= 0; i--) {
-      const num = parseInt(parts[i], 10);
-      if (!isNaN(num)) {
-        index = num;
+      if (/^\d+$/.test(parts[i])) {
+        index = parseInt(parts[i], 10);
         break;
       }
     }

--- a/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {z} from 'zod';
 import {ExpressionParser} from '../../../expressions/expression_parser.js';
 import {computed, isSignal, getValue} from '../../../reactivity/signals.js';
 import {createFunctionImplementation, FunctionImplementation} from '../../../catalog/types.js';
@@ -46,7 +45,6 @@ import {
   PluralizeApi,
   OpenUrlApi,
 } from './basic_functions_api.js';
-import {IndexApi} from '../../../v1_0/functions/system_functions.js';
 import {A2uiExpressionError} from '../../../errors.js';
 
 // Arithmetic
@@ -448,27 +446,6 @@ export const OpenUrlImplementation = createFunctionImplementation(OpenUrlApi, ar
 });
 
 /**
- * Implementation of the `@index` function.
- * Returns the loop index offset from context.
- */
-export const IndexImplementation = createFunctionImplementation(IndexApi, (args, context) => {
-  const offset = typeof args.offset === 'number' && Number.isFinite(args.offset) ? args.offset : 0;
-  let index = 0;
-  if (typeof (context as any)?.getIndex === 'function') {
-    index = (context as any).getIndex();
-  } else if (context?.path) {
-    const parts = context.path.split('/').filter(Boolean);
-    for (let i = parts.length - 1; i >= 0; i--) {
-      if (/^\d+$/.test(parts[i])) {
-        index = parseInt(parts[i], 10);
-        break;
-      }
-    }
-  }
-  return index + offset;
-});
-
-/**
  * Creates standard function implementations for the Basic Catalog.
  *
  * @param options Configuration options.
@@ -502,7 +479,6 @@ export function createBasicCatalogFunctions(options?: {locale?: string}): Functi
     FormatDateImplementation,
     createPluralizeImplementation(locale),
     OpenUrlImplementation,
-    IndexImplementation,
   ];
 }
 

--- a/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -45,8 +45,8 @@ import {
   FormatDateApi,
   PluralizeApi,
   OpenUrlApi,
-  IndexApi,
 } from './basic_functions_api.js';
+import {IndexApi} from '../../../v1_0/functions/system_functions.js';
 import {A2uiExpressionError} from '../../../errors.js';
 
 // Arithmetic

--- a/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -45,6 +45,7 @@ import {
   FormatDateApi,
   PluralizeApi,
   OpenUrlApi,
+  IndexApi,
 } from './basic_functions_api.js';
 import {A2uiExpressionError} from '../../../errors.js';
 
@@ -447,6 +448,28 @@ export const OpenUrlImplementation = createFunctionImplementation(OpenUrlApi, ar
 });
 
 /**
+ * Implementation of the `@index` function.
+ * Returns the loop index offset from context.
+ */
+export const IndexImplementation = createFunctionImplementation(IndexApi, (args, context) => {
+  const offset = typeof args.offset === 'number' ? args.offset : 0;
+  let index = 0;
+  if (typeof (context as any)?.getIndex === 'function') {
+    index = (context as any).getIndex();
+  } else if (context?.path) {
+    const parts = context.path.split('/').filter(Boolean);
+    for (let i = parts.length - 1; i >= 0; i--) {
+      const num = parseInt(parts[i], 10);
+      if (!isNaN(num)) {
+        index = num;
+        break;
+      }
+    }
+  }
+  return index + offset;
+});
+
+/**
  * Creates standard function implementations for the Basic Catalog.
  *
  * @param options Configuration options.
@@ -480,6 +503,7 @@ export function createBasicCatalogFunctions(options?: {locale?: string}): Functi
     FormatDateImplementation,
     createPluralizeImplementation(locale),
     OpenUrlImplementation,
+    IndexImplementation,
   ];
 }
 
@@ -488,33 +512,3 @@ export function createBasicCatalogFunctions(options?: {locale?: string}): Functi
  * These functions cover arithmetic, comparison, logic, string manipulation, validation, and formatting.
  */
 export const BASIC_FUNCTIONS: FunctionImplementation[] = createBasicCatalogFunctions();
-
-/**
- * Implementation of the `@index` function.
- * Returns the loop index offset from context.
- */
-export const IndexApi = {
-  name: '@index',
-  returnType: 'number' as const,
-  schema: z.object({
-    offset: z.number().optional(),
-  }),
-};
-
-export const IndexImplementation = createFunctionImplementation(IndexApi, (args, context) => {
-  const offset = typeof args.offset === 'number' ? args.offset : 0;
-  let index = 0;
-  if (typeof (context as any).getIndex === 'function') {
-    index = (context as any).getIndex();
-  } else if (context.path) {
-    const parts = context.path.split('/').filter(Boolean);
-    for (let i = parts.length - 1; i >= 0; i--) {
-      const num = parseInt(parts[i], 10);
-      if (!isNaN(num)) {
-        index = num;
-        break;
-      }
-    }
-  }
-  return index + offset;
-});

--- a/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
+++ b/typescript/web_core/src/v0_9/basic_catalog/functions/basic_functions.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {z} from 'zod';
 import {ExpressionParser} from '../../../expressions/expression_parser.js';
 import {computed, isSignal, getValue} from '../../../reactivity/signals.js';
 import {createFunctionImplementation, FunctionImplementation} from '../../../catalog/types.js';
@@ -487,3 +488,33 @@ export function createBasicCatalogFunctions(options?: {locale?: string}): Functi
  * These functions cover arithmetic, comparison, logic, string manipulation, validation, and formatting.
  */
 export const BASIC_FUNCTIONS: FunctionImplementation[] = createBasicCatalogFunctions();
+
+/**
+ * Implementation of the `@index` function.
+ * Returns the loop index offset from context.
+ */
+export const IndexApi = {
+  name: '@index',
+  returnType: 'number' as const,
+  schema: z.object({
+    offset: z.number().optional(),
+  }),
+};
+
+export const IndexImplementation = createFunctionImplementation(IndexApi, (args, context) => {
+  const offset = typeof args.offset === 'number' ? args.offset : 0;
+  let index = 0;
+  if (typeof (context as any).getIndex === 'function') {
+    index = (context as any).getIndex();
+  } else if (context.path) {
+    const parts = context.path.split('/').filter(Boolean);
+    for (let i = parts.length - 1; i >= 0; i--) {
+      const num = parseInt(parts[i], 10);
+      if (!isNaN(num)) {
+        index = num;
+        break;
+      }
+    }
+  }
+  return index + offset;
+});

--- a/typescript/web_core/src/v1_0/functions/system_functions.ts
+++ b/typescript/web_core/src/v1_0/functions/system_functions.ts
@@ -15,6 +15,7 @@
  */
 
 import {z} from 'zod';
+import {createFunctionImplementation, FunctionImplementation} from '../../catalog/types.js';
 
 /**
  * Universal v1.0 system function to calculate the current 0-based iteration index in array contexts.
@@ -29,3 +30,29 @@ export const IndexApi = {
     'offset': z.coerce.number().optional(),
   }),
 };
+
+/**
+ * Implementation of the `@index` function.
+ * Returns the loop index offset from context.
+ */
+export const IndexImplementation = createFunctionImplementation(IndexApi, (args, context) => {
+  const offset = typeof args.offset === 'number' && Number.isFinite(args.offset) ? args.offset : 0;
+  let index = 0;
+  if (typeof (context as any)?.getIndex === 'function') {
+    index = (context as any).getIndex();
+  } else if (context?.path) {
+    const parts = context.path.split('/').filter(Boolean);
+    for (let i = parts.length - 1; i >= 0; i--) {
+      if (/^\d+$/.test(parts[i])) {
+        index = parseInt(parts[i], 10);
+        break;
+      }
+    }
+  }
+  return index + offset;
+});
+
+/**
+ * Standard v1.0 system function implementations.
+ */
+export const SYSTEM_FUNCTIONS: FunctionImplementation[] = [IndexImplementation];

--- a/typescript/web_core/src/v1_0/index.ts
+++ b/typescript/web_core/src/v1_0/index.ts
@@ -18,3 +18,4 @@ export * from './schema/index.js';
 export * from './functions/system_functions.js';
 export * from './functions/validation_functions_api.js';
 export * from './functions/validation_functions.js';
+export * from './rpc/rpc-handler.js';

--- a/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
@@ -51,6 +51,7 @@ export class RpcError extends Error {
   ) {
     super(`[${code}] ${message}`);
     this.name = 'RpcError';
+    Object.setPrototypeOf(this, RpcError.prototype);
   }
 }
 
@@ -146,7 +147,14 @@ export class RpcHandler {
     const {call, catalogId, args} = callFunction;
 
     // 1. Resolve catalog (fallback to surface default catalog if catalogId is omitted)
-    const targetCatalogId = catalogId || context.surface.catalog.id;
+    const targetCatalogId = catalogId || context?.surface?.catalog?.id;
+    if (!targetCatalogId) {
+      return this.createResponseError(
+        functionCallId,
+        RpcErrorCode.INVALID_FUNCTION_CALL,
+        'No catalogId provided and surface catalog is unavailable.',
+      );
+    }
     const catalog = this.catalogs.find(c => c.id === targetCatalogId);
     if (!catalog) {
       return this.createResponseError(
@@ -285,7 +293,11 @@ export class RpcHandler {
     } else {
       call = functionCallIdOrCall;
       const opts = (callOrOptions as {functionCallId?: string; timeoutMs?: number}) ?? {};
-      functionCallId = opts.functionCallId ?? crypto.randomUUID();
+      functionCallId =
+        opts.functionCallId ??
+        (typeof globalThis.crypto?.randomUUID === 'function'
+          ? globalThis.crypto.randomUUID()
+          : `call-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`);
       effectiveTimeoutMs = opts.timeoutMs ?? this.defaultTimeoutMs;
     }
 

--- a/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import {Catalog, ComponentApi} from '../../catalog/types.js';
+import {Catalog} from '../../catalog/types.js';
 import {DataContext} from '../../rendering/data-context.js';
 import {isSignal, getValue} from '../../reactivity/signals.js';
+import {FunctionCall} from '../schema/common-types.js';
 import {
   CallRendererFunctionMessage,
   AgentFunctionResponseMessage,
@@ -27,14 +28,53 @@ import {
 } from '../schema/renderer-to-agent.js';
 
 /**
- * A callback function to emit outbound client messages to the agent.
+ * Standard error codes for A2UI RPC failures.
+ */
+export enum RpcErrorCode {
+  INVALID_FUNCTION_CALL = 'INVALID_FUNCTION_CALL',
+  EXECUTION_ERROR = 'EXECUTION_ERROR',
+  TIMEOUT = 'TIMEOUT',
+  CANCELLED = 'CANCELLED',
+  DISPOSED = 'DISPOSED',
+  DUPLICATE = 'DUPLICATE',
+  NO_LISTENER = 'NO_LISTENER',
+}
+
+/**
+ * Custom error class for A2UI RPC operation failures.
+ */
+export class RpcError extends Error {
+  constructor(
+    public readonly code: RpcErrorCode | string,
+    message: string,
+    public readonly functionCallId?: string,
+  ) {
+    super(`[${code}] ${message}`);
+    this.name = 'RpcError';
+  }
+}
+
+/**
+ * Callback function type receiving outbound renderer messages intended for the agent.
  */
 export type OutboundMessageListener = (
   message: RendererFunctionResponseMessage | CallAgentFunctionMessage,
-) => void;
+) => void | Promise<void>;
 
 /**
- * A pending agent function callback record.
+ * Options for configuring an RpcHandler instance.
+ */
+export interface RpcHandlerOptions {
+  /** Catalogs available for function resolution. */
+  catalogs: Catalog<any>[];
+  /** Listener receiving outbound renderer messages. Required for callAgentFunction. */
+  outboundListener?: OutboundMessageListener;
+  /** Default timeout in milliseconds for callAgentFunction requests (default: 30000ms). */
+  defaultTimeoutMs?: number;
+}
+
+/**
+ * Pending agent function callback record.
  */
 interface PendingAgentCall {
   resolve: (value: unknown) => void;
@@ -43,22 +83,37 @@ interface PendingAgentCall {
 
 /**
  * Manages bidirectional RPC function execution between renderer and server agent.
- *
- * @template T The concrete type of the ComponentApi.
  */
-export class RpcHandler<T extends ComponentApi> {
+export class RpcHandler {
+  private readonly catalogs: Catalog<any>[];
+  private readonly outboundListener?: OutboundMessageListener;
+  private readonly defaultTimeoutMs: number;
   private readonly pendingAgentCalls = new Map<string, PendingAgentCall>();
+  private isDisposed = false;
+
+  constructor(options: RpcHandlerOptions);
+  constructor(catalogs: Catalog<any>[], outboundListener?: OutboundMessageListener);
+  constructor(
+    optionsOrCatalogs: RpcHandlerOptions | Catalog<any>[],
+    outboundListener?: OutboundMessageListener,
+  ) {
+    if (Array.isArray(optionsOrCatalogs)) {
+      this.catalogs = optionsOrCatalogs;
+      this.outboundListener = outboundListener;
+      this.defaultTimeoutMs = 30000;
+    } else {
+      this.catalogs = optionsOrCatalogs.catalogs;
+      this.outboundListener = optionsOrCatalogs.outboundListener;
+      this.defaultTimeoutMs = optionsOrCatalogs.defaultTimeoutMs ?? 30000;
+    }
+  }
 
   /**
-   * Creates a new RpcHandler instance.
-   *
-   * @param catalogs The available catalogs for function lookup.
-   * @param outboundListener The listener receiving outbound renderer messages.
+   * Indicates whether this RpcHandler instance has been disposed.
    */
-  constructor(
-    private readonly catalogs: Catalog<T>[],
-    private readonly outboundListener?: OutboundMessageListener,
-  ) {}
+  get disposed(): boolean {
+    return this.isDisposed;
+  }
 
   /**
    * Executes a remote renderer function requested by the server agent.
@@ -72,10 +127,18 @@ export class RpcHandler<T extends ComponentApi> {
     context: DataContext,
     isUserActivated: boolean = false,
   ): Promise<RendererFunctionResponseMessage> {
+    if (this.isDisposed) {
+      return this.createResponseError(
+        message.callRendererFunction?.functionCallId ?? 'unknown',
+        RpcErrorCode.DISPOSED,
+        'RpcHandler has been disposed.',
+      );
+    }
+
     if (!message.callRendererFunction?.callFunction) {
       return this.createResponseError(
         message.callRendererFunction?.functionCallId ?? 'unknown',
-        'INVALID_FUNCTION_CALL',
+        RpcErrorCode.INVALID_FUNCTION_CALL,
         'Malformed message: missing callRendererFunction or callFunction.',
       );
     }
@@ -88,7 +151,7 @@ export class RpcHandler<T extends ComponentApi> {
     if (!catalog) {
       return this.createResponseError(
         functionCallId,
-        'INVALID_FUNCTION_CALL',
+        RpcErrorCode.INVALID_FUNCTION_CALL,
         `Catalog '${targetCatalogId}' not found.`,
       );
     }
@@ -98,7 +161,7 @@ export class RpcHandler<T extends ComponentApi> {
     if (!funcImpl) {
       return this.createResponseError(
         functionCallId,
-        'INVALID_FUNCTION_CALL',
+        RpcErrorCode.INVALID_FUNCTION_CALL,
         `Function '${call}' not found in catalog '${targetCatalogId}'.`,
       );
     }
@@ -108,7 +171,7 @@ export class RpcHandler<T extends ComponentApi> {
     if (boundary !== 'rendererOrAgent' && boundary !== 'agentOnly') {
       return this.createResponseError(
         functionCallId,
-        'INVALID_FUNCTION_CALL',
+        RpcErrorCode.INVALID_FUNCTION_CALL,
         `Function '${call}' cannot be called by agent (callableFrom is ${boundary}).`,
       );
     }
@@ -117,7 +180,7 @@ export class RpcHandler<T extends ComponentApi> {
     if (funcImpl.requiresUserActivation && !isUserActivated) {
       return this.createResponseError(
         functionCallId,
-        'INVALID_FUNCTION_CALL',
+        RpcErrorCode.INVALID_FUNCTION_CALL,
         `Function '${call}' requires user activation context to execute.`,
       );
     }
@@ -132,17 +195,16 @@ export class RpcHandler<T extends ComponentApi> {
       const errMsg = err instanceof Error ? err.message : String(err);
       return this.createResponseError(
         functionCallId,
-        'INVALID_FUNCTION_CALL',
+        RpcErrorCode.INVALID_FUNCTION_CALL,
         `Invalid function arguments for '${call}': ${errMsg}`,
       );
     }
 
     // 6. Execute function safely
-    let responseMsg: RendererFunctionResponseMessage;
     try {
       const rawResult = await Promise.resolve(funcImpl.execute(safeArgs, context));
       const result = isSignal(rawResult) ? getValue(rawResult) : rawResult;
-      responseMsg = {
+      return {
         version: 'v1.0',
         rendererFunctionResponse: {
           functionCallId,
@@ -151,22 +213,17 @@ export class RpcHandler<T extends ComponentApi> {
       };
     } catch (err: unknown) {
       const errMsg = err instanceof Error ? err.message : String(err);
-      responseMsg = {
+      return {
         version: 'v1.0',
         rendererFunctionResponse: {
           functionCallId,
           error: {
-            code: 'EXECUTION_ERROR',
+            code: RpcErrorCode.EXECUTION_ERROR,
             message: errMsg || 'An error occurred during function execution.',
           },
         },
       };
     }
-
-    if (this.outboundListener) {
-      this.outboundListener(responseMsg);
-    }
-    return responseMsg;
   }
 
   /**
@@ -182,7 +239,7 @@ export class RpcHandler<T extends ComponentApi> {
 
     this.pendingAgentCalls.delete(functionCallId);
     if (error) {
-      pending.reject(new Error(`[${error.code}] ${error.message}`));
+      pending.reject(new RpcError(error.code, error.message, functionCallId));
     } else {
       pending.resolve(value);
     }
@@ -192,38 +249,71 @@ export class RpcHandler<T extends ComponentApi> {
    * Invokes a remote function on the server agent from the renderer.
    *
    * @param surfaceId The ID of the surface requesting execution.
-   * @param functionCallId The unique identifier for this RPC call.
-   * @param call The function call details.
-   * @param timeoutMs Optional timeout duration in milliseconds.
+   * @param functionCallIdOrCall The unique ID or function call details.
+   * @param callOrOptions The function call details or invocation options.
+   * @param timeoutMs Optional timeout duration in milliseconds (legacy signature).
    * @returns A promise resolving to the agent function return value.
    */
   callAgentFunction(
     surfaceId: string,
-    functionCallId: string,
-    call: {call: string; catalogId?: string; args?: Record<string, unknown>},
+    functionCallIdOrCall: string | FunctionCall,
+    callOrOptions?: FunctionCall | {functionCallId?: string; timeoutMs?: number},
     timeoutMs?: number,
   ): Promise<unknown> {
+    if (this.isDisposed) {
+      return Promise.reject(
+        new RpcError(RpcErrorCode.DISPOSED, 'RpcHandler has been disposed.'),
+      );
+    }
+    if (!this.outboundListener) {
+      return Promise.reject(
+        new RpcError(
+          RpcErrorCode.NO_LISTENER,
+          'Cannot call agent function without outboundListener configured.',
+        ),
+      );
+    }
+
+    let functionCallId: string;
+    let call: FunctionCall;
+    let effectiveTimeoutMs: number;
+
+    if (typeof functionCallIdOrCall === 'string') {
+      functionCallId = functionCallIdOrCall;
+      call = callOrOptions as FunctionCall;
+      effectiveTimeoutMs = timeoutMs ?? this.defaultTimeoutMs;
+    } else {
+      call = functionCallIdOrCall;
+      const opts = (callOrOptions as {functionCallId?: string; timeoutMs?: number}) ?? {};
+      functionCallId = opts.functionCallId ?? crypto.randomUUID();
+      effectiveTimeoutMs = opts.timeoutMs ?? this.defaultTimeoutMs;
+    }
+
     return new Promise((resolve, reject) => {
       if (this.pendingAgentCalls.has(functionCallId)) {
         reject(
-          new Error(
-            `[DUPLICATE] A call with functionCallId '${functionCallId}' is already pending.`,
+          new RpcError(
+            RpcErrorCode.DUPLICATE,
+            `A call with functionCallId '${functionCallId}' is already pending.`,
+            functionCallId,
           ),
         );
         return;
       }
       let timer: ReturnType<typeof setTimeout> | undefined;
-      if (timeoutMs && timeoutMs > 0) {
+      if (effectiveTimeoutMs > 0) {
         timer = setTimeout(() => {
           if (this.pendingAgentCalls.has(functionCallId)) {
             this.pendingAgentCalls.delete(functionCallId);
             reject(
-              new Error(
-                `[TIMEOUT] Agent function call '${call.call}' timed out after ${timeoutMs}ms.`,
+              new RpcError(
+                RpcErrorCode.TIMEOUT,
+                `Agent function call '${call.call}' timed out after ${effectiveTimeoutMs}ms.`,
+                functionCallId,
               ),
             );
           }
-        }, timeoutMs);
+        }, effectiveTimeoutMs);
       }
 
       this.pendingAgentCalls.set(functionCallId, {
@@ -246,14 +336,19 @@ export class RpcHandler<T extends ComponentApi> {
         },
       };
 
-      if (this.outboundListener) {
-        try {
-          this.outboundListener(outboundMsg);
-        } catch (err) {
-          if (timer) clearTimeout(timer);
-          this.pendingAgentCalls.delete(functionCallId);
-          reject(err);
+      try {
+        const result = this.outboundListener!(outboundMsg);
+        if (result && typeof (result as any).catch === 'function') {
+          (result as Promise<void>).catch(err => {
+            if (timer) clearTimeout(timer);
+            this.pendingAgentCalls.delete(functionCallId);
+            reject(err);
+          });
         }
+      } catch (err) {
+        if (timer) clearTimeout(timer);
+        this.pendingAgentCalls.delete(functionCallId);
+        reject(err);
       }
     });
   }
@@ -262,28 +357,31 @@ export class RpcHandler<T extends ComponentApi> {
    * Disposes the RpcHandler and rejects all pending agent function calls.
    */
   dispose(): void {
+    if (this.isDisposed) return;
+    this.isDisposed = true;
     for (const [id, pending] of this.pendingAgentCalls.entries()) {
-      pending.reject(new Error(`[CANCELLED] RpcHandler disposed while call '${id}' was pending.`));
+      pending.reject(
+        new RpcError(
+          RpcErrorCode.CANCELLED,
+          `RpcHandler disposed while call '${id}' was pending.`,
+          id,
+        ),
+      );
     }
     this.pendingAgentCalls.clear();
   }
 
   private createResponseError(
     functionCallId: string,
-    code: string,
+    code: RpcErrorCode | string,
     message: string,
   ): RendererFunctionResponseMessage {
-    const responseMsg: RendererFunctionResponseMessage = {
+    return {
       version: 'v1.0',
       rendererFunctionResponse: {
         functionCallId,
         error: {code, message},
       },
     };
-
-    if (this.outboundListener) {
-      this.outboundListener(responseMsg);
-    }
-    return responseMsg;
   }
 }

--- a/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
@@ -185,7 +185,7 @@ export class RpcHandler {
 
     // 3. Validate boundary execution constraint (allowedCallers / callableFrom)
     const boundary =
-      (funcImpl as any).allowedCallers ?? funcImpl.callableFrom ?? 'rendererOnly';
+      funcImpl.allowedCallers ?? (funcImpl as any).callableFrom ?? 'rendererOnly';
     if (boundary !== 'rendererOrAgent' && boundary !== 'agentOnly') {
       return this.createResponseError(
         functionCallId,

--- a/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
@@ -183,8 +183,9 @@ export class RpcHandler {
       );
     }
 
-    // 3. Validate boundary execution constraint (callableFrom)
-    const boundary = funcImpl.callableFrom ?? 'rendererOnly';
+    // 3. Validate boundary execution constraint (allowedCallers / callableFrom)
+    const boundary =
+      (funcImpl as any).allowedCallers ?? funcImpl.callableFrom ?? 'rendererOnly';
     if (boundary !== 'rendererOrAgent' && boundary !== 'agentOnly') {
       return this.createResponseError(
         functionCallId,

--- a/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
@@ -103,9 +103,10 @@ export class RpcHandler {
       this.outboundListener = outboundListener;
       this.defaultTimeoutMs = 30000;
     } else {
-      this.catalogs = optionsOrCatalogs.catalogs;
-      this.outboundListener = optionsOrCatalogs.outboundListener;
-      this.defaultTimeoutMs = optionsOrCatalogs.defaultTimeoutMs ?? 30000;
+      const options = optionsOrCatalogs ?? {};
+      this.catalogs = options.catalogs ?? [];
+      this.outboundListener = options.outboundListener;
+      this.defaultTimeoutMs = options.defaultTimeoutMs ?? 30000;
     }
   }
 
@@ -128,6 +129,14 @@ export class RpcHandler {
     context: DataContext,
     isUserActivated: boolean = false,
   ): Promise<RendererFunctionResponseMessage> {
+    if (!message) {
+      return this.createResponseError(
+        'unknown',
+        RpcErrorCode.INVALID_FUNCTION_CALL,
+        'Inbound message is null or undefined.',
+      );
+    }
+
     if (this.isDisposed) {
       return this.createResponseError(
         message.callRendererFunction?.functionCallId ?? 'unknown',
@@ -240,7 +249,7 @@ export class RpcHandler {
    * @param message The inbound agentFunctionResponse message.
    */
   handleAgentFunctionResponse(message: AgentFunctionResponseMessage): void {
-    if (!message.agentFunctionResponse) return;
+    if (!message || !message.agentFunctionResponse) return;
     const {functionCallId, value, error} = message.agentFunctionResponse;
     const pending = this.pendingAgentCalls.get(functionCallId);
     if (!pending) return;
@@ -269,9 +278,7 @@ export class RpcHandler {
     timeoutMs?: number,
   ): Promise<unknown> {
     if (this.isDisposed) {
-      return Promise.reject(
-        new RpcError(RpcErrorCode.DISPOSED, 'RpcHandler has been disposed.'),
-      );
+      return Promise.reject(new RpcError(RpcErrorCode.DISPOSED, 'RpcHandler has been disposed.'));
     }
     if (!this.outboundListener) {
       return Promise.reject(
@@ -299,6 +306,12 @@ export class RpcHandler {
           ? globalThis.crypto.randomUUID()
           : `call-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`);
       effectiveTimeoutMs = opts.timeoutMs ?? this.defaultTimeoutMs;
+    }
+
+    if (!call || !call.call) {
+      return Promise.reject(
+        new RpcError(RpcErrorCode.INVALID_FUNCTION_CALL, 'Missing or invalid function call name.'),
+      );
     }
 
     return new Promise((resolve, reject) => {

--- a/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc-handler.ts
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Catalog, ComponentApi} from '../../catalog/types.js';
+import {DataContext} from '../../rendering/data-context.js';
+import {isSignal, getValue} from '../../reactivity/signals.js';
+import {
+  CallRendererFunctionMessage,
+  AgentFunctionResponseMessage,
+} from '../schema/agent-to-renderer.js';
+import {
+  RendererFunctionResponseMessage,
+  CallAgentFunctionMessage,
+} from '../schema/renderer-to-agent.js';
+
+/**
+ * A callback function to emit outbound client messages to the agent.
+ */
+export type OutboundMessageListener = (
+  message: RendererFunctionResponseMessage | CallAgentFunctionMessage,
+) => void;
+
+/**
+ * A pending agent function callback record.
+ */
+interface PendingAgentCall {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+}
+
+/**
+ * Manages bidirectional RPC function execution between renderer and server agent.
+ *
+ * @template T The concrete type of the ComponentApi.
+ */
+export class RpcHandler<T extends ComponentApi> {
+  private readonly pendingAgentCalls = new Map<string, PendingAgentCall>();
+
+  /**
+   * Creates a new RpcHandler instance.
+   *
+   * @param catalogs The available catalogs for function lookup.
+   * @param outboundListener The listener receiving outbound renderer messages.
+   */
+  constructor(
+    private readonly catalogs: Catalog<T>[],
+    private readonly outboundListener?: OutboundMessageListener,
+  ) {}
+
+  /**
+   * Executes a remote renderer function requested by the server agent.
+   *
+   * @param message The inbound callRendererFunction message.
+   * @param context The current DataContext for function execution.
+   * @param isUserActivated Whether execution occurs in an active user gesture context.
+   */
+  async handleCallRendererFunction(
+    message: CallRendererFunctionMessage,
+    context: DataContext,
+    isUserActivated: boolean = false,
+  ): Promise<RendererFunctionResponseMessage> {
+    if (!message.callRendererFunction?.callFunction) {
+      return this.createResponseError(
+        message.callRendererFunction?.functionCallId ?? 'unknown',
+        'INVALID_FUNCTION_CALL',
+        'Malformed message: missing callRendererFunction or callFunction.',
+      );
+    }
+    const {functionCallId, callFunction} = message.callRendererFunction;
+    const {call, catalogId, args} = callFunction;
+
+    // 1. Resolve catalog (fallback to surface default catalog if catalogId is omitted)
+    const targetCatalogId = catalogId || context.surface.catalog.id;
+    const catalog = this.catalogs.find(c => c.id === targetCatalogId);
+    if (!catalog) {
+      return this.createResponseError(
+        functionCallId,
+        'INVALID_FUNCTION_CALL',
+        `Catalog '${targetCatalogId}' not found.`,
+      );
+    }
+
+    // 2. Resolve function implementation
+    const funcImpl = catalog.functions?.get(call);
+    if (!funcImpl) {
+      return this.createResponseError(
+        functionCallId,
+        'INVALID_FUNCTION_CALL',
+        `Function '${call}' not found in catalog '${targetCatalogId}'.`,
+      );
+    }
+
+    // 3. Validate boundary execution constraint (callableFrom)
+    const boundary = funcImpl.callableFrom ?? 'rendererOnly';
+    if (boundary !== 'rendererOrAgent' && boundary !== 'agentOnly') {
+      return this.createResponseError(
+        functionCallId,
+        'INVALID_FUNCTION_CALL',
+        `Function '${call}' cannot be called by agent (callableFrom is ${boundary}).`,
+      );
+    }
+
+    // 4. Validate user activation constraint
+    if (funcImpl.requiresUserActivation && !isUserActivated) {
+      return this.createResponseError(
+        functionCallId,
+        'INVALID_FUNCTION_CALL',
+        `Function '${call}' requires user activation context to execute.`,
+      );
+    }
+
+    // 5. Enforce argument schema parsing
+    let safeArgs: Record<string, unknown>;
+    try {
+      safeArgs = funcImpl.schema
+        ? (funcImpl.schema.parse(args ?? {}) as Record<string, unknown>)
+        : (args ?? {});
+    } catch (err: unknown) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      return this.createResponseError(
+        functionCallId,
+        'INVALID_FUNCTION_CALL',
+        `Invalid function arguments for '${call}': ${errMsg}`,
+      );
+    }
+
+    // 6. Execute function safely
+    let responseMsg: RendererFunctionResponseMessage;
+    try {
+      const rawResult = await Promise.resolve(funcImpl.execute(safeArgs, context));
+      const result = isSignal(rawResult) ? getValue(rawResult) : rawResult;
+      responseMsg = {
+        version: 'v1.0',
+        rendererFunctionResponse: {
+          functionCallId,
+          value: result !== undefined ? result : null,
+        },
+      };
+    } catch (err: unknown) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      responseMsg = {
+        version: 'v1.0',
+        rendererFunctionResponse: {
+          functionCallId,
+          error: {
+            code: 'EXECUTION_ERROR',
+            message: errMsg || 'An error occurred during function execution.',
+          },
+        },
+      };
+    }
+
+    if (this.outboundListener) {
+      this.outboundListener(responseMsg);
+    }
+    return responseMsg;
+  }
+
+  /**
+   * Resolves a pending outbound callAgentFunction request upon receiving agentFunctionResponse.
+   *
+   * @param message The inbound agentFunctionResponse message.
+   */
+  handleAgentFunctionResponse(message: AgentFunctionResponseMessage): void {
+    if (!message.agentFunctionResponse) return;
+    const {functionCallId, value, error} = message.agentFunctionResponse;
+    const pending = this.pendingAgentCalls.get(functionCallId);
+    if (!pending) return;
+
+    this.pendingAgentCalls.delete(functionCallId);
+    if (error) {
+      pending.reject(new Error(`[${error.code}] ${error.message}`));
+    } else {
+      pending.resolve(value);
+    }
+  }
+
+  /**
+   * Invokes a remote function on the server agent from the renderer.
+   *
+   * @param surfaceId The ID of the surface requesting execution.
+   * @param functionCallId The unique identifier for this RPC call.
+   * @param call The function call details.
+   * @param timeoutMs Optional timeout duration in milliseconds.
+   * @returns A promise resolving to the agent function return value.
+   */
+  callAgentFunction(
+    surfaceId: string,
+    functionCallId: string,
+    call: {call: string; catalogId?: string; args?: Record<string, unknown>},
+    timeoutMs?: number,
+  ): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      if (this.pendingAgentCalls.has(functionCallId)) {
+        reject(
+          new Error(
+            `[DUPLICATE] A call with functionCallId '${functionCallId}' is already pending.`,
+          ),
+        );
+        return;
+      }
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      if (timeoutMs && timeoutMs > 0) {
+        timer = setTimeout(() => {
+          if (this.pendingAgentCalls.has(functionCallId)) {
+            this.pendingAgentCalls.delete(functionCallId);
+            reject(
+              new Error(
+                `[TIMEOUT] Agent function call '${call.call}' timed out after ${timeoutMs}ms.`,
+              ),
+            );
+          }
+        }, timeoutMs);
+      }
+
+      this.pendingAgentCalls.set(functionCallId, {
+        resolve: val => {
+          if (timer) clearTimeout(timer);
+          resolve(val);
+        },
+        reject: err => {
+          if (timer) clearTimeout(timer);
+          reject(err);
+        },
+      });
+
+      const outboundMsg: CallAgentFunctionMessage = {
+        version: 'v1.0',
+        callAgentFunction: {
+          surfaceId,
+          functionCallId,
+          callFunction: call,
+        },
+      };
+
+      if (this.outboundListener) {
+        try {
+          this.outboundListener(outboundMsg);
+        } catch (err) {
+          if (timer) clearTimeout(timer);
+          this.pendingAgentCalls.delete(functionCallId);
+          reject(err);
+        }
+      }
+    });
+  }
+
+  /**
+   * Disposes the RpcHandler and rejects all pending agent function calls.
+   */
+  dispose(): void {
+    for (const [id, pending] of this.pendingAgentCalls.entries()) {
+      pending.reject(new Error(`[CANCELLED] RpcHandler disposed while call '${id}' was pending.`));
+    }
+    this.pendingAgentCalls.clear();
+  }
+
+  private createResponseError(
+    functionCallId: string,
+    code: string,
+    message: string,
+  ): RendererFunctionResponseMessage {
+    const responseMsg: RendererFunctionResponseMessage = {
+      version: 'v1.0',
+      rendererFunctionResponse: {
+        functionCallId,
+        error: {code, message},
+      },
+    };
+
+    if (this.outboundListener) {
+      this.outboundListener(responseMsg);
+    }
+    return responseMsg;
+  }
+}

--- a/typescript/web_core/src/v1_0/rpc/rpc.test.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc.test.ts
@@ -201,8 +201,10 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
         },
       });
 
-      handler.callAgentFunction('s1', {call: 'testFunc'});
+      const callPromise = handler.callAgentFunction('s1', {call: 'testFunc'});
       assert.ok(emittedMsg.callAgentFunction.functionCallId.startsWith('call-'));
+      handler.dispose();
+      await assert.rejects(callPromise, /CANCELLED/);
     } finally {
       if (originalCrypto) {
         Object.defineProperty(globalThis, 'crypto', originalCrypto);

--- a/typescript/web_core/src/v1_0/rpc/rpc.test.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc.test.ts
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {describe, it} from 'node:test';
+import * as assert from 'node:assert';
+import {z} from 'zod';
+import {RpcHandler} from './rpc-handler.js';
+import {
+  Catalog,
+  createFunctionImplementation,
+} from '../../catalog/types.js';
+import {DataContext} from '../../rendering/data-context.js';
+import {SurfaceModel} from '../../state/surface-model.js';
+import {IndexImplementation} from '../../v0_9/basic_catalog/functions/basic_functions.js';
+
+describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', () => {
+  const customRpcApi = {
+    name: 'customRpc',
+    returnType: 'string' as const,
+    schema: z.object({text: z.string()}),
+    callableFrom: 'rendererOrAgent' as const,
+  };
+  const customRpcImpl = createFunctionImplementation(
+    customRpcApi,
+    args => `Processed: ${args.text}`,
+  );
+
+  const rendererOnlyApi = {
+    name: 'internalRenderer',
+    returnType: 'void' as const,
+    schema: z.object({}),
+    callableFrom: 'rendererOnly' as const,
+  };
+  const rendererOnlyImpl = createFunctionImplementation(rendererOnlyApi, () => {});
+
+  const restrictedApi = {
+    name: 'userActionOnly',
+    returnType: 'boolean' as const,
+    schema: z.object({}),
+    callableFrom: 'rendererOrAgent' as const,
+    requiresUserActivation: true,
+  };
+  const restrictedImpl = createFunctionImplementation(restrictedApi, () => true);
+
+  const mockCatalog = new Catalog(
+    'basic',
+    [],
+    [customRpcImpl, rendererOnlyImpl, restrictedImpl, IndexImplementation],
+  );
+
+  it('executes valid callRendererFunction remote RPC and returns value payload', async () => {
+    const handler = new RpcHandler([mockCatalog]);
+    const surface = new SurfaceModel('s1', mockCatalog);
+    const context = new DataContext(surface, '/');
+
+    const message = {
+      version: 'v1.0' as const,
+      callRendererFunction: {
+        functionCallId: 'rpc-1',
+        callFunction: {
+          call: 'customRpc',
+          catalogId: 'basic',
+          args: {text: 'Hello A2UI'},
+        },
+      },
+    };
+
+    const response = await handler.handleCallRendererFunction(message, context, false);
+    assert.strictEqual(response.version, 'v1.0');
+    assert.strictEqual(response.rendererFunctionResponse.functionCallId, 'rpc-1');
+    assert.strictEqual(response.rendererFunctionResponse.value, 'Processed: Hello A2UI');
+    assert.strictEqual(response.rendererFunctionResponse.error, undefined);
+  });
+
+  it('rejects callRendererFunction targeting rendererOnly function with INVALID_FUNCTION_CALL', async () => {
+    const handler = new RpcHandler([mockCatalog]);
+    const surface = new SurfaceModel('s1', mockCatalog);
+    const context = new DataContext(surface, '/');
+
+    const message = {
+      version: 'v1.0' as const,
+      callRendererFunction: {
+        functionCallId: 'rpc-2',
+        callFunction: {
+          call: 'internalRenderer',
+          catalogId: 'basic',
+        },
+      },
+    };
+
+    const response = await handler.handleCallRendererFunction(message, context, false);
+    assert.strictEqual(response.rendererFunctionResponse.functionCallId, 'rpc-2');
+    assert.strictEqual(response.rendererFunctionResponse.value, undefined);
+    assert.strictEqual(response.rendererFunctionResponse.error?.code, 'INVALID_FUNCTION_CALL');
+  });
+
+  it('rejects function call requiring user activation when isUserActivated is false', async () => {
+    const handler = new RpcHandler([mockCatalog]);
+    const surface = new SurfaceModel('s1', mockCatalog);
+    const context = new DataContext(surface, '/');
+
+    const message = {
+      version: 'v1.0' as const,
+      callRendererFunction: {
+        functionCallId: 'rpc-3',
+        callFunction: {
+          call: 'userActionOnly',
+          catalogId: 'basic',
+        },
+      },
+    };
+
+    const response = await handler.handleCallRendererFunction(message, context, false);
+    assert.strictEqual(response.rendererFunctionResponse.error?.code, 'INVALID_FUNCTION_CALL');
+
+    const authorizedResponse = await handler.handleCallRendererFunction(message, context, true);
+    assert.strictEqual(authorizedResponse.rendererFunctionResponse.value, true);
+  });
+
+  it('tracks outbound callAgentFunction and resolves promise via handleAgentFunctionResponse', async () => {
+    let emittedMessage: any;
+    const handler = new RpcHandler([mockCatalog], msg => {
+      emittedMessage = msg;
+    });
+
+    const callPromise = handler.callAgentFunction('surface-1', 'agent-call-100', {
+      call: 'fetchRemoteData',
+      catalogId: 'basic',
+      args: {query: 'test'},
+    });
+
+    assert.strictEqual(emittedMessage.version, 'v1.0');
+    assert.strictEqual(emittedMessage.callAgentFunction.functionCallId, 'agent-call-100');
+
+    handler.handleAgentFunctionResponse({
+      version: 'v1.0',
+      agentFunctionResponse: {
+        functionCallId: 'agent-call-100',
+        value: {items: [1, 2, 3]},
+      },
+    });
+
+    const result = await callPromise;
+    assert.deepStrictEqual(result, {items: [1, 2, 3]});
+  });
+
+  it('evaluates @index function returning loop index from nested DataContext path with offset', () => {
+    const surface = new SurfaceModel('s1', mockCatalog);
+    const context = new DataContext(surface, '/items/3/user/address');
+    const indexValue = IndexImplementation.execute({offset: 1}, context);
+    assert.strictEqual(indexValue, 4);
+  });
+
+  it('rejects pending agent function calls when RpcHandler is disposed', async () => {
+    const handler = new RpcHandler([mockCatalog]);
+    const promise = handler.callAgentFunction('surface-1', 'pending-1', {
+      call: 'slowFunc',
+    });
+    handler.dispose();
+    await assert.rejects(promise, /CANCELLED/);
+  });
+
+  it('times out callAgentFunction when timeoutMs is exceeded', async () => {
+    const handler = new RpcHandler([mockCatalog]);
+    const promise = handler.callAgentFunction(
+      'surface-1',
+      'pending-timeout',
+      {call: 'timeoutFunc'},
+      10,
+    );
+    await assert.rejects(promise, /TIMEOUT/);
+  });
+
+  it('falls back to surface default catalog when catalogId is omitted', async () => {
+    const handler = new RpcHandler([mockCatalog]);
+    const surface = new SurfaceModel('s1', mockCatalog);
+    const dataContext = new DataContext(surface, '/');
+
+    const res = await handler.handleCallRendererFunction(
+      {
+        version: 'v1.0',
+        callRendererFunction: {
+          functionCallId: 'call-default-cat',
+          callFunction: {
+            call: 'customRpc',
+            catalogId: 'basic',
+            args: {text: 'hello'},
+          },
+        },
+      },
+      dataContext,
+      true,
+    );
+
+    assert.strictEqual(res.rendererFunctionResponse.value, 'Processed: hello');
+  });
+
+  it('rejects callRendererFunction with INVALID_FUNCTION_CALL when argument schema validation fails', async () => {
+    const handler = new RpcHandler([mockCatalog]);
+    const surface = new SurfaceModel('s1', mockCatalog);
+    const dataContext = new DataContext(surface, '/');
+
+    const res = await handler.handleCallRendererFunction(
+      {
+        version: 'v1.0',
+        callRendererFunction: {
+          functionCallId: 'call-invalid-args',
+          callFunction: {
+            call: 'customRpc',
+            catalogId: 'basic',
+            args: {text: 12345}, // Number instead of expected string
+          },
+        },
+      },
+      dataContext,
+      true,
+    );
+
+    assert.ok(res.rendererFunctionResponse.error);
+    assert.strictEqual(res.rendererFunctionResponse.error.code, 'INVALID_FUNCTION_CALL');
+  });
+
+  it('cleans up pending agent call when outboundListener throws', async () => {
+    const handler = new RpcHandler([mockCatalog], () => {
+      throw new Error('Connection failed');
+    });
+
+    await assert.rejects(
+      handler.callAgentFunction('surface-1', 'fail-outbound', {call: 'testFunc'}),
+      /Connection failed/,
+    );
+  });
+});

--- a/typescript/web_core/src/v1_0/rpc/rpc.test.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc.test.ts
@@ -17,7 +17,7 @@
 import {describe, it} from 'node:test';
 import * as assert from 'node:assert';
 import {z} from 'zod';
-import {RpcHandler} from './rpc-handler.js';
+import {RpcHandler, RpcError, RpcErrorCode} from './rpc-handler.js';
 import {
   Catalog,
   createFunctionImplementation,
@@ -61,8 +61,16 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     [customRpcImpl, rendererOnlyImpl, restrictedImpl, IndexImplementation],
   );
 
+  it('instantiates via options bag RpcHandlerOptions', () => {
+    const handler = new RpcHandler({
+      catalogs: [mockCatalog],
+      defaultTimeoutMs: 5000,
+    });
+    assert.strictEqual(handler.disposed, false);
+  });
+
   it('executes valid callRendererFunction remote RPC and returns value payload', async () => {
-    const handler = new RpcHandler([mockCatalog]);
+    const handler = new RpcHandler({catalogs: [mockCatalog]});
     const surface = new SurfaceModel('s1', mockCatalog);
     const context = new DataContext(surface, '/');
 
@@ -104,7 +112,7 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     const response = await handler.handleCallRendererFunction(message, context, false);
     assert.strictEqual(response.rendererFunctionResponse.functionCallId, 'rpc-2');
     assert.strictEqual(response.rendererFunctionResponse.value, undefined);
-    assert.strictEqual(response.rendererFunctionResponse.error?.code, 'INVALID_FUNCTION_CALL');
+    assert.strictEqual(response.rendererFunctionResponse.error?.code, RpcErrorCode.INVALID_FUNCTION_CALL);
   });
 
   it('rejects function call requiring user activation when isUserActivated is false', async () => {
@@ -124,7 +132,7 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     };
 
     const response = await handler.handleCallRendererFunction(message, context, false);
-    assert.strictEqual(response.rendererFunctionResponse.error?.code, 'INVALID_FUNCTION_CALL');
+    assert.strictEqual(response.rendererFunctionResponse.error?.code, RpcErrorCode.INVALID_FUNCTION_CALL);
 
     const authorizedResponse = await handler.handleCallRendererFunction(message, context, true);
     assert.strictEqual(authorizedResponse.rendererFunctionResponse.value, true);
@@ -132,8 +140,11 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
 
   it('tracks outbound callAgentFunction and resolves promise via handleAgentFunctionResponse', async () => {
     let emittedMessage: any;
-    const handler = new RpcHandler([mockCatalog], msg => {
-      emittedMessage = msg;
+    const handler = new RpcHandler({
+      catalogs: [mockCatalog],
+      outboundListener: msg => {
+        emittedMessage = msg;
+      },
     });
 
     const callPromise = handler.callAgentFunction('surface-1', 'agent-call-100', {
@@ -165,23 +176,83 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
   });
 
   it('rejects pending agent function calls when RpcHandler is disposed', async () => {
-    const handler = new RpcHandler([mockCatalog]);
+    const handler = new RpcHandler({
+      catalogs: [mockCatalog],
+      outboundListener: () => {},
+    });
     const promise = handler.callAgentFunction('surface-1', 'pending-1', {
       call: 'slowFunc',
     });
     handler.dispose();
-    await assert.rejects(promise, /CANCELLED/);
+    assert.strictEqual(handler.disposed, true);
+    await assert.rejects(promise, (err: any) => {
+      assert.ok(err instanceof RpcError);
+      assert.strictEqual(err.code, RpcErrorCode.CANCELLED);
+      return true;
+    });
+  });
+
+  it('fails fast on post-disposal calls', async () => {
+    const handler = new RpcHandler({
+      catalogs: [mockCatalog],
+      outboundListener: () => {},
+    });
+    handler.dispose();
+
+    const surface = new SurfaceModel('s1', mockCatalog);
+    const context = new DataContext(surface, '/');
+    const response = await handler.handleCallRendererFunction(
+      {
+        version: 'v1.0',
+        callRendererFunction: {
+          functionCallId: 'call-post-dispose',
+          callFunction: {call: 'customRpc', catalogId: 'basic', args: {text: 'hi'}},
+        },
+      },
+      context,
+      true,
+    );
+
+    assert.strictEqual(response.rendererFunctionResponse.error?.code, RpcErrorCode.DISPOSED);
+
+    await assert.rejects(
+      handler.callAgentFunction('surface-1', {call: 'test'}),
+      (err: any) => {
+        assert.ok(err instanceof RpcError);
+        assert.strictEqual(err.code, RpcErrorCode.DISPOSED);
+        return true;
+      },
+    );
+  });
+
+  it('fails fast when calling callAgentFunction without outboundListener', async () => {
+    const handler = new RpcHandler({catalogs: [mockCatalog]});
+    await assert.rejects(
+      handler.callAgentFunction('surface-1', {call: 'test'}),
+      (err: any) => {
+        assert.ok(err instanceof RpcError);
+        assert.strictEqual(err.code, RpcErrorCode.NO_LISTENER);
+        return true;
+      },
+    );
   });
 
   it('times out callAgentFunction when timeoutMs is exceeded', async () => {
-    const handler = new RpcHandler([mockCatalog]);
+    const handler = new RpcHandler({
+      catalogs: [mockCatalog],
+      outboundListener: () => {},
+    });
     const promise = handler.callAgentFunction(
       'surface-1',
       'pending-timeout',
       {call: 'timeoutFunc'},
       10,
     );
-    await assert.rejects(promise, /TIMEOUT/);
+    await assert.rejects(promise, (err: any) => {
+      assert.ok(err instanceof RpcError);
+      assert.strictEqual(err.code, RpcErrorCode.TIMEOUT);
+      return true;
+    });
   });
 
   it('falls back to surface default catalog when catalogId is omitted', async () => {
@@ -230,7 +301,7 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     );
 
     assert.ok(res.rendererFunctionResponse.error);
-    assert.strictEqual(res.rendererFunctionResponse.error.code, 'INVALID_FUNCTION_CALL');
+    assert.strictEqual(res.rendererFunctionResponse.error.code, RpcErrorCode.INVALID_FUNCTION_CALL);
   });
 
   it('cleans up pending agent call when outboundListener throws', async () => {

--- a/typescript/web_core/src/v1_0/rpc/rpc.test.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc.test.ts
@@ -173,6 +173,41 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     const context = new DataContext(surface, '/items/3/user/address');
     const indexValue = IndexImplementation.execute({offset: 1}, context);
     assert.strictEqual(indexValue, 4);
+
+    // Alphanumeric segment starting with digit should be ignored
+    const context2 = new DataContext(surface, '/order_99/items/2');
+    const indexValue2 = IndexImplementation.execute({offset: 0}, context2);
+    assert.strictEqual(indexValue2, 2);
+
+    // Schema coercion parses string offsets and falls back safely on NaN
+    const parsedArgs = IndexImplementation.schema?.parse({offset: '5'});
+    const indexValue3 = IndexImplementation.execute(parsedArgs, context2);
+    assert.strictEqual(indexValue3, 7);
+  });
+
+  it('generates fallback call function ID when globalThis.crypto is unavailable', async () => {
+    const originalCrypto = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
+    try {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: undefined,
+        configurable: true,
+        writable: true,
+      });
+      let emittedMsg: any;
+      const handler = new RpcHandler({
+        catalogs: [mockCatalog],
+        outboundListener: msg => {
+          emittedMsg = msg;
+        },
+      });
+
+      handler.callAgentFunction('s1', {call: 'testFunc'});
+      assert.ok(emittedMsg.callAgentFunction.functionCallId.startsWith('call-'));
+    } finally {
+      if (originalCrypto) {
+        Object.defineProperty(globalThis, 'crypto', originalCrypto);
+      }
+    }
   });
 
   it('rejects pending agent function calls when RpcHandler is disposed', async () => {

--- a/typescript/web_core/src/v1_0/rpc/rpc.test.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc.test.ts
@@ -301,7 +301,6 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
           functionCallId: 'call-default-cat',
           callFunction: {
             call: 'customRpc',
-            catalogId: 'basic',
             args: {text: 'hello'},
           },
         },

--- a/typescript/web_core/src/v1_0/rpc/rpc.test.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc.test.ts
@@ -18,10 +18,7 @@ import {describe, it} from 'node:test';
 import * as assert from 'node:assert';
 import {z} from 'zod';
 import {RpcHandler, RpcError, RpcErrorCode} from './rpc-handler.js';
-import {
-  Catalog,
-  createFunctionImplementation,
-} from '../../catalog/types.js';
+import {Catalog, createFunctionImplementation} from '../../catalog/types.js';
 import {DataContext} from '../../rendering/data-context.js';
 import {SurfaceModel} from '../../state/surface-model.js';
 import {IndexImplementation} from '../../v0_9/basic_catalog/functions/basic_functions.js';
@@ -112,7 +109,10 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     const response = await handler.handleCallRendererFunction(message, context, false);
     assert.strictEqual(response.rendererFunctionResponse.functionCallId, 'rpc-2');
     assert.strictEqual(response.rendererFunctionResponse.value, undefined);
-    assert.strictEqual(response.rendererFunctionResponse.error?.code, RpcErrorCode.INVALID_FUNCTION_CALL);
+    assert.strictEqual(
+      response.rendererFunctionResponse.error?.code,
+      RpcErrorCode.INVALID_FUNCTION_CALL,
+    );
   });
 
   it('rejects function call requiring user activation when isUserActivated is false', async () => {
@@ -132,7 +132,10 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     };
 
     const response = await handler.handleCallRendererFunction(message, context, false);
-    assert.strictEqual(response.rendererFunctionResponse.error?.code, RpcErrorCode.INVALID_FUNCTION_CALL);
+    assert.strictEqual(
+      response.rendererFunctionResponse.error?.code,
+      RpcErrorCode.INVALID_FUNCTION_CALL,
+    );
 
     const authorizedResponse = await handler.handleCallRendererFunction(message, context, true);
     assert.strictEqual(authorizedResponse.rendererFunctionResponse.value, true);
@@ -252,26 +255,20 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
 
     assert.strictEqual(response.rendererFunctionResponse.error?.code, RpcErrorCode.DISPOSED);
 
-    await assert.rejects(
-      handler.callAgentFunction('surface-1', {call: 'test'}),
-      (err: any) => {
-        assert.ok(err instanceof RpcError);
-        assert.strictEqual(err.code, RpcErrorCode.DISPOSED);
-        return true;
-      },
-    );
+    await assert.rejects(handler.callAgentFunction('surface-1', {call: 'test'}), (err: any) => {
+      assert.ok(err instanceof RpcError);
+      assert.strictEqual(err.code, RpcErrorCode.DISPOSED);
+      return true;
+    });
   });
 
   it('fails fast when calling callAgentFunction without outboundListener', async () => {
     const handler = new RpcHandler({catalogs: [mockCatalog]});
-    await assert.rejects(
-      handler.callAgentFunction('surface-1', {call: 'test'}),
-      (err: any) => {
-        assert.ok(err instanceof RpcError);
-        assert.strictEqual(err.code, RpcErrorCode.NO_LISTENER);
-        return true;
-      },
-    );
+    await assert.rejects(handler.callAgentFunction('surface-1', {call: 'test'}), (err: any) => {
+      assert.ok(err instanceof RpcError);
+      assert.strictEqual(err.code, RpcErrorCode.NO_LISTENER);
+      return true;
+    });
   });
 
   it('times out callAgentFunction when timeoutMs is exceeded', async () => {
@@ -350,5 +347,36 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
       handler.callAgentFunction('surface-1', 'fail-outbound', {call: 'testFunc'}),
       /Connection failed/,
     );
+  });
+
+  it('rejects callAgentFunction when function call or call name is missing', async () => {
+    const handler = new RpcHandler([mockCatalog], () => {});
+    await assert.rejects(
+      handler.callAgentFunction('surface-1', 'call-1', undefined as any),
+      (err: RpcError) => err.code === RpcErrorCode.INVALID_FUNCTION_CALL,
+    );
+  });
+
+  it('handles null/undefined message gracefully in handleCallRendererFunction', async () => {
+    const handler = new RpcHandler([mockCatalog]);
+    const surface = new SurfaceModel('s1', mockCatalog);
+    const dataContext = new DataContext(surface, '/');
+    const res = await handler.handleCallRendererFunction(null as any, dataContext);
+    assert.strictEqual(
+      res.rendererFunctionResponse.error?.code,
+      RpcErrorCode.INVALID_FUNCTION_CALL,
+    );
+  });
+
+  it('handles null/undefined message gracefully in handleAgentFunctionResponse', () => {
+    const handler = new RpcHandler([mockCatalog]);
+    assert.doesNotThrow(() => {
+      handler.handleAgentFunctionResponse(null as any);
+    });
+  });
+
+  it('handles null/undefined options in RpcHandler constructor', () => {
+    const handler = new RpcHandler(null as any);
+    assert.strictEqual(handler.disposed, false);
   });
 });

--- a/typescript/web_core/src/v1_0/rpc/rpc.test.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc.test.ts
@@ -28,7 +28,7 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     name: 'customRpc',
     returnType: 'string' as const,
     schema: z.object({text: z.string()}),
-    callableFrom: 'rendererOrAgent' as const,
+    allowedCallers: 'rendererOrAgent' as const,
   };
   const customRpcImpl = createFunctionImplementation(
     customRpcApi,
@@ -39,7 +39,7 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     name: 'internalRenderer',
     returnType: 'void' as const,
     schema: z.object({}),
-    callableFrom: 'rendererOnly' as const,
+    allowedCallers: 'rendererOnly' as const,
   };
   const rendererOnlyImpl = createFunctionImplementation(rendererOnlyApi, () => {});
 
@@ -47,7 +47,7 @@ describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', 
     name: 'userActionOnly',
     returnType: 'boolean' as const,
     schema: z.object({}),
-    callableFrom: 'rendererOrAgent' as const,
+    allowedCallers: 'rendererOrAgent' as const,
     requiresUserActivation: true,
   };
   const restrictedImpl = createFunctionImplementation(restrictedApi, () => true);

--- a/typescript/web_core/src/v1_0/rpc/rpc.test.ts
+++ b/typescript/web_core/src/v1_0/rpc/rpc.test.ts
@@ -21,7 +21,7 @@ import {RpcHandler, RpcError, RpcErrorCode} from './rpc-handler.js';
 import {Catalog, createFunctionImplementation} from '../../catalog/types.js';
 import {DataContext} from '../../rendering/data-context.js';
 import {SurfaceModel} from '../../state/surface-model.js';
-import {IndexImplementation} from '../../v0_9/basic_catalog/functions/basic_functions.js';
+import {IndexImplementation} from '../functions/system_functions.js';
 
 describe('Stage 3 (Sauce-TS) Bidirectional RPC & @index Function Verification', () => {
   const customRpcApi = {


### PR DESCRIPTION
## Summary

This PR implements **Stage 3 (`Sauce-TS`)** deliverables for Web Core (`typescript/web_core`). It introduces `RpcHandler` for handling bidirectional remote function calls between client renderer and server agent, enforces execution boundaries, exports structured RPC errors, and registers built-in `@index` function.

## Stack Context
- 🥞 **PR 2 (Base of Stack)**: [#2342](https://github.com/a2ui-project/a2ui/pull/2342) (`v1_0_validation_parity_ts`)
- 🥞 **PR 3 (This PR)**: (`v1_0_sauce_ts`)

## Key Changes
- Bidirectional RPC Engine (`RpcHandler`, `RpcError`, `RpcErrorCode`).
- Basic catalog `@index` function with array index resolution.

## Verification
- Built cleanly via `yarn build`.
- All RPC unit tests and conformance tests passing.