### PR TITLE
fix(compliance): Fixed broken relative links in documentation pointing to schemas

### DIFF
--- a/docs/public/concepts/components.md
+++ b/docs/public/concepts/components.md
@@ -171,7 +171,7 @@ Every component has:
 
 ## The Basic Catalog
 
-To help developers get started quickly, the A2UI team maintains the [Basic Catalog](../specification/v0_9_1/catalogs/basic/catalog.json).
+To help developers get started quickly, the A2UI team maintains the [Basic Catalog](../../../specification/v0_9_1/catalogs/basic/catalog.json).
 
 This is a pre-defined catalog file that contains a basic set of general-purpose components (Buttons, Inputs, Cards). It is not a special "type" of catalog; it is simply a version of a catalog that has open source renderers available.
 

--- a/docs/public/concepts/glossary.md
+++ b/docs/public/concepts/glossary.md
@@ -59,7 +59,7 @@ It is observed that depending on use case, catalog components may be more or les
 
 A catalog maintained by the A2UI team to get up and running quickly with A2UI.
 
-See the [basic catalog](../specification/v1_0/catalogs/basic/catalog.json).
+See the [basic catalog](../../../specification/v1_0/catalogs/basic/catalog.json).
 
 ### Catalog Transformer
 
@@ -142,7 +142,7 @@ Functionality of A2UI renderer consists of layers that can be developed separate
 
     Definition of catalog in the form of JSON.
 
-    For example, see the [basic catalog schema](../specification/v1_0/catalogs/basic/catalog.json).
+    For example, see the [basic catalog schema](../../../specification/v1_0/catalogs/basic/catalog.json).
 
 - **Framework adapter**:<a id="fw-adapter"></a>
 
@@ -193,7 +193,7 @@ See the [data binding guide](data-binding.md).
 
 In component definition, a reference to a data element, resolvable either by path in the data model or by value.
 
-See the [example in the basic catalog](../specification/v1_0/catalogs/basic/catalog.json#L18).
+See the [example in the basic catalog](../../../specification/v1_0/catalogs/basic/catalog.json#L18).
 
 ### Client function
 
@@ -209,7 +209,7 @@ Do not confuse with LLM tool:
 | Definition   | Registered in client side function registry and advertised in catalog | Defined in ToolDefinition (passed to LLM)                                             |
 | State Access | Access to DataContext and Input values.                               | No access to trigger requests to AI. Access to external APIs, databases, and services |
 
-See the [example in common types](../specification/v0_9/json/common_types.json#L200).
+See the [example in common types](../../../specification/v0_9/json/common_types.json#L200).
 
 ### Action
 


### PR DESCRIPTION
# Description

This pull request addresses compliance recommendations by updating broken or incorrect relative links within the project's documentation. These changes ensure that references to specification files and catalog definitions are correctly resolved from the documentation pages.

docs/public/concepts/components.md: Fixed broken relative link to the v0.9.1 basic catalog schema (../../../specification/v0_9_1/catalogs/basic/catalog.json).
docs/public/concepts/glossary.md: Fixed broken relative links to the v1.0 basic catalog schema and v0.9 common types schema (../../../specification/v1_0/catalogs/basic/catalog.json, ../../../specification/v0_9/json/common_types.json).

Fixes https://github.com/a2ui-project/a2ui/issues/2391 recommendation 2