### PR TITLE
feat(spec): add core A2UI templates specification, version 0.1 schema, and examples

### DIFF
--- a/specification/proposals/templates/README.md
+++ b/specification/proposals/templates/README.md
@@ -1,0 +1,582 @@
+# A2UI Templates Specification
+
+## Abstract
+
+This document defines the authoritative specification for the **A2UI Templates System**. 
+
+Templates provide a declarative, human-readable mechanism for authoring reusable UI subtrees in nested YAML or via native programmatic render functions. At generation time, an agent or Large Language Model (LLM) outputs compact, high-level template invocations (such as `UserProfile("u1", "Alice")` or `PayrollSummary("Eng", true)`). The backend SDK expands these invocations into standard, flat A2UI Basic Catalog components in a single synchronous pass before emitting standard A2UI protocol messages (`updateComponents`) to the client.
+
+This architecture achieves three fundamental objectives:
+1. **Human Readability**: Layouts are authored as clean, natural tree hierarchies in YAML or native language code, eliminating artificial IDs and flat array boilerplate.
+2. **Token Efficiency & Context Optimization**: LLMs emit concise function-like signatures rather than verbose, deeply nested UI component trees, saving prompt context and generation tokens.
+3. **Zero Client Overhead**: Client renderers (@a2ui/react, @a2ui/lit, @a2ui/angular, @a2ui/flutter) implement only standard Basic Catalog primitives (`Card`, `Column`, `Row`, `Text`, `Divider`, `Icon`, `Button`). No custom client widgets, dynamic code deployment, or renderer plugins are required.
+
+---
+
+## 1. Architectural Overview & Execution Pipeline
+
+The template engine operates entirely server-side within the A2UI Agent SDK:
+
+```
++-------------------------------------------------------------------------------+
+| 1. Authoring & Registration                                                   |
+|    - Static YAML files (with multi-doc '---' support & cross-references)      |
+|    - Dynamic resolvers (data-binding mode & programmatic AST mode)            |
++---------------------------------------+---------------------------------------+
+                                        |
+                                        v
++-------------------------------------------------------------------------------+
+| 2. Synthetic Catalog Generation                                               |
+|    - TemplateProcessor scans registered templates                             |
+|    - Synthesizes virtual A2UI Component Catalog JSON schema                   |
++---------------------------------------+---------------------------------------+
+                                        |
+                                        v
++-------------------------------------------------------------------------------+
+| 3. Model Prompt Generation & Inference                                        |
+|    - PromptGenerator injects template signatures into system prompt           |
+|    - LLM emits compact Express DSL / JSON:                                    |
+|      root = TeamRoster("Engineering", [TeamCard("Core", [...])])              |
++---------------------------------------+---------------------------------------+
+                                        |
+                                        v
++-------------------------------------------------------------------------------+
+| 4. Synchronous Template Expansion (TemplateProcessor)                         |
+|    - Resolves dynamic callbacks or executes programmatic render functions     |
+|    - Substitutes typed parameters & evaluates dot-notation paths              |
+|    - Unrolls server loops & plumbs component slot arguments                   |
+|    - Assigns deterministic synthetic IDs: {parent}_{slot}_{index}_{type}      |
++---------------------------------------+---------------------------------------+
+                                        |
+                                        v
++-------------------------------------------------------------------------------+
+| 5. Standard A2UI Protocol Emission                                            |
+|    - Emits standard createSurface and updateComponents messages               |
+|    - Payload contains 100% standard Basic Catalog primitives                  |
++---------------------------------------+---------------------------------------+
+                                        |
+                                        v
++-------------------------------------------------------------------------------+
+| 6. Client Renderer Execution                                                  |
+|    - Standard Basic Catalog renderers paint the flat component graph          |
+|    - Binds reactive two-way paths to client DataModel                         |
++-------------------------------------------------------------------------------+
+```
+
+---
+
+## 2. Template Taxonomy
+
+A2UI defines three template modalities:
+
+### A. Declarative Static Templates (YAML)
+Declarative static templates define immutable layout trees authored in YAML files. All parameter placeholders are populated directly from arguments provided by the model or caller.
+
+```yaml
+version: "0.1"
+templateId: UserProfile
+description: Standard identity card for team members.
+parameters:
+  userId:
+    type: string
+    description: Unique user identifier.
+  userName:
+    type: string
+    description: Full name of the user.
+  role:
+    type: string
+    description: Position or title within the team.
+    default: Team Member
+
+layout:
+  component: Card
+  child:
+    component: Column
+    children:
+      - component: Icon
+        name: person
+      - component: Text
+        text: ${userName}
+        variant: h3
+      - component: Text
+        text: ${role}
+        variant: caption
+```
+
+### B. Dynamic Templates: Data-Binding Mode (`resolver + layout`)
+Data-binding dynamic templates decouple public model parameters from private or live backend data. 
+- **Public Surface**: The model only sees and outputs high-level lookup parameters (e.g. `employeeId: "emp_101"`).
+- **Server Resolver**: At expansion time, a backend callback executes (e.g., querying an internal HR database or API) and produces a data dictionary.
+- **Layout Inflation**: The resolved dictionary is merged with the caller's arguments and applied to an underlying static YAML layout.
+
+```python
+# Server Registration
+dynamic_salary = DynamicTemplate(
+    template_id="EmployeeSalaryCard",
+    resolver=fetch_private_compensation,
+    layout=salary_yaml_layout,
+    description="Verified compensation card. Pass only employeeId.",
+)
+```
+
+**Security Rationale**: Confidential numbers (e.g., executive salaries, PII) never enter the model's prompt context window or inference transcript.
+
+### C. Dynamic Templates: Programmatic Render Mode (`render_fn`)
+Programmatic dynamic templates bypass static YAML layouts entirely. Instead, a developer writes a native function in the host language (Python, Dart, etc.) that accepts parameters and directly returns a UI component tree.
+
+```python
+def render_payroll_summary(department: str = "Engineering", includeBonus: bool = True) -> dict:
+    total_base = sum(e.salary for e in db.get_dept(department))
+    total_bonus = sum(e.bonus for e in db.get_dept(department))
+    
+    rows = []
+    for emp in db.get_dept(department):
+        cols = [
+            {"component": "Text", "text": emp.name, "variant": "body"},
+            {"component": "Text", "text": f"${emp.salary:,}", "variant": "body"}
+        ]
+        if includeBonus:
+            cols.append({"component": "Text", "text": f"${emp.bonus:,}", "variant": "body"})
+        rows.append({"component": "Row", "justify": "spaceBetween", "children": cols})
+
+    return {
+        "component": "Card",
+        "child": {
+            "component": "Column",
+            "children": [
+                {"component": "Text", "text": f"Payroll Summary: {department}", "variant": "h2"},
+                {"component": "Divider", "axis": "horizontal"},
+                *rows,
+                {"component": "Divider", "axis": "horizontal"},
+                {"component": "Text", "text": f"Total Budget: ${total_base + (total_bonus if includeBonus else 0):,}", "variant": "h3"}
+            ]
+        }
+    }
+
+payroll_tmpl = DynamicTemplate(
+    template_id="PayrollSummary",
+    render=render_payroll_summary,
+    description="Dynamic payroll calculation matrix.",
+)
+```
+
+**Advantages**:
+- Full host language power: arbitrary `for` loops, mathematical calculations, currency formatting, conditionals, and recursion.
+- Polymorphic return values: accepts raw dictionaries/maps, dataclasses, or typesafe fluent builder objects (`Card()`, `Column()`).
+
+---
+
+## 3. Loop Processing: Server Unrolling vs. Client Data Model
+
+A critical question in template design is: **When does the template engine unroll loops vs. when are collections handled by the client runtime?**
+
+### Comparison Matrix
+
+| Dimension | Server-Side Template Unrolling | Client-Side DataModel Loop |
+| :--- | :--- | :--- |
+| **Execution Point** | Backend SDK (`TemplateProcessor`) during template expansion. | Client Renderer runtime during paint/state updates. |
+| **Data Source** | Static YAML literals, LLM invocation arguments, or server resolver output. | Client `DataModel` tree (e.g. `/session/cart/items`). |
+| **Component Output** | Emits $N$ concrete Basic Catalog component nodes with synthesized unique IDs. | Emits a single repeater/collection component with a `DataBinding` path. |
+| **Client Requirement** | Zero. Standard Basic Catalog renderers render it like any other static UI. | Requires client-side repeater support or SDK session re-renders. |
+| **Dynamic Mutation** | Immutable once generated unless the agent emits a new `updateComponents` message. | Reactively re-renders when the client data model updates (e.g. via button events). |
+
+### Example 1: Server-Side Template Loop Unrolling
+A template author specifies a loop over a parameter array:
+
+#### Template Definition:
+```yaml
+version: "0.1"
+templateId: TeamGoalList
+parameters:
+  teamName: {type: string}
+  goals: {type: array}
+layout:
+  component: Card
+  child:
+    component: Column
+    children:
+      - component: Text
+        text: "Objectives: ${teamName}"
+        variant: h2
+      - component: Column
+        children:
+          loop:
+            param: goals
+            as: goal
+            item:
+              component: Row
+              justify: spaceBetween
+              children:
+                - component: Text
+                  text: ${goal.title}
+                - component: Text
+                  text: ${goal.priority}
+                  variant: caption
+```
+
+#### Model Invocation:
+```text
+root = TeamGoalList("Core Team", [
+  {title: "Ship Protocol", priority: "High"},
+  {title: "Write Tests", priority: "Medium"}
+])
+```
+
+#### Expanded Output Sent to Client:
+The engine unrolls the loop into concrete, synthetic child components:
+```json
+[
+  {"id": "root", "component": "Card", "child": "root_child_column"},
+  {"id": "root_child_column", "component": "Column", "children": ["root_child_column_children_0_text", "root_child_column_children_1_column"]},
+  {"id": "root_child_column_children_0_text", "component": "Text", "text": "Objectives: Core Team", "variant": "h2"},
+  {"id": "root_child_column_children_1_column", "component": "Column", "children": [
+    "root_child_column_children_1_column_goals_0_row",
+    "root_child_column_children_1_column_goals_1_row"
+  ]},
+  {"id": "root_child_column_children_1_column_goals_0_row", "component": "Row", "justify": "spaceBetween", "children": [
+    "root_child_column_children_1_column_goals_0_row_children_0_text",
+    "root_child_column_children_1_column_goals_0_row_children_1_text"
+  ]},
+  {"id": "root_child_column_children_1_column_goals_0_row_children_0_text", "component": "Text", "text": "Ship Protocol"},
+  {"id": "root_child_column_children_1_column_goals_0_row_children_1_text", "component": "Text", "text": "High", "variant": "caption"},
+  {"id": "root_child_column_children_1_column_goals_1_row", "component": "Row", "justify": "spaceBetween", "children": [
+    "root_child_column_children_1_column_goals_1_row_children_0_text",
+    "root_child_column_children_1_column_goals_1_row_children_1_text"
+  ]},
+  {"id": "root_child_column_children_1_column_goals_1_row_children_0_text", "component": "Text", "text": "Write Tests"},
+  {"id": "root_child_column_children_1_column_goals_1_row_children_1_text", "component": "Text", "text": "Medium", "variant": "caption"}
+]
+```
+
+---
+
+## 4. Relationship to the A2UI Data Model
+
+Templates and the A2UI Data Model operate in complementary scopes:
+- **Templates** expand during **server-side inference / response formulation**.
+- **Data Model** operates during **client-side runtime interaction & reactivity**.
+
+Templates interact with the client Data Model in three distinct patterns:
+
+### Pattern 1: Dynamic Path Plumbing (Path Interpolation)
+Templates can accept path prefixes or IDs as parameters, constructing reactive client-side binding paths:
+
+```yaml
+version: "0.1"
+templateId: BoundLiveMetric
+parameters:
+  metricKey: {type: string}
+  label: {type: string}
+layout:
+  component: Card
+  child:
+    component: Column
+    children:
+      - component: Text
+        text: ${label}
+      - component: Text
+        text:
+          path: "/system/metrics/${metricKey}/currentValue"
+```
+
+**Expanded Output:**
+```json
+{
+  "id": "root_val",
+  "component": "Text",
+  "text": {
+    "path": "/system/metrics/cpuLoad/currentValue"
+  }
+}
+```
+*Client Behavior*: The client renderer attaches a live subscriber to `/system/metrics/cpuLoad/currentValue`. When telemetry updates arrive via `updateDataModel`, the component automatically re-renders without server roundtrips.
+
+### Pattern 2: Direct `DataBinding` Passthrough
+When a template parameter has `type: object`, an agent or caller can pass an explicit A2UI binding object:
+
+#### Model Invocation:
+```text
+root = MetricCard("Memory Used", {path: "/device/mem_percent"})
+```
+
+#### Template Layout:
+```yaml
+version: "0.1"
+templateId: MetricCard
+parameters:
+  title: {type: string}
+  val: {type: object}
+layout:
+  component: Column
+  children:
+    - component: Text
+      text: ${title}
+    - component: Text
+      text: ${val}
+```
+
+**Expanded Output:**
+Because `${val}` is an exact-match substitution, the dictionary type is strictly preserved:
+```json
+{
+  "component": "Text",
+  "text": {"path": "/device/mem_percent"}
+}
+```
+
+### Pattern 3: Hardcoded Session State References
+Templates can embed constant client bindings for global session preferences:
+
+```yaml
+layout:
+  component: Text
+  text:
+    path: "/session/currentUser/displayName"
+```
+
+---
+
+## 5. The Synthetic Catalog System
+
+To make templates discoverable and invoke-able by LLMs, the backend converts registered templates into a **Synthetic Component Catalog**.
+
+### The Catalog Synthesis Algorithm
+When `TemplateProcessor(templates)` is initialized:
+1. It copies the base catalog (e.g. Basic Catalog v0.9.1).
+2. For each registered `StaticTemplate` and `DynamicTemplate`:
+   - It registers a new component definition under `components[templateId]`.
+   - It maps semantic parameter definitions to JSON schema properties:
+     - `string` $\rightarrow$ `{"type": "string"}`
+     - `number` / `integer` $\rightarrow$ `{"type": "number"}` / `{"type": "integer"}`
+     - `boolean` $\rightarrow$ `{"type": "boolean"}`
+     - `enum` $\rightarrow$ `{"type": "string", "enum": param.values}`
+     - `object` $\rightarrow$ `{"type": "object", "properties": ...}`
+     - `array` $\rightarrow$ `{"type": "array", "items": ...}`
+     - `child` $\rightarrow$ `{"$ref": "#/$defs/ComponentReference"}`
+     - `children` $\rightarrow$ `{"$ref": "#/$defs/ComponentReferenceList"}`
+   - It copies the `description` to provide context for the model.
+3. The synthetic catalog is passed to `PromptGenerator` (Express, Elemental, Atom, Direct JSON), which automatically writes the syntax rules and documentation into the system prompt.
+
+### Surface Isolation Boundary
+```
+[LLM Agent] <---> [Synthetic Catalog (Templates + Primitives)] <---> [TemplateProcessor]
+                                                                            |
+                                                                   (Expands to Primitives)
+                                                                            |
+                                                                            v
+[Client Renderer] <---------------- (Standard Basic Catalog Only) <----------+
+```
+The synthetic catalog is an ephemeral compile-time construct. The client renderer is completely unaware that templates exist.
+
+---
+
+## 6. Parameter Expressions & Substitution Engine
+
+The template substitution engine replaces expressions according to strict typing and evaluation rules.
+
+### Rule 1: Exact Match Substitution (Type Preserving)
+If a string field value exactly matches the parameter token regex `^\$\{([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*)\}$`:
+- The entire field is replaced by the native runtime value of the parameter.
+- **Integers remain integers**: `level: ${userLevel}` $\rightarrow$ `level: 4` (not `"4"`).
+- **Booleans remain booleans**: `checked: ${isActive}` $\rightarrow$ `checked: true` (not `"true"`).
+- **Objects and Arrays remain native structures**: `items: ${memberList}` $\rightarrow$ `items: [{...}, {...}]`.
+
+### Rule 2: Embedded String Interpolation
+If a parameter token appears alongside other characters (e.g. `"Hello, ${userName}!"` or `"${dept} - ${code}"`):
+- All tokens are replaced by their string representations.
+- Evaluates to a native string.
+
+### Rule 3: Deep Dot-Notation for Structured Objects
+Templates natively support deep dot-notation paths on object parameters:
+
+#### Invocation:
+```text
+root = AccountCard({
+  account: {
+    id: "acc_99",
+    profile: {name: "Alpha Corp", tier: "Enterprise"}
+  }
+})
+```
+
+#### Template Layout:
+```yaml
+version: "0.1"
+templateId: AccountCard
+parameters:
+  account: {type: object}
+layout:
+  component: Card
+  child:
+    component: Text
+    text: "${account.profile.name} (${account.profile.tier})"
+```
+
+**Expanded Output:**
+```json
+{
+  "component": "Text",
+  "text": "Alpha Corp (Enterprise)"
+}
+```
+
+### Rule 4: String Format AST Expressions
+For complex string formatting across multiple languages:
+```yaml
+format: "Level {lvl} ({pts} points)"
+args:
+  lvl: ${level}
+  pts: ${experiencePoints}
+```
+
+### Rule 5: Token Escaping
+To emit a literal `${foo}` string without triggering parameter substitution, escape the leading dollar sign with a backslash:
+- `\${keep_literal}` $\rightarrow$ evaluates to literal `"${keep_literal}"`.
+
+### Rule 6: Missing Values & Defaults
+- If an argument is omitted but has a declared `default` in its parameter schema, the `default` is used.
+- If an argument is omitted, has no `default`, and is not required: the property is omitted from the synthesized component (it is not emitted as `null`).
+- If an argument is required and missing: expansion raises a `TemplateParameterError`.
+
+---
+
+## 7. Deterministic Synthetic ID Generation Algorithm
+
+To guarantee collision-free component IDs across multiple template instances and deep nesting, implementations in all languages (Python, Dart, TypeScript) must implement the following deterministic naming rules:
+
+### ID Synthesis Specification
+
+```
+Let instance_id be the ID passed to expand_template(instance_id, template_id, params)
+
+1. Root Node:
+   id = instance_id
+
+2. Single Child Slot (e.g. card.child):
+   id = "{parent_id}_{slot_name}_{normalized_type}"
+   (where normalized_type is the component or template type converted to lowercase)
+   Example: "root_child_column"
+
+3. Multi-Child List Slot (e.g. column.children[i]):
+   id = "{parent_id}_{slot_name}_{i}_{normalized_type}"
+   (where normalized_type is the component or template type converted to lowercase)
+   Example: "root_children_0_text", "root_children_1_button"
+
+4. Loop Iteration Item (e.g. loop over param "members", iteration index i):
+   id = "{parent_id}_{param_name}_{i}_{normalized_type}"
+   (where normalized_type is the component or template type converted to lowercase)
+   Example: "team_col_members_0_userprofile"
+
+5. Authored Explicit IDs:
+   If a component in the template specifies an explicit id (e.g. id: "hero_img"):
+   id = "{instance_id}_{authored_id}"
+   Example: "my_card_hero_img"
+```
+
+This guarantees that two instances of the same template (`card_1` and `card_2`) on the same surface will never produce colliding component IDs.
+
+---
+
+## 8. Higher-Order Container Templates (`child` and `children` Slots)
+
+Templates can define structural containers that receive caller-provided components.
+
+### Example: `SectionCard` Container
+```yaml
+version: "0.1"
+templateId: SectionCard
+parameters:
+  title: {type: string}
+  headerAction: {type: child}
+  children: {type: children}
+
+layout:
+  component: Card
+  child:
+    component: Column
+    children:
+      - component: Row
+        justify: spaceBetween
+        align: center
+        children:
+          - component: Text
+            text: ${title}
+            variant: h2
+          - component: Column
+            children: ${headerAction}
+      - component: Divider
+        axis: horizontal
+      - component: Column
+        children: ${children}
+```
+
+#### Model Invocation:
+```text
+root = SectionCard(
+  "Project Status",
+  Button("Refresh", {action: "reload"}),
+  [
+    Text("Phase 1: Complete"),
+    Text("Phase 2: In Progress")
+  ]
+)
+```
+
+The template engine replaces `${headerAction}` with the synthesized single child node, and concatenates the `${children}` component list into the body column.
+
+---
+
+## 9. Error Handling, Cycle Guards & Safety
+
+### Recursion & Circular Reference Detection
+Templates can invoke other templates. However, circular references (`A` invokes `B`, which invokes `A`) must be caught immediately to prevent stack overflow.
+
+- **Call Stack Tracking**: The `TemplateProcessor` maintains an active `_call_stack: Set[str]` throughout expansion.
+- **Cycle Guard**: Before expanding any template, if `template_id in _call_stack`, expansion terminates immediately with `TemplateCycleError: Circular template reference detected: A -> B -> A`.
+- **Maximum Depth Guard**: An absolute limit (`MAX_EXPANSION_DEPTH = 32`) enforces termination even in non-identical runaway recursion.
+
+### Standard Error Hierarchy
+1. `TemplateNotFoundError`: Attempted to expand a `templateId` not present in the catalog.
+2. `TemplateParameterError`: Missing required parameter or invalid parameter type.
+3. `TemplateCycleError`: Circular reference detected during expansion.
+4. `TemplateDepthExceededError`: Expansion exceeded maximum recursion depth.
+5. `TemplateResolverError`: Exception raised by a dynamic template resolver function.
+
+---
+
+## 10. Multi-Document YAML Streams (`---`)
+
+To streamline template maintenance, multiple templates can be defined in a single `.yaml` file separated by `---`:
+
+- **Order Independent**: Templates can reference templates declared later in the file (forward references).
+- **Batch Registration**: Loading a multi-doc file registers all defined templates atomically into the `TemplateProcessor`.
+
+---
+
+## 11. Template Versioning & Schema Evolution
+
+To ensure robust backward compatibility as template syntax and AST features evolve across future protocol releases, every template definition must declare a top-level `version` field.
+
+### Versioning Rules:
+1. **Mandatory Version Field**: Every YAML document (and each document within multi-doc streams separated by `---`) must include `version: "0.1"`.
+2. **Strict Schema Validation**: The canonical JSON schema enforces `"version": {"type": "string", "const": "0.1"}`. Attempting to inflate a template with an unsupported version raises an explicit `TemplateVersionError` / `ValueError`.
+3. **Future Extensibility**: As new template language capabilities are standardized (e.g. conditional slot rendering, client-expanded template directives), new version identifiers (such as `"0.2"` or `"1.0"`) allow engines to select the appropriate parser/evaluator without breaking legacy templates.
+
+---
+
+## 12. Conformance Checklist for SDK Implementations
+
+An implementation of the A2UI Template Engine in any language (Python, Dart, TypeScript, Go, etc.) is conformant if and only if it satisfies the following test requirements:
+
+- [ ] **Template Versioning**: Validates that all ingested templates declare `version: "0.1"` and rejects unsupported version strings.
+- [ ] **Multi-Document Ingestion**: Parses single-doc and multi-doc (`---`) YAML streams.
+- [ ] **Forward Reference Resolution**: Expands templates regardless of registration order.
+- [ ] **Strict Native Type Preservation**: Exact `${param}` substitutions preserve `int`, `float`, `bool`, `dict`, and `list` types.
+- [ ] **Dot-Notation Path Traversal**: Resolves arbitrary depth paths (e.g. `${user.details.address.zip}`).
+- [ ] **Inline and Named Loop Expansion**: Accurately unrolls arrays into synthesized component subtrees with indexed child IDs.
+- [ ] **Deterministic Synthetic IDs**: Emits canonical hierarchical IDs matching the `{parent}_{slot}_{index}_{type}` specification.
+- [ ] **Two-Way DataModel Passthrough**: Preserves `{path: "..."}` dictionary bindings without string conversion.
+- [ ] **Cycle and Recursion Safeguards**: Catches circular references and depth violations with explicit exceptions.
+- [ ] **Synthetic Catalog Generation**: Generates valid A2UI JSON schema catalogs matching input parameter definitions.
+- [ ] **Polymorphic Dynamic Templates**: Supports both resolver-based static bindings and programmatic render functions.
+

--- a/specification/proposals/templates/README.md
+++ b/specification/proposals/templates/README.md
@@ -2,11 +2,12 @@
 
 ## Abstract
 
-This document defines the authoritative specification for the **A2UI Templates System**. 
+This document defines the authoritative specification for the **A2UI Templates System**.
 
 Templates provide a declarative, human-readable mechanism for authoring reusable UI subtrees in nested YAML or via native programmatic render functions. At generation time, an agent or Large Language Model (LLM) outputs compact, high-level template invocations (such as `UserProfile("u1", "Alice")` or `PayrollSummary("Eng", true)`). The backend SDK expands these invocations into standard, flat A2UI Basic Catalog components in a single synchronous pass before emitting standard A2UI protocol messages (`updateComponents`) to the client.
 
 This architecture achieves three fundamental objectives:
+
 1. **Human Readability**: Layouts are authored as clean, natural tree hierarchies in YAML or native language code, eliminating artificial IDs and flat array boilerplate.
 2. **Token Efficiency & Context Optimization**: LLMs emit concise function-like signatures rather than verbose, deeply nested UI component trees, saving prompt context and generation tokens.
 3. **Zero Client Overhead**: Client renderers (@a2ui/react, @a2ui/lit, @a2ui/angular, @a2ui/flutter) implement only standard Basic Catalog primitives (`Card`, `Column`, `Row`, `Text`, `Divider`, `Icon`, `Button`). No custom client widgets, dynamic code deployment, or renderer plugins are required.
@@ -70,10 +71,11 @@ The template engine operates entirely server-side within the A2UI Agent SDK:
 A2UI defines three template modalities:
 
 ### A. Declarative Static Templates (YAML)
+
 Declarative static templates define immutable layout trees authored in YAML files. All parameter placeholders are populated directly from arguments provided by the model or caller.
 
 ```yaml
-version: "0.1"
+version: '0.1'
 templateId: UserProfile
 description: Standard identity card for team members.
 parameters:
@@ -104,7 +106,9 @@ layout:
 ```
 
 ### B. Dynamic Templates: Data-Binding Mode (`resolver + layout`)
-Data-binding dynamic templates decouple public model parameters from private or live backend data. 
+
+Data-binding dynamic templates decouple public model parameters from private or live backend data.
+
 - **Public Surface**: The model only sees and outputs high-level lookup parameters (e.g. `employeeId: "emp_101"`).
 - **Server Resolver**: At expansion time, a backend callback executes (e.g., querying an internal HR database or API) and produces a data dictionary.
 - **Layout Inflation**: The resolved dictionary is merged with the caller's arguments and applied to an underlying static YAML layout.
@@ -122,13 +126,14 @@ dynamic_salary = DynamicTemplate(
 **Security Rationale**: Confidential numbers (e.g., executive salaries, PII) never enter the model's prompt context window or inference transcript.
 
 ### C. Dynamic Templates: Programmatic Render Mode (`render_fn`)
+
 Programmatic dynamic templates bypass static YAML layouts entirely. Instead, a developer writes a native function in the host language (Python, Dart, etc.) that accepts parameters and directly returns a UI component tree.
 
 ```python
 def render_payroll_summary(department: str = "Engineering", includeBonus: bool = True) -> dict:
     total_base = sum(e.salary for e in db.get_dept(department))
     total_bonus = sum(e.bonus for e in db.get_dept(department))
-    
+
     rows = []
     for emp in db.get_dept(department):
         cols = [
@@ -161,6 +166,7 @@ payroll_tmpl = DynamicTemplate(
 ```
 
 **Advantages**:
+
 - Full host language power: arbitrary `for` loops, mathematical calculations, currency formatting, conditionals, and recursion.
 - Polymorphic return values: accepts raw dictionaries/maps, dataclasses, or typesafe fluent builder objects (`Card()`, `Column()`).
 
@@ -172,20 +178,22 @@ A critical question in template design is: **When does the template engine unrol
 
 ### Comparison Matrix
 
-| Dimension | Server-Side Template Unrolling | Client-Side DataModel Loop |
-| :--- | :--- | :--- |
-| **Execution Point** | Backend SDK (`TemplateProcessor`) during template expansion. | Client Renderer runtime during paint/state updates. |
-| **Data Source** | Static YAML literals, LLM invocation arguments, or server resolver output. | Client `DataModel` tree (e.g. `/session/cart/items`). |
-| **Component Output** | Emits $N$ concrete Basic Catalog component nodes with synthesized unique IDs. | Emits a single repeater/collection component with a `DataBinding` path. |
-| **Client Requirement** | Zero. Standard Basic Catalog renderers render it like any other static UI. | Requires client-side repeater support or SDK session re-renders. |
-| **Dynamic Mutation** | Immutable once generated unless the agent emits a new `updateComponents` message. | Reactively re-renders when the client data model updates (e.g. via button events). |
+| Dimension              | Server-Side Template Unrolling                                                    | Client-Side DataModel Loop                                                         |
+| :--------------------- | :-------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------- |
+| **Execution Point**    | Backend SDK (`TemplateProcessor`) during template expansion.                      | Client Renderer runtime during paint/state updates.                                |
+| **Data Source**        | Static YAML literals, LLM invocation arguments, or server resolver output.        | Client `DataModel` tree (e.g. `/session/cart/items`).                              |
+| **Component Output**   | Emits $N$ concrete Basic Catalog component nodes with synthesized unique IDs.     | Emits a single repeater/collection component with a `DataBinding` path.            |
+| **Client Requirement** | Zero. Standard Basic Catalog renderers render it like any other static UI.        | Requires client-side repeater support or SDK session re-renders.                   |
+| **Dynamic Mutation**   | Immutable once generated unless the agent emits a new `updateComponents` message. | Reactively re-renders when the client data model updates (e.g. via button events). |
 
 ### Example 1: Server-Side Template Loop Unrolling
+
 A template author specifies a loop over a parameter array:
 
 #### Template Definition:
+
 ```yaml
-version: "0.1"
+version: '0.1'
 templateId: TeamGoalList
 parameters:
   teamName: {type: string}
@@ -196,7 +204,7 @@ layout:
     component: Column
     children:
       - component: Text
-        text: "Objectives: ${teamName}"
+        text: 'Objectives: ${teamName}'
         variant: h2
       - component: Column
         children:
@@ -215,6 +223,7 @@ layout:
 ```
 
 #### Model Invocation:
+
 ```text
 root = TeamGoalList("Core Team", [
   {title: "Ship Protocol", priority: "High"},
@@ -223,28 +232,71 @@ root = TeamGoalList("Core Team", [
 ```
 
 #### Expanded Output Sent to Client:
+
 The engine unrolls the loop into concrete, synthetic child components:
+
 ```json
 [
   {"id": "root", "component": "Card", "child": "root_child_column"},
-  {"id": "root_child_column", "component": "Column", "children": ["root_child_column_children_0_text", "root_child_column_children_1_column"]},
-  {"id": "root_child_column_children_0_text", "component": "Text", "text": "Objectives: Core Team", "variant": "h2"},
-  {"id": "root_child_column_children_1_column", "component": "Column", "children": [
-    "root_child_column_children_1_column_goals_0_row",
-    "root_child_column_children_1_column_goals_1_row"
-  ]},
-  {"id": "root_child_column_children_1_column_goals_0_row", "component": "Row", "justify": "spaceBetween", "children": [
-    "root_child_column_children_1_column_goals_0_row_children_0_text",
-    "root_child_column_children_1_column_goals_0_row_children_1_text"
-  ]},
-  {"id": "root_child_column_children_1_column_goals_0_row_children_0_text", "component": "Text", "text": "Ship Protocol"},
-  {"id": "root_child_column_children_1_column_goals_0_row_children_1_text", "component": "Text", "text": "High", "variant": "caption"},
-  {"id": "root_child_column_children_1_column_goals_1_row", "component": "Row", "justify": "spaceBetween", "children": [
-    "root_child_column_children_1_column_goals_1_row_children_0_text",
-    "root_child_column_children_1_column_goals_1_row_children_1_text"
-  ]},
-  {"id": "root_child_column_children_1_column_goals_1_row_children_0_text", "component": "Text", "text": "Write Tests"},
-  {"id": "root_child_column_children_1_column_goals_1_row_children_1_text", "component": "Text", "text": "Medium", "variant": "caption"}
+  {
+    "id": "root_child_column",
+    "component": "Column",
+    "children": ["root_child_column_children_0_text", "root_child_column_children_1_column"]
+  },
+  {
+    "id": "root_child_column_children_0_text",
+    "component": "Text",
+    "text": "Objectives: Core Team",
+    "variant": "h2"
+  },
+  {
+    "id": "root_child_column_children_1_column",
+    "component": "Column",
+    "children": [
+      "root_child_column_children_1_column_goals_0_row",
+      "root_child_column_children_1_column_goals_1_row"
+    ]
+  },
+  {
+    "id": "root_child_column_children_1_column_goals_0_row",
+    "component": "Row",
+    "justify": "spaceBetween",
+    "children": [
+      "root_child_column_children_1_column_goals_0_row_children_0_text",
+      "root_child_column_children_1_column_goals_0_row_children_1_text"
+    ]
+  },
+  {
+    "id": "root_child_column_children_1_column_goals_0_row_children_0_text",
+    "component": "Text",
+    "text": "Ship Protocol"
+  },
+  {
+    "id": "root_child_column_children_1_column_goals_0_row_children_1_text",
+    "component": "Text",
+    "text": "High",
+    "variant": "caption"
+  },
+  {
+    "id": "root_child_column_children_1_column_goals_1_row",
+    "component": "Row",
+    "justify": "spaceBetween",
+    "children": [
+      "root_child_column_children_1_column_goals_1_row_children_0_text",
+      "root_child_column_children_1_column_goals_1_row_children_1_text"
+    ]
+  },
+  {
+    "id": "root_child_column_children_1_column_goals_1_row_children_0_text",
+    "component": "Text",
+    "text": "Write Tests"
+  },
+  {
+    "id": "root_child_column_children_1_column_goals_1_row_children_1_text",
+    "component": "Text",
+    "text": "Medium",
+    "variant": "caption"
+  }
 ]
 ```
 
@@ -253,16 +305,18 @@ The engine unrolls the loop into concrete, synthetic child components:
 ## 4. Relationship to the A2UI Data Model
 
 Templates and the A2UI Data Model operate in complementary scopes:
+
 - **Templates** expand during **server-side inference / response formulation**.
 - **Data Model** operates during **client-side runtime interaction & reactivity**.
 
 Templates interact with the client Data Model in three distinct patterns:
 
 ### Pattern 1: Dynamic Path Plumbing (Path Interpolation)
+
 Templates can accept path prefixes or IDs as parameters, constructing reactive client-side binding paths:
 
 ```yaml
-version: "0.1"
+version: '0.1'
 templateId: BoundLiveMetric
 parameters:
   metricKey: {type: string}
@@ -276,10 +330,11 @@ layout:
         text: ${label}
       - component: Text
         text:
-          path: "/system/metrics/${metricKey}/currentValue"
+          path: '/system/metrics/${metricKey}/currentValue'
 ```
 
 **Expanded Output:**
+
 ```json
 {
   "id": "root_val",
@@ -289,19 +344,23 @@ layout:
   }
 }
 ```
-*Client Behavior*: The client renderer attaches a live subscriber to `/system/metrics/cpuLoad/currentValue`. When telemetry updates arrive via `updateDataModel`, the component automatically re-renders without server roundtrips.
+
+_Client Behavior_: The client renderer attaches a live subscriber to `/system/metrics/cpuLoad/currentValue`. When telemetry updates arrive via `updateDataModel`, the component automatically re-renders without server roundtrips.
 
 ### Pattern 2: Direct `DataBinding` Passthrough
+
 When a template parameter has `type: object`, an agent or caller can pass an explicit A2UI binding object:
 
 #### Model Invocation:
+
 ```text
 root = MetricCard("Memory Used", {path: "/device/mem_percent"})
 ```
 
 #### Template Layout:
+
 ```yaml
-version: "0.1"
+version: '0.1'
 templateId: MetricCard
 parameters:
   title: {type: string}
@@ -317,6 +376,7 @@ layout:
 
 **Expanded Output:**
 Because `${val}` is an exact-match substitution, the dictionary type is strictly preserved:
+
 ```json
 {
   "component": "Text",
@@ -325,13 +385,14 @@ Because `${val}` is an exact-match substitution, the dictionary type is strictly
 ```
 
 ### Pattern 3: Hardcoded Session State References
+
 Templates can embed constant client bindings for global session preferences:
 
 ```yaml
 layout:
   component: Text
   text:
-    path: "/session/currentUser/displayName"
+    path: '/session/currentUser/displayName'
 ```
 
 ---
@@ -341,7 +402,9 @@ layout:
 To make templates discoverable and invoke-able by LLMs, the backend converts registered templates into a **Synthetic Component Catalog**.
 
 ### The Catalog Synthesis Algorithm
+
 When `TemplateProcessor(templates)` is initialized:
+
 1. It copies the base catalog (e.g. Basic Catalog v0.9.1).
 2. For each registered `StaticTemplate` and `DynamicTemplate`:
    - It registers a new component definition under `components[templateId]`.
@@ -358,6 +421,7 @@ When `TemplateProcessor(templates)` is initialized:
 3. The synthetic catalog is passed to `PromptGenerator` (Express, Elemental, Atom, Direct JSON), which automatically writes the syntax rules and documentation into the system prompt.
 
 ### Surface Isolation Boundary
+
 ```
 [LLM Agent] <---> [Synthetic Catalog (Templates + Primitives)] <---> [TemplateProcessor]
                                                                             |
@@ -366,6 +430,7 @@ When `TemplateProcessor(templates)` is initialized:
                                                                             v
 [Client Renderer] <---------------- (Standard Basic Catalog Only) <----------+
 ```
+
 The synthetic catalog is an ephemeral compile-time construct. The client renderer is completely unaware that templates exist.
 
 ---
@@ -375,21 +440,27 @@ The synthetic catalog is an ephemeral compile-time construct. The client rendere
 The template substitution engine replaces expressions according to strict typing and evaluation rules.
 
 ### Rule 1: Exact Match Substitution (Type Preserving)
+
 If a string field value exactly matches the parameter token regex `^\$\{([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*)\}$`:
+
 - The entire field is replaced by the native runtime value of the parameter.
 - **Integers remain integers**: `level: ${userLevel}` $\rightarrow$ `level: 4` (not `"4"`).
 - **Booleans remain booleans**: `checked: ${isActive}` $\rightarrow$ `checked: true` (not `"true"`).
 - **Objects and Arrays remain native structures**: `items: ${memberList}` $\rightarrow$ `items: [{...}, {...}]`.
 
 ### Rule 2: Embedded String Interpolation
+
 If a parameter token appears alongside other characters (e.g. `"Hello, ${userName}!"` or `"${dept} - ${code}"`):
+
 - All tokens are replaced by their string representations.
 - Evaluates to a native string.
 
 ### Rule 3: Deep Dot-Notation for Structured Objects
+
 Templates natively support deep dot-notation paths on object parameters:
 
 #### Invocation:
+
 ```text
 root = AccountCard({
   account: {
@@ -400,8 +471,9 @@ root = AccountCard({
 ```
 
 #### Template Layout:
+
 ```yaml
-version: "0.1"
+version: '0.1'
 templateId: AccountCard
 parameters:
   account: {type: object}
@@ -409,10 +481,11 @@ layout:
   component: Card
   child:
     component: Text
-    text: "${account.profile.name} (${account.profile.tier})"
+    text: '${account.profile.name} (${account.profile.tier})'
 ```
 
 **Expanded Output:**
+
 ```json
 {
   "component": "Text",
@@ -421,19 +494,24 @@ layout:
 ```
 
 ### Rule 4: String Format AST Expressions
+
 For complex string formatting across multiple languages:
+
 ```yaml
-format: "Level {lvl} ({pts} points)"
+format: 'Level {lvl} ({pts} points)'
 args:
   lvl: ${level}
   pts: ${experiencePoints}
 ```
 
 ### Rule 5: Token Escaping
+
 To emit a literal `${foo}` string without triggering parameter substitution, escape the leading dollar sign with a backslash:
+
 - `\${keep_literal}` $\rightarrow$ evaluates to literal `"${keep_literal}"`.
 
 ### Rule 6: Missing Values & Defaults
+
 - If an argument is omitted but has a declared `default` in its parameter schema, the `default` is used.
 - If an argument is omitted, has no `default`, and is not required: the property is omitted from the synthesized component (it is not emitted as `null`).
 - If an argument is required and missing: expansion raises a `TemplateParameterError`.
@@ -482,8 +560,9 @@ This guarantees that two instances of the same template (`card_1` and `card_2`) 
 Templates can define structural containers that receive caller-provided components.
 
 ### Example: `SectionCard` Container
+
 ```yaml
-version: "0.1"
+version: '0.1'
 templateId: SectionCard
 parameters:
   title: {type: string}
@@ -511,6 +590,7 @@ layout:
 ```
 
 #### Model Invocation:
+
 ```text
 root = SectionCard(
   "Project Status",
@@ -529,6 +609,7 @@ The template engine replaces `${headerAction}` with the synthesized single child
 ## 9. Error Handling, Cycle Guards & Safety
 
 ### Recursion & Circular Reference Detection
+
 Templates can invoke other templates. However, circular references (`A` invokes `B`, which invokes `A`) must be caught immediately to prevent stack overflow.
 
 - **Call Stack Tracking**: The `TemplateProcessor` maintains an active `_call_stack: Set[str]` throughout expansion.
@@ -536,6 +617,7 @@ Templates can invoke other templates. However, circular references (`A` invokes 
 - **Maximum Depth Guard**: An absolute limit (`MAX_EXPANSION_DEPTH = 32`) enforces termination even in non-identical runaway recursion.
 
 ### Standard Error Hierarchy
+
 1. `TemplateNotFoundError`: Attempted to expand a `templateId` not present in the catalog.
 2. `TemplateParameterError`: Missing required parameter or invalid parameter type.
 3. `TemplateCycleError`: Circular reference detected during expansion.
@@ -558,6 +640,7 @@ To streamline template maintenance, multiple templates can be defined in a singl
 To ensure robust backward compatibility as template syntax and AST features evolve across future protocol releases, every template definition must declare a top-level `version` field.
 
 ### Versioning Rules:
+
 1. **Mandatory Version Field**: Every YAML document (and each document within multi-doc streams separated by `---`) must include `version: "0.1"`.
 2. **Strict Schema Validation**: The canonical JSON schema enforces `"version": {"type": "string", "const": "0.1"}`. Attempting to inflate a template with an unsupported version raises an explicit `TemplateVersionError` / `ValueError`.
 3. **Future Extensibility**: As new template language capabilities are standardized (e.g. conditional slot rendering, client-expanded template directives), new version identifiers (such as `"0.2"` or `"1.0"`) allow engines to select the appropriate parser/evaluator without breaking legacy templates.
@@ -579,4 +662,3 @@ An implementation of the A2UI Template Engine in any language (Python, Dart, Typ
 - [ ] **Cycle and Recursion Safeguards**: Catches circular references and depth violations with explicit exceptions.
 - [ ] **Synthetic Catalog Generation**: Generates valid A2UI JSON schema catalogs matching input parameter definitions.
 - [ ] **Polymorphic Dynamic Templates**: Supports both resolver-based static bindings and programmatic render functions.
-

--- a/specification/proposals/templates/README.md
+++ b/specification/proposals/templates/README.md
@@ -1,8 +1,8 @@
-# A2UI Templates Specification
+# A2UI Template Specification
 
 ## Abstract
 
-This document defines the authoritative specification for the **A2UI Templates System**.
+This document defines the authoritative specification for **A2UI Templates**.
 
 Templates provide a declarative, human-readable mechanism for authoring reusable UI subtrees in nested YAML or via native programmatic render functions. At generation time, an agent or Large Language Model (LLM) outputs compact, high-level template invocations (such as `UserProfile("u1", "Alice")` or `PayrollSummary("Eng", true)`). The backend SDK expands these invocations into standard, flat A2UI Basic Catalog components in a single synchronous pass before emitting standard A2UI protocol messages (`updateComponents`) to the client.
 
@@ -18,57 +18,46 @@ This architecture achieves three fundamental objectives:
 
 The template engine operates entirely server-side within the A2UI Agent SDK:
 
-```
-+-------------------------------------------------------------------------------+
-| 1. Authoring & Registration                                                   |
-|    - Static YAML files (with multi-doc '---' support & cross-references)      |
-|    - Dynamic resolvers (data-binding mode & programmatic AST mode)            |
-+---------------------------------------+---------------------------------------+
-                                        |
-                                        v
-+-------------------------------------------------------------------------------+
-| 2. Synthetic Catalog Generation                                               |
-|    - TemplateProcessor scans registered templates                             |
-|    - Synthesizes virtual A2UI Component Catalog JSON schema                   |
-+---------------------------------------+---------------------------------------+
-                                        |
-                                        v
-+-------------------------------------------------------------------------------+
-| 3. Model Prompt Generation & Inference                                        |
-|    - PromptGenerator injects template signatures into system prompt           |
-|    - LLM emits compact Express DSL / JSON:                                    |
-|      root = TeamRoster("Engineering", [TeamCard("Core", [...])])              |
-+---------------------------------------+---------------------------------------+
-                                        |
-                                        v
-+-------------------------------------------------------------------------------+
-| 4. Synchronous Template Expansion (TemplateProcessor)                         |
-|    - Resolves dynamic callbacks or executes programmatic render functions     |
-|    - Substitutes typed parameters & evaluates dot-notation paths              |
-|    - Unrolls server loops & plumbs component slot arguments                   |
-|    - Assigns deterministic synthetic IDs: {parent}_{slot}_{index}_{type}      |
-+---------------------------------------+---------------------------------------+
-                                        |
-                                        v
-+-------------------------------------------------------------------------------+
-| 5. Standard A2UI Protocol Emission                                            |
-|    - Emits standard createSurface and updateComponents messages               |
-|    - Payload contains 100% standard Basic Catalog primitives                  |
-+---------------------------------------+---------------------------------------+
-                                        |
-                                        v
-+-------------------------------------------------------------------------------+
-| 6. Client Renderer Execution                                                  |
-|    - Standard Basic Catalog renderers paint the flat component graph          |
-|    - Binds reactive two-way paths to client DataModel                         |
-+-------------------------------------------------------------------------------+
+```mermaid
+flowchart TD
+    subgraph Stage1["1. Authoring & Registration"]
+        YAML["Static YAML Files<br/>(multi-doc '---' & cross-references)"]
+        Dynamic["Dynamic Resolvers<br/>(data-binding & programmatic AST)"]
+    end
+
+    subgraph Stage2["2. Synthetic Catalog Generation"]
+        Proc["TemplateProcessor indexes templates<br/>& synthesizes virtual Component Catalog"]
+    end
+
+    subgraph Stage3["3. Model Prompt Generation & Inference"]
+        Prompt["PromptGenerator injects template signatures into prompt"]
+        LLM["LLM emits compact Express DSL / JSON<br/>(e.g. root = TeamRoster(...))"]
+    end
+
+    subgraph Stage4["4. Synchronous Template Expansion"]
+        Expand["TemplateProcessor unrolls loops,<br/>substitutes params, assigns synthetic IDs"]
+    end
+
+    subgraph Stage5["5. Standard A2UI Protocol Emission"]
+        Msg["Emits createSurface & updateComponents<br/>(100% standard Basic Catalog primitives)"]
+    end
+
+    subgraph Stage6["6. Client Renderer Execution"]
+        Client["Client renderers paint standard components<br/>& bind reactive paths to client DataModel"]
+    end
+
+    Stage1 --> Stage2
+    Stage2 --> Stage3
+    Stage3 --> Stage4
+    Stage4 --> Stage5
+    Stage5 --> Stage6
 ```
 
 ---
 
 ## 2. Template Taxonomy
 
-A2UI defines three template modalities:
+A2UI supports three template authoring styles:
 
 ### A. Declarative Static Templates (YAML)
 
@@ -478,13 +467,11 @@ When `TemplateProcessor(templates, catalogs)` is initialized:
 
 ### Surface Isolation Boundary
 
-```
-[LLM Agent] <---> [Synthetic Catalog (Templates + Primitives)] <---> [TemplateProcessor]
-                                                                            |
-                                                                   (Expands to Primitives)
-                                                                            |
-                                                                            v
-[Client Renderer] <---------------- (Standard Catalog Components) <---------+
+```mermaid
+flowchart LR
+    Agent["LLM Agent"] <--> SyntheticCatalog["Synthetic Catalog<br/>(Templates + Primitives)"]
+    SyntheticCatalog <--> Processor["TemplateProcessor"]
+    Processor -->|"Synchronously expands<br/>to flat primitives"| Client["Client Renderer<br/>(Basic Catalog)"]
 ```
 
 The synthetic catalog is an ephemeral compile-time construct. The client renderer is completely unaware that templates exist.
@@ -668,11 +655,14 @@ The template engine replaces `${headerAction}` with the synthesized single child
 
 ### Recursion & Circular Reference Detection
 
-Templates can invoke other templates. However, circular references (`A` invokes `B`, which invokes `A`) must be caught immediately to prevent stack overflow.
+Templates can invoke other templates. However, circular references in template definitions (`A` invokes `B`, which invokes `A`) must be caught immediately to prevent stack overflow.
 
-- **Call Stack Tracking**: The `TemplateProcessor` maintains an active `_call_stack: Set[str]` throughout expansion.
-- **Cycle Guard**: Before expanding any template, if `template_name in _call_stack`, expansion terminates immediately with `TemplateCycleError: Circular template reference detected: A -> B -> A`.
-- **Maximum Depth Guard**: An absolute limit (`MAX_EXPANSION_DEPTH = 32`) enforces termination even in non-identical runaway recursion.
+- **Definition Cycles vs. Instance Nesting**:
+  - **Definition Cycles (Prohibited)**: The cycle guard specifically tracks the chain of template _definitions_ being expanded (`TemplateA -> TemplateB -> TemplateA`). If a template definition unconditionally references itself or another template in a cycle, expansion terminates with `TemplateCycleError`.
+  - **Instance Nesting (Fully Supported)**: When a caller passes an instance of a template as an argument into another template's `child` or `children` slot (for example, a `Card` template containing a `Carousel` template whose items are other `Card` template instances), this is standard, safe hierarchical composition. Each instance receives a unique synthetic ID and is bounded by caller input.
+- **Call Stack Tracking**: The `TemplateProcessor` maintains an active `_call_stack: Set[str]` of template definition names currently being evaluated.
+- **Cycle Guard**: Before expanding any template definition, if `template_name in _call_stack`, expansion terminates immediately with `TemplateCycleError: Circular template reference detected: A -> B -> A`.
+- **Maximum Depth Guard**: An absolute limit (`MAX_EXPANSION_DEPTH = 50`) enforces termination even in deeply nested or runaway recursion.
 
 ### Standard Error Hierarchy
 

--- a/specification/proposals/templates/README.md
+++ b/specification/proposals/templates/README.md
@@ -89,10 +89,10 @@ layout:
       - component: Icon
         name: person
       - component: Text
-        text: ${userName}
+        text: '{{ userName }}'
         variant: h3
       - component: Text
-        text: ${role}
+        text: '{{ role }}'
         variant: caption
 ```
 
@@ -199,7 +199,7 @@ layout:
     component: Column
     children:
       - component: Text
-        text: 'Objectives: ${teamName}'
+        text: 'Objectives: {{ teamName }}'
         variant: h2
       - component: Column
         children:
@@ -211,9 +211,9 @@ layout:
               justify: spaceBetween
               children:
                 - component: Text
-                  text: ${goal.title}
+                  text: '{{ goal.title }}'
                 - component: Text
-                  text: ${goal.priority}
+                  text: '{{ goal.priority }}'
                   variant: caption
 ```
 
@@ -324,10 +324,10 @@ layout:
     component: Column
     children:
       - component: Text
-        text: ${label}
+        text: '{{ label }}'
       - component: Text
         text:
-          path: '/system/metrics/${metricKey}/currentValue'
+          path: '/system/metrics/{{ metricKey }}/currentValue'
 ```
 
 **Expanded Output:**
@@ -366,13 +366,14 @@ layout:
   component: Column
   children:
     - component: Text
-      text: ${title}
+      text: '{{ title }}'
     - component: Text
-      text: ${val}
+      text: '{{ val }}'
 ```
 
 **Expanded Output:**
-Because `${val}` is an exact-match substitution, the dictionary type is strictly preserved:
+
+Because `{{ val }}` is an exact-match substitution, the dictionary type is strictly preserved:
 
 ```json
 {
@@ -480,25 +481,42 @@ The synthetic catalog is an ephemeral compile-time construct. The client rendere
 
 ## 8. Parameter Expressions & Substitution Engine
 
-The template substitution engine replaces expressions according to strict typing and evaluation rules.
+The template substitution engine replaces expressions according to strict typing and evaluation rules using standard double-curly Mustache syntax (`{{ param }}`).
 
 ### Rule 1: Exact Match Substitution (Type Preserving)
 
-If a string field value exactly matches the parameter token regex `^\$\{([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*)\}$`:
+If a string field value exactly matches the parameter token regex `^\{\{\s*([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*)\s*\}\}$`:
 
 - The entire field is replaced by the native runtime value of the parameter.
-- **Integers remain integers**: `level: ${userLevel}` $\rightarrow$ `level: 4` (not `"4"`).
-- **Booleans remain booleans**: `checked: ${isActive}` $\rightarrow$ `checked: true` (not `"true"`).
-- **Objects and Arrays remain native structures**: `items: ${memberList}` $\rightarrow$ `items: [{...}, {...}]`.
+- **Integers remain integers**: `level: "{{ userLevel }}"` $\rightarrow$ `level: 4` (not `"4"`).
+- **Booleans remain booleans**: `checked: "{{ isActive }}"` $\rightarrow$ `checked: true` (not `"true"`).
+- **Objects and Arrays remain native structures**: `items: "{{ memberList }}"` $\rightarrow$ `items: [{...}, {...}]`.
 
 ### Rule 2: Embedded String Interpolation
 
-If a parameter token appears alongside other characters (e.g. `"Hello, ${userName}!"` or `"${dept} - ${code}"`):
+If a parameter token appears alongside other characters (e.g. `"Hello, {{ userName }}!"` or `"{{ dept }} - {{ code }}"`):
 
-- All tokens are replaced by their string representations.
+- All tokens matching `\{\{\s*([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*)\s*\}\}` are replaced by their string representations.
 - Evaluates to a native string.
 
-### Rule 3: Deep Dot-Notation for Structured Objects
+### Rule 3: Client DataModel Disambiguation (`formatString`)
+
+Because template substitutions use double curlies `{{ ... }}`, client-side reactive expressions and data-model bindings in `formatString` (e.g. `${/user/name}`) pass through completely untouched without requiring escaping:
+
+```yaml
+component: Text
+text:
+  call: formatString
+  args:
+    value: 'Hello, ${/user/name}! Your team is {{ teamName }}.'
+```
+
+During server-side template expansion:
+
+- `{{ teamName }}` is resolved server-side and replaced with `"Engineering"`.
+- `${/user/name}` is preserved verbatim and emitted directly to the client renderer for reactive data-binding.
+
+### Rule 4: Deep Dot-Notation for Structured Objects
 
 Templates natively support deep dot-notation paths on object parameters:
 
@@ -524,7 +542,7 @@ layout:
   component: Card
   child:
     component: Text
-    text: '${account.profile.name} (${account.profile.tier})'
+    text: '{{ account.profile.name }} ({{ account.profile.tier }})'
 ```
 
 **Expanded Output:**
@@ -536,24 +554,24 @@ layout:
 }
 ```
 
-### Rule 4: String Format AST Expressions
+### Rule 5: String Format AST Expressions
 
 For complex string formatting across multiple languages:
 
 ```yaml
 format: 'Level {lvl} ({pts} points)'
 args:
-  lvl: ${level}
-  pts: ${experiencePoints}
+  lvl: '{{ level }}'
+  pts: '{{ experiencePoints }}'
 ```
 
-### Rule 5: Token Escaping
+### Rule 6: Token Escaping
 
-To emit a literal `${foo}` string without triggering parameter substitution, escape the leading dollar sign with a backslash:
+To emit a literal `{{ foo }}` string without triggering parameter substitution, escape the opening curly braces with a backslash:
 
-- `\${keep_literal}` $\rightarrow$ evaluates to literal `"${keep_literal}"`.
+- `\{{ keep_literal }}` $\rightarrow$ evaluates to literal `"{{ keep_literal }}"`.
 
-### Rule 6: Missing Values & Defaults
+### Rule 7: Missing Values & Defaults
 
 - If an argument is omitted but has a declared `default` in its parameter schema, the `default` is used.
 - If an argument is omitted, has no `default`, and is not required: the property is omitted from the synthesized component (it is not emitted as `null`).
@@ -624,14 +642,14 @@ layout:
         align: center
         children:
           - component: Text
-            text: ${title}
+            text: '{{ title }}'
             variant: h2
           - component: Column
-            children: ${headerAction}
+            children: '{{ headerAction }}'
       - component: Divider
         axis: horizontal
       - component: Column
-        children: ${children}
+        children: '{{ children }}'
 ```
 
 #### Model Invocation:
@@ -647,7 +665,7 @@ root = SectionCard(
 )
 ```
 
-The template engine replaces `${headerAction}` with the synthesized single child node, and concatenates the `${children}` component list into the body column.
+The template engine replaces `{{ headerAction }}` with the synthesized single child node, and concatenates the `{{ children }}` component list into the body column.
 
 ---
 
@@ -709,8 +727,8 @@ An implementation of the A2UI Template Engine in any language (Python, Dart, Typ
 - [ ] **Sub-Template Imports**: Supports Tier 1 (local by `name`) and Tier 2 (modular by `id` with `imports` list and alias dictionary).
 - [ ] **Multi-Document Ingestion**: Parses single-doc and multi-doc (`---`) YAML streams.
 - [ ] **Forward Reference Resolution**: Expands templates regardless of registration order.
-- [ ] **Strict Native Type Preservation**: Exact `${param}` substitutions preserve `int`, `float`, `bool`, `dict`, and `list` types.
-- [ ] **Dot-Notation Path Traversal**: Resolves arbitrary depth paths (e.g. `${user.details.address.zip}`).
+- [ ] **Strict Native Type Preservation**: Exact `{{ param }}` substitutions preserve `int`, `float`, `bool`, `dict`, and `list` types.
+- [ ] **Dot-Notation Path Traversal**: Resolves arbitrary depth paths (e.g. `{{ user.details.address.zip }}`).
 - [ ] **Inline and Named Loop Expansion**: Accurately unrolls arrays into synthesized component subtrees with indexed child IDs.
 - [ ] **Deterministic Synthetic IDs**: Emits canonical hierarchical IDs matching the `{parent}_{slot}_{index}_{type}` specification.
 - [ ] **Two-Way DataModel Passthrough**: Preserves `{path: "..."}` dictionary bindings without string conversion.

--- a/specification/proposals/templates/README.md
+++ b/specification/proposals/templates/README.md
@@ -76,7 +76,9 @@ Declarative static templates define immutable layout trees authored in YAML file
 
 ```yaml
 version: '0.1'
-templateId: UserProfile
+name: UserProfile
+catalogs:
+  - 'https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json'
 description: Standard identity card for team members.
 parameters:
   userId:
@@ -116,7 +118,8 @@ Data-binding dynamic templates decouple public model parameters from private or 
 ```python
 # Server Registration
 dynamic_salary = DynamicTemplate(
-    template_id="EmployeeSalaryCard",
+    name="EmployeeSalaryCard",
+    catalogs=["https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"],
     resolver=fetch_private_compensation,
     layout=salary_yaml_layout,
     description="Verified compensation card. Pass only employeeId.",
@@ -159,7 +162,8 @@ def render_payroll_summary(department: str = "Engineering", includeBonus: bool =
     }
 
 payroll_tmpl = DynamicTemplate(
-    template_id="PayrollSummary",
+    name="PayrollSummary",
+    catalogs=["https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"],
     render=render_payroll_summary,
     description="Dynamic payroll calculation matrix.",
 )
@@ -194,7 +198,9 @@ A template author specifies a loop over a parameter array:
 
 ```yaml
 version: '0.1'
-templateId: TeamGoalList
+name: TeamGoalList
+catalogs:
+  - 'https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json'
 parameters:
   teamName: {type: string}
   goals: {type: array}
@@ -317,7 +323,9 @@ Templates can accept path prefixes or IDs as parameters, constructing reactive c
 
 ```yaml
 version: '0.1'
-templateId: BoundLiveMetric
+name: BoundLiveMetric
+catalogs:
+  - 'https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json'
 parameters:
   metricKey: {type: string}
   label: {type: string}
@@ -397,17 +405,65 @@ layout:
 
 ---
 
-## 5. The Synthetic Catalog System
+## 5. Catalog Declaration, Validation & Multi-Catalog Disambiguation
+
+Templates must declare which catalog(s) they are authored against via the top-level `catalogs` property.
+
+### A. Mandatory Explicit Catalogs (No Basic Catalog Defaults)
+
+The template engine enforces strict decoupling from any specific catalog:
+
+- **No Hardcoded Defaults**: `TemplateProcessor` does not default to the Basic Catalog or any other specific catalog.
+- **Explicit Catalog Requirement**: All catalogs required by registered templates must be explicitly provided to the processor upon initialization (e.g. via `catalogs={...}`).
+- **Static Integrity Validation**: At registration time, the engine validates that every template's declared `catalogs` can be resolved against the provided catalog registry, and every primitive component referenced in `layout` exists within those catalogs with valid properties.
+
+### B. Prefix-Free Automatic Component Resolution
+
+In layout trees, authors write clean, standard component names (`Card`, `Text`, `HeartRateGraph`) without prefixes or namespace boilerplate:
+
+- **Unique Match (Standard Case)**: If component `Foo` exists in exactly one declared catalog, it automatically resolves to that catalog.
+- **Name Collision**: If two declared catalogs define `Foo`, the author can specify `catalogId` on that specific component in the layout to disambiguate. If omitted, the engine raises an `AmbiguousComponentError`.
+- **Unknown Component**: If `Foo` is found in zero declared catalogs, the engine raises an `UnknownComponentError`.
+
+### C. Protocol Version Rules: v0.9 vs. v1.0
+
+The template engine tailors its expansion and output depending on the target protocol version:
+
+| Dimension                     | A2UI v0.9 / v0.9.1 Behavior                                                                                               | A2UI v1.0 Behavior                                                                                 |
+| :---------------------------- | :------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------- |
+| **Surface Catalog Model**     | Single catalog per surface (`createSurface.catalogId` required).                                                          | Mixable catalogs (`createSurface.catalogId` optional default).                                     |
+| **Multi-Catalog Templates**   | **Rejected**: If a template declares multiple catalogs, unrolling onto a v0.9 surface raises `CatalogCompatibilityError`. | **Supported**: Expanded seamlessly across mixed catalogs.                                          |
+| **Surface Validation**        | Template's resolved catalog MUST match `createSurface.catalogId`.                                                         | All catalogs referenced by the template must be present in surface `supportedCatalogIds`.          |
+| **Expanded Component Output** | `catalogId` is **never** emitted on expanded component dicts (illegal property in v0.9).                                  | `catalogId` is automatically injected on any component whose catalog differs from surface default. |
+
+---
+
+## 6. Sub-Template Imports & Global Identity
+
+Templates decouple their local invocation name from their optional global identity:
+
+- **`name`** (Required): Component tag name used in layout trees and LLM prompts (`^[A-Za-z][A-Za-z0-9_]*$`). `templateId` is accepted as a backwards-compatible alias.
+- **`id`** (Optional): Globally unique URI or URN string (e.g. `https://company.org/templates/card/v1.json`) for package distribution and version pinning.
+- **`imports`** (Optional): List of global template IDs, or dictionary mapping local aliases to global template IDs (`imports: { VendorCard: "https://vendor.com/card.json" }`).
+
+### Usage Tiers
+
+1. **Tier 1 (Simple / Local)**: Templates omit `id` and `imports`. Sibling templates in the same file or registry resolve each other directly by `name`.
+2. **Tier 2 (Modular / Distributed)**: Templates declare `id` and import external sub-templates by `id` or alias via `imports`.
+
+---
+
+## 7. The Synthetic Catalog System
 
 To make templates discoverable and invoke-able by LLMs, the backend converts registered templates into a **Synthetic Component Catalog**.
 
 ### The Catalog Synthesis Algorithm
 
-When `TemplateProcessor(templates)` is initialized:
+When `TemplateProcessor(templates, catalogs)` is initialized:
 
-1. It copies the base catalog (e.g. Basic Catalog v0.9.1).
+1. It indexes all provided catalogs.
 2. For each registered `StaticTemplate` and `DynamicTemplate`:
-   - It registers a new component definition under `components[templateId]`.
+   - It registers a new component definition under `components[template.name]`.
    - It maps semantic parameter definitions to JSON schema properties:
      - `string` $\rightarrow$ `{"type": "string"}`
      - `number` / `integer` $\rightarrow$ `{"type": "number"}` / `{"type": "integer"}`
@@ -428,14 +484,14 @@ When `TemplateProcessor(templates)` is initialized:
                                                                    (Expands to Primitives)
                                                                             |
                                                                             v
-[Client Renderer] <---------------- (Standard Basic Catalog Only) <----------+
+[Client Renderer] <---------------- (Standard Catalog Components) <---------+
 ```
 
 The synthetic catalog is an ephemeral compile-time construct. The client renderer is completely unaware that templates exist.
 
 ---
 
-## 6. Parameter Expressions & Substitution Engine
+## 8. Parameter Expressions & Substitution Engine
 
 The template substitution engine replaces expressions according to strict typing and evaluation rules.
 
@@ -518,7 +574,7 @@ To emit a literal `${foo}` string without triggering parameter substitution, esc
 
 ---
 
-## 7. Deterministic Synthetic ID Generation Algorithm
+## 9. Deterministic Synthetic ID Generation Algorithm
 
 To guarantee collision-free component IDs across multiple template instances and deep nesting, implementations in all languages (Python, Dart, TypeScript) must implement the following deterministic naming rules:
 
@@ -555,7 +611,7 @@ This guarantees that two instances of the same template (`card_1` and `card_2`) 
 
 ---
 
-## 8. Higher-Order Container Templates (`child` and `children` Slots)
+## 10. Higher-Order Container Templates (`child` and `children` Slots)
 
 Templates can define structural containers that receive caller-provided components.
 
@@ -563,7 +619,9 @@ Templates can define structural containers that receive caller-provided componen
 
 ```yaml
 version: '0.1'
-templateId: SectionCard
+name: SectionCard
+catalogs:
+  - 'https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json'
 parameters:
   title: {type: string}
   headerAction: {type: child}
@@ -606,27 +664,30 @@ The template engine replaces `${headerAction}` with the synthesized single child
 
 ---
 
-## 9. Error Handling, Cycle Guards & Safety
+## 11. Error Handling, Cycle Guards & Safety
 
 ### Recursion & Circular Reference Detection
 
 Templates can invoke other templates. However, circular references (`A` invokes `B`, which invokes `A`) must be caught immediately to prevent stack overflow.
 
 - **Call Stack Tracking**: The `TemplateProcessor` maintains an active `_call_stack: Set[str]` throughout expansion.
-- **Cycle Guard**: Before expanding any template, if `template_id in _call_stack`, expansion terminates immediately with `TemplateCycleError: Circular template reference detected: A -> B -> A`.
+- **Cycle Guard**: Before expanding any template, if `template_name in _call_stack`, expansion terminates immediately with `TemplateCycleError: Circular template reference detected: A -> B -> A`.
 - **Maximum Depth Guard**: An absolute limit (`MAX_EXPANSION_DEPTH = 32`) enforces termination even in non-identical runaway recursion.
 
 ### Standard Error Hierarchy
 
-1. `TemplateNotFoundError`: Attempted to expand a `templateId` not present in the catalog.
+1. `TemplateNotFoundError`: Attempted to expand a template `name` or `id` not present in the registry.
 2. `TemplateParameterError`: Missing required parameter or invalid parameter type.
 3. `TemplateCycleError`: Circular reference detected during expansion.
 4. `TemplateDepthExceededError`: Expansion exceeded maximum recursion depth.
 5. `TemplateResolverError`: Exception raised by a dynamic template resolver function.
+6. `CatalogCompatibilityError`: Declared catalogs incompatible with target surface (e.g. multi-catalog template on v0.9 surface).
+7. `AmbiguousComponentError`: Component exists in multiple declared catalogs without disambiguation.
+8. `UnknownComponentError`: Component not found in any declared catalog.
 
 ---
 
-## 10. Multi-Document YAML Streams (`---`)
+## 12. Multi-Document YAML Streams (`---`)
 
 To streamline template maintenance, multiple templates can be defined in a single `.yaml` file separated by `---`:
 
@@ -635,7 +696,7 @@ To streamline template maintenance, multiple templates can be defined in a singl
 
 ---
 
-## 11. Template Versioning & Schema Evolution
+## 13. Template Versioning & Schema Evolution
 
 To ensure robust backward compatibility as template syntax and AST features evolve across future protocol releases, every template definition must declare a top-level `version` field.
 
@@ -647,11 +708,15 @@ To ensure robust backward compatibility as template syntax and AST features evol
 
 ---
 
-## 12. Conformance Checklist for SDK Implementations
+## 14. Conformance Checklist for SDK Implementations
 
 An implementation of the A2UI Template Engine in any language (Python, Dart, TypeScript, Go, etc.) is conformant if and only if it satisfies the following test requirements:
 
 - [ ] **Template Versioning**: Validates that all ingested templates declare `version: "0.1"` and rejects unsupported version strings.
+- [ ] **Catalog Decoupling**: Does not default to the Basic Catalog; requires catalogs to be passed explicitly and validates all components against them.
+- [ ] **Catalog Resolution & Disambiguation**: Resolves components across declared catalogs without prefixes; handles collision disambiguation via component-level `catalogId`.
+- [ ] **Protocol Version Output Rules**: Enforces v0.9 single-catalog surface constraints (stripping component `catalogId`); supports v1.0 mixable catalogs with automatic `catalogId` stamping.
+- [ ] **Sub-Template Imports**: Supports Tier 1 (local by `name`) and Tier 2 (modular by `id` with `imports` list and alias dictionary).
 - [ ] **Multi-Document Ingestion**: Parses single-doc and multi-doc (`---`) YAML streams.
 - [ ] **Forward Reference Resolution**: Expands templates regardless of registration order.
 - [ ] **Strict Native Type Preservation**: Exact `${param}` substitutions preserve `int`, `float`, `bool`, `dict`, and `list` types.

--- a/specification/proposals/templates/examples/basic_cards.yaml
+++ b/specification/proposals/templates/examples/basic_cards.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "0.1"
 templateId: BasicUserProfile
 description: Standard identity card for team members.
@@ -34,7 +48,6 @@ sampleData:
   role: Lead Architect
 
 ---
-
 version: "0.1"
 templateId: BasicMetricCard
 description: Metric display card supporting both literal values and dynamic data model bindings.

--- a/specification/proposals/templates/examples/basic_cards.yaml
+++ b/specification/proposals/templates/examples/basic_cards.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 version: "0.1"
-templateId: BasicUserProfile
+name: BasicUserProfile
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: Standard identity card for team members.
 parameters:
   userId:
@@ -49,7 +51,9 @@ sampleData:
 
 ---
 version: "0.1"
-templateId: BasicMetricCard
+name: BasicMetricCard
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: Metric display card supporting both literal values and dynamic data model bindings.
 parameters:
   title:

--- a/specification/proposals/templates/examples/basic_cards.yaml
+++ b/specification/proposals/templates/examples/basic_cards.yaml
@@ -38,10 +38,10 @@ layout:
       - component: Icon
         name: person
       - component: Text
-        text: ${userName}
+        text: "{{ userName }}"
         variant: h3
       - component: Text
-        text: ${role}
+        text: "{{ role }}"
         variant: caption
 
 sampleData:
@@ -73,10 +73,10 @@ layout:
     component: Column
     children:
       - component: Text
-        text: ${title}
+        text: "{{ title }}"
         variant: caption
       - component: Text
-        text: ${metricValue}
+        text: "{{ metricValue }}"
         variant: h1
 
 sampleData:

--- a/specification/proposals/templates/examples/basic_cards.yaml
+++ b/specification/proposals/templates/examples/basic_cards.yaml
@@ -1,0 +1,69 @@
+version: "0.1"
+templateId: BasicUserProfile
+description: Standard identity card for team members.
+parameters:
+  userId:
+    type: string
+    description: Unique user identifier.
+  userName:
+    type: string
+    description: Full name of the user.
+  role:
+    type: string
+    description: Position or title within the team.
+    default: Team Member
+
+layout:
+  component: Card
+  child:
+    component: Column
+    align: center
+    children:
+      - component: Icon
+        name: person
+      - component: Text
+        text: ${userName}
+        variant: h3
+      - component: Text
+        text: ${role}
+        variant: caption
+
+sampleData:
+  userId: usr_101
+  userName: Alice Smith
+  role: Lead Architect
+
+---
+
+version: "0.1"
+templateId: BasicMetricCard
+description: Metric display card supporting both literal values and dynamic data model bindings.
+parameters:
+  title:
+    type: string
+    description: Metric title.
+  metricValue:
+    type: object
+    description: "Literal value or reactive DataBinding object (e.g. {path: '/telemetry/cpu'})."
+  status:
+    type: enum
+    values: ["normal", "warning", "critical"]
+    default: "normal"
+
+layout:
+  component: Card
+  child:
+    component: Column
+    children:
+      - component: Text
+        text: ${title}
+        variant: caption
+      - component: Text
+        text: ${metricValue}
+        variant: h1
+
+sampleData:
+  title: CPU Load
+  metricValue:
+    path: /system/metrics/cpuLoad
+  status: normal

--- a/specification/proposals/templates/examples/feedback_item.yaml
+++ b/specification/proposals/templates/examples/feedback_item.yaml
@@ -41,7 +41,7 @@ layout:
     component: Column
     children:
       - component: Text
-        text: ${note}
+        text: "{{ note }}"
         variant: body
       - component: Divider
         axis: horizontal
@@ -50,10 +50,10 @@ layout:
         align: center
         children:
           - component: Text
-            text: ${author}
+            text: "{{ author }}"
             variant: caption
           - component: Text
-            text: "Rating: ${rating}/5"
+            text: "Rating: {{ rating }}/5"
             variant: caption
 
 sampleData:

--- a/specification/proposals/templates/examples/feedback_item.yaml
+++ b/specification/proposals/templates/examples/feedback_item.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 version: "0.1"
-templateId: FeedbackItem
+name: FeedbackItem
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: Card showing feedback note, author, and rating.
 
 parameters:

--- a/specification/proposals/templates/examples/feedback_item.yaml
+++ b/specification/proposals/templates/examples/feedback_item.yaml
@@ -1,0 +1,46 @@
+version: "0.1"
+templateId: FeedbackItem
+description: Card showing feedback note, author, and rating.
+
+parameters:
+  author:
+    type: string
+    title: Author Name
+    description: The name of the colleague or customer providing feedback.
+  note:
+    type: string
+    title: Feedback Note
+    description: The written feedback or retrospective comment.
+  rating:
+    type: number
+    title: Feedback Rating
+    description: Score from 1 to 5.
+    minimum: 1
+    maximum: 5
+    default: 5
+
+layout:
+  component: Card
+  child:
+    component: Column
+    children:
+      - component: Text
+        text: ${note}
+        variant: body
+      - component: Divider
+        axis: horizontal
+      - component: Row
+        justify: spaceBetween
+        align: center
+        children:
+          - component: Text
+            text: ${author}
+            variant: caption
+          - component: Text
+            text: "Rating: ${rating}/5"
+            variant: caption
+
+sampleData:
+  author: Dr. Elena Vance
+  note: A2UI templates are fast and easy to compose.
+  rating: 5

--- a/specification/proposals/templates/examples/feedback_item.yaml
+++ b/specification/proposals/templates/examples/feedback_item.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "0.1"
 templateId: FeedbackItem
 description: Card showing feedback note, author, and rating.

--- a/specification/proposals/templates/examples/goal_item.yaml
+++ b/specification/proposals/templates/examples/goal_item.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 version: "0.1"
-templateId: GoalItem
+name: GoalItem
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: Card showing an individual objective with priority, title, target date, and action button.
 
 parameters:

--- a/specification/proposals/templates/examples/goal_item.yaml
+++ b/specification/proposals/templates/examples/goal_item.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "0.1"
 templateId: GoalItem
 description: Card showing an individual objective with priority, title, target date, and action button.

--- a/specification/proposals/templates/examples/goal_item.yaml
+++ b/specification/proposals/templates/examples/goal_item.yaml
@@ -1,0 +1,59 @@
+version: "0.1"
+templateId: GoalItem
+description: Card showing an individual objective with priority, title, target date, and action button.
+
+parameters:
+  title:
+    type: string
+    title: Goal Title
+    description: Summary title of the objective.
+  priority:
+    type: enum
+    title: Priority Level
+    description: Urgency rating for the objective.
+    values:
+      - High
+      - Medium
+      - Low
+    default: Medium
+  targetDate:
+    type: string
+    title: Target Date
+    description: Target completion date in YYYY-MM-DD format.
+    default: "2026-12-31"
+
+layout:
+  component: Card
+  child:
+    component: Column
+    children:
+      - component: Row
+        justify: spaceBetween
+        align: center
+        children:
+          - component: Text
+            text: "Priority: ${priority}"
+            variant: caption
+          - component: Icon
+            name: star
+      - component: Text
+        text: ${title}
+        variant: h4
+      - component: Divider
+        axis: horizontal
+      - component: Row
+        justify: spaceBetween
+        align: center
+        children:
+          - component: Text
+            text: "Due: ${targetDate}"
+            variant: caption
+          - component: Button
+            child:
+              component: Text
+              text: View Details
+
+sampleData:
+  title: Launch A2UI SDK v1.0
+  priority: High
+  targetDate: "2026-09-30"

--- a/specification/proposals/templates/examples/goal_item.yaml
+++ b/specification/proposals/templates/examples/goal_item.yaml
@@ -48,12 +48,12 @@ layout:
         align: center
         children:
           - component: Text
-            text: "Priority: ${priority}"
+            text: "Priority: {{ priority }}"
             variant: caption
           - component: Icon
             name: star
       - component: Text
-        text: ${title}
+        text: "{{ title }}"
         variant: h4
       - component: Divider
         axis: horizontal
@@ -62,7 +62,7 @@ layout:
         align: center
         children:
           - component: Text
-            text: "Due: ${targetDate}"
+            text: "Due: {{ targetDate }}"
             variant: caption
           - component: Button
             child:

--- a/specification/proposals/templates/examples/nested_lists.yaml
+++ b/specification/proposals/templates/examples/nested_lists.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 version: "0.1"
-templateId: NestedTeamRoster
+name: NestedTeamRoster
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: Team directory roster with styled header banner and nested team lists.
 parameters:
   directoryTitle:
@@ -52,7 +54,9 @@ sampleData:
 
 ---
 version: "0.1"
-templateId: NestedTeamCard
+name: NestedTeamCard
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: Team container card displaying member cards.
 parameters:
   teamName:

--- a/specification/proposals/templates/examples/nested_lists.yaml
+++ b/specification/proposals/templates/examples/nested_lists.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "0.1"
 templateId: NestedTeamRoster
 description: Team directory roster with styled header banner and nested team lists.
@@ -37,7 +51,6 @@ sampleData:
           role: Streaming Lead
 
 ---
-
 version: "0.1"
 templateId: NestedTeamCard
 description: Team container card displaying member cards.

--- a/specification/proposals/templates/examples/nested_lists.yaml
+++ b/specification/proposals/templates/examples/nested_lists.yaml
@@ -30,7 +30,7 @@ layout:
   component: Column
   children:
     - component: Text
-      text: ${directoryTitle}
+      text: "{{ directoryTitle }}"
       variant: h1
     - component: Divider
       axis: horizontal
@@ -73,7 +73,7 @@ layout:
     component: Column
     children:
       - component: Text
-        text: ${teamName}
+        text: "{{ teamName }}"
         variant: h2
       - component: Divider
         axis: horizontal
@@ -87,9 +87,9 @@ layout:
               justify: spaceBetween
               children:
                 - component: Text
-                  text: ${member.userName}
+                  text: "{{ member.userName }}"
                 - component: Text
-                  text: ${member.role}
+                  text: "{{ member.role }}"
                   variant: caption
 
 sampleData:

--- a/specification/proposals/templates/examples/nested_lists.yaml
+++ b/specification/proposals/templates/examples/nested_lists.yaml
@@ -1,0 +1,86 @@
+version: "0.1"
+templateId: NestedTeamRoster
+description: Team directory roster with styled header banner and nested team lists.
+parameters:
+  directoryTitle:
+    type: string
+    description: Title text for the team directory.
+  teams:
+    type: array
+    description: List of team objects or TeamCard children.
+    default: []
+
+layout:
+  component: Column
+  children:
+    - component: Text
+      text: ${directoryTitle}
+      variant: h1
+    - component: Divider
+      axis: horizontal
+    - component: Column
+      children:
+        loop:
+          param: teams
+          template: NestedTeamCard
+
+sampleData:
+  directoryTitle: Global Engineering Directory
+  teams:
+    - teamName: Core Architecture
+      members:
+        - userId: u1
+          userName: Dr. Elena Vance
+          role: Principal Architect
+        - userId: u2
+          userName: Marcus Vance
+          role: Streaming Lead
+
+---
+
+version: "0.1"
+templateId: NestedTeamCard
+description: Team container card displaying member cards.
+parameters:
+  teamName:
+    type: string
+    description: Name of the engineering team.
+  members:
+    type: array
+    description: List of team members.
+    default: []
+
+layout:
+  component: Card
+  child:
+    component: Column
+    children:
+      - component: Text
+        text: ${teamName}
+        variant: h2
+      - component: Divider
+        axis: horizontal
+      - component: Column
+        children:
+          loop:
+            param: members
+            as: member
+            item:
+              component: Row
+              justify: spaceBetween
+              children:
+                - component: Text
+                  text: ${member.userName}
+                - component: Text
+                  text: ${member.role}
+                  variant: caption
+
+sampleData:
+  teamName: Core Architecture
+  members:
+    - userId: u1
+      userName: Dr. Elena Vance
+      role: Principal Architect
+    - userId: u2
+      userName: Marcus Vance
+      role: Streaming Lead

--- a/specification/proposals/templates/examples/salary_card.yaml
+++ b/specification/proposals/templates/examples/salary_card.yaml
@@ -1,0 +1,116 @@
+version: "0.1"
+templateId: SalaryCard
+description: Layout card for employee compensation package with security verification badge.
+
+parameters:
+  employeeName:
+    type: string
+    title: Employee Full Name
+    description: Full name of the verified employee.
+  role:
+    type: string
+    title: Job Title
+    description: Official company role.
+  baseSalary:
+    type: string
+    title: Base Salary
+    description: Annual base compensation.
+  annualBonus:
+    type: string
+    title: Annual Bonus
+    description: Target annual incentive bonus.
+  equity:
+    type: string
+    title: Equity Grants
+    description: Stock units or RSU package.
+  clearanceLevel:
+    type: string
+    title: Security Clearance
+    description: Confidentiality level.
+    default: "Level 4 - Confidential"
+  verifiedAt:
+    type: string
+    title: Verification Date
+    description: Timestamp of record retrieval.
+    default: "2026-08-13"
+
+layout:
+  component: Card
+  child:
+    component: Column
+    children:
+      - component: Row
+        justify: spaceBetween
+        align: center
+        children:
+          - component: Row
+            align: center
+            children:
+              - component: Icon
+                name: lock
+              - component: Text
+                text: "Verified Compensation"
+                variant: caption
+          - component: Text
+            text: ${clearanceLevel}
+            variant: caption
+      - component: Column
+        children:
+          - component: Text
+            text: ${employeeName}
+            variant: h3
+            id: name_txt
+          - component: Text
+            text: ${role}
+            variant: body
+      - component: Divider
+        axis: horizontal
+      - component: Row
+        justify: spaceBetween
+        children:
+          - component: Column
+            children:
+              - component: Text
+                text: "Base Salary"
+                variant: caption
+              - component: Text
+                text: ${baseSalary}
+                variant: h4
+                id: sal_val
+          - component: Column
+            children:
+              - component: Text
+                text: "Annual Bonus"
+                variant: caption
+              - component: Text
+                text: ${annualBonus}
+                variant: h4
+          - component: Column
+            children:
+              - component: Text
+                text: "Equity Grants"
+                variant: caption
+              - component: Text
+                text: ${equity}
+                variant: h4
+      - component: Divider
+        axis: horizontal
+      - component: Row
+        justify: spaceBetween
+        align: center
+        children:
+          - component: Text
+            text: "🔒 Fetched live from secure HR database"
+            variant: caption
+          - component: Text
+            text: "Verified: ${verifiedAt}"
+            variant: caption
+
+sampleData:
+  employeeName: Dr. Elena Vance
+  role: Principal Systems Architect
+  baseSalary: "$215,000"
+  annualBonus: "$45,000"
+  equity: "3,500 RSUs"
+  clearanceLevel: "Level 5 - Confidential"
+  verifiedAt: "2026-08-13"

--- a/specification/proposals/templates/examples/salary_card.yaml
+++ b/specification/proposals/templates/examples/salary_card.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 version: "0.1"
-templateId: SalaryCard
+name: SalaryCard
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: Layout card for employee compensation package with security verification badge.
 
 parameters:

--- a/specification/proposals/templates/examples/salary_card.yaml
+++ b/specification/proposals/templates/examples/salary_card.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "0.1"
 templateId: SalaryCard
 description: Layout card for employee compensation package with security verification badge.

--- a/specification/proposals/templates/examples/salary_card.yaml
+++ b/specification/proposals/templates/examples/salary_card.yaml
@@ -68,16 +68,16 @@ layout:
                 text: "Verified Compensation"
                 variant: caption
           - component: Text
-            text: ${clearanceLevel}
+            text: "{{ clearanceLevel }}"
             variant: caption
       - component: Column
         children:
           - component: Text
-            text: ${employeeName}
+            text: "{{ employeeName }}"
             variant: h3
             id: name_txt
           - component: Text
-            text: ${role}
+            text: "{{ role }}"
             variant: body
       - component: Divider
         axis: horizontal
@@ -90,7 +90,7 @@ layout:
                 text: "Base Salary"
                 variant: caption
               - component: Text
-                text: ${baseSalary}
+                text: "{{ baseSalary }}"
                 variant: h4
                 id: sal_val
           - component: Column
@@ -99,7 +99,7 @@ layout:
                 text: "Annual Bonus"
                 variant: caption
               - component: Text
-                text: ${annualBonus}
+                text: "{{ annualBonus }}"
                 variant: h4
           - component: Column
             children:
@@ -107,7 +107,7 @@ layout:
                 text: "Equity Grants"
                 variant: caption
               - component: Text
-                text: ${equity}
+                text: "{{ equity }}"
                 variant: h4
       - component: Divider
         axis: horizontal
@@ -119,7 +119,7 @@ layout:
             text: "🔒 Fetched live from secure HR database"
             variant: caption
           - component: Text
-            text: "Verified: ${verifiedAt}"
+            text: "Verified: {{ verifiedAt }}"
             variant: caption
 
 sampleData:

--- a/specification/proposals/templates/examples/section_card.yaml
+++ b/specification/proposals/templates/examples/section_card.yaml
@@ -48,19 +48,19 @@ layout:
         align: center
         children:
           - component: Text
-            text: ${title}
+            text: "{{ title }}"
             variant: h3
           - component: Column
             id: action_slot
-            children: ${headerAction}
+            children: "{{ headerAction }}"
       - component: Text
-        text: ${description}
+        text: "{{ description }}"
         variant: caption
       - component: Divider
         axis: horizontal
       - component: Column
         id: body_container
-        children: ${children}
+        children: "{{ children }}"
 
 sampleData:
   title: Protocol Overview

--- a/specification/proposals/templates/examples/section_card.yaml
+++ b/specification/proposals/templates/examples/section_card.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "0.1"
 templateId: SectionCard
 description: Standard container card with title, description, optional action, and child components.

--- a/specification/proposals/templates/examples/section_card.yaml
+++ b/specification/proposals/templates/examples/section_card.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 version: "0.1"
-templateId: SectionCard
+name: SectionCard
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: Standard container card with title, description, optional action, and child components.
 
 parameters:

--- a/specification/proposals/templates/examples/section_card.yaml
+++ b/specification/proposals/templates/examples/section_card.yaml
@@ -1,0 +1,52 @@
+version: "0.1"
+templateId: SectionCard
+description: Standard container card with title, description, optional action, and child components.
+
+parameters:
+  title:
+    type: string
+    title: Section Title
+    description: Heading text displayed at the top of the section card.
+  description:
+    type: string
+    title: Section Description
+    description: Subordinate descriptive text beneath the title.
+    default: ""
+  headerAction:
+    type: child
+    title: Header Action Component
+    description: Single child component placed in the right side of the header.
+  children:
+    type: children
+    title: Section Children
+    description: Child component IDs rendered in the section body.
+    default: []
+
+layout:
+  component: Card
+  child:
+    component: Column
+    children:
+      - component: Row
+        justify: spaceBetween
+        align: center
+        children:
+          - component: Text
+            text: ${title}
+            variant: h3
+          - component: Column
+            id: action_slot
+            children: ${headerAction}
+      - component: Text
+        text: ${description}
+        variant: caption
+      - component: Divider
+        axis: horizontal
+      - component: Column
+        id: body_container
+        children: ${children}
+
+sampleData:
+  title: Protocol Overview
+  description: High-level summary of the streaming architecture.
+  children: []

--- a/specification/proposals/templates/examples/slot_composition.yaml
+++ b/specification/proposals/templates/examples/slot_composition.yaml
@@ -39,14 +39,14 @@ layout:
         align: center
         children:
           - component: Text
-            text: ${title}
+            text: "{{ title }}"
             variant: h2
           - component: Column
-            children: ${headerAction}
+            children: "{{ headerAction }}"
       - component: Divider
         axis: horizontal
       - component: Column
-        children: ${children}
+        children: "{{ children }}"
 
 sampleData:
   title: Project Milestones
@@ -76,7 +76,7 @@ layout:
   component: Column
   children:
     - component: Column
-      children: ${headerChild}
+      children: "{{ headerChild }}"
     - component: Divider
       axis: horizontal
     - component: Row
@@ -84,9 +84,9 @@ layout:
       align: start
       children:
         - component: Column
-          children: ${leftChildren}
+          children: "{{ leftChildren }}"
         - component: Column
-          children: ${rightChildren}
+          children: "{{ rightChildren }}"
 
 sampleData:
   headerChild:

--- a/specification/proposals/templates/examples/slot_composition.yaml
+++ b/specification/proposals/templates/examples/slot_composition.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 version: "0.1"
-templateId: CompositeSectionCard
+name: CompositeSectionCard
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: Collapsible or styled content section card with title, custom header action slot, and children slot.
 parameters:
   title:
@@ -55,7 +57,9 @@ sampleData:
 
 ---
 version: "0.1"
-templateId: TwoColumnLayoutWithHeader
+name: TwoColumnLayoutWithHeader
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: Responsive two-column dashboard grid with a hero header, left column, and right column.
 parameters:
   headerChild:

--- a/specification/proposals/templates/examples/slot_composition.yaml
+++ b/specification/proposals/templates/examples/slot_composition.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "0.1"
 templateId: CompositeSectionCard
 description: Collapsible or styled content section card with title, custom header action slot, and children slot.
@@ -40,7 +54,6 @@ sampleData:
   children: []
 
 ---
-
 version: "0.1"
 templateId: TwoColumnLayoutWithHeader
 description: Responsive two-column dashboard grid with a hero header, left column, and right column.

--- a/specification/proposals/templates/examples/slot_composition.yaml
+++ b/specification/proposals/templates/examples/slot_composition.yaml
@@ -1,0 +1,80 @@
+version: "0.1"
+templateId: CompositeSectionCard
+description: Collapsible or styled content section card with title, custom header action slot, and children slot.
+parameters:
+  title:
+    type: string
+    description: Section header title.
+  headerAction:
+    type: child
+    description: Single child component placed in the right side of the header.
+  children:
+    type: children
+    description: Content components contained within the section body.
+    default: []
+
+layout:
+  component: Card
+  child:
+    component: Column
+    children:
+      - component: Row
+        justify: spaceBetween
+        align: center
+        children:
+          - component: Text
+            text: ${title}
+            variant: h2
+          - component: Column
+            children: ${headerAction}
+      - component: Divider
+        axis: horizontal
+      - component: Column
+        children: ${children}
+
+sampleData:
+  title: Project Milestones
+  headerAction:
+    component: Button
+    text: Refresh
+  children: []
+
+---
+
+version: "0.1"
+templateId: TwoColumnLayoutWithHeader
+description: Responsive two-column dashboard grid with a hero header, left column, and right column.
+parameters:
+  headerChild:
+    type: child
+    description: Component rendered in the full-width header slot.
+  leftChildren:
+    type: children
+    description: Components rendered in the left column.
+  rightChildren:
+    type: children
+    description: Components rendered in the right column.
+
+layout:
+  component: Column
+  children:
+    - component: Column
+      children: ${headerChild}
+    - component: Divider
+      axis: horizontal
+    - component: Row
+      justify: spaceBetween
+      align: start
+      children:
+        - component: Column
+          children: ${leftChildren}
+        - component: Column
+          children: ${rightChildren}
+
+sampleData:
+  headerChild:
+    component: Text
+    text: Executive Operations Dashboard
+    variant: h1
+  leftChildren: []
+  rightChildren: []

--- a/specification/proposals/templates/examples/team_card.yaml
+++ b/specification/proposals/templates/examples/team_card.yaml
@@ -58,7 +58,7 @@ layout:
         align: center
         children:
           - component: Text
-            text: ${teamName}
+            text: "{{ teamName }}"
             variant: h3
           - component: Icon
             name: person

--- a/specification/proposals/templates/examples/team_card.yaml
+++ b/specification/proposals/templates/examples/team_card.yaml
@@ -1,0 +1,68 @@
+version: "0.1"
+templateId: TeamCard
+description: Card showing team header and unrolled member cards.
+
+parameters:
+  teamName:
+    type: string
+    title: Team Name
+    description: The display name of the team.
+  members:
+    type: array
+    title: Team Members List
+    description: Array of team member objects.
+    items:
+      type: object
+      title: Team Member
+      properties:
+        userId:
+          type: string
+          title: User ID
+          description: Unique identifier of the user.
+        userName:
+          type: string
+          title: User Name
+          description: Full name of the user.
+        role:
+          type: string
+          title: Role Name
+          description: Role or title of the user.
+          default: Member
+      required:
+        - userId
+        - userName
+
+layout:
+  component: Card
+  child:
+    component: Column
+    children:
+      - component: Row
+        justify: spaceBetween
+        align: center
+        children:
+          - component: Text
+            text: ${teamName}
+            variant: h3
+          - component: Icon
+            name: person
+      - component: Divider
+        axis: horizontal
+      - component: Column
+        children:
+          loop:
+            param: members
+            template: UserProfile
+
+sampleData:
+  teamName: Antigravity Devs
+  members:
+    - userId: usr_101
+      userName: Alice Smith
+      role: Lead Architect
+    - userId: usr_102
+      userName: Bob Jones
+      role: Senior Engineer
+    - userId: usr_103
+      userName: Charlie Brown
+      role: Product Manager

--- a/specification/proposals/templates/examples/team_card.yaml
+++ b/specification/proposals/templates/examples/team_card.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "0.1"
 templateId: TeamCard
 description: Card showing team header and unrolled member cards.

--- a/specification/proposals/templates/examples/team_card.yaml
+++ b/specification/proposals/templates/examples/team_card.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 version: "0.1"
-templateId: TeamCard
+name: TeamCard
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: Card showing team header and unrolled member cards.
 
 parameters:

--- a/specification/proposals/templates/examples/team_feedback_board.yaml
+++ b/specification/proposals/templates/examples/team_feedback_board.yaml
@@ -1,0 +1,64 @@
+version: "0.1"
+templateId: TeamFeedbackBoard
+description: Feedback board showing team header and feedback items.
+
+parameters:
+  teamName:
+    type: string
+    title: Team Name
+    description: The display name of the team whose feedback board is being rendered.
+  feedbacks:
+    type: array
+    title: Feedbacks List
+    description: Array of feedback objects with author, note, and rating.
+    items:
+      type: object
+      title: Feedback Review
+      properties:
+        author:
+          type: string
+          title: Author Name
+          description: Full name of the person giving feedback.
+        note:
+          type: string
+          title: Feedback Note
+          description: Textual comment or recommendation.
+        rating:
+          type: number
+          title: Rating Score
+          minimum: 1
+          maximum: 5
+          default: 5
+      required:
+        - author
+        - note
+
+layout:
+  component: Column
+  children:
+    - component: Card
+      child:
+        component: Row
+        align: center
+        children:
+          - component: Icon
+            name: mail
+          - component: Text
+            text: "Feedback & Retrospective: ${teamName}"
+            variant: h2
+    - component: Column
+      id: feedbacks_container
+      children:
+        loop:
+          param: feedbacks
+          template: FeedbackItem
+
+sampleData:
+  teamName: Streaming & Protocols Guild
+  feedbacks:
+    - author: Dr. Elena Vance
+      note: Splitting createSurface and updateComponents cleanly unblocked sequential stream processing.
+      rating: 5
+    - author: Marcus Vance
+      note: Unrolling nested lists statically in Python enables instant frontend mounting with zero runtime recursion.
+      rating: 5

--- a/specification/proposals/templates/examples/team_feedback_board.yaml
+++ b/specification/proposals/templates/examples/team_feedback_board.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "0.1"
 templateId: TeamFeedbackBoard
 description: Feedback board showing team header and feedback items.

--- a/specification/proposals/templates/examples/team_feedback_board.yaml
+++ b/specification/proposals/templates/examples/team_feedback_board.yaml
@@ -60,7 +60,7 @@ layout:
           - component: Icon
             name: mail
           - component: Text
-            text: "Feedback & Retrospective: ${teamName}"
+            text: "Feedback & Retrospective: {{ teamName }}"
             variant: h2
     - component: Column
       id: feedbacks_container

--- a/specification/proposals/templates/examples/team_feedback_board.yaml
+++ b/specification/proposals/templates/examples/team_feedback_board.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 version: "0.1"
-templateId: TeamFeedbackBoard
+name: TeamFeedbackBoard
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: Feedback board showing team header and feedback items.
 
 parameters:

--- a/specification/proposals/templates/examples/team_goal_list.yaml
+++ b/specification/proposals/templates/examples/team_goal_list.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "0.1"
 templateId: TeamGoalList
 description: List of team goals with header banner.

--- a/specification/proposals/templates/examples/team_goal_list.yaml
+++ b/specification/proposals/templates/examples/team_goal_list.yaml
@@ -1,0 +1,65 @@
+version: "0.1"
+templateId: TeamGoalList
+description: List of team goals with header banner.
+
+parameters:
+  teamName:
+    type: string
+    title: Team Name
+    description: The display name of the team whose goals are being listed.
+  goals:
+    type: array
+    title: Goals List
+    description: Array of goal objects with title, priority, and targetDate.
+    items:
+      type: object
+      title: Goal Definition
+      properties:
+        title:
+          type: string
+          title: Goal Title
+          description: Summary title of the objective
+        priority:
+          type: enum
+          title: Priority Level
+          values:
+            - High
+            - Medium
+            - Low
+          default: Medium
+        targetDate:
+          type: string
+          title: Target Date
+          description: Target completion date (YYYY-MM-DD)
+      required:
+        - title
+
+layout:
+  component: Column
+  children:
+    - component: Card
+      child:
+        component: Row
+        align: center
+        children:
+          - component: Icon
+            name: star
+          - component: Text
+            text: "Strategic Objectives: ${teamName}"
+            variant: h2
+    - component: Column
+      id: goals_container
+      children:
+        loop:
+          param: goals
+          template: GoalItem
+
+sampleData:
+  teamName: A2UI Core Team
+  goals:
+    - title: Implement bidirectional child/children container resolution
+      priority: High
+      targetDate: "2026-07-15"
+    - title: Upgrade all templates to standard Basic Catalog components
+      priority: High
+      targetDate: "2026-07-10"

--- a/specification/proposals/templates/examples/team_goal_list.yaml
+++ b/specification/proposals/templates/examples/team_goal_list.yaml
@@ -61,7 +61,7 @@ layout:
           - component: Icon
             name: star
           - component: Text
-            text: "Strategic Objectives: ${teamName}"
+            text: "Strategic Objectives: {{ teamName }}"
             variant: h2
     - component: Column
       id: goals_container

--- a/specification/proposals/templates/examples/team_goal_list.yaml
+++ b/specification/proposals/templates/examples/team_goal_list.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 version: "0.1"
-templateId: TeamGoalList
+name: TeamGoalList
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: List of team goals with header banner.
 
 parameters:

--- a/specification/proposals/templates/examples/team_member_knowledge_panel.yaml
+++ b/specification/proposals/templates/examples/team_member_knowledge_panel.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "0.1"
 templateId: TeamMemberKnowledgePanel
 description: Card showing competency panel with user experience years and completed task count.

--- a/specification/proposals/templates/examples/team_member_knowledge_panel.yaml
+++ b/specification/proposals/templates/examples/team_member_knowledge_panel.yaml
@@ -49,7 +49,7 @@ layout:
           - component: Icon
             name: check
           - component: Text
-            text: "Competency: ${userName}"
+            text: "Competency: {{ userName }}"
             variant: h4
       - component: Divider
         axis: horizontal
@@ -63,7 +63,7 @@ layout:
                 text: Role
                 variant: caption
               - component: Text
-                text: ${role}
+                text: "{{ role }}"
                 variant: body
           - component: Column
             align: center
@@ -72,7 +72,7 @@ layout:
                 text: Experience
                 variant: caption
               - component: Text
-                text: "${experienceYears} Yrs"
+                text: "{{ experienceYears }} Yrs"
                 variant: body
           - component: Column
             align: center
@@ -81,7 +81,7 @@ layout:
                 text: Tasks
                 variant: caption
               - component: Text
-                text: "${completedTasks} Done"
+                text: "{{ completedTasks }} Done"
                 variant: body
       - component: Text
         text: Verified Core Contributor

--- a/specification/proposals/templates/examples/team_member_knowledge_panel.yaml
+++ b/specification/proposals/templates/examples/team_member_knowledge_panel.yaml
@@ -1,0 +1,78 @@
+version: "0.1"
+templateId: TeamMemberKnowledgePanel
+description: Card showing competency panel with user experience years and completed task count.
+
+parameters:
+  userName:
+    type: string
+    title: User Display Name
+    description: The full name of the team member.
+  role:
+    type: string
+    title: Role Name
+    description: The operational role of the team member.
+  experienceYears:
+    type: integer
+    title: Years of Experience
+    description: The number of years of professional experience.
+    minimum: 0
+  completedTasks:
+    type: integer
+    title: Completed Tasks Count
+    description: The count of completed tasks or tickets.
+    minimum: 0
+
+layout:
+  component: Card
+  child:
+    component: Column
+    children:
+      - component: Row
+        align: center
+        children:
+          - component: Icon
+            name: check
+          - component: Text
+            text: "Competency: ${userName}"
+            variant: h4
+      - component: Divider
+        axis: horizontal
+      - component: Row
+        justify: spaceBetween
+        children:
+          - component: Column
+            align: center
+            children:
+              - component: Text
+                text: Role
+                variant: caption
+              - component: Text
+                text: ${role}
+                variant: body
+          - component: Column
+            align: center
+            children:
+              - component: Text
+                text: Experience
+                variant: caption
+              - component: Text
+                text: "${experienceYears} Yrs"
+                variant: body
+          - component: Column
+            align: center
+            children:
+              - component: Text
+                text: Tasks
+                variant: caption
+              - component: Text
+                text: "${completedTasks} Done"
+                variant: body
+      - component: Text
+        text: Verified Core Contributor
+        variant: caption
+
+sampleData:
+  userName: Alice Smith
+  role: Systems Architect
+  experienceYears: 9
+  completedTasks: 142

--- a/specification/proposals/templates/examples/team_member_knowledge_panel.yaml
+++ b/specification/proposals/templates/examples/team_member_knowledge_panel.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 version: "0.1"
-templateId: TeamMemberKnowledgePanel
+name: TeamMemberKnowledgePanel
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: Card showing competency panel with user experience years and completed task count.
 
 parameters:

--- a/specification/proposals/templates/examples/team_roster.yaml
+++ b/specification/proposals/templates/examples/team_roster.yaml
@@ -33,12 +33,12 @@ layout:
   component: Column
   children:
     - component: Text
-      text: ${directoryTitle}
+      text: "{{ directoryTitle }}"
       variant: h1
     - component: Divider
       axis: horizontal
     - component: Column
-      children: ${children}
+      children: "{{ children }}"
 
 sampleData:
   directoryTitle: Global Engineering Directory

--- a/specification/proposals/templates/examples/team_roster.yaml
+++ b/specification/proposals/templates/examples/team_roster.yaml
@@ -1,0 +1,29 @@
+version: "0.1"
+templateId: TeamRoster
+description: Team directory roster with styled header banner and nested team lists.
+
+parameters:
+  directoryTitle:
+    type: string
+    title: Directory Title
+    description: Title text for the team directory.
+  children:
+    type: children
+    title: Team Cards List
+    description: List of child TeamCard components.
+    default: []
+
+layout:
+  component: Column
+  children:
+    - component: Text
+      text: ${directoryTitle}
+      variant: h1
+    - component: Divider
+      axis: horizontal
+    - component: Column
+      children: ${children}
+
+sampleData:
+  directoryTitle: Global Engineering Directory
+  children: []

--- a/specification/proposals/templates/examples/team_roster.yaml
+++ b/specification/proposals/templates/examples/team_roster.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "0.1"
 templateId: TeamRoster
 description: Team directory roster with styled header banner and nested team lists.

--- a/specification/proposals/templates/examples/team_roster.yaml
+++ b/specification/proposals/templates/examples/team_roster.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 version: "0.1"
-templateId: TeamRoster
+name: TeamRoster
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: Team directory roster with styled header banner and nested team lists.
 
 parameters:

--- a/specification/proposals/templates/examples/two_column_layout.yaml
+++ b/specification/proposals/templates/examples/two_column_layout.yaml
@@ -38,15 +38,15 @@ layout:
   component: Column
   children:
     - component: Column
-      children: ${headerChild}
+      children: "{{ headerChild }}"
     - component: Divider
       axis: horizontal
     - component: Row
       children:
         - component: Column
-          children: ${leftChildren}
+          children: "{{ leftChildren }}"
         - component: Column
-          children: ${rightChildren}
+          children: "{{ rightChildren }}"
 
 sampleData:
   headerChild:

--- a/specification/proposals/templates/examples/two_column_layout.yaml
+++ b/specification/proposals/templates/examples/two_column_layout.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "0.1"
 templateId: TwoColumnLayout
 description: Responsive two-column dashboard layout with banner header and split content regions.

--- a/specification/proposals/templates/examples/two_column_layout.yaml
+++ b/specification/proposals/templates/examples/two_column_layout.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 version: "0.1"
-templateId: TwoColumnLayout
+name: TwoColumnLayout
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: Responsive two-column dashboard layout with banner header and split content regions.
 
 parameters:

--- a/specification/proposals/templates/examples/two_column_layout.yaml
+++ b/specification/proposals/templates/examples/two_column_layout.yaml
@@ -1,0 +1,40 @@
+version: "0.1"
+templateId: TwoColumnLayout
+description: Responsive two-column dashboard layout with banner header and split content regions.
+
+parameters:
+  headerChild:
+    type: child
+    title: Header Component Slot
+    description: Single child component ID mounted at the top banner.
+  leftChildren:
+    type: children
+    title: Left Column Children
+    description: Child components placed in the left primary region.
+    default: []
+  rightChildren:
+    type: children
+    title: Right Column Children
+    description: Child components placed in the right secondary region.
+    default: []
+
+layout:
+  component: Column
+  children:
+    - component: Column
+      children: ${headerChild}
+    - component: Divider
+      axis: horizontal
+    - component: Row
+      children:
+        - component: Column
+          children: ${leftChildren}
+        - component: Column
+          children: ${rightChildren}
+
+sampleData:
+  headerChild:
+    component: Text
+    text: Header Title
+  leftChildren: []
+  rightChildren: []

--- a/specification/proposals/templates/examples/user_profile.yaml
+++ b/specification/proposals/templates/examples/user_profile.yaml
@@ -42,10 +42,10 @@ layout:
       - component: Icon
         name: person
       - component: Text
-        text: ${userName}
+        text: "{{ userName }}"
         variant: h3
       - component: Text
-        text: ${role}
+        text: "{{ role }}"
         variant: caption
 
 sampleData:

--- a/specification/proposals/templates/examples/user_profile.yaml
+++ b/specification/proposals/templates/examples/user_profile.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 version: "0.1"
-templateId: UserProfile
+name: UserProfile
+catalogs:
+  - "https://a2ui.org/specification/v0_9_1/catalogs/basic/catalog.json"
 description: User profile card displaying avatar, full name, and role.
 
 parameters:

--- a/specification/proposals/templates/examples/user_profile.yaml
+++ b/specification/proposals/templates/examples/user_profile.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "0.1"
 templateId: UserProfile
 description: User profile card displaying avatar, full name, and role.

--- a/specification/proposals/templates/examples/user_profile.yaml
+++ b/specification/proposals/templates/examples/user_profile.yaml
@@ -1,0 +1,38 @@
+version: "0.1"
+templateId: UserProfile
+description: User profile card displaying avatar, full name, and role.
+
+parameters:
+  userId:
+    type: string
+    title: User ID
+    description: Unique user account ID.
+  userName:
+    type: string
+    title: User Name
+    description: Full name of the user.
+  role:
+    type: string
+    title: Role
+    description: Job title or role.
+    default: Member
+
+layout:
+  component: Card
+  child:
+    component: Column
+    align: center
+    children:
+      - component: Icon
+        name: person
+      - component: Text
+        text: ${userName}
+        variant: h3
+      - component: Text
+        text: ${role}
+        variant: caption
+
+sampleData:
+  userId: usr_101
+  userName: Alice Smith
+  role: Lead Architect

--- a/specification/proposals/templates/schema/template_definition.json
+++ b/specification/proposals/templates/schema/template_definition.json
@@ -47,10 +47,7 @@
       "description": "Sample parameter values used for previewing and testing template inflation."
     }
   },
-  "anyOf": [
-    {"required": ["layout"]},
-    {"required": ["components"]}
-  ],
+  "anyOf": [{"required": ["layout"]}, {"required": ["components"]}],
   "additionalProperties": false,
   "$defs": {
     "ParameterDefinition": {
@@ -176,10 +173,7 @@
     "LoopDefinition": {
       "type": "object",
       "required": ["param"],
-      "anyOf": [
-        {"required": ["template"]},
-        {"required": ["item"]}
-      ],
+      "anyOf": [{"required": ["template"]}, {"required": ["item"]}],
       "properties": {
         "param": {
           "type": "string",
@@ -227,10 +221,7 @@
           "description": "Catalog component tag name."
         },
         "child": {
-          "anyOf": [
-            {"$ref": "#/$defs/NestedTemplateNode"},
-            {"$ref": "#/$defs/TemplateValue"}
-          ]
+          "anyOf": [{"$ref": "#/$defs/NestedTemplateNode"}, {"$ref": "#/$defs/TemplateValue"}]
         },
         "children": {
           "anyOf": [

--- a/specification/proposals/templates/schema/template_definition.json
+++ b/specification/proposals/templates/schema/template_definition.json
@@ -1,0 +1,273 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "A2UI Template Definition",
+  "description": "Schema defining a parameterized A2UI declarative template authored in YAML with a nested layout tree and synthetic ID generation.",
+  "type": "object",
+  "required": ["version", "templateId", "parameters"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "0.1",
+      "description": "Specification version of the template definition format. Forced to '0.1'."
+    },
+    "templateId": {
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9_]*$",
+      "description": "Unique identifier and component tag name of the template."
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description of what this template represents."
+    },
+    "parameters": {
+      "type": "object",
+      "description": "Mapping of parameter names to their explicit A2UI type definitions.",
+      "additionalProperties": {
+        "$ref": "#/$defs/ParameterDefinition"
+      }
+    },
+    "requiredParameters": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Optional list of parameter names that are required when invoking the template."
+    },
+    "layout": {
+      "$ref": "#/$defs/NestedTemplateNode",
+      "description": "Root component of the nested layout tree."
+    },
+    "components": {
+      "type": "array",
+      "description": "Optional flattened component list for internal graph representation.",
+      "items": {
+        "$ref": "#/$defs/TemplateComponent"
+      }
+    },
+    "sampleData": {
+      "type": "object",
+      "description": "Sample parameter values used for previewing and testing template inflation."
+    }
+  },
+  "anyOf": [
+    {"required": ["layout"]},
+    {"required": ["components"]}
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "ParameterDefinition": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "enum",
+            "object",
+            "array",
+            "child",
+            "children",
+            "action"
+          ],
+          "description": "A2UI semantic parameter type."
+        },
+        "title": {
+          "type": "string",
+          "description": "Short human-readable title of the parameter."
+        },
+        "description": {
+          "type": "string",
+          "description": "Detailed explanation of the parameter's purpose and usage."
+        },
+        "default": {
+          "description": "Default fallback value if not specified."
+        },
+        "values": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Allowed string values when type is 'enum'."
+        },
+        "items": {
+          "description": "Item type definition when type is 'array'. Can be an A2UI type name or nested ParameterDefinition."
+        },
+        "properties": {
+          "type": "object",
+          "description": "Property definitions when type is 'object'.",
+          "additionalProperties": {
+            "$ref": "#/$defs/ParameterDefinition"
+          }
+        },
+        "required": {
+          "anyOf": [
+            {
+              "type": "boolean",
+              "description": "Whether this parameter is required when instantiating the template."
+            },
+            {
+              "type": "array",
+              "items": {"type": "string"},
+              "description": "List of required property names for object types."
+            }
+          ]
+        },
+        "minimum": {
+          "type": "number",
+          "description": "Minimum value constraint for numeric parameters."
+        },
+        "maximum": {
+          "type": "number",
+          "description": "Maximum value constraint for numeric parameters."
+        }
+      },
+      "additionalProperties": false
+    },
+    "ParamReference": {
+      "type": "object",
+      "required": ["param"],
+      "properties": {
+        "param": {
+          "type": "string",
+          "description": "Name or dot-separated path of the template parameter to substitute."
+        },
+        "template": {
+          "type": "string",
+          "description": "Child template identifier when mapping an array parameter to child component instances."
+        },
+        "default": {
+          "description": "Fallback value if the parameter path resolves to None."
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConcatExpression": {
+      "type": "object",
+      "required": ["concat"],
+      "properties": {
+        "concat": {
+          "type": "array",
+          "description": "List of literal values and parameter references to concatenate into a string.",
+          "items": {
+            "anyOf": [{"type": "string"}, {"type": "number"}, {"$ref": "#/$defs/ParamReference"}]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "FormatExpression": {
+      "type": "object",
+      "required": ["format"],
+      "properties": {
+        "format": {
+          "type": "string",
+          "description": "Format string containing {key} placeholders."
+        },
+        "args": {
+          "type": "object",
+          "description": "Mapping of placeholder keys to values or parameter references.",
+          "additionalProperties": {
+            "anyOf": [{"type": "string"}, {"type": "number"}, {"$ref": "#/$defs/ParamReference"}]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "LoopDefinition": {
+      "type": "object",
+      "required": ["param"],
+      "anyOf": [
+        {"required": ["template"]},
+        {"required": ["item"]}
+      ],
+      "properties": {
+        "param": {
+          "type": "string",
+          "description": "Parameter name holding the list/array data to iterate over."
+        },
+        "template": {
+          "type": "string",
+          "description": "Identifier of a named template to instantiate for each item."
+        },
+        "item": {
+          "$ref": "#/$defs/NestedTemplateNode",
+          "description": "Self-contained inline component layout to instantiate for each item."
+        },
+        "as": {
+          "type": "string",
+          "description": "Optional variable scope alias for accessing item fields in expressions."
+        }
+      },
+      "additionalProperties": false
+    },
+    "TemplateValue": {
+      "description": "A literal value, parameter substitution, or expression in a template component property.",
+      "anyOf": [
+        {"type": "string"},
+        {"type": "number"},
+        {"type": "boolean"},
+        {"type": "null"},
+        {"$ref": "#/$defs/ParamReference"},
+        {"$ref": "#/$defs/ConcatExpression"},
+        {"$ref": "#/$defs/FormatExpression"},
+        {"type": "array"},
+        {"type": "object"}
+      ]
+    },
+    "NestedTemplateNode": {
+      "type": "object",
+      "required": ["component"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Optional explicit component ID within the template."
+        },
+        "component": {
+          "type": "string",
+          "description": "Catalog component tag name."
+        },
+        "child": {
+          "anyOf": [
+            {"$ref": "#/$defs/NestedTemplateNode"},
+            {"$ref": "#/$defs/TemplateValue"}
+          ]
+        },
+        "children": {
+          "anyOf": [
+            {
+              "type": "object",
+              "required": ["loop"],
+              "properties": {
+                "loop": {"$ref": "#/$defs/LoopDefinition"}
+              },
+              "additionalProperties": false
+            },
+            {"type": "array"},
+            {"$ref": "#/$defs/ParamReference"},
+            {"type": "string"}
+          ]
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/TemplateValue"
+      }
+    },
+    "TemplateComponent": {
+      "type": "object",
+      "required": ["id", "component"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique component ID within the template."
+        },
+        "component": {
+          "type": "string",
+          "description": "Catalog component tag name."
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/TemplateValue"
+      }
+    }
+  }
+}

--- a/specification/proposals/templates/schema/template_definition.json
+++ b/specification/proposals/templates/schema/template_definition.json
@@ -3,17 +3,50 @@
   "title": "A2UI Template Definition",
   "description": "Schema defining a parameterized A2UI declarative template authored in YAML with a nested layout tree and synthetic ID generation.",
   "type": "object",
-  "required": ["version", "templateId", "parameters"],
+  "required": ["version", "parameters", "catalogs"],
   "properties": {
     "version": {
       "type": "string",
       "const": "0.1",
       "description": "Specification version of the template definition format. Forced to '0.1'."
     },
+    "id": {
+      "type": "string",
+      "description": "Optional globally unique identifier or URI for the template."
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9_]*$",
+      "description": "Component tag name of the template used in layout trees and LLM prompts."
+    },
     "templateId": {
       "type": "string",
       "pattern": "^[A-Za-z][A-Za-z0-9_]*$",
-      "description": "Unique identifier and component tag name of the template."
+      "description": "Deprecated alias for 'name'."
+    },
+    "catalogs": {
+      "description": "Catalog identifier (URI) or list of catalog identifiers against which components are resolved.",
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 1
+        },
+        {"type": "string"}
+      ]
+    },
+    "imports": {
+      "description": "Optional list or mapping of dependent templates imported by global ID.",
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        }
+      ]
     },
     "description": {
       "type": "string",
@@ -47,7 +80,14 @@
       "description": "Sample parameter values used for previewing and testing template inflation."
     }
   },
-  "anyOf": [{"required": ["layout"]}, {"required": ["components"]}],
+  "allOf": [
+    {
+      "anyOf": [{"required": ["name"]}, {"required": ["templateId"]}]
+    },
+    {
+      "anyOf": [{"required": ["layout"]}, {"required": ["components"]}]
+    }
+  ],
   "additionalProperties": false,
   "$defs": {
     "ParameterDefinition": {
@@ -220,6 +260,10 @@
           "type": "string",
           "description": "Catalog component tag name."
         },
+        "catalogId": {
+          "type": "string",
+          "description": "Optional catalog ID to disambiguate if the component name exists in multiple declared catalogs."
+        },
         "child": {
           "anyOf": [{"$ref": "#/$defs/NestedTemplateNode"}, {"$ref": "#/$defs/TemplateValue"}]
         },
@@ -254,6 +298,10 @@
         "component": {
           "type": "string",
           "description": "Catalog component tag name."
+        },
+        "catalogId": {
+          "type": "string",
+          "description": "Optional catalog ID to disambiguate if the component name exists in multiple declared catalogs."
         }
       },
       "additionalProperties": {


### PR DESCRIPTION
## Summary

This PR introduces the authoritative **A2UI Templates Specification**, formal JSON Schema, and multi-document YAML test fixtures under `specification/proposals/templates/`.

Templates provide a declarative, human-readable mechanism for authoring reusable UI subtrees in nested YAML. At generation time, an LLM emits compact, high-level template signatures (such as `UserProfile("u1", "Alice")`), which the backend expands into canonical Basic Catalog primitives in a single synchronous pass before emitting standard A2UI protocol messages (`createSurface`, `updateComponents`) to the client.

---

## Architectural Highlights

- **Zero Client Overhead**: Client renderers (@a2ui/react, @a2ui/lit, @a2ui/angular, @a2ui/flutter) require no custom widget code or dynamic plugins. They continue rendering 100% standard Basic Catalog primitives.
- **Context & Token Efficiency**: Agents output concise function-like signatures rather than deeply nested component trees.
- **Deterministic Synthetic ID Generation**: Implements canonical ID synthesis (`{parent}_{slot}_{index}_{type}`) guaranteeing zero ID collisions when multiple template instances are placed on a single surface.
- **Loop Expansion Boundaries**: Differentiates server-side synchronous unrolling (for literal parameter arrays) from client-side reactive loops bound to the client DataModel.
- **Two-Way DataModel Interoperability**: Preserves dynamic data binding paths (`{path: "/user/name"}`) and path prefix plumbing.
- **Strict Template Versioning (`0.1`)**: Enforces top-level `version: "0.1"` across all template definitions to support smooth schema evolution across future protocol releases.
- **Safety & Recursion Guards**: Formal call-stack tracking algorithm (`TemplateCycleError`) and `MAX_EXPANSION_DEPTH = 32` recursion limits.

---

## Files Added

- `specification/proposals/templates/README.md`: Complete, authoritative specification with pipeline diagrams, grammar rules, and multi-language conformance checklist.
- `specification/proposals/templates/schema/template_definition.json`: Canonical JSON Schema (Draft 2020-12) enforcing required `version: "0.1"`, `templateId`, `parameters`, and nested `layout`.
- `specification/proposals/templates/examples/*.yaml`: 11 multi-document YAML template fixtures and test suites (`basic_cards`, `nested_lists`, `slot_composition`, `user_profile`, `salary_card`, `team_roster`, etc.).

---

## Stack Context
- **PR 1 of 4**: Core Specification, Schema & Test Fixtures (This PR)
- **PR 2 of 4**: Python Agent SDK Template Engine Implementation
- **PR 3 of 4**: Community Templates Sample App & Interactive Studio
- **PR 4 of 4**: Future Proposals (Client-Expanded Templates & Python Fluent Builders)