### PR TITLE
fix(swift): safe failable initializers for basic functions without force try

### DIFF
--- a/swift/core/Sources/A2UICore/Models/Resolved+Conformances.swift
+++ b/swift/core/Sources/A2UICore/Models/Resolved+Conformances.swift
@@ -81,4 +81,3 @@ public struct ResolvedArray: Resolved, Equatable, Sendable {
     return true
   }
 }
-

--- a/swift/core/Sources/BasicCatalog/Functions/AndFunction.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/AndFunction.swift
@@ -16,27 +16,31 @@ import A2UICore
 import JSONSchema
 
 public final class AndFunction: FunctionImplementation, Sendable {
-  public let api = FunctionAPI(
-    name: "and",
-    returnType: .boolean,
-    schema: try! Schema(
-      instance: """
-        {
-          "type": "object",
-          "properties": {
-            "values": {
-              "type": "array",
-              "items": { "type": "boolean" },
-              "minItems": 2
-            }
-          },
-          "required": ["values"]
-        }
-        """
-    )
-  )
+  public let api: FunctionAPI
 
-  public init() {}
+  public init?() {
+    do {
+      let schema = try Schema(
+        instance: """
+          {
+            "type": "object",
+            "properties": {
+              "values": {
+                "type": "array",
+                "items": { "type": "boolean" },
+                "minItems": 2
+              }
+            },
+            "required": ["values"]
+          }
+          """
+      )
+      self.api = FunctionAPI(name: "and", returnType: .boolean, schema: schema)
+    } catch {
+      assertionFailure("Failed to compile schema for AndFunction: \(error)")
+      return nil
+    }
+  }
 
   public func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     guard let values = arguments["values"]?.arrayValue else { return .boolean(false) }

--- a/swift/core/Sources/BasicCatalog/Functions/EmailFunction.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/EmailFunction.swift
@@ -17,23 +17,27 @@ import Foundation
 import JSONSchema
 
 public final class EmailFunction: FunctionImplementation, Sendable {
-  public let api = FunctionAPI(
-    name: "email",
-    returnType: .boolean,
-    schema: try! Schema(
-      instance: """
-        {
-          "type": "object",
-          "properties": {
-            "value": { "type": "string" }
-          },
-          "required": ["value"]
-        }
-        """
-    )
-  )
+  public let api: FunctionAPI
 
-  public init() {}
+  public init?() {
+    do {
+      let schema = try Schema(
+        instance: """
+          {
+            "type": "object",
+            "properties": {
+              "value": { "type": "string" }
+            },
+            "required": ["value"]
+          }
+          """
+      )
+      self.api = FunctionAPI(name: "email", returnType: .boolean, schema: schema)
+    } catch {
+      assertionFailure("Failed to compile schema for EmailFunction: \(error)")
+      return nil
+    }
+  }
 
   public func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     guard let value = arguments["value"]?.stringValue else {

--- a/swift/core/Sources/BasicCatalog/Functions/FormatCurrencyFunction.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/FormatCurrencyFunction.swift
@@ -17,26 +17,30 @@ import Foundation
 import JSONSchema
 
 public final class FormatCurrencyFunction: FunctionImplementation, Sendable {
-  public let api = FunctionAPI(
-    name: "formatCurrency",
-    returnType: .string,
-    schema: try! Schema(
-      instance: """
-        {
-          "type": "object",
-          "properties": {
-            "value": { "type": ["number", "string"] },
-            "currency": { "type": "string" },
-            "decimals": { "type": "number" },
-            "grouping": { "type": "boolean" }
-          },
-          "required": ["currency", "value"]
-        }
-        """
-    )
-  )
+  public let api: FunctionAPI
 
-  public init() {}
+  public init?() {
+    do {
+      let schema = try Schema(
+        instance: """
+          {
+            "type": "object",
+            "properties": {
+              "value": { "type": ["number", "string"] },
+              "currency": { "type": "string" },
+              "decimals": { "type": "number" },
+              "grouping": { "type": "boolean" }
+            },
+            "required": ["currency", "value"]
+          }
+          """
+      )
+      self.api = FunctionAPI(name: "formatCurrency", returnType: .string, schema: schema)
+    } catch {
+      assertionFailure("Failed to compile schema for FormatCurrencyFunction: \(error)")
+      return nil
+    }
+  }
 
   public func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     guard let currency = arguments["currency"]?.stringValue else {

--- a/swift/core/Sources/BasicCatalog/Functions/FormatDateFunction.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/FormatDateFunction.swift
@@ -17,24 +17,28 @@ import Foundation
 import JSONSchema
 
 public final class FormatDateFunction: FunctionImplementation, Sendable {
-  public let api = FunctionAPI(
-    name: "formatDate",
-    returnType: .string,
-    schema: try! Schema(
-      instance: """
-        {
-          "type": "object",
-          "properties": {
-            "value": {},
-            "format": { "type": "string" }
-          },
-          "required": ["format", "value"]
-        }
-        """
-    )
-  )
+  public let api: FunctionAPI
 
-  public init() {}
+  public init?() {
+    do {
+      let schema = try Schema(
+        instance: """
+          {
+            "type": "object",
+            "properties": {
+              "value": {},
+              "format": { "type": "string" }
+            },
+            "required": ["format", "value"]
+          }
+          """
+      )
+      self.api = FunctionAPI(name: "formatDate", returnType: .string, schema: schema)
+    } catch {
+      assertionFailure("Failed to compile schema for FormatDateFunction: \(error)")
+      return nil
+    }
+  }
 
   public func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     guard let format = arguments["format"]?.stringValue else {

--- a/swift/core/Sources/BasicCatalog/Functions/FormatNumberFunction.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/FormatNumberFunction.swift
@@ -17,25 +17,29 @@ import Foundation
 import JSONSchema
 
 public final class FormatNumberFunction: FunctionImplementation, Sendable {
-  public let api = FunctionAPI(
-    name: "formatNumber",
-    returnType: .string,
-    schema: try! Schema(
-      instance: """
-        {
-          "type": "object",
-          "properties": {
-            "value": { "type": ["number", "string"] },
-            "decimals": { "type": "number" },
-            "grouping": { "type": "boolean" }
-          },
-          "required": ["value"]
-        }
-        """
-    )
-  )
+  public let api: FunctionAPI
 
-  public init() {}
+  public init?() {
+    do {
+      let schema = try Schema(
+        instance: """
+          {
+            "type": "object",
+            "properties": {
+              "value": { "type": ["number", "string"] },
+              "decimals": { "type": "number" },
+              "grouping": { "type": "boolean" }
+            },
+            "required": ["value"]
+          }
+          """
+      )
+      self.api = FunctionAPI(name: "formatNumber", returnType: .string, schema: schema)
+    } catch {
+      assertionFailure("Failed to compile schema for FormatNumberFunction: \(error)")
+      return nil
+    }
+  }
 
   public func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     let numberValue: Double

--- a/swift/core/Sources/BasicCatalog/Functions/FormatStringFunction.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/FormatStringFunction.swift
@@ -17,25 +17,29 @@ import JSONSchema
 
 /// Performs string interpolation of data model values and other functions.
 public final class FormatStringFunction: FunctionImplementation, Sendable {
-  public let api = FunctionAPI(
-    name: "formatString",
-    returnType: .string,
-    schema: try! Schema(
-      instance: """
-        {
-          "type": "object",
-          "properties": {
-            "value": { "type": "string" }
-          },
-          "required": ["value"]
-        }
-        """
-    )
-  )
+  public let api: FunctionAPI
 
   private let parser = ExpressionParser()
 
-  public init() {}
+  public init?() {
+    do {
+      let schema = try Schema(
+        instance: """
+          {
+            "type": "object",
+            "properties": {
+              "value": { "type": "string" }
+            },
+            "required": ["value"]
+          }
+          """
+      )
+      self.api = FunctionAPI(name: "formatString", returnType: .string, schema: schema)
+    } catch {
+      assertionFailure("Failed to compile schema for FormatStringFunction: \(error)")
+      return nil
+    }
+  }
 
   public func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     guard let valueString = arguments["value"]?.stringValue else {

--- a/swift/core/Sources/BasicCatalog/Functions/LengthFunction.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/LengthFunction.swift
@@ -16,29 +16,33 @@ import A2UICore
 import JSONSchema
 
 public final class LengthFunction: FunctionImplementation, Sendable {
-  public let api = FunctionAPI(
-    name: "length",
-    returnType: .boolean,
-    schema: try! Schema(
-      instance: """
-        {
-          "type": "object",
-          "properties": {
-            "value": { "type": "string" },
-            "min": { "type": "integer", "minimum": 0 },
-            "max": { "type": "integer", "minimum": 0 }
-          },
-          "required": ["value"],
-          "anyOf": [
-            { "required": ["min"] },
-            { "required": ["max"] }
-          ]
-        }
-        """
-    )
-  )
+  public let api: FunctionAPI
 
-  public init() {}
+  public init?() {
+    do {
+      let schema = try Schema(
+        instance: """
+          {
+            "type": "object",
+            "properties": {
+              "value": { "type": "string" },
+              "min": { "type": "integer", "minimum": 0 },
+              "max": { "type": "integer", "minimum": 0 }
+            },
+            "required": ["value"],
+            "anyOf": [
+              { "required": ["min"] },
+              { "required": ["max"] }
+            ]
+          }
+          """
+      )
+      self.api = FunctionAPI(name: "length", returnType: .boolean, schema: schema)
+    } catch {
+      assertionFailure("Failed to compile schema for LengthFunction: \(error)")
+      return nil
+    }
+  }
 
   public func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     guard let valueStr = arguments["value"]?.stringValue else { return .boolean(false) }

--- a/swift/core/Sources/BasicCatalog/Functions/NotFunction.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/NotFunction.swift
@@ -16,23 +16,27 @@ import A2UICore
 import JSONSchema
 
 public final class NotFunction: FunctionImplementation, Sendable {
-  public let api = FunctionAPI(
-    name: "not",
-    returnType: .boolean,
-    schema: try! Schema(
-      instance: """
-        {
-          "type": "object",
-          "properties": {
-            "value": { "type": "boolean" }
-          },
-          "required": ["value"]
-        }
-        """
-    )
-  )
+  public let api: FunctionAPI
 
-  public init() {}
+  public init?() {
+    do {
+      let schema = try Schema(
+        instance: """
+          {
+            "type": "object",
+            "properties": {
+              "value": { "type": "boolean" }
+            },
+            "required": ["value"]
+          }
+          """
+      )
+      self.api = FunctionAPI(name: "not", returnType: .boolean, schema: schema)
+    } catch {
+      assertionFailure("Failed to compile schema for NotFunction: \(error)")
+      return nil
+    }
+  }
 
   public func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     guard let value = arguments["value"]?.boolValue else { return .boolean(false) }

--- a/swift/core/Sources/BasicCatalog/Functions/NumericFunction.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/NumericFunction.swift
@@ -16,29 +16,33 @@ import A2UICore
 import JSONSchema
 
 public final class NumericFunction: FunctionImplementation, Sendable {
-  public let api = FunctionAPI(
-    name: "numeric",
-    returnType: .boolean,
-    schema: try! Schema(
-      instance: """
-        {
-          "type": "object",
-          "properties": {
-            "value": { "type": "number" },
-            "min": { "type": "number" },
-            "max": { "type": "number" }
-          },
-          "required": ["value"],
-          "anyOf": [
-            { "required": ["min"] },
-            { "required": ["max"] }
-          ]
-        }
-        """
-    )
-  )
+  public let api: FunctionAPI
 
-  public init() {}
+  public init?() {
+    do {
+      let schema = try Schema(
+        instance: """
+          {
+            "type": "object",
+            "properties": {
+              "value": { "type": "number" },
+              "min": { "type": "number" },
+              "max": { "type": "number" }
+            },
+            "required": ["value"],
+            "anyOf": [
+              { "required": ["min"] },
+              { "required": ["max"] }
+            ]
+          }
+          """
+      )
+      self.api = FunctionAPI(name: "numeric", returnType: .boolean, schema: schema)
+    } catch {
+      assertionFailure("Failed to compile schema for NumericFunction: \(error)")
+      return nil
+    }
+  }
 
   public func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     let numberValue: Double

--- a/swift/core/Sources/BasicCatalog/Functions/OpenUrlFunction.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/OpenUrlFunction.swift
@@ -24,21 +24,7 @@ public protocol OpenURLHandler: AnyObject, Sendable {
 
 /// Opens a URL using a registered handler, ensuring it has an `http` or `https` scheme.
 public final class OpenURLFunction: FunctionImplementation, @unchecked Sendable {
-  public let api = FunctionAPI(
-    name: "openUrl",
-    returnType: .void,
-    schema: try! Schema(
-      instance: """
-        {
-          "type": "object",
-          "properties": {
-            "url": { "type": "string" }
-          },
-          "required": ["url"]
-        }
-        """
-    )
-  )
+  public let api: FunctionAPI
 
   public weak var handler: (any OpenURLHandler)?
   public let baseURL: URL?
@@ -48,9 +34,26 @@ public final class OpenURLFunction: FunctionImplementation, @unchecked Sendable 
   /// - Parameters:
   ///   - handler: An optional weak reference to a handler that actually opens the URL on the host platform.
   ///   - baseURL: An optional base URL to resolve relative URLs against.
-  public init(handler: (any OpenURLHandler)? = nil, baseURL: URL? = nil) {
-    self.handler = handler
-    self.baseURL = baseURL
+  public init?(handler: (any OpenURLHandler)? = nil, baseURL: URL? = nil) {
+    do {
+      let schema = try Schema(
+        instance: """
+          {
+            "type": "object",
+            "properties": {
+              "url": { "type": "string" }
+            },
+            "required": ["url"]
+          }
+          """
+      )
+      self.api = FunctionAPI(name: "openUrl", returnType: .void, schema: schema)
+      self.handler = handler
+      self.baseURL = baseURL
+    } catch {
+      assertionFailure("Failed to compile schema for OpenURLFunction: \(error)")
+      return nil
+    }
   }
 
   /// Evaluates the openUrl function by resolving the URL and invoking the handler.

--- a/swift/core/Sources/BasicCatalog/Functions/OrFunction.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/OrFunction.swift
@@ -16,27 +16,31 @@ import A2UICore
 import JSONSchema
 
 public final class OrFunction: FunctionImplementation, Sendable {
-  public let api = FunctionAPI(
-    name: "or",
-    returnType: .boolean,
-    schema: try! Schema(
-      instance: """
-        {
-          "type": "object",
-          "properties": {
-            "values": {
-              "type": "array",
-              "items": { "type": "boolean" },
-              "minItems": 2
-            }
-          },
-          "required": ["values"]
-        }
-        """
-    )
-  )
+  public let api: FunctionAPI
 
-  public init() {}
+  public init?() {
+    do {
+      let schema = try Schema(
+        instance: """
+          {
+            "type": "object",
+            "properties": {
+              "values": {
+                "type": "array",
+                "items": { "type": "boolean" },
+                "minItems": 2
+              }
+            },
+            "required": ["values"]
+          }
+          """
+      )
+      self.api = FunctionAPI(name: "or", returnType: .boolean, schema: schema)
+    } catch {
+      assertionFailure("Failed to compile schema for OrFunction: \(error)")
+      return nil
+    }
+  }
 
   public func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     guard let values = arguments["values"]?.arrayValue else { return .boolean(false) }

--- a/swift/core/Sources/BasicCatalog/Functions/PluralizeFunction.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/PluralizeFunction.swift
@@ -33,27 +33,7 @@ public protocol PluralResolver: AnyObject, Sendable {
 }
 
 public final class PluralizeFunction: FunctionImplementation, @unchecked Sendable {
-  public let api = FunctionAPI(
-    name: "pluralize",
-    returnType: .string,
-    schema: try! Schema(
-      instance: """
-        {
-          "type": "object",
-          "properties": {
-            "value": { "type": ["number", "string"] },
-            "zero": { "type": "string" },
-            "one": { "type": "string" },
-            "two": { "type": "string" },
-            "few": { "type": "string" },
-            "many": { "type": "string" },
-            "other": { "type": "string" }
-          },
-          "required": ["value", "other"]
-        }
-        """
-    )
-  )
+  public let api: FunctionAPI
 
   public weak var resolver: (any PluralResolver)?
 
@@ -62,8 +42,31 @@ public final class PluralizeFunction: FunctionImplementation, @unchecked Sendabl
   /// - Parameter resolver: An optional weak reference to a `PluralResolver`. If `nil`,
   ///   the function falls back to a simplified English-centric heuristic matching
   ///   exact cases for `0`, `1`, and `2`, and falling back to `other`.
-  public init(resolver: (any PluralResolver)? = nil) {
-    self.resolver = resolver
+  public init?(resolver: (any PluralResolver)? = nil) {
+    do {
+      let schema = try Schema(
+        instance: """
+          {
+            "type": "object",
+            "properties": {
+              "value": { "type": ["number", "string"] },
+              "zero": { "type": "string" },
+              "one": { "type": "string" },
+              "two": { "type": "string" },
+              "few": { "type": "string" },
+              "many": { "type": "string" },
+              "other": { "type": "string" }
+            },
+            "required": ["value", "other"]
+          }
+          """
+      )
+      self.api = FunctionAPI(name: "pluralize", returnType: .string, schema: schema)
+      self.resolver = resolver
+    } catch {
+      assertionFailure("Failed to compile schema for PluralizeFunction: \(error)")
+      return nil
+    }
   }
 
   private func defaultCategory(for numberValue: Double) -> PluralCategory {

--- a/swift/core/Sources/BasicCatalog/Functions/RegexFunction.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/RegexFunction.swift
@@ -17,24 +17,28 @@ import Foundation
 import JSONSchema
 
 public final class RegexFunction: FunctionImplementation, Sendable {
-  public let api = FunctionAPI(
-    name: "regex",
-    returnType: .boolean,
-    schema: try! Schema(
-      instance: """
-        {
-          "type": "object",
-          "properties": {
-            "value": { "type": "string" },
-            "pattern": { "type": "string" }
-          },
-          "required": ["value", "pattern"]
-        }
-        """
-    )
-  )
+  public let api: FunctionAPI
 
-  public init() {}
+  public init?() {
+    do {
+      let schema = try Schema(
+        instance: """
+          {
+            "type": "object",
+            "properties": {
+              "value": { "type": "string" },
+              "pattern": { "type": "string" }
+            },
+            "required": ["value", "pattern"]
+          }
+          """
+      )
+      self.api = FunctionAPI(name: "regex", returnType: .boolean, schema: schema)
+    } catch {
+      assertionFailure("Failed to compile schema for RegexFunction: \(error)")
+      return nil
+    }
+  }
 
   public func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     guard let value = arguments["value"]?.stringValue,

--- a/swift/core/Sources/BasicCatalog/Functions/RequiredFunction.swift
+++ b/swift/core/Sources/BasicCatalog/Functions/RequiredFunction.swift
@@ -16,23 +16,27 @@ import A2UICore
 import JSONSchema
 
 public final class RequiredFunction: FunctionImplementation, Sendable {
-  public let api = FunctionAPI(
-    name: "required",
-    returnType: .boolean,
-    schema: try! Schema(
-      instance: """
-        {
-          "type": "object",
-          "properties": {
-            "value": {}
-          },
-          "required": ["value"]
-        }
-        """
-    )
-  )
+  public let api: FunctionAPI
 
-  public init() {}
+  public init?() {
+    do {
+      let schema = try Schema(
+        instance: """
+          {
+            "type": "object",
+            "properties": {
+              "value": {}
+            },
+            "required": ["value"]
+          }
+          """
+      )
+      self.api = FunctionAPI(name: "required", returnType: .boolean, schema: schema)
+    } catch {
+      assertionFailure("Failed to compile schema for RequiredFunction: \(error)")
+      return nil
+    }
+  }
 
   public func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     guard let value = arguments["value"] else { return .boolean(false) }

--- a/swift/core/Tests/BasicCatalogTests/AndFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/AndFunctionTests.swift
@@ -25,9 +25,13 @@ private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
 
 struct AndFunctionTests {
 
-  let function = AndFunction()
+  let function: AndFunction
   let context = DataContext(
     dataModel: DataModel(), path: "", functionHandler: MockFunctionHandler())
+
+  init() throws {
+    self.function = try #require(AndFunction())
+  }
 
   // MARK: - Initialization
 

--- a/swift/core/Tests/BasicCatalogTests/EmailFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/EmailFunctionTests.swift
@@ -25,9 +25,13 @@ private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
 
 struct EmailFunctionTests {
 
-  let function = EmailFunction()
+  let function: EmailFunction
   let context = DataContext(
     dataModel: DataModel(), path: "", functionHandler: MockFunctionHandler())
+
+  init() throws {
+    self.function = try #require(EmailFunction())
+  }
 
   // MARK: - Initialization
 

--- a/swift/core/Tests/BasicCatalogTests/FormatCurrencyFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/FormatCurrencyFunctionTests.swift
@@ -26,9 +26,13 @@ private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
 
 struct FormatCurrencyFunctionTests {
 
-  let function = FormatCurrencyFunction()
+  let function: FormatCurrencyFunction
   let context = DataContext(
     dataModel: DataModel(), path: "", functionHandler: MockFunctionHandler())
+
+  init() throws {
+    self.function = try #require(FormatCurrencyFunction())
+  }
 
   // Helper to generate expected strings based on current locale
   func expectedFormat(value: Double, currency: String, grouping: Bool = true, decimals: Int? = nil)

--- a/swift/core/Tests/BasicCatalogTests/FormatDateFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/FormatDateFunctionTests.swift
@@ -26,9 +26,13 @@ private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
 
 struct FormatDateFunctionTests {
 
-  let function = FormatDateFunction()
+  let function: FormatDateFunction
   let context = DataContext(
     dataModel: DataModel(), path: "", functionHandler: MockFunctionHandler())
+
+  init() throws {
+    self.function = try #require(FormatDateFunction())
+  }
 
   // Helper to generate expected strings based on current locale
   func expectedFormat(date: Date, format: String) -> String {
@@ -49,7 +53,7 @@ struct FormatDateFunctionTests {
 
   @Test func formatsISO8601String() throws {
     let isoString = "2026-01-16T14:30:00Z"
-    let date = ISO8601DateFormatter().date(from: isoString)!
+    let date = try #require(ISO8601DateFormatter().date(from: isoString))
     let format = "MMM dd, yyyy"
     let expected = expectedFormat(date: date, format: format)
 
@@ -95,7 +99,7 @@ struct FormatDateFunctionTests {
     let dateString = "2026-01-16"
     let fallbackFormatter = DateFormatter()
     fallbackFormatter.dateFormat = "yyyy-MM-dd"
-    let date = fallbackFormatter.date(from: dateString)!
+    let date = try #require(fallbackFormatter.date(from: dateString))
 
     let format = "MMMM d"
     let expected = expectedFormat(date: date, format: format)

--- a/swift/core/Tests/BasicCatalogTests/FormatNumberFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/FormatNumberFunctionTests.swift
@@ -26,9 +26,13 @@ private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
 
 struct FormatNumberFunctionTests {
 
-  let function = FormatNumberFunction()
+  let function: FormatNumberFunction
   let context = DataContext(
     dataModel: DataModel(), path: "", functionHandler: MockFunctionHandler())
+
+  init() throws {
+    self.function = try #require(FormatNumberFunction())
+  }
 
   // Helper to generate expected strings based on current locale
   func expectedFormat(value: Double, grouping: Bool = true, decimals: Int? = nil) -> String {

--- a/swift/core/Tests/BasicCatalogTests/FormatStringFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/FormatStringFunctionTests.swift
@@ -29,8 +29,12 @@ private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
 }
 
 private struct UpperFunction: FunctionImplementation, Sendable {
-  let api = FunctionAPI(
-    name: "upper", returnType: .string, schema: try! JSONSchema.Schema(instance: "{}"))
+  let api: FunctionAPI
+
+  init?() {
+    guard let schema = try? JSONSchema.Schema(instance: "{}") else { return nil }
+    self.api = FunctionAPI(name: "upper", returnType: .string, schema: schema)
+  }
 
   func evaluate(arguments: [String: JSONValue], context: DataContext) throws -> JSONValue {
     return .string(arguments["text"]?.stringValue?.uppercased() ?? "")
@@ -39,12 +43,13 @@ private struct UpperFunction: FunctionImplementation, Sendable {
 
 struct FormatStringFunctionTests {
 
-  let function = FormatStringFunction()
+  let function: FormatStringFunction
   let dataModel: DataModel
   let context: DataContext
   private let handler: MockFunctionHandler
 
-  init() {
+  init() throws {
+    self.function = try #require(FormatStringFunction())
     let dm = DataModel()
     dm.set(JSONValue.absolutePath(for: "/user/name", in: ""), value: .string("Alice"))
     dm.set(JSONValue.absolutePath(for: "/count", in: ""), value: .integer(5))

--- a/swift/core/Tests/BasicCatalogTests/LengthFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/LengthFunctionTests.swift
@@ -25,9 +25,13 @@ private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
 
 struct LengthFunctionTests {
 
-  let function = LengthFunction()
+  let function: LengthFunction
   let context = DataContext(
     dataModel: DataModel(), path: "", functionHandler: MockFunctionHandler())
+
+  init() throws {
+    self.function = try #require(LengthFunction())
+  }
 
   // MARK: - Initialization
 

--- a/swift/core/Tests/BasicCatalogTests/NotFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/NotFunctionTests.swift
@@ -25,9 +25,13 @@ private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
 
 struct NotFunctionTests {
 
-  let function = NotFunction()
+  let function: NotFunction
   let context = DataContext(
     dataModel: DataModel(), path: "", functionHandler: MockFunctionHandler())
+
+  init() throws {
+    self.function = try #require(NotFunction())
+  }
 
   // MARK: - Initialization
 

--- a/swift/core/Tests/BasicCatalogTests/NumericFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/NumericFunctionTests.swift
@@ -25,9 +25,13 @@ private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
 
 struct NumericFunctionTests {
 
-  let function = NumericFunction()
+  let function: NumericFunction
   let context = DataContext(
     dataModel: DataModel(), path: "", functionHandler: MockFunctionHandler())
+
+  init() throws {
+    self.function = try #require(NumericFunction())
+  }
 
   // MARK: - Initialization
 

--- a/swift/core/Tests/BasicCatalogTests/OpenUrlFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/OpenUrlFunctionTests.swift
@@ -39,8 +39,8 @@ struct OpenURLFunctionTests {
 
   // MARK: - Initialization
 
-  @Test func initializesWithExpectedAPI() {
-    let function = OpenURLFunction()
+  @Test func initializesWithExpectedAPI() throws {
+    let function = try #require(OpenURLFunction())
     #expect(function.api.name == "openUrl")
     #expect(function.api.returnType == .void)
   }
@@ -49,7 +49,7 @@ struct OpenURLFunctionTests {
 
   @Test func opensValidHTTPSUrl() throws {
     let handler = MockOpenURLHandler()
-    let function = OpenURLFunction(handler: handler)
+    let function = try #require(OpenURLFunction(handler: handler))
 
     let result = try function.evaluate(
       arguments: ["url": .string("https://example.com/foo?bar=baz")],
@@ -62,7 +62,7 @@ struct OpenURLFunctionTests {
 
   @Test func opensValidHTTPUrl() throws {
     let handler = MockOpenURLHandler()
-    let function = OpenURLFunction(handler: handler)
+    let function = try #require(OpenURLFunction(handler: handler))
 
     _ = try function.evaluate(
       arguments: ["url": .string("http://insecure.com")],
@@ -74,8 +74,8 @@ struct OpenURLFunctionTests {
 
   @Test func resolvesRelativeUrlWhenBaseUrlIsProvided() throws {
     let handler = MockOpenURLHandler()
-    let baseURL = URL(string: "https://google.com/search")!
-    let function = OpenURLFunction(handler: handler, baseURL: baseURL)
+    let baseURL = try #require(URL(string: "https://google.com/search"))
+    let function = try #require(OpenURLFunction(handler: handler, baseURL: baseURL))
 
     _ = try function.evaluate(
       arguments: ["url": .string("?q=swift")],
@@ -85,8 +85,8 @@ struct OpenURLFunctionTests {
     #expect(handler.openedURL?.absoluteString == "https://google.com/search?q=swift")
   }
 
-  @Test func throwsErrorWhenMissingUrlArgument() {
-    let function = OpenURLFunction()
+  @Test func throwsErrorWhenMissingUrlArgument() throws {
+    let function = try #require(OpenURLFunction())
 
     #expect(throws: FunctionError.self) {
       try function.evaluate(arguments: [:], context: context)
@@ -95,8 +95,8 @@ struct OpenURLFunctionTests {
 
   // MARK: - Security Constraints
 
-  @Test func throwsErrorWhenUsingJavascriptScheme() {
-    let function = OpenURLFunction()
+  @Test func throwsErrorWhenUsingJavascriptScheme() throws {
+    let function = try #require(OpenURLFunction())
 
     #expect(throws: FunctionError.self) {
       try function.evaluate(
@@ -106,8 +106,8 @@ struct OpenURLFunctionTests {
     }
   }
 
-  @Test func throwsErrorWhenUsingDataScheme() {
-    let function = OpenURLFunction()
+  @Test func throwsErrorWhenUsingDataScheme() throws {
+    let function = try #require(OpenURLFunction())
 
     #expect(throws: FunctionError.self) {
       try function.evaluate(
@@ -117,8 +117,8 @@ struct OpenURLFunctionTests {
     }
   }
 
-  @Test func throwsErrorWhenRelativeUrlHasNoSchemeAndNoBaseUrl() {
-    let function = OpenURLFunction()
+  @Test func throwsErrorWhenRelativeUrlHasNoSchemeAndNoBaseUrl() throws {
+    let function = try #require(OpenURLFunction())
 
     #expect(throws: FunctionError.self) {
       try function.evaluate(

--- a/swift/core/Tests/BasicCatalogTests/OrFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/OrFunctionTests.swift
@@ -25,9 +25,13 @@ private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
 
 struct OrFunctionTests {
 
-  let function = OrFunction()
+  let function: OrFunction
   let context = DataContext(
     dataModel: DataModel(), path: "", functionHandler: MockFunctionHandler())
+
+  init() throws {
+    self.function = try #require(OrFunction())
+  }
 
   // MARK: - Initialization
 

--- a/swift/core/Tests/BasicCatalogTests/PluralizeFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/PluralizeFunctionTests.swift
@@ -39,9 +39,13 @@ private final class MockPluralResolver: PluralResolver, @unchecked Sendable {
 
 struct PluralizeFunctionTests {
 
-  let function = PluralizeFunction()
+  let function: PluralizeFunction
   let context = DataContext(
     dataModel: DataModel(), path: "", functionHandler: MockFunctionHandler())
+
+  init() throws {
+    self.function = try #require(PluralizeFunction())
+  }
 
   // MARK: - Initialization
 
@@ -139,7 +143,7 @@ struct PluralizeFunctionTests {
 
   @Test func customResolverReturnsFew() throws {
     let resolver = MockPluralResolver()
-    let funcWithResolver = PluralizeFunction(resolver: resolver)
+    let funcWithResolver = try #require(PluralizeFunction(resolver: resolver))
     let result = try funcWithResolver.evaluate(
       arguments: [
         "value": .number(5),
@@ -151,7 +155,7 @@ struct PluralizeFunctionTests {
 
   @Test func customResolverReturnsMany() throws {
     let resolver = MockPluralResolver()
-    let funcWithResolver = PluralizeFunction(resolver: resolver)
+    let funcWithResolver = try #require(PluralizeFunction(resolver: resolver))
     let result = try funcWithResolver.evaluate(
       arguments: [
         "value": .number(15),
@@ -163,7 +167,7 @@ struct PluralizeFunctionTests {
 
   @Test func customResolverFallsBackToOtherIfCategoryMissing() throws {
     let resolver = MockPluralResolver()
-    let funcWithResolver = PluralizeFunction(resolver: resolver)
+    let funcWithResolver = try #require(PluralizeFunction(resolver: resolver))
     let result = try funcWithResolver.evaluate(
       arguments: [
         "value": .number(5),  // Resolver returns .few

--- a/swift/core/Tests/BasicCatalogTests/RegexFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/RegexFunctionTests.swift
@@ -25,9 +25,13 @@ private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
 
 struct RegexFunctionTests {
 
-  let function = RegexFunction()
+  let function: RegexFunction
   let context = DataContext(
     dataModel: DataModel(), path: "", functionHandler: MockFunctionHandler())
+
+  init() throws {
+    self.function = try #require(RegexFunction())
+  }
 
   // MARK: - Initialization
 

--- a/swift/core/Tests/BasicCatalogTests/RequiredFunctionTests.swift
+++ b/swift/core/Tests/BasicCatalogTests/RequiredFunctionTests.swift
@@ -25,9 +25,13 @@ private final class MockFunctionHandler: FunctionHandler, @unchecked Sendable {
 
 struct RequiredFunctionTests {
 
-  let function = RequiredFunction()
+  let function: RequiredFunction
   let context = DataContext(
     dataModel: DataModel(), path: "", functionHandler: MockFunctionHandler())
+
+  init() throws {
+    self.function = try #require(RequiredFunction())
+  }
 
   // MARK: - Initialization
 


### PR DESCRIPTION
## Summary

Replaces forced unwrapping (`try!`) with defensive schema compilation inside failable initializers across all 14 Basic Catalog functions.

## Changes

* **Failable initializers (`init?()`)**: Moves JSON Schema parsing into `public init?()` on each function class in `swift/core/Sources/BasicCatalog/Functions/`. If schema construction fails at runtime, an assertion failure is emitted and `nil` is returned instead of crashing the host process.
* **Protocol stability**: Leaves `FunctionImplementation` unchanged.
* **Test suites**: Updates unit tests in `swift/core/Tests/BasicCatalogTests/` to account for failable initialization.

## Testing

* `swift test --package-path swift/core` (all 415 tests pass)
